### PR TITLE
PR-WB-05 feat(workbench): operations cockpit

### DIFF
--- a/apps/workbench/src-tauri/src/adapter.rs
+++ b/apps/workbench/src-tauri/src/adapter.rs
@@ -217,7 +217,7 @@ fn resolve_semantic_cli(
   ("cargo".into(), fallback_args)
 }
 
-fn repo_root() -> Result<PathBuf, String> {
+pub fn repo_root() -> Result<PathBuf, String> {
   let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   base
     .join("..")

--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod adapter;
+mod snapshot;
 
 use adapter::{
   adapter_contract,
@@ -9,6 +10,7 @@ use adapter::{
   JobResult,
   WorkspaceSummary,
 };
+use snapshot::{read_overview_snapshot, OverviewSnapshot};
 
 #[tauri::command]
 fn get_adapter_contract() -> Result<AdapterContract, String> {
@@ -27,6 +29,11 @@ fn resolve_workspace_root(candidate: Option<String>) -> Result<WorkspaceSummary,
   resolve_workspace(candidate)
 }
 
+#[tauri::command]
+fn get_overview_snapshot() -> Result<OverviewSnapshot, String> {
+  read_overview_snapshot()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -43,7 +50,8 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       get_adapter_contract,
       run_cli_job,
-      resolve_workspace_root
+      resolve_workspace_root,
+      get_overview_snapshot
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/workbench/src-tauri/src/snapshot.rs
+++ b/apps/workbench/src-tauri/src/snapshot.rs
@@ -1,0 +1,185 @@
+use crate::adapter::repo_root;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const BASELINE_TAG: &str = "semantic-v1-language-maturity-baseline";
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OverviewDocument {
+  pub key: &'static str,
+  pub title: String,
+  pub path: String,
+  pub status: Option<String>,
+  pub highlight: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OverviewSnapshot {
+  pub repo_root: String,
+  pub branch: String,
+  pub head_commit: String,
+  pub short_commit: String,
+  pub head_tags: Vec<String>,
+  pub baseline_tag_name: String,
+  pub baseline_tag_points_at_head: bool,
+  pub baseline_manifest_path: String,
+  pub baseline_manifest_exists: bool,
+  pub release_docs: Vec<OverviewDocument>,
+  pub known_limits: Vec<String>,
+}
+
+pub fn read_overview_snapshot() -> Result<OverviewSnapshot, String> {
+  let repo_root = repo_root()?;
+  let branch = git_output(&repo_root, &["branch", "--show-current"])?;
+  let head_commit = git_output(&repo_root, &["rev-parse", "HEAD"])?;
+  let short_commit = git_output(&repo_root, &["rev-parse", "--short", "HEAD"])?;
+  let head_tags = git_output(&repo_root, &["tag", "--points-at", "HEAD"])?
+    .lines()
+    .map(str::trim)
+    .filter(|line| !line.is_empty())
+    .map(ToOwned::to_owned)
+    .collect::<Vec<_>>();
+  let baseline_tag_points_at_head = head_tags.iter().any(|tag| tag == BASELINE_TAG);
+  let baseline_manifest = repo_root
+    .join("artifacts")
+    .join("baselines")
+    .join("semantic_v1_language_maturity_release_bundle_manifest.json");
+
+  let readiness_path = repo_root.join("docs").join("roadmap").join("v1_readiness.md");
+  let readiness_body = read_markdown(&readiness_path)?;
+
+  Ok(OverviewSnapshot {
+    repo_root: repo_root.to_string_lossy().into_owned(),
+    branch,
+    head_commit,
+    short_commit,
+    head_tags,
+    baseline_tag_name: BASELINE_TAG.into(),
+    baseline_tag_points_at_head,
+    baseline_manifest_path: baseline_manifest.to_string_lossy().into_owned(),
+    baseline_manifest_exists: baseline_manifest.exists(),
+    release_docs: vec![
+      read_overview_document(&repo_root, "readiness", "docs/roadmap/v1_readiness.md", None)?,
+      read_overview_document(
+        &repo_root,
+        "compatibility",
+        "docs/roadmap/compatibility_statement.md",
+        None,
+      )?,
+      read_overview_document(
+        &repo_root,
+        "bundle_checklist",
+        "docs/roadmap/release_bundle_checklist.md",
+        None,
+      )?,
+      read_overview_document(
+        &repo_root,
+        "asset_smoke",
+        "docs/roadmap/release_asset_smoke_matrix.md",
+        Some("Current Validated Tag"),
+      )?,
+      read_overview_document(
+        &repo_root,
+        "stable_policy",
+        "docs/roadmap/stable_release_policy.md",
+        None,
+      )?,
+    ],
+    known_limits: extract_section_bullets(&readiness_body, "Current Known Limits"),
+  })
+}
+
+fn read_overview_document(
+  repo_root: &Path,
+  key: &'static str,
+  relative_path: &str,
+  highlight_heading: Option<&str>,
+) -> Result<OverviewDocument, String> {
+  let path = relative_repo_path(repo_root, relative_path);
+  let markdown = read_markdown(&path)?;
+  Ok(OverviewDocument {
+    key,
+    title: first_heading(&markdown).unwrap_or_else(|| relative_path.into()),
+    path: path.to_string_lossy().into_owned(),
+    status: status_line(&markdown),
+    highlight: highlight_heading.and_then(|heading| first_bullet_in_section(&markdown, heading)),
+  })
+}
+
+fn git_output(repo_root: &Path, args: &[&str]) -> Result<String, String> {
+  let output = Command::new("git")
+    .args(args)
+    .current_dir(repo_root)
+    .output()
+    .map_err(|error| format!("failed to run git {:?}: {error}", args))?;
+
+  if !output.status.success() {
+    return Err(format!(
+      "git {:?} failed: {}",
+      args,
+      String::from_utf8_lossy(&output.stderr)
+    ));
+  }
+
+  Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn read_markdown(path: &Path) -> Result<String, String> {
+  fs::read_to_string(path).map_err(|error| format!("failed to read '{}': {error}", path.display()))
+}
+
+fn first_heading(markdown: &str) -> Option<String> {
+  markdown.lines().find_map(|line| {
+    line.strip_prefix("# ")
+      .map(str::trim)
+      .filter(|line| !line.is_empty())
+      .map(ToOwned::to_owned)
+  })
+}
+
+fn status_line(markdown: &str) -> Option<String> {
+  markdown.lines().find_map(|line| {
+    line.strip_prefix("Status:")
+      .map(str::trim)
+      .filter(|line| !line.is_empty())
+      .map(ToOwned::to_owned)
+  })
+}
+
+fn extract_section_bullets(markdown: &str, heading: &str) -> Vec<String> {
+  let mut in_section = false;
+  let mut bullets = Vec::new();
+
+  for line in markdown.lines() {
+    if let Some(title) = line.strip_prefix("## ") {
+      if in_section {
+        break;
+      }
+      in_section = title.trim() == heading;
+      continue;
+    }
+
+    if in_section {
+      let trimmed = line.trim_start();
+      if let Some(bullet) = trimmed.strip_prefix("- ") {
+        bullets.push(bullet.trim().to_owned());
+      }
+    }
+  }
+
+  bullets
+}
+
+fn first_bullet_in_section(markdown: &str, heading: &str) -> Option<String> {
+  extract_section_bullets(markdown, heading).into_iter().next()
+}
+
+fn relative_repo_path(repo_root: &Path, relative_path: &str) -> PathBuf {
+  relative_path
+    .split('/')
+    .fold(repo_root.to_path_buf(), |path, segment| path.join(segment))
+}

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -177,6 +177,12 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: 1rem;
+}
+
 .screen-stack {
   display: grid;
   gap: 1rem;
@@ -242,6 +248,36 @@
   font-family: 'Cascadia Code', 'Consolas', monospace;
 }
 
+.facts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem 1rem;
+  margin: 1rem 0 0;
+}
+
+.facts-grid div {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.facts-grid dt {
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5a6675;
+}
+
+.facts-grid dd {
+  margin: 0;
+  color: var(--text-main);
+  word-break: break-word;
+}
+
+.facts-grid-wide {
+  grid-column: 1 / -1;
+}
+
 .repo-root code,
 .code-block {
   display: block;
@@ -256,6 +292,12 @@
 .job-list {
   display: grid;
   gap: 0.9rem;
+}
+
+.activity-list,
+.document-list {
+  display: grid;
+  gap: 0.85rem;
 }
 
 .adapter-spec,
@@ -274,10 +316,44 @@
   align-items: flex-start;
 }
 
+.document-topline,
+.validation-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
 .adapter-spec h4,
 .job-topline strong {
   margin: 0;
   font-size: 1.02rem;
+  color: #0f1720;
+}
+
+.document-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.document-highlight {
+  margin: 0.7rem 0 0;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(32, 190, 167, 0.08);
+  color: #164b46;
+}
+
+.validation-row {
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.validation-row strong {
   color: #0f1720;
 }
 
@@ -455,6 +531,7 @@
 
   .hero-grid,
   .screen-grid,
+  .overview-grid,
   .command-grid {
     grid-template-columns: 1fr;
   }

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -2,12 +2,14 @@ import { startTransition, useEffect, useState } from 'react'
 import { NavLink, Route, Routes } from 'react-router-dom'
 import {
   fetchAdapterContract,
+  fetchOverviewSnapshot,
   resolveWorkspaceRoot,
   runCliJob,
   type AdapterContract,
   type AdapterJobSpec,
   type JobKind,
   type JobResult,
+  type OverviewSnapshot,
   type WorkspaceSummary,
 } from './workbench-api'
 import {
@@ -31,6 +33,7 @@ type ScreenSpec = {
 
 type JobRecord = {
   id: string
+  kind: JobKind
   label: string
   status: 'running' | 'success' | 'failed'
   commandLine: string
@@ -170,7 +173,11 @@ function App() {
   const [adapterContract, setAdapterContract] = useState<AdapterContract | null>(
     null,
   )
+  const [overviewSnapshot, setOverviewSnapshot] = useState<OverviewSnapshot | null>(
+    null,
+  )
   const [adapterError, setAdapterError] = useState<string | null>(null)
+  const [snapshotError, setSnapshotError] = useState<string | null>(null)
   const [jobs, setJobs] = useState<JobRecord[]>([])
   const [activeJob, setActiveJob] = useState<JobKind | null>(null)
   const [workspaceInput, setWorkspaceInput] = useState('')
@@ -198,6 +205,27 @@ function App() {
       .catch((error) => {
         if (!cancelled) {
           setAdapterError(String(error))
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetchOverviewSnapshot()
+      .then((snapshot) => {
+        if (!cancelled) {
+          startTransition(() => setOverviewSnapshot(snapshot))
+          setSnapshotError(null)
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setSnapshotError(String(error))
         }
       })
 
@@ -240,6 +268,7 @@ function App() {
       setJobs((current) => [
         {
           id,
+          kind: spec.kind,
           label: spec.label,
           status: 'running',
           commandLine: [spec.label, ...spec.exampleArgs].join(' '),
@@ -380,35 +409,35 @@ function App() {
       <main className="main-panel">
         <header className="topbar">
           <div>
-            <p className="eyebrow">WB-04 Project open and workspace settings</p>
-            <h2>Workspace-aware jobs without inventing project metadata</h2>
+            <p className="eyebrow">WB-0.1 Cockpit</p>
+            <h2>Operations cockpit from repository truth, not UI guesswork</h2>
           </div>
           <div className="status-cluster">
             <span className="status-pill stable">Stable now: shell, adapter contract, workspace context</span>
-            <span className="status-pill draft">Draft target: cockpit signals from real git and validation state</span>
+            <span className="status-pill draft">Draft target: richer diagnostics, formatter, and inspectors</span>
           </div>
         </header>
 
         <section className="hero-grid">
           <article className="hero-card">
             <p className="card-kicker">Current slice</p>
-            <h3>Jobs now inherit explicit workspace context</h3>
+            <h3>Repository identity and release truth surface together</h3>
             <p>
-              The shell now resolves and persists a canonical workspace root, keeps recent projects, and feeds that root into every adapter execution.
+              The overview now surfaces branch, commit, baseline tag, baseline manifest, release documents, and known limits from real repository sources.
             </p>
           </article>
           <article className="hero-card">
             <p className="card-kicker">Do not cross</p>
-            <h3>No alternate package or repository semantics</h3>
+            <h3>No alternate readiness model inside the UI</h3>
             <p>
-              Workbench stores only local UI state. Workspace roots are canonicalized by the backend adapter and still constrained to the repository tree.
+              Workbench stores only local UI state. Readiness, compatibility, and release validity still come from repository docs and real command output.
             </p>
           </article>
           <article className="hero-card">
             <p className="card-kicker">Immediate next</p>
-            <h3>Operations cockpit on top of real state</h3>
+            <h3>Project explorer and authoring shell</h3>
             <p>
-              `WB-05` should surface branch, commit, baseline tag, and validation signals from real commands and documents.
+              `WB-09` should build the first editor-facing loop on top of this cockpit without inventing parser, verifier, or runtime semantics.
             </p>
           </article>
         </section>
@@ -422,7 +451,9 @@ function App() {
                 <WorkbenchScreen
                   route={route}
                   adapterContract={adapterContract}
+                  overviewSnapshot={overviewSnapshot}
                   adapterError={adapterError}
+                  snapshotError={snapshotError}
                   jobs={jobs}
                   activeJob={activeJob}
                   onRunProbe={runProbe}
@@ -447,7 +478,9 @@ function App() {
 function WorkbenchScreen({
   route,
   adapterContract,
+  overviewSnapshot,
   adapterError,
+  snapshotError,
   jobs,
   activeJob,
   onRunProbe,
@@ -462,7 +495,9 @@ function WorkbenchScreen({
 }: {
   route: ScreenSpec
   adapterContract: AdapterContract | null
+  overviewSnapshot: OverviewSnapshot | null
   adapterError: string | null
+  snapshotError: string | null
   jobs: JobRecord[]
   activeJob: JobKind | null
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
@@ -506,7 +541,9 @@ function WorkbenchScreen({
       {route.path === '/' ? (
         <CommandBusPanel
           adapterContract={adapterContract}
+          overviewSnapshot={overviewSnapshot}
           adapterError={adapterError}
+          snapshotError={snapshotError}
           jobs={jobs}
           activeJob={activeJob}
           onRunProbe={onRunProbe}
@@ -539,21 +576,135 @@ function WorkbenchScreen({
 
 function CommandBusPanel({
   adapterContract,
+  overviewSnapshot,
   adapterError,
+  snapshotError,
   jobs,
   activeJob,
   onRunProbe,
   selectedWorkspace,
 }: {
   adapterContract: AdapterContract | null
+  overviewSnapshot: OverviewSnapshot | null
   adapterError: string | null
+  snapshotError: string | null
   jobs: JobRecord[]
   activeJob: JobKind | null
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
   selectedWorkspace: WorkspaceSummary | null
 }) {
+  const latestCargo = latestJobOfKind(jobs, 'cargo')
+  const latestSmc = latestJobOfKind(jobs, 'smc')
+  const latestSvm = latestJobOfKind(jobs, 'svm')
+  const latestBundle = latestJobOfKind(jobs, 'release_bundle_verify')
+
   return (
-    <section className="command-grid">
+    <div className="screen-stack">
+      <section className="overview-grid">
+        <article className="screen-card">
+          <p className="card-kicker">Repository snapshot</p>
+          <h3>Current git and baseline identity</h3>
+          {snapshotError ? <p className="adapter-error">{snapshotError}</p> : null}
+          <dl className="facts-grid">
+            <div>
+              <dt>Branch</dt>
+              <dd>{overviewSnapshot?.branch ?? 'Loading...'}</dd>
+            </div>
+            <div>
+              <dt>Commit</dt>
+              <dd>
+                <code>{overviewSnapshot?.shortCommit ?? 'Loading...'}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Head tags</dt>
+              <dd>
+                {overviewSnapshot?.headTags.length ? (
+                  overviewSnapshot.headTags.join(', ')
+                ) : (
+                  'No tags on HEAD'
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt>Baseline tag</dt>
+              <dd>
+                {overviewSnapshot
+                  ? overviewSnapshot.baselineTagPointsAtHead
+                    ? `${overviewSnapshot.baselineTagName} on HEAD`
+                    : `${overviewSnapshot.baselineTagName} exists off HEAD`
+                  : 'Loading...'}
+              </dd>
+            </div>
+            <div className="facts-grid-wide">
+              <dt>Baseline manifest</dt>
+              <dd>
+                {overviewSnapshot?.baselineManifestExists ? 'Present' : 'Missing'}
+                {overviewSnapshot ? (
+                  <>
+                    {' '}
+                    <code>{overviewSnapshot.baselineManifestPath}</code>
+                  </>
+                ) : null}
+              </dd>
+            </div>
+            <div className="facts-grid-wide">
+              <dt>Workspace root</dt>
+              <dd>
+                <code>{selectedWorkspace?.resolvedPath ?? adapterContract?.repoRoot ?? 'Loading...'}</code>
+              </dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Latest local validation activity</p>
+          <h3>Signals from real commands</h3>
+          <div className="activity-list">
+            <ValidationRow label="Cargo" job={latestCargo} />
+            <ValidationRow label="smc" job={latestSmc} />
+            <ValidationRow label="svm" job={latestSvm} />
+            <ValidationRow label="Release bundle verify" job={latestBundle} />
+          </div>
+        </article>
+      </section>
+
+      <section className="overview-grid">
+        <article className="screen-card">
+          <p className="card-kicker">Release docs</p>
+          <h3>Readiness and compatibility pointers</h3>
+          <div className="document-list">
+            {(overviewSnapshot?.releaseDocs ?? []).map((document) => (
+              <section key={document.key} className="document-card">
+                <div className="document-topline">
+                  <strong>{document.title}</strong>
+                  {document.status ? (
+                    <span className="status-pill stable">{document.status}</span>
+                  ) : null}
+                </div>
+                <p className="job-meta">
+                  <code>{document.path}</code>
+                </p>
+                {document.highlight ? (
+                  <p className="document-highlight">{document.highlight}</p>
+                ) : null}
+              </section>
+            ))}
+          </div>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Current known limits</p>
+          <h3>Honesty rules carried from readiness</h3>
+          <ul className="bullet-list">
+            {(overviewSnapshot?.knownLimits ?? []).map((limit) => (
+              <li key={limit}>{limit}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section className="command-grid">
       <article className="screen-card">
         <p className="card-kicker">Adapter contract</p>
         <h3>Supported public command surfaces</h3>
@@ -633,6 +784,27 @@ function CommandBusPanel({
           )}
         </div>
       </article>
+      </section>
+    </div>
+  )
+}
+
+function ValidationRow({
+  label,
+  job,
+}: {
+  label: string
+  job?: JobRecord
+}) {
+  return (
+    <section className="validation-row">
+      <div>
+        <strong>{label}</strong>
+        <p className="job-meta">{job ? job.commandLine : 'No local run yet'}</p>
+      </div>
+      <span className={`status-pill ${job?.status ?? 'draft'}`}>
+        {job?.status ?? 'not run'}
+      </span>
     </section>
   )
 }
@@ -833,6 +1005,10 @@ function SettingsPanel({
       </article>
     </section>
   )
+}
+
+function latestJobOfKind(jobs: JobRecord[], kind: JobKind) {
+  return jobs.find((job) => job.kind === kind)
 }
 
 export default App

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -39,6 +39,28 @@ export type WorkspaceSummary = {
   isRepoRoot: boolean
 }
 
+export type OverviewDocument = {
+  key: string
+  title: string
+  path: string
+  status: string | null
+  highlight: string | null
+}
+
+export type OverviewSnapshot = {
+  repoRoot: string
+  branch: string
+  headCommit: string
+  shortCommit: string
+  headTags: string[]
+  baselineTagName: string
+  baselineTagPointsAtHead: boolean
+  baselineManifestPath: string
+  baselineManifestExists: boolean
+  releaseDocs: OverviewDocument[]
+  knownLimits: string[]
+}
+
 export async function fetchAdapterContract() {
   return invoke<AdapterContract>('get_adapter_contract')
 }
@@ -49,4 +71,8 @@ export async function runCliJob(request: JobRequest) {
 
 export async function resolveWorkspaceRoot(candidate?: string) {
   return invoke<WorkspaceSummary>('resolve_workspace_root', { candidate })
+}
+
+export async function fetchOverviewSnapshot() {
+  return invoke<OverviewSnapshot>('get_overview_snapshot')
 }


### PR DESCRIPTION
## Summary
- add an operations cockpit that reads repository identity from real git state
- surface baseline manifest, release documents, and known limits from canonical docs
- keep validation activity derived from real adapter job history instead of UI-owned readiness state

## Includes
- backend overview snapshot command over git and release docs
- overview cards for branch, commit, baseline tag, manifest, release docs, and known limits
- latest local validation activity cards for cargo, smc, svm, and bundle verification

## Excludes
- no private crate coupling
- no editor or diagnostics model work yet
- no release gating logic duplicated in the UI

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #14