### PR TITLE
PR-WB-09 feat(workbench): project explorer and editor shell

### DIFF
--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod docs;
 mod snapshot;
+mod workspace_files;
 
 use adapter::{
   adapter_contract,
@@ -11,8 +12,17 @@ use adapter::{
   JobResult,
   WorkspaceSummary,
 };
-use snapshot::{read_overview_snapshot, OverviewSnapshot};
 use docs::{read_spec_catalog, read_spec_document, SpecCatalogSection, SpecDocumentView};
+use snapshot::{read_overview_snapshot, OverviewSnapshot};
+use workspace_files::{
+  list_workspace_tree,
+  read_workspace_file,
+  save_workspace_file,
+  SaveWorkspaceFileRequest,
+  WorkspaceFileDocument,
+  WorkspaceFileRequest,
+  WorkspaceTreeNode,
+};
 
 #[tauri::command]
 fn get_adapter_contract() -> Result<AdapterContract, String> {
@@ -46,6 +56,23 @@ fn get_spec_document(relative_path: String) -> Result<SpecDocumentView, String> 
   read_spec_document(relative_path)
 }
 
+#[tauri::command]
+fn get_workspace_tree(workspace_root: String) -> Result<Vec<WorkspaceTreeNode>, String> {
+  list_workspace_tree(workspace_root)
+}
+
+#[tauri::command]
+fn get_workspace_file(request: WorkspaceFileRequest) -> Result<WorkspaceFileDocument, String> {
+  read_workspace_file(request)
+}
+
+#[tauri::command]
+fn save_workspace_file_contents(
+  request: SaveWorkspaceFileRequest,
+) -> Result<WorkspaceFileDocument, String> {
+  save_workspace_file(request)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -65,7 +92,10 @@ pub fn run() {
       resolve_workspace_root,
       get_overview_snapshot,
       get_spec_catalog,
-      get_spec_document
+      get_spec_document,
+      get_workspace_tree,
+      get_workspace_file,
+      save_workspace_file_contents
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/workbench/src-tauri/src/workspace_files.rs
+++ b/apps/workbench/src-tauri/src/workspace_files.rs
@@ -1,0 +1,178 @@
+use crate::adapter::repo_root;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SKIP_DIRS: &[&str] = &[".git", "node_modules", "target", "dist"];
+const TEXT_EXTENSIONS: &[&str] = &[
+  "sm", "md", "toml", "json", "ts", "tsx", "css", "rs", "yml", "yaml", "ps1", "txt",
+];
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceTreeNode {
+  pub name: String,
+  pub relative_path: String,
+  pub node_type: String,
+  pub children: Vec<WorkspaceTreeNode>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceFileDocument {
+  pub relative_path: String,
+  pub absolute_path: String,
+  pub content: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceFileRequest {
+  pub workspace_root: String,
+  pub relative_path: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveWorkspaceFileRequest {
+  pub workspace_root: String,
+  pub relative_path: String,
+  pub content: String,
+}
+
+pub fn list_workspace_tree(workspace_root: String) -> Result<Vec<WorkspaceTreeNode>, String> {
+  let root = resolve_workspace_root_path(&workspace_root)?;
+  read_children(&root, &root)
+}
+
+pub fn read_workspace_file(request: WorkspaceFileRequest) -> Result<WorkspaceFileDocument, String> {
+  let root = resolve_workspace_root_path(&request.workspace_root)?;
+  let path = resolve_file_path(&root, &request.relative_path)?;
+  let content = fs::read_to_string(&path)
+    .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+
+  Ok(WorkspaceFileDocument {
+    relative_path: request.relative_path,
+    absolute_path: path.to_string_lossy().into_owned(),
+    content,
+  })
+}
+
+pub fn save_workspace_file(request: SaveWorkspaceFileRequest) -> Result<WorkspaceFileDocument, String> {
+  let root = resolve_workspace_root_path(&request.workspace_root)?;
+  let path = resolve_file_path(&root, &request.relative_path)?;
+
+  fs::write(&path, request.content.as_bytes())
+    .map_err(|error| format!("failed to write '{}': {error}", path.display()))?;
+
+  Ok(WorkspaceFileDocument {
+    relative_path: request.relative_path,
+    absolute_path: path.to_string_lossy().into_owned(),
+    content: request.content,
+  })
+}
+
+fn read_children(root: &Path, current: &Path) -> Result<Vec<WorkspaceTreeNode>, String> {
+  let mut entries = fs::read_dir(current)
+    .map_err(|error| format!("failed to read '{}': {error}", current.display()))?
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(|error| format!("failed to read directory entry in '{}': {error}", current.display()))?;
+
+  entries.sort_by_key(|entry| entry.file_name());
+
+  let mut nodes = Vec::new();
+
+  for entry in entries {
+    let path = entry.path();
+    let file_name = entry.file_name().to_string_lossy().into_owned();
+
+    if entry.file_type().map_err(|error| format!("failed to inspect '{}': {error}", path.display()))?.is_dir()
+    {
+      if SKIP_DIRS.iter().any(|skip| skip == &file_name.as_str()) {
+        continue;
+      }
+
+      let children = read_children(root, &path)?;
+      if children.is_empty() {
+        continue;
+      }
+
+      nodes.push(WorkspaceTreeNode {
+        name: file_name,
+        relative_path: relative_to_root(root, &path),
+        node_type: "dir".into(),
+        children,
+      });
+      continue;
+    }
+
+    if !is_text_file(&path) {
+      continue;
+    }
+
+    nodes.push(WorkspaceTreeNode {
+      name: file_name,
+      relative_path: relative_to_root(root, &path),
+      node_type: "file".into(),
+      children: Vec::new(),
+    });
+  }
+
+  Ok(nodes)
+}
+
+fn resolve_workspace_root_path(workspace_root: &str) -> Result<PathBuf, String> {
+  let repo_root = repo_root()?;
+  let requested = PathBuf::from(workspace_root);
+  let absolute = if requested.is_absolute() {
+    requested
+  } else {
+    repo_root.join(requested)
+  };
+  let canonical = absolute
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve workspace root '{}': {error}", absolute.display()))?;
+
+  if !canonical.starts_with(&repo_root) {
+    return Err("workspace root must stay inside the repository root".into());
+  }
+
+  Ok(canonical)
+}
+
+fn resolve_file_path(workspace_root: &Path, relative_path: &str) -> Result<PathBuf, String> {
+  let requested = workspace_root.join(relative_path);
+  let canonical = requested
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve file '{}': {error}", requested.display()))?;
+
+  if !canonical.starts_with(workspace_root) {
+    return Err("file path must stay inside the selected workspace root".into());
+  }
+
+  if !canonical.is_file() {
+    return Err(format!("'{}' is not a file", canonical.display()));
+  }
+
+  if !is_text_file(&canonical) {
+    return Err(format!("'{}' is not an editable text file", canonical.display()));
+  }
+
+  Ok(canonical)
+}
+
+fn relative_to_root(root: &Path, path: &Path) -> String {
+  path
+    .strip_prefix(root)
+    .ok()
+    .map(|path| path.to_string_lossy().replace('\\', "/"))
+    .unwrap_or_else(|| path.to_string_lossy().replace('\\', "/"))
+}
+
+fn is_text_file(path: &Path) -> bool {
+  path
+    .extension()
+    .and_then(|ext| ext.to_str())
+    .map(|ext| TEXT_EXTENSIONS.iter().any(|candidate| candidate.eq_ignore_ascii_case(ext)))
+    .unwrap_or(false)
+}

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -190,6 +190,13 @@
   align-items: start;
 }
 
+.project-shell {
+  display: grid;
+  grid-template-columns: minmax(300px, 0.7fr) minmax(0, 1.3fr);
+  gap: 1rem;
+  align-items: start;
+}
+
 .screen-stack {
   display: grid;
   gap: 1rem;
@@ -315,6 +322,13 @@
 .spec-section-list,
 .spec-doc-list,
 .spec-outline-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project-tree,
+.tree-children,
+.editor-shell-stack {
   display: grid;
   gap: 0.75rem;
 }
@@ -529,6 +543,127 @@
   line-height: 1.6;
 }
 
+.tree-branch {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.tree-children {
+  margin-left: 1rem;
+}
+
+.tree-branch-label {
+  margin: 0;
+  font-weight: 700;
+  color: #0f1720;
+}
+
+.tree-file-button {
+  display: grid;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  border: 1px solid rgba(15, 23, 32, 0.1);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.75);
+  color: #0f1720;
+  font: inherit;
+  cursor: pointer;
+}
+
+.tree-file-button:hover,
+.tree-file-button:focus-visible {
+  border-color: rgba(32, 190, 167, 0.45);
+  outline: none;
+}
+
+.tree-file-button-active {
+  border-color: rgba(32, 190, 167, 0.55);
+  background:
+    linear-gradient(145deg, rgba(32, 190, 167, 0.1), rgba(255, 255, 255, 0.92)),
+    rgba(255, 255, 255, 0.75);
+}
+
+.tree-node-label {
+  font-weight: 700;
+}
+
+.tree-node-path {
+  color: #5a6675;
+  font-size: 0.84rem;
+  word-break: break-word;
+}
+
+.editor-tab-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+}
+
+.editor-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 32, 0.1);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.editor-tab-active {
+  border-color: rgba(32, 190, 167, 0.55);
+  background:
+    linear-gradient(145deg, rgba(32, 190, 167, 0.12), rgba(255, 255, 255, 0.92)),
+    rgba(255, 255, 255, 0.7);
+}
+
+.editor-tab-select,
+.editor-tab-close {
+  border: none;
+  background: transparent;
+  color: #0f1720;
+  font: inherit;
+  cursor: pointer;
+}
+
+.editor-tab-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.7rem;
+}
+
+.editor-tab-close {
+  padding: 0.45rem 0.55rem;
+  border-radius: 999px;
+}
+
+.editor-tab-close:hover,
+.editor-tab-close:focus-visible {
+  background: rgba(15, 23, 32, 0.08);
+  outline: none;
+}
+
+.editor-textarea {
+  min-height: 480px;
+  width: 100%;
+  resize: vertical;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.12);
+  background: rgba(255, 255, 255, 0.82);
+  color: #0f1720;
+  font: 0.95rem/1.55 'Cascadia Code', 'Consolas', monospace;
+}
+
+.editor-textarea:focus-visible {
+  border-color: rgba(32, 190, 167, 0.5);
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(32, 190, 167, 0.12);
+}
+
 .action-button {
   margin-top: 0.9rem;
   padding: 0.75rem 1rem;
@@ -705,6 +840,7 @@
   .screen-grid,
   .overview-grid,
   .spec-shell,
+  .project-shell,
   .spec-document-grid,
   .command-grid {
     grid-template-columns: 1fr;

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -5,8 +5,11 @@ import {
   fetchOverviewSnapshot,
   fetchSpecCatalog,
   fetchSpecDocument,
+  fetchWorkspaceFile,
+  fetchWorkspaceTree,
   resolveWorkspaceRoot,
   runCliJob,
+  saveWorkspaceFile,
   type AdapterContract,
   type AdapterJobSpec,
   type JobKind,
@@ -15,6 +18,8 @@ import {
   type SpecCatalogSection,
   type SpecDocumentHeading,
   type SpecDocumentView,
+  type WorkspaceFileDocument,
+  type WorkspaceTreeNode,
   type WorkspaceSummary,
 } from './workbench-api'
 import {
@@ -55,6 +60,15 @@ type JobActionSpec = {
   args: string[]
   notes: string
   cwdMode: 'repo' | 'workspace'
+}
+
+type EditorTab = {
+  relativePath: string
+  absolutePath: string
+  title: string
+  content: string
+  savedContent: string
+  status: 'clean' | 'dirty' | 'saving'
 }
 
 const initialWorkbenchState = loadWorkbenchState()
@@ -131,18 +145,18 @@ const routeSpecs: ScreenSpec[] = [
   {
     path: '/project',
     label: 'Project',
-    eyebrow: 'WB-0 Bootstrap',
-    title: 'Workspace context before orchestration.',
+    eyebrow: 'WB-0.2 Authoring',
+    title: 'Project explorer and editor shell without hidden semantics.',
     summary:
-      'Project owns workspace selection, recent roots, and local settings. It does not create an alternate package or repository model.',
+      'Project owns workspace selection, file-tree navigation, tabs, and text editing. It does not create an alternate package, parser, or repository model.',
     stable: [
       'Workspace resolver over canonical repository paths',
       'Recent projects list and default workspace persistence',
-      'Explicit rule that all jobs inherit the selected root',
+      'Workspace file tree and read/write text editor tabs for authoring shell',
     ],
     next: [
-      'Add native directory-pick affordances if needed',
-      'Keep project context read-only with respect to repository semantics',
+      'Add compile and check current file actions through the shared jobs pipeline',
+      'Keep editor shell intentionally lighter than a full IDE until later slices arrive',
     ],
   },
   {
@@ -250,6 +264,10 @@ function App() {
   const [selectedSpecPath, setSelectedSpecPath] = useState<string | null>(null)
   const [selectedSpecDocument, setSelectedSpecDocument] =
     useState<SpecDocumentView | null>(null)
+  const [workspaceTree, setWorkspaceTree] = useState<WorkspaceTreeNode[]>([])
+  const [workspaceTreeError, setWorkspaceTreeError] = useState<string | null>(null)
+  const [editorTabs, setEditorTabs] = useState<EditorTab[]>([])
+  const [activeEditorPath, setActiveEditorPath] = useState<string | null>(null)
   const [workspaceInput, setWorkspaceInput] = useState('')
   const [workspaceError, setWorkspaceError] = useState<string | null>(null)
   const [selectedWorkspace, setSelectedWorkspace] = useState<WorkspaceSummary | null>(
@@ -353,6 +371,36 @@ function App() {
       cancelled = true
     }
   }, [selectedSpecPath])
+
+  useEffect(() => {
+    if (!selectedWorkspace?.resolvedPath) {
+      return
+    }
+
+    let cancelled = false
+
+    fetchWorkspaceTree(selectedWorkspace.resolvedPath)
+      .then((tree) => {
+        if (!cancelled) {
+          setWorkspaceTree(tree)
+          setWorkspaceTreeError(null)
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setWorkspaceTreeError(String(error))
+        }
+      })
+
+    startTransition(() => {
+      setEditorTabs([])
+      setActiveEditorPath(null)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [selectedWorkspace?.resolvedPath])
 
   useEffect(() => {
     saveWorkbenchState({
@@ -485,6 +533,129 @@ function App() {
     }
   }
 
+  async function openEditorFile(relativePath: string) {
+    if (!selectedWorkspace) {
+      return
+    }
+
+    const existingTab = editorTabs.find((tab) => tab.relativePath === relativePath)
+    if (existingTab) {
+      setActiveEditorPath(relativePath)
+      return
+    }
+
+    try {
+      const document = await fetchWorkspaceFile({
+        workspaceRoot: selectedWorkspace.resolvedPath,
+        relativePath,
+      })
+
+      startTransition(() => {
+        setEditorTabs((current) => [
+          ...current,
+          createEditorTab(document),
+        ])
+        setActiveEditorPath(relativePath)
+        setWorkspaceTreeError(null)
+      })
+    } catch (error) {
+      setWorkspaceTreeError(String(error))
+    }
+  }
+
+  function updateEditorContent(relativePath: string, content: string) {
+    setEditorTabs((current) =>
+      current.map((tab) =>
+        tab.relativePath === relativePath
+          ? {
+              ...tab,
+              content,
+              status: content === tab.savedContent ? 'clean' : 'dirty',
+            }
+          : tab,
+      ),
+    )
+  }
+
+  async function saveEditorFile(relativePath: string) {
+    if (!selectedWorkspace) {
+      return
+    }
+
+    const tab = editorTabs.find((entry) => entry.relativePath === relativePath)
+    if (!tab) {
+      return
+    }
+
+    setEditorTabs((current) =>
+      current.map((entry) =>
+        entry.relativePath === relativePath
+          ? { ...entry, status: 'saving' }
+          : entry,
+      ),
+    )
+
+    try {
+      const document = await saveWorkspaceFile({
+        workspaceRoot: selectedWorkspace.resolvedPath,
+        relativePath,
+        content: tab.content,
+      })
+
+      setEditorTabs((current) =>
+        current.map((entry) =>
+          entry.relativePath === relativePath
+            ? createEditorTab(document)
+            : entry,
+        ),
+      )
+      setWorkspaceTreeError(null)
+    } catch (error) {
+      setWorkspaceTreeError(String(error))
+      setEditorTabs((current) =>
+        current.map((entry) =>
+          entry.relativePath === relativePath
+            ? { ...entry, status: entry.content === entry.savedContent ? 'clean' : 'dirty' }
+            : entry,
+        ),
+      )
+    }
+  }
+
+  async function reloadEditorFile(relativePath: string) {
+    if (!selectedWorkspace) {
+      return
+    }
+
+    try {
+      const document = await fetchWorkspaceFile({
+        workspaceRoot: selectedWorkspace.resolvedPath,
+        relativePath,
+      })
+
+      setEditorTabs((current) =>
+        current.map((entry) =>
+          entry.relativePath === relativePath
+            ? createEditorTab(document)
+            : entry,
+        ),
+      )
+      setWorkspaceTreeError(null)
+    } catch (error) {
+      setWorkspaceTreeError(String(error))
+    }
+  }
+
+  function closeEditorTab(relativePath: string) {
+    setEditorTabs((current) => {
+      const remaining = current.filter((tab) => tab.relativePath !== relativePath)
+      if (activeEditorPath === relativePath) {
+        setActiveEditorPath(remaining[remaining.length - 1]?.relativePath ?? null)
+      }
+      return remaining
+    })
+  }
+
   function updateSettings(next: Partial<WorkbenchSettings>) {
     setSettings((current) => ({
       ...current,
@@ -594,6 +765,10 @@ function App() {
                   specSearch={specSearch}
                   selectedSpecDocument={selectedSpecDocument}
                   selectedSpecPath={selectedSpecPath}
+                  workspaceTree={workspaceTree}
+                  workspaceTreeError={workspaceTreeError}
+                  editorTabs={editorTabs}
+                  activeEditorPath={activeEditorPath}
                   jobs={jobs}
                   selectedJobId={selectedJobId}
                   activeJob={activeJob}
@@ -601,6 +776,12 @@ function App() {
                   onRunProbe={runProbe}
                   onSpecSearchChange={setSpecSearch}
                   onSelectSpecPath={setSelectedSpecPath}
+                  onOpenEditorFile={openEditorFile}
+                  onSelectEditorPath={setActiveEditorPath}
+                  onUpdateEditorContent={updateEditorContent}
+                  onSaveEditorFile={saveEditorFile}
+                  onReloadEditorFile={reloadEditorFile}
+                  onCloseEditorTab={closeEditorTab}
                   onSelectJob={setSelectedJobId}
                   selectedWorkspace={selectedWorkspace}
                   workspaceInput={workspaceInput}
@@ -631,6 +812,10 @@ function WorkbenchScreen({
   specSearch,
   selectedSpecDocument,
   selectedSpecPath,
+  workspaceTree,
+  workspaceTreeError,
+  editorTabs,
+  activeEditorPath,
   jobs,
   selectedJobId,
   activeJob,
@@ -638,6 +823,12 @@ function WorkbenchScreen({
   onRunProbe,
   onSpecSearchChange,
   onSelectSpecPath,
+  onOpenEditorFile,
+  onSelectEditorPath,
+  onUpdateEditorContent,
+  onSaveEditorFile,
+  onReloadEditorFile,
+  onCloseEditorTab,
   onSelectJob,
   selectedWorkspace,
   workspaceInput,
@@ -658,6 +849,10 @@ function WorkbenchScreen({
   specSearch: string
   selectedSpecDocument: SpecDocumentView | null
   selectedSpecPath: string | null
+  workspaceTree: WorkspaceTreeNode[]
+  workspaceTreeError: string | null
+  editorTabs: EditorTab[]
+  activeEditorPath: string | null
   jobs: JobRecord[]
   selectedJobId: string | null
   activeJob: JobKind | null
@@ -665,6 +860,12 @@ function WorkbenchScreen({
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
   onSpecSearchChange: (value: string) => void
   onSelectSpecPath: (value: string) => void
+  onOpenEditorFile: (relativePath: string) => Promise<void>
+  onSelectEditorPath: (relativePath: string | null) => void
+  onUpdateEditorContent: (relativePath: string, content: string) => void
+  onSaveEditorFile: (relativePath: string) => Promise<void>
+  onReloadEditorFile: (relativePath: string) => Promise<void>
+  onCloseEditorTab: (relativePath: string) => void
   onSelectJob: (jobId: string) => void
   selectedWorkspace: WorkspaceSummary | null
   workspaceInput: string
@@ -744,11 +945,21 @@ function WorkbenchScreen({
         <ProjectPanel
           adapterContract={adapterContract}
           selectedWorkspace={selectedWorkspace}
+          workspaceTree={workspaceTree}
+          workspaceTreeError={workspaceTreeError}
+          editorTabs={editorTabs}
+          activeEditorPath={activeEditorPath}
           workspaceInput={workspaceInput}
           workspaceError={workspaceError}
           recentWorkspaces={recentWorkspaces}
           onWorkspaceInputChange={onWorkspaceInputChange}
           onOpenWorkspace={onOpenWorkspace}
+          onOpenEditorFile={onOpenEditorFile}
+          onSelectEditorPath={onSelectEditorPath}
+          onUpdateEditorContent={onUpdateEditorContent}
+          onSaveEditorFile={onSaveEditorFile}
+          onReloadEditorFile={onReloadEditorFile}
+          onCloseEditorTab={onCloseEditorTab}
         />
       ) : null}
 
@@ -1438,6 +1649,17 @@ function formatFreshness(modifiedEpochMs: number | null) {
   return `${Math.max(1, Math.round(deltaMs / day))} day ago`
 }
 
+function createEditorTab(document: WorkspaceFileDocument): EditorTab {
+  return {
+    relativePath: document.relativePath,
+    absolutePath: document.absolutePath,
+    title: document.relativePath.split('/').pop() ?? document.relativePath,
+    content: document.content,
+    savedContent: document.content,
+    status: 'clean',
+  }
+}
+
 function renderMarkdown(markdown: string, headings: SpecDocumentHeading[]) {
   const headingAnchors = new Map(headings.map((heading) => [heading.title, heading.anchor]))
   const lines = markdown.split(/\r?\n/)
@@ -1533,26 +1755,89 @@ function renderMarkdown(markdown: string, headings: SpecDocumentHeading[]) {
   return nodes
 }
 
+function WorkspaceTreeBranch({
+  node,
+  activePath,
+  onOpenFile,
+}: {
+  node: WorkspaceTreeNode
+  activePath: string | null
+  onOpenFile: (relativePath: string) => Promise<void>
+}) {
+  if (node.nodeType === 'file') {
+    return (
+      <button
+        type="button"
+        className={`tree-file-button ${activePath === node.relativePath ? 'tree-file-button-active' : ''}`}
+        onClick={() => void onOpenFile(node.relativePath)}
+      >
+        <span className="tree-node-label">{node.name}</span>
+        <span className="tree-node-path">{node.relativePath}</span>
+      </button>
+    )
+  }
+
+  return (
+    <section className="tree-branch">
+      <p className="tree-branch-label">{node.name}</p>
+      <div className="tree-children">
+        {node.children.map((child) => (
+          <WorkspaceTreeBranch
+            key={child.relativePath || child.name}
+            node={child}
+            activePath={activePath}
+            onOpenFile={onOpenFile}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
 function ProjectPanel({
   adapterContract,
   selectedWorkspace,
+  workspaceTree,
+  workspaceTreeError,
+  editorTabs,
+  activeEditorPath,
   workspaceInput,
   workspaceError,
   recentWorkspaces,
   onWorkspaceInputChange,
   onOpenWorkspace,
+  onOpenEditorFile,
+  onSelectEditorPath,
+  onUpdateEditorContent,
+  onSaveEditorFile,
+  onReloadEditorFile,
+  onCloseEditorTab,
 }: {
   adapterContract: AdapterContract | null
   selectedWorkspace: WorkspaceSummary | null
+  workspaceTree: WorkspaceTreeNode[]
+  workspaceTreeError: string | null
+  editorTabs: EditorTab[]
+  activeEditorPath: string | null
   workspaceInput: string
   workspaceError: string | null
   recentWorkspaces: RecentWorkspace[]
   onWorkspaceInputChange: (value: string) => void
   onOpenWorkspace: (candidate: string, persist?: boolean) => Promise<void>
+  onOpenEditorFile: (relativePath: string) => Promise<void>
+  onSelectEditorPath: (relativePath: string | null) => void
+  onUpdateEditorContent: (relativePath: string, content: string) => void
+  onSaveEditorFile: (relativePath: string) => Promise<void>
+  onReloadEditorFile: (relativePath: string) => Promise<void>
+  onCloseEditorTab: (relativePath: string) => void
 }) {
+  const activeEditorTab =
+    editorTabs.find((tab) => tab.relativePath === activeEditorPath) ?? editorTabs[0] ?? null
+
   return (
-    <section className="command-grid">
-      <article className="screen-card">
+    <div className="screen-stack">
+      <section className="command-grid">
+        <article className="screen-card">
         <p className="card-kicker">Open workspace</p>
         <h3>Canonical root selection for every job</h3>
         <p className="screen-summary">
@@ -1618,39 +1903,140 @@ function ProjectPanel({
           repo-relative:{' '}
           <code>{selectedWorkspace?.repoRelativePath ?? '(repository root)'}</code>
         </p>
-      </article>
+        </article>
 
-      <article className="screen-card">
-        <p className="card-kicker">Recent projects</p>
-        <h3>Persisted local workspace history</h3>
-        <div className="job-list">
-          {recentWorkspaces.length === 0 ? (
-            <p className="empty-state">
-              No recent workspaces yet. Opening a canonical root stores it locally for future sessions.
-            </p>
-          ) : (
-            recentWorkspaces.map((workspace) => (
-              <section key={workspace.path} className="job-card">
-                <div className="job-topline">
-                  <div>
-                    <strong>{workspace.repoRelativePath ?? 'repository root'}</strong>
-                    <p className="job-meta">{workspace.path}</p>
+        <article className="screen-card">
+          <p className="card-kicker">Recent projects</p>
+          <h3>Persisted local workspace history</h3>
+          <div className="job-list">
+            {recentWorkspaces.length === 0 ? (
+              <p className="empty-state">
+                No recent workspaces yet. Opening a canonical root stores it locally for future sessions.
+              </p>
+            ) : (
+              recentWorkspaces.map((workspace) => (
+                <section key={workspace.path} className="job-card">
+                  <div className="job-topline">
+                    <div>
+                      <strong>{workspace.repoRelativePath ?? 'repository root'}</strong>
+                      <p className="job-meta">{workspace.path}</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="ghost-button"
+                      onClick={() => void onOpenWorkspace(workspace.path)}
+                    >
+                      Reopen
+                    </button>
                   </div>
+                  <p className="job-meta">last opened: {workspace.openedAtIso}</p>
+                </section>
+              ))
+            )}
+          </div>
+        </article>
+      </section>
+
+      <section className="project-shell">
+        <article className="screen-card project-tree-panel">
+          <p className="card-kicker">Project explorer</p>
+          <h3>Workspace file tree</h3>
+          <p className="screen-summary">
+            The explorer stays inside the selected workspace root and only exposes text files for the editor shell.
+          </p>
+          {workspaceTreeError ? <p className="adapter-error">{workspaceTreeError}</p> : null}
+          <div className="project-tree">
+            {workspaceTree.length === 0 ? (
+              <p className="empty-state">
+                No editable text files are visible under the selected workspace yet.
+              </p>
+            ) : (
+              workspaceTree.map((node) => (
+                <WorkspaceTreeBranch
+                  key={node.relativePath || node.name}
+                  node={node}
+                  activePath={activeEditorPath}
+                  onOpenFile={onOpenEditorFile}
+                />
+              ))
+            )}
+          </div>
+        </article>
+
+        <article className="screen-card editor-shell-panel">
+          <p className="card-kicker">Editor shell</p>
+          <h3>Tabs, dirty state, and safe file actions</h3>
+          <div className="editor-tab-strip">
+            {editorTabs.length === 0 ? (
+              <p className="empty-state">
+                Open a file from the project explorer to start the authoring loop.
+              </p>
+            ) : (
+              editorTabs.map((tab) => (
+                <div
+                  key={tab.relativePath}
+                  className={`editor-tab ${activeEditorTab?.relativePath === tab.relativePath ? 'editor-tab-active' : ''}`}
+                >
                   <button
                     type="button"
-                    className="ghost-button"
-                    onClick={() => void onOpenWorkspace(workspace.path)}
+                    className="editor-tab-select"
+                    onClick={() => onSelectEditorPath(tab.relativePath)}
                   >
-                    Reopen
+                    <span>{tab.title}</span>
+                    {tab.status !== 'clean' ? (
+                      <span className={`status-pill ${tab.status === 'saving' ? 'running' : 'draft'}`}>
+                        {tab.status}
+                      </span>
+                    ) : null}
+                  </button>
+                  <button
+                    type="button"
+                    className="editor-tab-close"
+                    onClick={() => onCloseEditorTab(tab.relativePath)}
+                    aria-label={`Close ${tab.title}`}
+                  >
+                    x
                   </button>
                 </div>
-                <p className="job-meta">last opened: {workspace.openedAtIso}</p>
-              </section>
-            ))
-          )}
-        </div>
-      </article>
-    </section>
+              ))
+            )}
+          </div>
+
+          {activeEditorTab ? (
+            <div className="editor-shell-stack">
+              <div className="field-actions">
+                <button
+                  type="button"
+                  className="action-button"
+                  onClick={() => void onSaveEditorFile(activeEditorTab.relativePath)}
+                  disabled={activeEditorTab.status === 'saving'}
+                >
+                  {activeEditorTab.status === 'saving' ? 'Saving...' : 'Save file'}
+                </button>
+                <button
+                  type="button"
+                  className="ghost-button"
+                  onClick={() => void onReloadEditorFile(activeEditorTab.relativePath)}
+                >
+                  Reload from disk
+                </button>
+              </div>
+              <p className="job-meta">
+                path: <code>{activeEditorTab.absolutePath}</code>
+              </p>
+              <textarea
+                className="editor-textarea"
+                value={activeEditorTab.content}
+                onChange={(event) =>
+                  onUpdateEditorContent(activeEditorTab.relativePath, event.target.value)
+                }
+                spellCheck={false}
+              />
+            </div>
+          ) : null}
+        </article>
+      </section>
+    </div>
   )
 }
 

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -39,6 +39,30 @@ export type WorkspaceSummary = {
   isRepoRoot: boolean
 }
 
+export type WorkspaceTreeNode = {
+  name: string
+  relativePath: string
+  nodeType: 'dir' | 'file'
+  children: WorkspaceTreeNode[]
+}
+
+export type WorkspaceFileRequest = {
+  workspaceRoot: string
+  relativePath: string
+}
+
+export type WorkspaceFileDocument = {
+  relativePath: string
+  absolutePath: string
+  content: string
+}
+
+export type SaveWorkspaceFileRequest = {
+  workspaceRoot: string
+  relativePath: string
+  content: string
+}
+
 export type OverviewDocument = {
   key: string
   title: string
@@ -117,4 +141,16 @@ export async function fetchSpecCatalog() {
 
 export async function fetchSpecDocument(relativePath: string) {
   return invoke<SpecDocumentView>('get_spec_document', { relativePath })
+}
+
+export async function fetchWorkspaceTree(workspaceRoot: string) {
+  return invoke<WorkspaceTreeNode[]>('get_workspace_tree', { workspaceRoot })
+}
+
+export async function fetchWorkspaceFile(request: WorkspaceFileRequest) {
+  return invoke<WorkspaceFileDocument>('get_workspace_file', { request })
+}
+
+export async function saveWorkspaceFile(request: SaveWorkspaceFileRequest) {
+  return invoke<WorkspaceFileDocument>('save_workspace_file_contents', { request })
 }


### PR DESCRIPTION
## Summary
- add a workspace-scoped project explorer and editor shell over safe file tree, read, and write operations
- keep authoring limited to tabs, dirty markers, save, and reload without introducing parser or IDE semantics
- preserve existing workspace-root discipline so file operations cannot escape the selected repository subtree

## Includes
- backend workspace tree and text file read/write commands
- project explorer with nested file tree under the selected workspace
- multi-tab editor shell with dirty markers, save, reload, and close actions

## Excludes
- no compile/check current file actions yet
- no LSP, hover, symbol navigation, or diagnostics parsing
- no hidden package or parser model in the UI

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #18