### PR TITLE
Freeze source language contract

### DIFF
--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -1,0 +1,32 @@
+# Source Language Contract Freeze
+
+Status: proposed
+
+## Goal
+
+Turn the current Semantic source surface into a single canonical language contract rather than a set of scattered implementation notes.
+
+## Why
+
+Semantic already has a strong execution contract. What it still lacks is a fully frozen source-language contract that a user can treat as the primary truth for writing programs.
+
+## Scope
+
+- define canonical source syntax and grammar boundaries
+- define expression and statement semantics
+- define type rules for `quad`, `bool`, `i32`, `u32`, `f64`, and `fx`
+- define import and export behavior as part of the language contract
+- define user-facing diagnostics expectations for source-level contract violations
+
+## Non-Goals
+
+- adding new runtime semantics
+- widening the PROMETHEUS boundary
+- changing bytecode or VM behavior beyond what is required to document the source contract honestly
+
+## Acceptance Criteria
+
+- one canonical source-language specification bundle exists and is linked from the main spec index
+- syntax, typing, and module semantics are documented in one intentional contract family
+- examples and diagnostics match the documented source surface
+- no major source feature remains described only by implementation behavior

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -7,6 +7,8 @@ execution contract.
 
 Current documents in this PR:
 
+- `syntax.md` - canonical Rust-like source syntax contract
+- `types.md` - source-level type contract and current type-family limits
 - `semcode.md` - SemCode binary contract and compatibility rules
 - `profile.md` - `ParserProfile` policy contract
 - `verifier.md` - SemCode admission verification contract
@@ -20,8 +22,14 @@ Current documents in this PR:
 - `rules.md` - deterministic rule and agenda contract
 - `audit.md` - audit trail and replay metadata contract
 
-Later PRs may extend this bundle with source-surface, IR, CLI, versioning, and
-release-facing validation specifications.
+Adjacent source-surface documents also remain relevant:
+
+- `docs/imports.md`
+- `docs/exports.md`
+- `docs/LANGUAGE.md`
+
+Later PRs may extend this bundle further with richer module, package, CLI,
+versioning, and release-facing validation specifications.
 
 Contract precedence:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -1,0 +1,159 @@
+# Source Syntax Specification
+
+Status: draft v0
+Primary frontend owners: `sm-front`, `sm-sema`
+
+## Purpose
+
+This document defines the current canonical source-level syntax for the public
+Semantic language surface.
+
+It describes the source language accepted by the Rust-like frontend path. It
+does not redefine:
+
+- SemCode binary structure
+- verifier admission rules
+- VM runtime behavior
+- PROMETHEUS ABI semantics
+
+## Current Source Surfaces
+
+Semantic currently exposes two distinct source-oriented surfaces:
+
+- a Rust-like executable surface used for functions, expressions, and control
+  flow
+- a Logos-oriented declarative surface used for `System`, `Entity`, and `Law`
+  forms
+
+This document covers the Rust-like executable surface first. Import/export and
+Logos semantics remain part of the public source contract, but are still
+documented in:
+
+- `docs/imports.md`
+- `docs/exports.md`
+- `docs/LANGUAGE.md`
+
+## Program Structure
+
+The current Rust-like executable program is a sequence of top-level functions:
+
+```sm
+fn name(arg: type, ...) -> ret_type {
+    ...
+}
+```
+
+Current rules:
+
+- `fn` introduces a function
+- parameters are named and typed explicitly
+- the return type is optional; omitted return type means `unit`
+- function bodies are block-delimited with `{ ... }`
+- the public program entrypoint is `fn main()`
+
+## Statements
+
+Current statement forms:
+
+- `let name = expr;`
+- `let name: type = expr;`
+- `if condition { ... } else { ... }`
+- `match quad_expr { T => { ... } ... _ => { ... } }`
+- `return;`
+- `return expr;`
+- expression statements: `expr;`
+
+Current statement rules:
+
+- semicolons terminate executable statements
+- `if` conditions must be `bool`
+- `match` is currently restricted to `quad`
+- `match` requires an explicit default arm `_ => { ... }`
+- unit-returning calls may be used as statements
+
+## Expressions
+
+Current expression forms:
+
+- literals:
+  - quad literals: `N`, `F`, `T`, `S`
+  - bool literals: `true`, `false`
+  - integer literals
+  - floating literals
+- variables
+- function calls
+- parenthesized expressions
+- unary operators:
+  - `!`
+  - unary `+`
+  - unary `-`
+- binary operators:
+  - `*`, `/`
+  - `+`, `-`
+  - `==`, `!=`
+  - `&&`, `||`
+  - `->`
+
+Current precedence, from tighter to looser:
+
+1. primary expressions and calls
+2. unary `!`, unary `+`, unary `-`
+3. `*`, `/`
+4. `+`, `-`
+5. `==`, `!=`
+6. `&&`
+7. `||`
+8. `->`
+
+## Quad-Specific Surface Rules
+
+Current `quad` model values are:
+
+- `N` = unknown
+- `F` = false
+- `T` = true
+- `S` = conflict
+
+Current source restrictions:
+
+- `if quad_expr` is forbidden; users must write an explicit comparison
+- `match` currently accepts only `quad` scrutinees
+- quad implication uses `->`
+
+## Builtin Calls
+
+Builtin calls currently share call syntax with ordinary functions:
+
+```sm
+sqrt(9.0)
+pow(2.0, 3.0)
+abs(-1.0)
+```
+
+Current builtins are resolved as part of the public source surface and must not
+require a separate foreign-call syntax.
+
+## Imports And Module Surface
+
+The current repository supports source-level imports and re-exports. That
+surface is part of the language contract, but remains documented in dedicated
+documents until the source contract bundle is widened further:
+
+- `docs/imports.md`
+- `docs/exports.md`
+
+## Current Exclusions
+
+The current source contract does not yet claim stable support for:
+
+- relational operators such as `>`, `<`, `>=`, `<=`
+- user-defined aggregate types
+- collections as first-class language forms
+- generics or trait-like abstraction
+- exceptions or Python-style dynamic execution
+- concurrency-oriented source constructs
+
+## Contract Rule
+
+Any public change to source syntax, source statement forms, or operator meaning
+should update this document in the same change series.

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -1,0 +1,157 @@
+# Source Type Specification
+
+Status: draft v0
+Primary frontend owners: `sm-front`, `sm-sema`
+
+## Purpose
+
+This document defines the current public source-level type contract for
+Semantic programs.
+
+It covers the executable source surface rather than the SemCode or VM
+representation layer.
+
+## Current Type Family
+
+Current source-visible types:
+
+- `quad`
+- `bool`
+- `i32`
+- `u32`
+- `f64`
+- `fx`
+- `unit`
+- `qvec(N)` as a reserved parser-level family
+
+## Unit
+
+`unit` is the implicit type of functions without an explicit return type.
+
+Current rule:
+
+- `fn main()` must currently have implicit `unit` return and no parameters in
+  the canonical executable path
+
+## Quad
+
+`quad` is a first-class semantic logic type with four values:
+
+- `N`
+- `F`
+- `T`
+- `S`
+
+Current rules:
+
+- `quad` participates in equality and implication
+- `match` currently operates only on `quad`
+- `quad` is not accepted directly as an `if` condition
+
+## Bool
+
+`bool` is the ordinary binary condition type.
+
+Current rules:
+
+- `if` conditions must evaluate to `bool`
+- `!`, `&&`, and `||` are valid on `bool`
+- equality comparisons on `bool` are valid
+
+## I32 And U32
+
+`i32` and `u32` are the current integer-oriented execution types.
+
+Current rules:
+
+- arithmetic operators are expected to stay within the same numeric family
+- equality comparisons are valid inside the same family
+- implicit cross-family numeric coercion is not part of the current contract
+
+## F64
+
+`f64` is the current floating-point math family.
+
+Current rules:
+
+- `f64` availability is gated by the active parser profile / compile policy
+- arithmetic operators `+`, `-`, `*`, `/` are supported on `f64`
+- equality comparisons are supported on `f64`
+- current builtin math calls include:
+  - `sin`
+  - `cos`
+  - `tan`
+  - `sqrt`
+  - `abs`
+  - `pow`
+
+## Fx
+
+`fx` is the fixed-point-oriented numeric family.
+
+Current rules:
+
+- the canonical `fx` value path is end-to-end
+- explicit `fx` annotations are supported
+- `fx` currently accepts literals and existing `fx`-typed values in the public
+  Rust-like path
+
+Current honest limits:
+
+- richer `fx` arithmetic remains narrower than the `f64` surface
+- coercion from non-literal non-`fx` expressions is not yet the full intended
+  long-term contract
+- unary `+` and unary `-` on `fx` are still intentionally limited in the
+  canonical Rust-like path
+
+## QVec
+
+`qvec(N)` exists as a parser-level family and should be treated as reserved or
+partial rather than fully stabilized in the current public source contract.
+
+Until the repository documents a fuller execution and library story for
+`qvec(N)`, it should not be treated as a broadly stable user-facing type family.
+
+## Equality And Control Rules
+
+Current equality and control rules:
+
+- `==` and `!=` require meaningful same-family comparisons
+- `if` requires `bool`
+- `match` requires `quad`
+
+## Function Typing Rules
+
+Current function typing rules:
+
+- every parameter has an explicit type
+- return type defaults to `unit` if omitted
+- `return expr;` must match the declared return type
+- `return;` is valid only for `unit`-returning functions
+
+## Builtin Typing Rule
+
+Builtin functions are part of the public type contract and are checked as typed
+calls, not as dynamically typed escape hatches.
+
+That means:
+
+- argument count must match
+- argument types must match the builtin signature
+- builtin typing failures are ordinary source-level type errors
+
+## Current Exclusions
+
+The current source type contract does not yet claim stable support for:
+
+- user-defined aggregate types
+- algebraic data types
+- generics
+- trait or protocol systems
+- implicit numeric widening across unrelated families
+- a broad collection type ecosystem
+
+## Contract Rule
+
+Any public change to source-visible type meaning or source type-checking rules
+should update this document in the same change series.


### PR DESCRIPTION
Adds a roadmap brief for freezing the user-facing Semantic source language contract. Scope covers syntax, types, module semantics, and diagnostics without reopening runtime or ABI scope.