### PR TITLE
PR-WB-03 feat(workbench): command bus and cli adapter

### DIFF
--- a/apps/workbench/eslint.config.js
+++ b/apps/workbench/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src-tauri/target', 'src-tauri/gen']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/apps/workbench/src-tauri/src/adapter.rs
+++ b/apps/workbench/src-tauri/src/adapter.rs
@@ -1,0 +1,250 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobKind {
+  Smc,
+  Svm,
+  Cargo,
+  ReleaseBundleVerify,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdapterJobSpec {
+  pub kind: JobKind,
+  pub label: &'static str,
+  pub resolution: &'static str,
+  pub example_args: Vec<String>,
+  pub notes: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdapterContract {
+  pub repo_root: String,
+  pub jobs: Vec<AdapterJobSpec>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobRequest {
+  pub kind: JobKind,
+  pub args: Vec<String>,
+  pub cwd: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobResult {
+  pub kind: JobKind,
+  pub resolved_command: Vec<String>,
+  pub cwd: String,
+  pub exit_code: i32,
+  pub duration_ms: u64,
+  pub success: bool,
+  pub stdout: String,
+  pub stderr: String,
+}
+
+pub fn adapter_contract() -> Result<AdapterContract, String> {
+  let repo_root = repo_root()?;
+
+  Ok(AdapterContract {
+    repo_root: repo_root.to_string_lossy().into_owned(),
+    jobs: vec![
+      AdapterJobSpec {
+        kind: JobKind::Cargo,
+        label: "Cargo",
+        resolution: "cargo from PATH",
+        example_args: vec!["--version".into()],
+        notes: "Used for workspace validation and repository-centric commands.",
+      },
+      AdapterJobSpec {
+        kind: JobKind::Smc,
+        label: "smc",
+        resolution:
+          "target/release/smc(.exe) -> target/debug/smc(.exe) -> smc on PATH -> cargo run --bin smc --",
+        example_args: vec!["--help".into()],
+        notes: "Canonical Semantic compile/check/run CLI surface.",
+      },
+      AdapterJobSpec {
+        kind: JobKind::Svm,
+        label: "svm",
+        resolution:
+          "target/release/svm(.exe) -> target/debug/svm(.exe) -> svm on PATH -> cargo run --bin svm --",
+        example_args: vec!["--help".into()],
+        notes: "Canonical Semantic execution and disassembly CLI surface.",
+      },
+      AdapterJobSpec {
+        kind: JobKind::ReleaseBundleVerify,
+        label: "Release bundle verify",
+        resolution: "pwsh -File scripts/verify_release_bundle.ps1",
+        example_args: vec![
+          "-ManifestPath".into(),
+          "artifacts/baselines/semantic_v1_language_maturity_release_bundle_manifest.json".into(),
+        ],
+        notes: "Release validation remains driven by the existing repository script.",
+      },
+    ],
+  })
+}
+
+pub fn execute_job(request: JobRequest) -> Result<JobResult, String> {
+  let repo_root = repo_root()?;
+  let cwd = resolve_cwd(&repo_root, request.cwd.as_deref())?;
+  let (program, args) = resolve_invocation(&repo_root, &request.kind, &request.args);
+
+  let started = Instant::now();
+  let output = Command::new(&program)
+    .args(&args)
+    .current_dir(&cwd)
+    .output()
+    .map_err(|error| format!("failed to spawn command '{}': {error}", program))?;
+
+  let duration_ms = started
+    .elapsed()
+    .as_millis()
+    .try_into()
+    .unwrap_or(u64::MAX);
+
+  Ok(JobResult {
+    kind: request.kind,
+    resolved_command: std::iter::once(program.clone())
+      .chain(args.iter().cloned())
+      .collect(),
+    cwd: cwd.to_string_lossy().into_owned(),
+    exit_code: output.status.code().unwrap_or(-1),
+    duration_ms,
+    success: output.status.success(),
+    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+  })
+}
+
+fn resolve_invocation(
+  repo_root: &Path,
+  kind: &JobKind,
+  args: &[String],
+) -> (String, Vec<String>) {
+  match kind {
+    JobKind::Cargo => ("cargo".into(), args.to_vec()),
+    JobKind::Smc => resolve_semantic_cli(repo_root, "smc", args),
+    JobKind::Svm => resolve_semantic_cli(repo_root, "svm", args),
+    JobKind::ReleaseBundleVerify => {
+      let script = repo_root.join("scripts").join("verify_release_bundle.ps1");
+      let resolved_args = if args.is_empty() {
+        vec![
+          "-ManifestPath".into(),
+          repo_root
+            .join("artifacts")
+            .join("baselines")
+            .join("semantic_v1_language_maturity_release_bundle_manifest.json")
+            .to_string_lossy()
+            .into_owned(),
+        ]
+      } else {
+        args.to_vec()
+      };
+
+      let mut command_args = vec!["-File".into(), script.to_string_lossy().into_owned()];
+      command_args.extend(resolved_args);
+      ("pwsh".into(), command_args)
+    }
+  }
+}
+
+fn resolve_semantic_cli(
+  repo_root: &Path,
+  tool: &str,
+  args: &[String],
+) -> (String, Vec<String>) {
+  let exe_name = executable_name(tool);
+
+  for candidate in [
+    repo_root.join("target").join("release").join(&exe_name),
+    repo_root.join("target").join("debug").join(&exe_name),
+  ] {
+    if candidate.exists() {
+      return (
+        candidate.to_string_lossy().into_owned(),
+        args.to_vec(),
+      );
+    }
+  }
+
+  if command_available(&exe_name) {
+    return (exe_name, args.to_vec());
+  }
+
+  let mut fallback_args = vec![
+    "run".into(),
+    "--quiet".into(),
+    "--bin".into(),
+    tool.into(),
+    "--".into(),
+  ];
+  fallback_args.extend(args.iter().cloned());
+  ("cargo".into(), fallback_args)
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+  let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  base
+    .join("..")
+    .join("..")
+    .join("..")
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve repository root: {error}"))
+}
+
+fn resolve_cwd(repo_root: &Path, cwd: Option<&str>) -> Result<PathBuf, String> {
+  let requested = cwd
+    .map(PathBuf::from)
+    .unwrap_or_else(|| repo_root.to_path_buf());
+  let absolute = if requested.is_absolute() {
+    requested
+  } else {
+    repo_root.join(requested)
+  };
+
+  let canonical = absolute
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve job cwd: {error}"))?;
+  let root = repo_root
+    .canonicalize()
+    .map_err(|error| format!("failed to canonicalize repository root: {error}"))?;
+
+  if !canonical.starts_with(&root) {
+    return Err("job cwd must stay inside the repository root".into());
+  }
+
+  Ok(canonical)
+}
+
+fn executable_name(tool: &str) -> String {
+  if cfg!(target_os = "windows") {
+    format!("{tool}.exe")
+  } else {
+    tool.into()
+  }
+}
+
+fn command_available(command: &str) -> bool {
+  if cfg!(target_os = "windows") {
+    Command::new("where")
+      .arg(command)
+      .output()
+      .map(|output| output.status.success())
+      .unwrap_or(false)
+  } else {
+    Command::new("which")
+      .arg(command)
+      .output()
+      .map(|output| output.status.success())
+      .unwrap_or(false)
+  }
+}

--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,3 +1,19 @@
+mod adapter;
+
+use adapter::{adapter_contract, execute_job, AdapterContract, JobRequest, JobResult};
+
+#[tauri::command]
+fn get_adapter_contract() -> Result<AdapterContract, String> {
+  adapter_contract()
+}
+
+#[tauri::command]
+async fn run_cli_job(request: JobRequest) -> Result<JobResult, String> {
+  tauri::async_runtime::spawn_blocking(move || execute_job(request))
+    .await
+    .map_err(|error| format!("command task failed: {error}"))?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -11,6 +27,10 @@ pub fn run() {
       }
       Ok(())
     })
+    .invoke_handler(tauri::generate_handler![
+      get_adapter_contract,
+      run_cli_job
+    ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -177,6 +177,11 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.screen-stack {
+  display: grid;
+  gap: 1rem;
+}
+
 .screen-card-primary {
   background:
     linear-gradient(145deg, rgba(32, 190, 167, 0.12), rgba(255, 255, 255, 0.92)),
@@ -201,6 +206,141 @@
   margin-top: 0.45rem;
 }
 
+.command-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.repo-root {
+  display: grid;
+  gap: 0.35rem;
+  margin: 1rem 0 1.2rem;
+}
+
+.repo-root-label,
+.job-meta {
+  margin: 0;
+  color: #5a6675;
+}
+
+.repo-root code,
+.code-block,
+.terminal-output {
+  font-family: 'Cascadia Code', 'Consolas', monospace;
+}
+
+.repo-root code,
+.code-block {
+  display: block;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 32, 0.08);
+  color: #0f1720;
+  overflow-x: auto;
+}
+
+.spec-grid,
+.job-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.adapter-spec,
+.job-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.adapter-header,
+.job-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.adapter-spec h4,
+.job-topline strong {
+  margin: 0;
+  font-size: 1.02rem;
+  color: #0f1720;
+}
+
+.action-button {
+  margin-top: 0.9rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.12);
+  border-radius: 999px;
+  background: linear-gradient(135deg, #0f1720, #1d2a3f);
+  color: #ecf5f4;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    opacity 160ms ease;
+}
+
+.action-button:hover,
+.action-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 32, 0.18);
+  outline: none;
+}
+
+.action-button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+  transform: none;
+  box-shadow: none;
+}
+
+.status-pill.running {
+  background: rgba(15, 23, 32, 0.1);
+  color: #374151;
+  border-color: rgba(15, 23, 32, 0.14);
+}
+
+.status-pill.success {
+  background: rgba(32, 190, 167, 0.15);
+  color: #0a5d52;
+  border-color: rgba(32, 190, 167, 0.35);
+}
+
+.status-pill.failed {
+  background: rgba(191, 51, 61, 0.14);
+  color: #8f1d29;
+  border-color: rgba(191, 51, 61, 0.3);
+}
+
+.terminal-output {
+  margin: 0.8rem 0 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: #0f1720;
+  color: #d3e4e1;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.terminal-output-error {
+  background: #2a1114;
+  color: #ffd8d9;
+}
+
+.adapter-error,
+.empty-state {
+  margin: 0;
+  padding: 0.85rem 0.95rem;
+  border-radius: 0.9rem;
+  background: rgba(191, 51, 61, 0.1);
+  color: #8f1d29;
+}
+
 @media (max-width: 1180px) {
   .workbench-shell {
     grid-template-columns: 1fr;
@@ -212,7 +352,8 @@
   }
 
   .hero-grid,
-  .screen-grid {
+  .screen-grid,
+  .command-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,4 +1,13 @@
+import { startTransition, useEffect, useState } from 'react'
 import { NavLink, Route, Routes } from 'react-router-dom'
+import {
+  fetchAdapterContract,
+  runCliJob,
+  type AdapterContract,
+  type AdapterJobSpec,
+  type JobKind,
+  type JobResult,
+} from './workbench-api'
 import './App.css'
 
 type ScreenSpec = {
@@ -11,6 +20,18 @@ type ScreenSpec = {
   next: string[]
 }
 
+type JobRecord = {
+  id: string
+  label: string
+  status: 'running' | 'success' | 'failed'
+  commandLine: string
+  cwd: string
+  durationMs?: number
+  exitCode?: number
+  stdout: string
+  stderr: string
+}
+
 const routeSpecs: ScreenSpec[] = [
   {
     path: '/',
@@ -21,12 +42,13 @@ const routeSpecs: ScreenSpec[] = [
       'Overview is the command-and-readiness cockpit. It exists to surface branch, baseline tag, recent validation signals, and known limits from real repository sources.',
     stable: [
       'Branch, commit, and baseline tag cards',
-      'Release and readiness status derived from repository docs',
       'Source-of-truth callouts for specs, roadmap, and release artifacts',
+      'Deterministic command adapter contract for smc, svm, cargo, and release verification',
+      'Real probe actions routed through the backend process adapter',
     ],
     next: [
-      'Wire real git and validation snapshots through the CLI adapter',
-      'Show known-limit notes from readiness and compatibility docs',
+      'Wire git and validation snapshots into overview state',
+      'Add workspace-root selection instead of the fixed repository root',
     ],
   },
   {
@@ -134,6 +156,103 @@ const routeSpecs: ScreenSpec[] = [
 ]
 
 function App() {
+  const [adapterContract, setAdapterContract] = useState<AdapterContract | null>(
+    null,
+  )
+  const [adapterError, setAdapterError] = useState<string | null>(null)
+  const [jobs, setJobs] = useState<JobRecord[]>([])
+  const [activeJob, setActiveJob] = useState<JobKind | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetchAdapterContract()
+      .then((contract) => {
+        if (!cancelled) {
+          startTransition(() => setAdapterContract(contract))
+          setAdapterError(null)
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setAdapterError(String(error))
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function runProbe(spec: AdapterJobSpec) {
+    const id = crypto.randomUUID()
+
+    startTransition(() =>
+      setJobs((current) => [
+        {
+          id,
+          label: spec.label,
+          status: 'running',
+          commandLine: [spec.label, ...spec.exampleArgs].join(' '),
+          cwd: adapterContract?.repoRoot ?? '',
+          stdout: '',
+          stderr: '',
+        },
+        ...current,
+      ]),
+    )
+    setActiveJob(spec.kind)
+
+    try {
+      const result = await runCliJob({
+        kind: spec.kind,
+        args: spec.exampleArgs,
+      })
+      setAdapterError(null)
+      commitJob(id, spec.label, result)
+    } catch (error) {
+      const message = String(error)
+      startTransition(() =>
+        setJobs((current) =>
+          current.map((job) =>
+            job.id === id
+              ? {
+                  ...job,
+                  status: 'failed',
+                  stderr: message,
+                }
+              : job,
+          ),
+        ),
+      )
+      setAdapterError(message)
+    } finally {
+      setActiveJob(null)
+    }
+  }
+
+  function commitJob(id: string, label: string, result: JobResult) {
+    startTransition(() =>
+      setJobs((current) =>
+        current.map((job) =>
+          job.id === id
+            ? {
+                ...job,
+                label,
+                status: result.success ? 'success' : 'failed',
+                commandLine: result.resolvedCommand.join(' '),
+                cwd: result.cwd,
+                durationMs: result.durationMs,
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr,
+              }
+            : job,
+        ),
+      ),
+    )
+  }
+
   return (
     <div className="workbench-shell">
       <aside className="sidebar">
@@ -174,12 +293,12 @@ function App() {
       <main className="main-panel">
         <header className="topbar">
           <div>
-            <p className="eyebrow">WB-02 Bootstrap</p>
-            <h2>React + TypeScript + Tauri desktop shell</h2>
+            <p className="eyebrow">WB-03 Command bus and CLI adapter</p>
+            <h2>Deterministic process orchestration over public Semantic tools</h2>
           </div>
           <div className="status-cluster">
-            <span className="status-pill stable">Stable now: shell and routes</span>
-            <span className="status-pill draft">Draft target: command adapter</span>
+            <span className="status-pill stable">Stable now: shell, routes, adapter contract</span>
+            <span className="status-pill draft">Draft target: project open and workspace settings</span>
           </div>
         </header>
 
@@ -188,21 +307,21 @@ function App() {
             <p className="card-kicker">Current slice</p>
             <h3>Foundation before behavior</h3>
             <p>
-              The app shell exists, routes are real, and the layout already encodes the distinction between repository truth and Workbench presentation.
+              The shell now owns a deterministic job model and backend adapter while still refusing to absorb compiler, verifier, VM, or runtime semantics.
             </p>
           </article>
           <article className="hero-card">
             <p className="card-kicker">Do not cross</p>
             <h3>No second compiler, verifier, or runtime</h3>
             <p>
-              The next PRs will add orchestration over public commands only. Private crate internals stay outside this application boundary.
+              Command execution is limited to `smc`, `svm`, `cargo`, and the release verification script. Private crate internals remain outside this boundary.
             </p>
           </article>
           <article className="hero-card">
             <p className="card-kicker">Immediate next</p>
-            <h3>Command bus and CLI adapter</h3>
+            <h3>Project open and workspace settings</h3>
             <p>
-              `WB-03` wires deterministic jobs and process adapters over `smc`, `svm`, `cargo`, and release scripts.
+              `WB-04` should replace the fixed repository root with user-selected workspace context and local settings.
             </p>
           </article>
         </section>
@@ -212,7 +331,16 @@ function App() {
             <Route
               key={route.path}
               path={route.path}
-              element={<WorkbenchScreen route={route} />}
+              element={
+                <WorkbenchScreen
+                  route={route}
+                  adapterContract={adapterContract}
+                  adapterError={adapterError}
+                  jobs={jobs}
+                  activeJob={activeJob}
+                  onRunProbe={runProbe}
+                />
+              }
             />
           ))}
         </Routes>
@@ -221,31 +349,151 @@ function App() {
   )
 }
 
-function WorkbenchScreen({ route }: { route: ScreenSpec }) {
+function WorkbenchScreen({
+  route,
+  adapterContract,
+  adapterError,
+  jobs,
+  activeJob,
+  onRunProbe,
+}: {
+  route: ScreenSpec
+  adapterContract: AdapterContract | null
+  adapterError: string | null
+  jobs: JobRecord[]
+  activeJob: JobKind | null
+  onRunProbe: (spec: AdapterJobSpec) => Promise<void>
+}) {
   return (
-    <section className="screen-grid">
-      <article className="screen-card screen-card-primary">
-        <p className="card-kicker">{route.eyebrow}</p>
-        <h3>{route.title}</h3>
-        <p className="screen-summary">{route.summary}</p>
+    <div className="screen-stack">
+      <section className="screen-grid">
+        <article className="screen-card screen-card-primary">
+          <p className="card-kicker">{route.eyebrow}</p>
+          <h3>{route.title}</h3>
+          <p className="screen-summary">{route.summary}</p>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">In this slice</p>
+          <ul className="bullet-list">
+            {route.stable.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Next implementation steps</p>
+          <ul className="bullet-list">
+            {route.next.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      {route.path === '/' ? (
+        <CommandBusPanel
+          adapterContract={adapterContract}
+          adapterError={adapterError}
+          jobs={jobs}
+          activeJob={activeJob}
+          onRunProbe={onRunProbe}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function CommandBusPanel({
+  adapterContract,
+  adapterError,
+  jobs,
+  activeJob,
+  onRunProbe,
+}: {
+  adapterContract: AdapterContract | null
+  adapterError: string | null
+  jobs: JobRecord[]
+  activeJob: JobKind | null
+  onRunProbe: (spec: AdapterJobSpec) => Promise<void>
+}) {
+  return (
+    <section className="command-grid">
+      <article className="screen-card">
+        <p className="card-kicker">Adapter contract</p>
+        <h3>Supported public command surfaces</h3>
+        <p className="screen-summary">
+          The backend adapter resolves only approved tools and keeps all job cwd values inside the repository root.
+        </p>
+        <div className="repo-root">
+          <span className="repo-root-label">Repository root</span>
+          <code>{adapterContract?.repoRoot ?? 'Loading adapter contract...'}</code>
+        </div>
+        {adapterError ? (
+          <p className="adapter-error">{adapterError}</p>
+        ) : null}
+        <div className="spec-grid">
+          {(adapterContract?.jobs ?? []).map((spec) => (
+            <section key={spec.kind} className="adapter-spec">
+              <div className="adapter-header">
+                <h4>{spec.label}</h4>
+                <span className="status-pill draft">{spec.kind}</span>
+              </div>
+              <p>{spec.notes}</p>
+              <code className="code-block">{spec.resolution}</code>
+              <button
+                type="button"
+                className="action-button"
+                onClick={() => void onRunProbe(spec)}
+                disabled={activeJob === spec.kind}
+              >
+                {activeJob === spec.kind ? 'Running probe...' : `Run ${spec.label} probe`}
+              </button>
+            </section>
+          ))}
+        </div>
       </article>
 
       <article className="screen-card">
-        <p className="card-kicker">In this slice</p>
-        <ul className="bullet-list">
-          {route.stable.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-      </article>
-
-      <article className="screen-card">
-        <p className="card-kicker">Next implementation steps</p>
-        <ul className="bullet-list">
-          {route.next.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+        <p className="card-kicker">Deterministic jobs</p>
+        <h3>Recent adapter executions</h3>
+        <div className="job-list">
+          {jobs.length === 0 ? (
+            <p className="empty-state">
+              No jobs yet. Run a probe to validate the adapter path without touching private crate internals.
+            </p>
+          ) : (
+            jobs.map((job) => (
+              <section key={job.id} className={`job-card job-card-${job.status}`}>
+                <div className="job-topline">
+                  <div>
+                    <strong>{job.label}</strong>
+                    <p className="job-meta">{job.commandLine}</p>
+                  </div>
+                  <span className={`status-pill ${job.status}`}>
+                    {job.status}
+                  </span>
+                </div>
+                <p className="job-meta">
+                  cwd: <code>{job.cwd}</code>
+                </p>
+                <p className="job-meta">
+                  exit: {job.exitCode ?? 'pending'} | duration:{' '}
+                  {job.durationMs !== undefined ? `${job.durationMs} ms` : 'running'}
+                </p>
+                {job.stdout ? (
+                  <pre className="terminal-output">{job.stdout}</pre>
+                ) : null}
+                {job.stderr ? (
+                  <pre className="terminal-output terminal-output-error">
+                    {job.stderr}
+                  </pre>
+                ) : null}
+              </section>
+            ))
+          )}
+        </div>
       </article>
     </section>
   )

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -1,0 +1,41 @@
+import { invoke } from '@tauri-apps/api/core'
+
+export type JobKind = 'smc' | 'svm' | 'cargo' | 'release_bundle_verify'
+
+export type AdapterJobSpec = {
+  kind: JobKind
+  label: string
+  resolution: string
+  exampleArgs: string[]
+  notes: string
+}
+
+export type AdapterContract = {
+  repoRoot: string
+  jobs: AdapterJobSpec[]
+}
+
+export type JobRequest = {
+  kind: JobKind
+  args: string[]
+  cwd?: string
+}
+
+export type JobResult = {
+  kind: JobKind
+  resolvedCommand: string[]
+  cwd: string
+  exitCode: number
+  durationMs: number
+  success: boolean
+  stdout: string
+  stderr: string
+}
+
+export async function fetchAdapterContract() {
+  return invoke<AdapterContract>('get_adapter_contract')
+}
+
+export async function runCliJob(request: JobRequest) {
+  return invoke<JobResult>('run_cli_job', { request })
+}


### PR DESCRIPTION
## Summary
- add a deterministic Workbench command bus on the frontend
- add a Rust-side process adapter over `smc`, `svm`, `cargo`, and release bundle verification
- wire real probe executions into the overview route without duplicating Semantic logic

## Includes
- backend adapter contract and job execution command
- frontend adapter API types and invoke wrappers
- overview command-bus panel with supported tools and recent jobs
- adapter hygiene for generated Tauri artifacts in lint config

## Excludes
- no project open/settings flow yet
- no persistent job history yet
- no general jobs panel yet

## Validation
- `npm run lint`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo tauri build --debug --no-bundle`

## Acceptance
- deterministic job model exists
- CLI execution goes only through the process adapter
- adapter is limited to `smc`, `svm`, `cargo`, and release verification
- Workbench still does not call private crate internals

Refs #12
