### PR TITLE
PR-WB-08 feat(workbench): release map and readiness panel

### DIFF
--- a/apps/workbench/src-tauri/src/docs.rs
+++ b/apps/workbench/src-tauri/src/docs.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 struct DocEntryDef {
   key: &'static str,
@@ -247,6 +248,7 @@ pub struct SpecCatalogDocument {
   pub relative_path: String,
   pub absolute_path: String,
   pub status: Option<String>,
+  pub modified_epoch_ms: Option<u128>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -275,6 +277,7 @@ pub struct SpecDocumentView {
   pub relative_path: String,
   pub absolute_path: String,
   pub status: Option<String>,
+  pub modified_epoch_ms: Option<u128>,
   pub markdown: String,
   pub headings: Vec<SpecDocumentHeading>,
 }
@@ -298,6 +301,7 @@ pub fn read_spec_catalog() -> Result<Vec<SpecCatalogSection>, String> {
         relative_path: entry.relative_path.to_owned(),
         absolute_path: path.to_string_lossy().into_owned(),
         status: status_line(&markdown),
+        modified_epoch_ms: modified_epoch_ms(&path),
       });
   }
 
@@ -331,6 +335,7 @@ pub fn read_spec_document(relative_path: String) -> Result<SpecDocumentView, Str
     relative_path: entry.relative_path.to_owned(),
     absolute_path: path.to_string_lossy().into_owned(),
     status: status_line(&markdown),
+    modified_epoch_ms: modified_epoch_ms(&path),
     markdown: markdown.clone(),
     headings: extract_headings(&markdown),
   })
@@ -416,4 +421,12 @@ fn slugify(input: &str) -> String {
   }
 
   slug.trim_matches('-').to_owned()
+}
+
+fn modified_epoch_ms(path: &Path) -> Option<u128> {
+  fs::metadata(path)
+    .ok()
+    .and_then(|metadata| metadata.modified().ok())
+    .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+    .map(|duration| duration.as_millis())
 }

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -307,6 +307,11 @@
   gap: 0.85rem;
 }
 
+.release-guard-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
 .spec-section-list,
 .spec-doc-list,
 .spec-outline-list {
@@ -384,6 +389,10 @@
 
 .validation-row strong {
   color: #0f1720;
+}
+
+.document-card .bullet-list {
+  margin-top: 0.75rem;
 }
 
 .job-card-button {

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -204,13 +204,13 @@ const routeSpecs: ScreenSpec[] = [
     summary:
       'Release is the eventual command center for gates, bundle verification, asset smoke, docs alignment, and known limits. Every signal must remain explainable.',
     stable: [
-      'Release route anchored around gates, assets, and docs alignment',
+      'Release route anchored around canonical release docs and baseline artifacts',
       'Known-limits panel separated from pass/fail gates',
-      'Reminder that release-valid comes only from real checks',
+      'Freshness hints and source paths shown for release-facing documents',
     ],
     next: [
-      'Wire release bundle verification and smoke matrix status',
       'Export a validation report from real job history',
+      'Keep release map in sync with future operate slices without adding UI-owned scoring',
     ],
   },
   {
@@ -731,6 +731,15 @@ function WorkbenchScreen({
         />
       ) : null}
 
+      {route.path === '/release' ? (
+        <ReleasePanel
+          overviewSnapshot={overviewSnapshot}
+          specCatalog={specCatalog}
+          jobs={jobs}
+          selectedWorkspace={selectedWorkspace}
+        />
+      ) : null}
+
       {route.path === '/project' ? (
         <ProjectPanel
           adapterContract={adapterContract}
@@ -1223,6 +1232,169 @@ function SpecNavigatorPanel({
   )
 }
 
+function ReleasePanel({
+  overviewSnapshot,
+  specCatalog,
+  jobs,
+  selectedWorkspace,
+}: {
+  overviewSnapshot: OverviewSnapshot | null
+  specCatalog: SpecCatalogSection[]
+  jobs: JobRecord[]
+  selectedWorkspace: WorkspaceSummary | null
+}) {
+  const releaseSection = specCatalog.find((section) => section.key === 'release')
+  const latestCargo = latestJobOfKind(jobs, 'cargo')
+  const latestSmc = latestJobOfKind(jobs, 'smc')
+  const latestSvm = latestJobOfKind(jobs, 'svm')
+  const latestBundle = latestJobOfKind(jobs, 'release_bundle_verify')
+
+  return (
+    <div className="screen-stack">
+      <section className="overview-grid">
+        <article className="screen-card">
+          <p className="card-kicker">Release identity</p>
+          <h3>What the current line is anchored to</h3>
+          <dl className="facts-grid">
+            <div>
+              <dt>Branch</dt>
+              <dd>{overviewSnapshot?.branch ?? 'Loading...'}</dd>
+            </div>
+            <div>
+              <dt>HEAD</dt>
+              <dd>
+                <code>{overviewSnapshot?.shortCommit ?? 'Loading...'}</code>
+              </dd>
+            </div>
+            <div className="facts-grid-wide">
+              <dt>Baseline tag</dt>
+              <dd>
+                {overviewSnapshot
+                  ? overviewSnapshot.baselineTagPointsAtHead
+                    ? `${overviewSnapshot.baselineTagName} on HEAD`
+                    : `${overviewSnapshot.baselineTagName} exists off HEAD`
+                  : 'Loading...'}
+              </dd>
+            </div>
+            <div className="facts-grid-wide">
+              <dt>Baseline manifest</dt>
+              <dd>
+                {overviewSnapshot?.baselineManifestExists ? 'Present' : 'Missing'}
+                {overviewSnapshot ? (
+                  <>
+                    {' '}
+                    <code>{overviewSnapshot.baselineManifestPath}</code>
+                  </>
+                ) : null}
+              </dd>
+            </div>
+            <div className="facts-grid-wide">
+              <dt>Active workspace</dt>
+              <dd>
+                <code>{selectedWorkspace?.resolvedPath ?? overviewSnapshot?.repoRoot ?? 'Loading...'}</code>
+              </dd>
+            </div>
+          </dl>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Release-critical jobs</p>
+          <h3>Signals from actual command history</h3>
+          <div className="activity-list">
+            <ValidationRow label="Workspace tests" job={latestCargo} />
+            <ValidationRow label="smc workflows" job={latestSmc} />
+            <ValidationRow label="svm workflows" job={latestSvm} />
+            <ValidationRow label="Bundle verification" job={latestBundle} />
+          </div>
+        </article>
+      </section>
+
+      <section className="command-grid">
+        <article className="screen-card">
+          <p className="card-kicker">Release-facing docs</p>
+          <h3>Source paths and freshness from repository files</h3>
+          <div className="document-list">
+            {(releaseSection?.documents ?? []).map((document) => (
+              <section key={document.relativePath} className="document-card">
+                <div className="document-topline">
+                  <strong>{document.title}</strong>
+                  <span className={`status-pill ${statusTone(document.status ?? 'draft')}`}>
+                    {document.status ?? 'draft'}
+                  </span>
+                </div>
+                <p className="job-meta">
+                  path: <code>{document.absolutePath}</code>
+                </p>
+                <p className="job-meta">
+                  freshness: {formatFreshness(document.modifiedEpochMs)}
+                </p>
+              </section>
+            ))}
+          </div>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Readiness truths</p>
+          <h3>Known limits and validated tag callouts</h3>
+          <div className="screen-stack">
+            <section className="document-card">
+              <div className="document-topline">
+                <strong>Known limits</strong>
+                <span className="status-pill draft">honesty</span>
+              </div>
+              <ul className="bullet-list">
+                {(overviewSnapshot?.knownLimits ?? []).map((limit) => (
+                  <li key={limit}>{limit}</li>
+                ))}
+              </ul>
+            </section>
+            <section className="document-card">
+              <div className="document-topline">
+                <strong>Current validated tag</strong>
+                <span className="status-pill stable">derived</span>
+              </div>
+              <div className="document-list">
+                {(overviewSnapshot?.releaseDocs ?? [])
+                  .filter((document) => document.highlight)
+                  .map((document) => (
+                    <div key={document.key}>
+                      <p className="job-meta">
+                        <code>{document.path}</code>
+                      </p>
+                      <p className="document-highlight">{document.highlight}</p>
+                    </div>
+                  ))}
+              </div>
+            </section>
+          </div>
+        </article>
+      </section>
+
+      <section className="command-grid">
+        <article className="screen-card">
+          <p className="card-kicker">No second release model</p>
+          <h3>What the UI must not do</h3>
+          <ul className="bullet-list">
+            <li>Do not invent a release score that is not backed by repository docs or job output.</li>
+            <li>Do not hide known limits behind green local commands.</li>
+            <li>Do not claim stable readiness unless the canonical release documents and bundle checks say so.</li>
+          </ul>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Next operate slices</p>
+          <h3>What still belongs to later PRs</h3>
+          <ul className="bullet-list">
+            <li>`WB-16` will formalize the release console around gate views and artifact lists.</li>
+            <li>`WB-17` will add one-click validation runs and report export.</li>
+            <li>This slice stays presentation-only over current release artifacts.</li>
+          </ul>
+        </article>
+      </section>
+    </div>
+  )
+}
+
 function jumpToHeading(anchor: string) {
   const element = globalThis.document?.getElementById(anchor)
   element?.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -1243,6 +1415,27 @@ function statusTone(status: string) {
   }
 
   return 'draft'
+}
+
+function formatFreshness(modifiedEpochMs: number | null) {
+  if (!modifiedEpochMs) {
+    return 'unknown'
+  }
+
+  const deltaMs = Date.now() - modifiedEpochMs
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+
+  if (deltaMs < hour) {
+    return `${Math.max(1, Math.round(deltaMs / minute))} min ago`
+  }
+
+  if (deltaMs < day) {
+    return `${Math.max(1, Math.round(deltaMs / hour))} hr ago`
+  }
+
+  return `${Math.max(1, Math.round(deltaMs / day))} day ago`
 }
 
 function renderMarkdown(markdown: string, headings: SpecDocumentHeading[]) {

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -67,6 +67,7 @@ export type SpecCatalogDocument = {
   relativePath: string
   absolutePath: string
   status: string | null
+  modifiedEpochMs: number | null
 }
 
 export type SpecCatalogSection = {
@@ -89,6 +90,7 @@ export type SpecDocumentView = {
   relativePath: string
   absolutePath: string
   status: string | null
+  modifiedEpochMs: number | null
   markdown: string
   headings: SpecDocumentHeading[]
 }


### PR DESCRIPTION
## Summary
- add a dedicated release route that surfaces release-facing docs, known limits, and baseline artifacts
- show source paths and freshness indicators derived from repository file metadata
- keep release signals grounded in canonical docs and real command history instead of UI-owned scoring

## Includes
- freshness metadata for canonical docs
- release-facing document cards with path and freshness
- known-limits, validated-tag callouts, and release-critical job summaries

## Excludes
- no one-click validation automation yet
- no independent release scoring model
- no mutation of release docs from the UI

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #17