### PR TITLE
PR-WB-07 feat(workbench): spec navigator

### DIFF
--- a/apps/workbench/src-tauri/src/docs.rs
+++ b/apps/workbench/src-tauri/src/docs.rs
@@ -1,0 +1,419 @@
+use crate::adapter::repo_root;
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+struct DocEntryDef {
+  key: &'static str,
+  section_key: &'static str,
+  section_title: &'static str,
+  title: &'static str,
+  relative_path: &'static str,
+}
+
+const DOC_ENTRIES: &[DocEntryDef] = &[
+  DocEntryDef {
+    key: "language_overview",
+    section_key: "language",
+    section_title: "Language",
+    title: "Language overview",
+    relative_path: "docs/LANGUAGE.md",
+  },
+  DocEntryDef {
+    key: "syntax",
+    section_key: "language",
+    section_title: "Language",
+    title: "Syntax",
+    relative_path: "docs/spec/syntax.md",
+  },
+  DocEntryDef {
+    key: "types",
+    section_key: "language",
+    section_title: "Language",
+    title: "Types",
+    relative_path: "docs/spec/types.md",
+  },
+  DocEntryDef {
+    key: "source_semantics",
+    section_key: "language",
+    section_title: "Language",
+    title: "Source semantics",
+    relative_path: "docs/spec/source_semantics.md",
+  },
+  DocEntryDef {
+    key: "modules",
+    section_key: "language",
+    section_title: "Language",
+    title: "Modules",
+    relative_path: "docs/spec/modules.md",
+  },
+  DocEntryDef {
+    key: "imports",
+    section_key: "language",
+    section_title: "Language",
+    title: "Imports",
+    relative_path: "docs/imports.md",
+  },
+  DocEntryDef {
+    key: "exports",
+    section_key: "language",
+    section_title: "Language",
+    title: "Exports",
+    relative_path: "docs/exports.md",
+  },
+  DocEntryDef {
+    key: "logos",
+    section_key: "language",
+    section_title: "Language",
+    title: "Logos",
+    relative_path: "docs/spec/logos.md",
+  },
+  DocEntryDef {
+    key: "diagnostics",
+    section_key: "language",
+    section_title: "Language",
+    title: "Diagnostics",
+    relative_path: "docs/spec/diagnostics.md",
+  },
+  DocEntryDef {
+    key: "semcode",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "SemCode",
+    relative_path: "docs/spec/semcode.md",
+  },
+  DocEntryDef {
+    key: "verifier",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "Verifier",
+    relative_path: "docs/spec/verifier.md",
+  },
+  DocEntryDef {
+    key: "vm",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "VM",
+    relative_path: "docs/spec/vm.md",
+  },
+  DocEntryDef {
+    key: "quotas",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "Quotas",
+    relative_path: "docs/spec/quotas.md",
+  },
+  DocEntryDef {
+    key: "profile",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "Profile",
+    relative_path: "docs/spec/profile.md",
+  },
+  DocEntryDef {
+    key: "cli",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "CLI",
+    relative_path: "docs/spec/cli.md",
+  },
+  DocEntryDef {
+    key: "ir",
+    section_key: "execution",
+    section_title: "Execution",
+    title: "IR",
+    relative_path: "docs/spec/ir.md",
+  },
+  DocEntryDef {
+    key: "abi",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "ABI",
+    relative_path: "docs/spec/abi.md",
+  },
+  DocEntryDef {
+    key: "capabilities",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "Capabilities",
+    relative_path: "docs/spec/capabilities.md",
+  },
+  DocEntryDef {
+    key: "gates",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "Gates",
+    relative_path: "docs/spec/gates.md",
+  },
+  DocEntryDef {
+    key: "runtime",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "Runtime",
+    relative_path: "docs/spec/runtime.md",
+  },
+  DocEntryDef {
+    key: "state",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "State",
+    relative_path: "docs/spec/state.md",
+  },
+  DocEntryDef {
+    key: "rules",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "Rules",
+    relative_path: "docs/spec/rules.md",
+  },
+  DocEntryDef {
+    key: "audit",
+    section_key: "prometheus",
+    section_title: "PROMETHEUS",
+    title: "Audit",
+    relative_path: "docs/spec/audit.md",
+  },
+  DocEntryDef {
+    key: "milestones",
+    section_key: "release",
+    section_title: "Release",
+    title: "Milestones",
+    relative_path: "docs/roadmap/milestones.md",
+  },
+  DocEntryDef {
+    key: "readiness",
+    section_key: "release",
+    section_title: "Release",
+    title: "Readiness",
+    relative_path: "docs/roadmap/v1_readiness.md",
+  },
+  DocEntryDef {
+    key: "compatibility",
+    section_key: "release",
+    section_title: "Release",
+    title: "Compatibility statement",
+    relative_path: "docs/roadmap/compatibility_statement.md",
+  },
+  DocEntryDef {
+    key: "bundle_checklist",
+    section_key: "release",
+    section_title: "Release",
+    title: "Release bundle checklist",
+    relative_path: "docs/roadmap/release_bundle_checklist.md",
+  },
+  DocEntryDef {
+    key: "runtime_validation",
+    section_key: "release",
+    section_title: "Release",
+    title: "Runtime validation policy",
+    relative_path: "docs/roadmap/runtime_validation_policy.md",
+  },
+  DocEntryDef {
+    key: "asset_smoke",
+    section_key: "release",
+    section_title: "Release",
+    title: "Release asset smoke matrix",
+    relative_path: "docs/roadmap/release_asset_smoke_matrix.md",
+  },
+  DocEntryDef {
+    key: "stable_policy",
+    section_key: "release",
+    section_title: "Release",
+    title: "Stable release policy",
+    relative_path: "docs/roadmap/stable_release_policy.md",
+  },
+  DocEntryDef {
+    key: "backlog",
+    section_key: "release",
+    section_title: "Release",
+    title: "Backlog",
+    relative_path: "docs/roadmap/backlog.md",
+  },
+  DocEntryDef {
+    key: "wbs",
+    section_key: "release",
+    section_title: "Release",
+    title: "WBS",
+    relative_path: "docs/roadmap/wbs.md",
+  },
+];
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecCatalogDocument {
+  pub key: String,
+  pub title: String,
+  pub relative_path: String,
+  pub absolute_path: String,
+  pub status: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecCatalogSection {
+  pub key: String,
+  pub title: String,
+  pub documents: Vec<SpecCatalogDocument>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecDocumentHeading {
+  pub level: u8,
+  pub title: String,
+  pub anchor: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpecDocumentView {
+  pub key: String,
+  pub section_key: String,
+  pub section_title: String,
+  pub title: String,
+  pub relative_path: String,
+  pub absolute_path: String,
+  pub status: Option<String>,
+  pub markdown: String,
+  pub headings: Vec<SpecDocumentHeading>,
+}
+
+pub fn read_spec_catalog() -> Result<Vec<SpecCatalogSection>, String> {
+  let repo_root = repo_root()?;
+  let mut sections = BTreeMap::<String, (String, Vec<SpecCatalogDocument>)>::new();
+
+  for entry in DOC_ENTRIES {
+    let path = repo_relative_path(&repo_root, entry.relative_path);
+    let markdown = fs::read_to_string(&path)
+      .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+
+    sections
+      .entry(entry.section_key.to_owned())
+      .or_insert_with(|| (entry.section_title.to_owned(), Vec::new()))
+      .1
+      .push(SpecCatalogDocument {
+        key: entry.key.to_owned(),
+        title: entry.title.to_owned(),
+        relative_path: entry.relative_path.to_owned(),
+        absolute_path: path.to_string_lossy().into_owned(),
+        status: status_line(&markdown),
+      });
+  }
+
+  Ok(
+    sections
+      .into_iter()
+      .map(|(key, (title, documents))| SpecCatalogSection {
+        key,
+        title,
+        documents,
+      })
+      .collect(),
+  )
+}
+
+pub fn read_spec_document(relative_path: String) -> Result<SpecDocumentView, String> {
+  let entry = DOC_ENTRIES
+    .iter()
+    .find(|entry| entry.relative_path == relative_path)
+    .ok_or_else(|| format!("document '{}' is not part of the canonical navigator", relative_path))?;
+  let repo_root = repo_root()?;
+  let path = repo_relative_path(&repo_root, entry.relative_path);
+  let markdown = fs::read_to_string(&path)
+    .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+
+  Ok(SpecDocumentView {
+    key: entry.key.to_owned(),
+    section_key: entry.section_key.to_owned(),
+    section_title: entry.section_title.to_owned(),
+    title: first_heading(&markdown).unwrap_or_else(|| entry.title.to_owned()),
+    relative_path: entry.relative_path.to_owned(),
+    absolute_path: path.to_string_lossy().into_owned(),
+    status: status_line(&markdown),
+    markdown: markdown.clone(),
+    headings: extract_headings(&markdown),
+  })
+}
+
+fn repo_relative_path(repo_root: &Path, relative_path: &str) -> PathBuf {
+  relative_path
+    .split('/')
+    .fold(repo_root.to_path_buf(), |path, segment| path.join(segment))
+}
+
+fn first_heading(markdown: &str) -> Option<String> {
+  markdown.lines().find_map(|line| {
+    line.strip_prefix("# ")
+      .map(str::trim)
+      .filter(|line| !line.is_empty())
+      .map(ToOwned::to_owned)
+  })
+}
+
+fn status_line(markdown: &str) -> Option<String> {
+  markdown.lines().find_map(|line| {
+    line.strip_prefix("Status:")
+      .map(str::trim)
+      .filter(|line| !line.is_empty())
+      .map(ToOwned::to_owned)
+  })
+}
+
+fn extract_headings(markdown: &str) -> Vec<SpecDocumentHeading> {
+  let mut slug_counts = HashMap::<String, usize>::new();
+  let mut headings = Vec::new();
+
+  for line in markdown.lines() {
+    let trimmed = line.trim();
+    let (level, title) = if let Some(title) = trimmed.strip_prefix("# ") {
+      (1, title)
+    } else if let Some(title) = trimmed.strip_prefix("## ") {
+      (2, title)
+    } else if let Some(title) = trimmed.strip_prefix("### ") {
+      (3, title)
+    } else {
+      continue;
+    };
+
+    let title = title.trim();
+    if title.is_empty() {
+      continue;
+    }
+
+    let base_slug = slugify(title);
+    let counter = slug_counts.entry(base_slug.clone()).or_insert(0);
+    let anchor = if *counter == 0 {
+      base_slug
+    } else {
+      format!("{base_slug}-{}", *counter + 1)
+    };
+    *counter += 1;
+
+    headings.push(SpecDocumentHeading {
+      level,
+      title: title.to_owned(),
+      anchor,
+    });
+  }
+
+  headings
+}
+
+fn slugify(input: &str) -> String {
+  let mut slug = String::new();
+  let mut last_dash = false;
+
+  for ch in input.chars() {
+    let normalized = ch.to_ascii_lowercase();
+    if normalized.is_ascii_alphanumeric() {
+      slug.push(normalized);
+      last_dash = false;
+    } else if !last_dash {
+      slug.push('-');
+      last_dash = true;
+    }
+  }
+
+  slug.trim_matches('-').to_owned()
+}

--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod adapter;
+mod docs;
 mod snapshot;
 
 use adapter::{
@@ -11,6 +12,7 @@ use adapter::{
   WorkspaceSummary,
 };
 use snapshot::{read_overview_snapshot, OverviewSnapshot};
+use docs::{read_spec_catalog, read_spec_document, SpecCatalogSection, SpecDocumentView};
 
 #[tauri::command]
 fn get_adapter_contract() -> Result<AdapterContract, String> {
@@ -34,6 +36,16 @@ fn get_overview_snapshot() -> Result<OverviewSnapshot, String> {
   read_overview_snapshot()
 }
 
+#[tauri::command]
+fn get_spec_catalog() -> Result<Vec<SpecCatalogSection>, String> {
+  read_spec_catalog()
+}
+
+#[tauri::command]
+fn get_spec_document(relative_path: String) -> Result<SpecDocumentView, String> {
+  read_spec_document(relative_path)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -51,7 +63,9 @@ pub fn run() {
       get_adapter_contract,
       run_cli_job,
       resolve_workspace_root,
-      get_overview_snapshot
+      get_overview_snapshot,
+      get_spec_catalog,
+      get_spec_document
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -183,6 +183,13 @@
   gap: 1rem;
 }
 
+.spec-shell {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.8fr) minmax(0, 1.4fr);
+  gap: 1rem;
+  align-items: start;
+}
+
 .screen-stack {
   display: grid;
   gap: 1rem;
@@ -300,6 +307,13 @@
   gap: 0.85rem;
 }
 
+.spec-section-list,
+.spec-doc-list,
+.spec-outline-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .workflow-grid,
 .job-output-stack {
   display: grid;
@@ -396,6 +410,114 @@
 .job-detail-stack {
   display: grid;
   gap: 0.8rem;
+}
+
+.spec-section-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.spec-doc-button,
+.spec-outline-button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(15, 23, 32, 0.1);
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.75);
+  color: #0f1720;
+  font: inherit;
+  cursor: pointer;
+}
+
+.spec-doc-button {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+}
+
+.spec-doc-button:hover,
+.spec-doc-button:focus-visible,
+.spec-outline-button:hover,
+.spec-outline-button:focus-visible {
+  border-color: rgba(32, 190, 167, 0.45);
+  outline: none;
+}
+
+.spec-doc-button-active {
+  border-color: rgba(32, 190, 167, 0.55);
+  background:
+    linear-gradient(145deg, rgba(32, 190, 167, 0.1), rgba(255, 255, 255, 0.92)),
+    rgba(255, 255, 255, 0.75);
+}
+
+.spec-doc-title {
+  font-weight: 700;
+}
+
+.spec-doc-path {
+  color: #5a6675;
+  font-size: 0.88rem;
+  word-break: break-word;
+}
+
+.spec-document-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.5fr) minmax(0, 1.5fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.spec-outline-panel {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.spec-outline-button {
+  padding: 0.75rem 0.9rem;
+}
+
+.spec-outline-level-2 {
+  padding-left: 1.25rem;
+}
+
+.spec-outline-level-3 {
+  padding-left: 1.75rem;
+}
+
+.markdown-sheet {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem 1.15rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.09);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.markdown-heading {
+  margin: 0.2rem 0 0;
+  color: #0f1720;
+}
+
+.markdown-heading-1 {
+  font-size: 1.35rem;
+}
+
+.markdown-heading-2 {
+  font-size: 1.15rem;
+}
+
+.markdown-heading-3 {
+  font-size: 1rem;
+}
+
+.markdown-paragraph {
+  margin: 0;
+  color: var(--text-soft-strong);
+  line-height: 1.6;
 }
 
 .action-button {
@@ -573,6 +695,8 @@
   .hero-grid,
   .screen-grid,
   .overview-grid,
+  .spec-shell,
+  .spec-document-grid,
   .command-grid {
     grid-template-columns: 1fr;
   }

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,8 +1,10 @@
-import { startTransition, useEffect, useState } from 'react'
+import { startTransition, useEffect, useState, type ReactNode } from 'react'
 import { NavLink, Route, Routes } from 'react-router-dom'
 import {
   fetchAdapterContract,
   fetchOverviewSnapshot,
+  fetchSpecCatalog,
+  fetchSpecDocument,
   resolveWorkspaceRoot,
   runCliJob,
   type AdapterContract,
@@ -10,6 +12,9 @@ import {
   type JobKind,
   type JobResult,
   type OverviewSnapshot,
+  type SpecCatalogSection,
+  type SpecDocumentHeading,
+  type SpecDocumentView,
   type WorkspaceSummary,
 } from './workbench-api'
 import {
@@ -148,13 +153,13 @@ const routeSpecs: ScreenSpec[] = [
     summary:
       'Spec navigation is a presentation layer over docs/spec and docs/roadmap. Workbench points at the documents; it does not fork them.',
     stable: [
-      'Route and layout for spec and roadmap navigation',
-      'Placeholder panels for trees, sections, and freshness indicators',
+      'Canonical tree over docs/spec, docs/roadmap, and synced language overview documents',
+      'Title/path search and section navigator driven by repository markdown',
       'Source-path discipline called out directly in the UI',
     ],
     next: [
-      'Index canonical spec and roadmap documents',
-      'Add search and section navigation without mutating docs',
+      'Add freshness hints and stronger release-document callouts',
+      'Keep navigator read-only even when authoring shell arrives',
     ],
   },
   {
@@ -236,9 +241,15 @@ function App() {
   )
   const [adapterError, setAdapterError] = useState<string | null>(null)
   const [snapshotError, setSnapshotError] = useState<string | null>(null)
+  const [specError, setSpecError] = useState<string | null>(null)
   const [jobs, setJobs] = useState<JobRecord[]>([])
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
   const [activeJob, setActiveJob] = useState<JobKind | null>(null)
+  const [specCatalog, setSpecCatalog] = useState<SpecCatalogSection[]>([])
+  const [specSearch, setSpecSearch] = useState('')
+  const [selectedSpecPath, setSelectedSpecPath] = useState<string | null>(null)
+  const [selectedSpecDocument, setSelectedSpecDocument] =
+    useState<SpecDocumentView | null>(null)
   const [workspaceInput, setWorkspaceInput] = useState('')
   const [workspaceError, setWorkspaceError] = useState<string | null>(null)
   const [selectedWorkspace, setSelectedWorkspace] = useState<WorkspaceSummary | null>(
@@ -292,6 +303,56 @@ function App() {
       cancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetchSpecCatalog()
+      .then((catalog) => {
+        if (!cancelled) {
+          setSpecCatalog(catalog)
+          setSpecError(null)
+          const firstPath = catalog[0]?.documents[0]?.relativePath
+          if (firstPath) {
+            setSelectedSpecPath((current) => current ?? firstPath)
+          }
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setSpecError(String(error))
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!selectedSpecPath) {
+      return
+    }
+
+    let cancelled = false
+
+    fetchSpecDocument(selectedSpecPath)
+      .then((document) => {
+        if (!cancelled) {
+          setSelectedSpecDocument(document)
+          setSpecError(null)
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setSpecError(String(error))
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedSpecPath])
 
   useEffect(() => {
     saveWorkbenchState({
@@ -528,11 +589,18 @@ function App() {
                   overviewSnapshot={overviewSnapshot}
                   adapterError={adapterError}
                   snapshotError={snapshotError}
+                  specCatalog={specCatalog}
+                  specError={specError}
+                  specSearch={specSearch}
+                  selectedSpecDocument={selectedSpecDocument}
+                  selectedSpecPath={selectedSpecPath}
                   jobs={jobs}
                   selectedJobId={selectedJobId}
                   activeJob={activeJob}
                   onRunAction={runJobAction}
                   onRunProbe={runProbe}
+                  onSpecSearchChange={setSpecSearch}
+                  onSelectSpecPath={setSelectedSpecPath}
                   onSelectJob={setSelectedJobId}
                   selectedWorkspace={selectedWorkspace}
                   workspaceInput={workspaceInput}
@@ -558,11 +626,18 @@ function WorkbenchScreen({
   overviewSnapshot,
   adapterError,
   snapshotError,
+  specCatalog,
+  specError,
+  specSearch,
+  selectedSpecDocument,
+  selectedSpecPath,
   jobs,
   selectedJobId,
   activeJob,
   onRunAction,
   onRunProbe,
+  onSpecSearchChange,
+  onSelectSpecPath,
   onSelectJob,
   selectedWorkspace,
   workspaceInput,
@@ -578,11 +653,18 @@ function WorkbenchScreen({
   overviewSnapshot: OverviewSnapshot | null
   adapterError: string | null
   snapshotError: string | null
+  specCatalog: SpecCatalogSection[]
+  specError: string | null
+  specSearch: string
+  selectedSpecDocument: SpecDocumentView | null
+  selectedSpecPath: string | null
   jobs: JobRecord[]
   selectedJobId: string | null
   activeJob: JobKind | null
   onRunAction: (action: JobActionSpec) => Promise<void>
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
+  onSpecSearchChange: (value: string) => void
+  onSelectSpecPath: (value: string) => void
   onSelectJob: (jobId: string) => void
   selectedWorkspace: WorkspaceSummary | null
   workspaceInput: string
@@ -634,6 +716,18 @@ function WorkbenchScreen({
           onRunProbe={onRunProbe}
           onSelectJob={onSelectJob}
           selectedWorkspace={selectedWorkspace}
+        />
+      ) : null}
+
+      {route.path === '/spec' ? (
+        <SpecNavigatorPanel
+          specCatalog={specCatalog}
+          specError={specError}
+          specSearch={specSearch}
+          selectedSpecDocument={selectedSpecDocument}
+          selectedSpecPath={selectedSpecPath}
+          onSpecSearchChange={onSpecSearchChange}
+          onSelectSpecPath={onSelectSpecPath}
         />
       ) : null}
 
@@ -998,6 +1092,252 @@ function ValidationRow({
       </span>
     </section>
   )
+}
+
+function SpecNavigatorPanel({
+  specCatalog,
+  specError,
+  specSearch,
+  selectedSpecDocument,
+  selectedSpecPath,
+  onSpecSearchChange,
+  onSelectSpecPath,
+}: {
+  specCatalog: SpecCatalogSection[]
+  specError: string | null
+  specSearch: string
+  selectedSpecDocument: SpecDocumentView | null
+  selectedSpecPath: string | null
+  onSpecSearchChange: (value: string) => void
+  onSelectSpecPath: (value: string) => void
+}) {
+  const query = specSearch.trim().toLowerCase()
+  const filteredSections = specCatalog
+    .map((section) => ({
+      ...section,
+      documents: section.documents.filter((document) => {
+        if (!query) {
+          return true
+        }
+
+        const haystack = `${document.title} ${document.relativePath}`.toLowerCase()
+        return haystack.includes(query)
+      }),
+    }))
+    .filter((section) => section.documents.length > 0)
+
+  return (
+    <section className="spec-shell">
+      <article className="screen-card spec-sidebar-panel">
+        <p className="card-kicker">Canonical document tree</p>
+        <h3>Spec and roadmap navigator</h3>
+        <label className="field-label" htmlFor="spec-search">
+          Search titles and paths
+        </label>
+        <input
+          id="spec-search"
+          className="text-field"
+          type="text"
+          value={specSearch}
+          onChange={(event) => onSpecSearchChange(event.target.value)}
+          placeholder="Search syntax, vm, readiness, release..."
+        />
+        {specError ? <p className="adapter-error">{specError}</p> : null}
+        <div className="spec-section-list">
+          {filteredSections.length === 0 ? (
+            <p className="empty-state">No canonical documents match the current search.</p>
+          ) : (
+            filteredSections.map((section) => (
+              <section key={section.key} className="spec-section-card">
+                <p className="card-kicker">{section.title}</p>
+                <div className="spec-doc-list">
+                  {section.documents.map((document) => (
+                    <button
+                      key={document.relativePath}
+                      type="button"
+                      className={`spec-doc-button ${selectedSpecPath === document.relativePath ? 'spec-doc-button-active' : ''}`}
+                      onClick={() => onSelectSpecPath(document.relativePath)}
+                    >
+                      <span className="spec-doc-title">{document.title}</span>
+                      <span className="spec-doc-path">{document.relativePath}</span>
+                      {document.status ? (
+                        <span className={`status-pill ${statusTone(document.status)}`}>
+                          {document.status}
+                        </span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+      </article>
+
+      <article className="screen-card spec-document-panel">
+        {selectedSpecDocument ? (
+          <div className="screen-stack">
+            <div className="document-topline">
+              <div>
+                <p className="card-kicker">{selectedSpecDocument.sectionTitle}</p>
+                <h3>{selectedSpecDocument.title}</h3>
+              </div>
+              {selectedSpecDocument.status ? (
+                <span className={`status-pill ${statusTone(selectedSpecDocument.status)}`}>
+                  {selectedSpecDocument.status}
+                </span>
+              ) : null}
+            </div>
+            <p className="job-meta">
+              source path: <code>{selectedSpecDocument.absolutePath}</code>
+            </p>
+            <div className="spec-document-grid">
+              <aside className="spec-outline-panel">
+                <p className="card-kicker">Section navigator</p>
+                <div className="spec-outline-list">
+                  {selectedSpecDocument.headings.map((heading) => (
+                    <button
+                      key={heading.anchor}
+                      type="button"
+                      className={`spec-outline-button spec-outline-level-${heading.level}`}
+                      onClick={() => jumpToHeading(heading.anchor)}
+                    >
+                      {heading.title}
+                    </button>
+                  ))}
+                </div>
+              </aside>
+
+              <div className="markdown-sheet">
+                {renderMarkdown(selectedSpecDocument.markdown, selectedSpecDocument.headings)}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <p className="empty-state">
+            Select a canonical document to inspect its headings and body.
+          </p>
+        )}
+      </article>
+    </section>
+  )
+}
+
+function jumpToHeading(anchor: string) {
+  const element = globalThis.document?.getElementById(anchor)
+  element?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function statusTone(status: string) {
+  const normalized = status.toLowerCase()
+  if (
+    normalized.includes('stable') ||
+    normalized.includes('validated') ||
+    normalized.includes('ready')
+  ) {
+    return 'stable'
+  }
+
+  if (normalized.includes('failed')) {
+    return 'failed'
+  }
+
+  return 'draft'
+}
+
+function renderMarkdown(markdown: string, headings: SpecDocumentHeading[]) {
+  const headingAnchors = new Map(headings.map((heading) => [heading.title, heading.anchor]))
+  const lines = markdown.split(/\r?\n/)
+  const nodes: ReactNode[] = []
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+    const trimmed = line.trim()
+
+    if (!trimmed) {
+      index += 1
+      continue
+    }
+
+    if (trimmed.startsWith('```')) {
+      const codeLines: string[] = []
+      index += 1
+      while (index < lines.length && !lines[index].trim().startsWith('```')) {
+        codeLines.push(lines[index])
+        index += 1
+      }
+      index += 1
+      nodes.push(
+        <pre key={`code-${index}`} className="terminal-output">
+          {codeLines.join('\n')}
+        </pre>,
+      )
+      continue
+    }
+
+    const headingMatch = /^(#{1,3})\s+(.*)$/.exec(trimmed)
+    if (headingMatch) {
+      const level = headingMatch[1].length
+      const title = headingMatch[2].trim()
+      const anchor = headingAnchors.get(title) ?? `heading-${index}`
+      if (level === 1) {
+        nodes.push(
+          <h1 key={anchor} id={anchor} className="markdown-heading markdown-heading-1">
+            {title}
+          </h1>,
+        )
+      } else if (level === 2) {
+        nodes.push(
+          <h2 key={anchor} id={anchor} className="markdown-heading markdown-heading-2">
+            {title}
+          </h2>,
+        )
+      } else {
+        nodes.push(
+          <h3 key={anchor} id={anchor} className="markdown-heading markdown-heading-3">
+            {title}
+          </h3>,
+        )
+      }
+      index += 1
+      continue
+    }
+
+    if (trimmed.startsWith('- ')) {
+      const bullets: string[] = []
+      while (index < lines.length && lines[index].trim().startsWith('- ')) {
+        bullets.push(lines[index].trim().slice(2))
+        index += 1
+      }
+      nodes.push(
+        <ul key={`list-${index}`} className="bullet-list">
+          {bullets.map((bullet) => (
+            <li key={`${bullet}-${index}`}>{bullet}</li>
+          ))}
+        </ul>,
+      )
+      continue
+    }
+
+    const paragraphLines: string[] = []
+    while (index < lines.length) {
+      const next = lines[index].trim()
+      if (!next || next.startsWith('#') || next.startsWith('- ') || next.startsWith('```')) {
+        break
+      }
+      paragraphLines.push(lines[index].trim())
+      index += 1
+    }
+
+    nodes.push(
+      <p key={`p-${index}`} className="markdown-paragraph">
+        {paragraphLines.join(' ')}
+      </p>,
+    )
+  }
+
+  return nodes
 }
 
 function ProjectPanel({

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -61,6 +61,38 @@ export type OverviewSnapshot = {
   knownLimits: string[]
 }
 
+export type SpecCatalogDocument = {
+  key: string
+  title: string
+  relativePath: string
+  absolutePath: string
+  status: string | null
+}
+
+export type SpecCatalogSection = {
+  key: string
+  title: string
+  documents: SpecCatalogDocument[]
+}
+
+export type SpecDocumentHeading = {
+  level: number
+  title: string
+  anchor: string
+}
+
+export type SpecDocumentView = {
+  key: string
+  sectionKey: string
+  sectionTitle: string
+  title: string
+  relativePath: string
+  absolutePath: string
+  status: string | null
+  markdown: string
+  headings: SpecDocumentHeading[]
+}
+
 export async function fetchAdapterContract() {
   return invoke<AdapterContract>('get_adapter_contract')
 }
@@ -75,4 +107,12 @@ export async function resolveWorkspaceRoot(candidate?: string) {
 
 export async function fetchOverviewSnapshot() {
   return invoke<OverviewSnapshot>('get_overview_snapshot')
+}
+
+export async function fetchSpecCatalog() {
+  return invoke<SpecCatalogSection[]>('get_spec_catalog')
+}
+
+export async function fetchSpecDocument(relativePath: string) {
+  return invoke<SpecDocumentView>('get_spec_document', { relativePath })
 }


### PR DESCRIPTION
## Summary
- add a real spec navigator over canonical docs/spec and docs/roadmap documents
- keep document viewing read-only while exposing search, section navigation, and source paths
- route document indexing and loading through a backend catalog instead of ad hoc frontend file assumptions

## Includes
- backend catalog and document loader for canonical workbench docs
- spec route with document tree, title/path search, section navigator, and markdown view
- source-path and status badges derived from repository markdown

## Excludes
- no document editing from the UI
- no parallel source of truth for readiness or spec semantics
- no diagnostics or authoring semantics yet

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #16