### PR TITLE
PR-WB-01 docs(workbench): architecture and source-of-truth policy

### DIFF
--- a/docs/workbench/architecture.md
+++ b/docs/workbench/architecture.md
@@ -1,0 +1,168 @@
+# Workbench Architecture
+
+Status: proposed v1
+
+## Purpose
+
+Semantic Workbench is a desktop orchestration and presentation layer over the
+existing Semantic repository contracts.
+
+Workbench exists to make the current project, release, and authoring workflows
+usable without requiring users to manually navigate the repository and run every
+command from a terminal.
+
+## Architectural Rule
+
+Workbench is not a second compiler, verifier, VM, runtime, or release model.
+
+Workbench owns:
+
+- desktop shell and routes
+- UI state
+- command orchestration
+- cached presentation models
+- job history
+- workspace settings
+
+Workbench does not own:
+
+- parser or type-checking semantics
+- verifier logic
+- VM logic
+- ABI, capability, or gate semantics
+- PROMETHEUS runtime, state, rules, or audit semantics
+- release-truth calculations independent from repository commands and docs
+
+## Source Of Truth Policy
+
+Workbench may read and present:
+
+- `docs/spec/*`
+- `docs/roadmap/*`
+- release artifacts and manifests
+- test, golden, and release command outputs
+- public CLI and script surfaces
+
+Workbench must not introduce:
+
+- a second readiness score
+- a second compatibility matrix
+- hidden semantic rewrites over command output
+- alternate ownership maps
+
+## Integration Rule
+
+The first integration path is process-based:
+
+- `smc`
+- `svm`
+- `cargo`
+- release verification scripts
+
+Later integration may use public Rust facades when a facade is already part of
+the supported public surface. Private crate internals remain off-limits.
+
+## Runtime Boundary Rule
+
+Workbench must respect the existing repository ownership boundaries:
+
+- construction contracts stay in construction crates
+- execution contracts stay in execution crates
+- integration contracts stay behind ABI, capability, and gate surfaces
+
+Workbench may inspect command outputs from those layers, but it may not absorb
+ownership of those layers.
+
+## Application Modules
+
+### `workbench-shell`
+
+Desktop shell, routes, layout, navigation, window state.
+
+### `workbench-core`
+
+Job queue, event model, command dispatch, shared UI state primitives.
+
+### `workbench-adapter-cli`
+
+Process adapter over:
+
+- `smc`
+- `svm`
+- `cargo`
+- release scripts
+
+### `workbench-spec-index`
+
+Read-only index for spec, roadmap, readiness, compatibility, and release docs.
+
+### `workbench-project`
+
+Workspace open/close flow, recent projects, project-level settings, local cache
+keys.
+
+### `workbench-editor`
+
+Editor shell only: tabs, save/reload, dirty markers, current-file actions.
+
+### `workbench-diagnostics`
+
+Structured diagnostics list, filters, grouping, jump targets, spec links.
+
+### `workbench-inspector`
+
+Disasm, verify, trace, quota, and runtime inspection views.
+
+### `workbench-release`
+
+Release gates, readiness, asset validation, bundle verification, known limits,
+and release reports.
+
+## Event Model
+
+The minimal event model for v1:
+
+- workspace opened
+- file opened
+- file saved
+- command requested
+- job started
+- job finished
+- diagnostics published
+- release snapshot refreshed
+- spec index refreshed
+
+Events are orchestration events only. They are not semantic execution events.
+
+## Route Map
+
+The expected v1 route families are:
+
+- overview
+- project
+- editor
+- diagnostics
+- spec
+- inspect
+- release
+- settings
+
+## Stability Labels
+
+Workbench must surface repository maturity labels instead of flattening them.
+
+Every workflow shown to users should be marked as one of:
+
+- stable now
+- draft target
+- experimental idea
+
+## Definition Of Done For Foundation
+
+The foundation layer is considered valid when:
+
+- Workbench is documented as an orchestration/UI layer, not a second core
+- source-of-truth rules are explicit
+- private internal coupling is forbidden
+- module ownership is separated cleanly
+- route families and event model are defined before implementation grows

--- a/docs/workbench/scope.md
+++ b/docs/workbench/scope.md
@@ -1,0 +1,133 @@
+# Workbench Scope
+
+Status: proposed v1
+
+## Goal
+
+Define the user-facing scope for Workbench v1 without reopening Semantic core
+scope or encouraging IDE-overreach.
+
+## Workbench v1 Includes
+
+### Operations
+
+- project open
+- command runner
+- jobs history
+- command output panels
+
+### Readiness And Release
+
+- overview cockpit
+- release status panel
+- readiness and compatibility links
+- bundle verification entrypoint
+- asset smoke visibility
+
+### Spec Navigation
+
+- spec tree
+- roadmap tree
+- section navigation
+- search over canonical document titles and paths
+
+### Authoring Shell
+
+- file tree
+- multi-tab editor shell
+- open/save/reload
+- dirty markers
+- current-file compile and check actions
+
+### Diagnostics
+
+- grouped diagnostics
+- filters by family
+- error-code lookup
+- jump-to-file location
+- links to related spec sections
+
+### Inspection
+
+- disasm view
+- verify-result view
+- trace and runtime summary view
+- quota and capability summaries when present in outputs
+
+### Tooling Integration
+
+- formatter integration through the canonical formatter surface
+- basic project bootstrap through canonical project layout commands
+
+## Workbench v1 Excludes
+
+- a second parser or type checker inside the UI
+- direct VM or runtime embedding as an alternate execution authority
+- deep source-level debugger with time-travel semantics
+- private PROMETHEUS state editing
+- alternate release scoring independent from repository gates
+- widening narrow Semantic v1 scope for the sake of UI features
+
+## Public Surface Rule
+
+Workbench must use only:
+
+- `smc`
+- `svm`
+- `cargo`
+- public release scripts
+- later, explicit public Rust facades
+
+Workbench must not couple to private crate internals.
+
+## Screen Inventory
+
+The expected v1 screens are:
+
+- overview
+- project explorer
+- editor shell
+- diagnostics hub
+- spec navigator
+- inspect
+- release console
+- settings
+
+## Scope Sequencing
+
+Critical path:
+
+1. foundation
+2. cockpit
+3. spec navigation
+4. editor shell
+5. diagnostics
+6. formatter
+7. inspectors
+8. release console
+
+Deferred path:
+
+- scaffolding depth beyond baseline bootstrap
+- `smlsp` bridge
+- richer editor protocol features
+
+## UX Honesty Rule
+
+Workbench must show current repository reality, including:
+
+- stable vs draft vs experimental status
+- known limits
+- release blockers
+- command failures
+
+Workbench must not mask repository limitations behind optimistic UI wording.
+
+## Acceptance Criteria
+
+This scope is valid when:
+
+- included flows map to current public Semantic surfaces
+- excluded flows prevent Workbench from becoming a second core
+- critical-path ordering is explicit
+- users can infer what Workbench does and does not promise from one document

--- a/docs/workbench/view_models.md
+++ b/docs/workbench/view_models.md
@@ -1,0 +1,205 @@
+# Workbench View Models
+
+Status: proposed v1
+
+## Purpose
+
+Define the presentation models Workbench may cache and render without becoming a
+second semantic authority.
+
+View models are derived from repository files, command outputs, and public tool
+surfaces. They are never the canonical source of truth.
+
+## `OverviewViewModel`
+
+Derived from:
+
+- git branch and commit
+- baseline tags
+- latest test/build/release command results
+- readiness and compatibility docs
+
+Fields:
+
+- current branch
+- current commit
+- baseline tag
+- latest workspace test status
+- latest release build status
+- latest bundle verification status
+- latest asset smoke summary
+- known-limits summary
+
+Must not contain:
+
+- invented readiness percentages
+- manual override flags that replace command truth
+
+## `ProjectViewModel`
+
+Derived from:
+
+- selected workspace root
+- recent-project cache
+- local settings
+- repository file tree
+
+Fields:
+
+- workspace root
+- recent projects
+- open files
+- dirty files
+- workspace settings
+
+Must not contain:
+
+- alternate package metadata semantics
+
+## `JobViewModel`
+
+Derived from:
+
+- requested command
+- process execution metadata
+- stdout/stderr
+- exit code
+- parsed diagnostics references when available
+
+Fields:
+
+- job id
+- command kind
+- arguments
+- start time
+- finish time
+- duration
+- status
+- exit code
+- output
+- related file
+
+Must not contain:
+
+- hidden semantic rewrites over output
+
+## `DiagnosticsViewModel`
+
+Derived from:
+
+- parser diagnostics
+- type diagnostics
+- module/import/export diagnostics
+- verifier diagnostics
+- runtime failures
+
+Fields:
+
+- family
+- severity
+- code
+- message
+- file path
+- start/end location
+- related spec link
+
+Must preserve:
+
+- error code
+- location
+- severity
+- original message text or faithful rendering
+
+## `SpecDocumentViewModel`
+
+Derived from:
+
+- `docs/spec/*`
+- `docs/roadmap/*`
+- selected path and heading anchors
+
+Fields:
+
+- path
+- title
+- section headings
+- last refreshed time
+- stability label when declared by the document
+
+Must not contain:
+
+- silently edited mirror content
+
+## `InspectorViewModel`
+
+Derived from:
+
+- `svm disasm`
+- verify outputs
+- trace outputs
+- quota and capability summaries
+
+Fields:
+
+- artifact path
+- disasm text
+- verify summary
+- trace summary
+- runtime summary
+- quota summary
+- capability summary
+
+Must not contain:
+
+- a second VM interpretation layer
+
+## `ReleaseViewModel`
+
+Derived from:
+
+- readiness docs
+- compatibility docs
+- release checklist
+- smoke matrix
+- bundle verification output
+- latest validation jobs
+
+Fields:
+
+- gate statuses
+- artifact list
+- smoke status
+- docs alignment notes
+- known limits
+- release-valid summary
+
+Rule:
+
+`release-valid` may be computed only from real gates and document states already
+defined by the repository.
+
+## `SettingsViewModel`
+
+Derived from:
+
+- local user settings
+- selected workspace settings
+
+Fields:
+
+- default workspace
+- shell preferences
+- formatter preferences
+- display preferences
+
+Must not contain:
+
+- hidden feature switches that widen Semantic scope
+
+## View-Model Discipline
+
+All Workbench view models must follow three rules:
+
+1. derived, not canonical
+2. explainable from public inputs
+3. replaceable by refresh from repository state


### PR DESCRIPTION
## Summary
- add initial `docs/workbench` foundation bundle
- define Workbench as orchestration/UI layer over public Semantic surfaces
- freeze source-of-truth, route, and view-model rules before app code starts

## Includes
- `docs/workbench/architecture.md`
- `docs/workbench/scope.md`
- `docs/workbench/view_models.md`

## Excludes
- no app shell yet
- no Tauri bootstrap yet
- no code changes outside docs

## Acceptance
- Workbench is explicitly scoped as non-owner of compiler/verifier/vm/runtime semantics
- public-surface-only rule is documented
- route map, event model, and v1 screen inventory are defined
- view models are documented as derived, not canonical

Refs #10
