### PR TITLE
PR-WB-11 feat(workbench): diagnostics model and panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.smc
 !tests/golden/*.smc
 Cargo.lock
+/.semantic-cache/

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -826,6 +826,147 @@
   height: 1.2rem;
 }
 
+.diagnostics-summary-grid,
+.diagnostics-shell {
+  display: grid;
+  gap: 1rem;
+}
+
+.diagnostics-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.diagnostics-shell {
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+}
+
+.diagnostics-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.diagnostics-metric,
+.diagnostic-meta-grid > div,
+.diagnostic-callout {
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.1);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.diagnostics-metric strong {
+  display: block;
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.diagnostics-metric span,
+.diagnostic-meta-label {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #5a6675;
+}
+
+.diagnostics-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 1rem 0 0.85rem;
+}
+
+.diagnostics-filter-button {
+  border: 1px solid rgba(15, 23, 32, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  color: #0f1720;
+  padding: 0.55rem 0.8rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.diagnostics-filter-button span {
+  display: inline-flex;
+  margin-left: 0.35rem;
+  opacity: 0.75;
+}
+
+.diagnostics-filter-button-active {
+  border-color: rgba(32, 190, 167, 0.35);
+  background: rgba(32, 190, 167, 0.14);
+  color: #0a5d52;
+}
+
+.diagnostics-list-panel,
+.diagnostics-detail-panel {
+  min-height: 0;
+}
+
+.diagnostics-groups,
+.diagnostics-group-list,
+.diagnostics-detail-stack {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.diagnostics-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.diagnostics-group-header,
+.diagnostic-card-topline,
+.diagnostic-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.diagnostic-card {
+  display: grid;
+  gap: 0.45rem;
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.diagnostic-card-active {
+  border-color: rgba(32, 190, 167, 0.35);
+  box-shadow: 0 0 0 3px rgba(32, 190, 167, 0.12);
+}
+
+.diagnostic-code {
+  display: inline-flex;
+  width: fit-content;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.55rem;
+  background: rgba(15, 23, 32, 0.08);
+}
+
+.diagnostic-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.diagnostic-meta-grid code {
+  display: block;
+  margin-top: 0.35rem;
+  word-break: break-word;
+}
+
 @media (max-width: 1180px) {
   .workbench-shell {
     grid-template-columns: 1fr;
@@ -839,6 +980,10 @@
   .hero-grid,
   .screen-grid,
   .overview-grid,
+  .diagnostics-summary-grid,
+  .diagnostics-shell,
+  .diagnostics-metrics,
+  .diagnostic-meta-grid,
   .spec-shell,
   .project-shell,
   .spec-document-grid,

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -29,6 +29,13 @@ import {
   type RecentWorkspace,
   type WorkbenchSettings,
 } from './workbench-state'
+import {
+  deriveDiagnosticsFromJobs,
+  diagnosticFamilyLabel,
+  diagnosticFamilyOrder,
+  type DiagnosticFamily,
+  type WorkbenchDiagnostic,
+} from './diagnostics'
 import './App.css'
 
 type ScreenSpec = {
@@ -48,6 +55,7 @@ type JobRecord = {
   status: 'running' | 'success' | 'failed'
   commandLine: string
   cwd: string
+  resolvedCommand: string[]
   durationMs?: number
   exitCode?: number
   stdout: string
@@ -445,6 +453,7 @@ function App() {
           status: 'running',
           commandLine: [action.label, ...action.args].join(' '),
           cwd,
+          resolvedCommand: [],
           stdout: '',
           stderr: '',
         },
@@ -504,6 +513,7 @@ function App() {
                 status: result.success ? 'success' : 'failed',
                 commandLine: result.resolvedCommand.join(' '),
                 cwd: result.cwd,
+                resolvedCommand: result.resolvedCommand,
                 durationMs: result.durationMs,
                 exitCode: result.exitCode,
                 stdout: result.stdout,
@@ -961,6 +971,16 @@ function WorkbenchScreen({
           onSaveEditorFile={onSaveEditorFile}
           onReloadEditorFile={onReloadEditorFile}
           onCloseEditorTab={onCloseEditorTab}
+        />
+      ) : null}
+
+      {route.path === '/diagnostics' ? (
+        <DiagnosticsPanel
+          jobs={jobs}
+          selectedJobId={selectedJobId}
+          selectedWorkspace={selectedWorkspace}
+          onOpenEditorFile={onOpenEditorFile}
+          onSelectJob={onSelectJob}
         />
       ) : null}
 
@@ -1676,6 +1696,72 @@ function compileOutputPath(repoRelativePath: string) {
   return `target/workbench-${stem}.smc`
 }
 
+function severityPillClass(severity: WorkbenchDiagnostic['severity']) {
+  switch (severity) {
+    case 'warning':
+      return 'draft'
+    case 'info':
+      return 'running'
+    default:
+      return 'failed'
+  }
+}
+
+function formatDiagnosticLocation(diagnostic: WorkbenchDiagnostic) {
+  const filePart = diagnostic.filePath ?? 'no file path'
+  if (diagnostic.line !== null && diagnostic.column !== null) {
+    return `${filePart}:${diagnostic.line}:${diagnostic.column}`
+  }
+
+  if (diagnostic.offsetHex) {
+    return `${filePart} @ ${diagnostic.offsetHex}`
+  }
+
+  if (diagnostic.instruction !== null) {
+    return `${filePart} @ instruction ${diagnostic.instruction}`
+  }
+
+  return filePart
+}
+
+function resolveDiagnosticWorkspacePath(
+  filePath: string | null,
+  workspace: WorkspaceSummary,
+) {
+  if (!filePath) {
+    return null
+  }
+
+  const normalizedFilePath = filePath.replace(/\\/g, '/')
+  const normalizedWorkspacePath = workspace.resolvedPath.replace(/\\/g, '/')
+  const normalizedRepoRoot = workspace.repoRoot.replace(/\\/g, '/')
+
+  if (/^[A-Za-z]:\//.test(normalizedFilePath) || normalizedFilePath.startsWith('/')) {
+    if (!normalizedFilePath.toLowerCase().startsWith(normalizedWorkspacePath.toLowerCase())) {
+      return null
+    }
+
+    return normalizedFilePath
+      .slice(normalizedWorkspacePath.length)
+      .replace(/^\/+/, '')
+  }
+
+  const repoRelativePath = normalizedFilePath.startsWith(normalizedRepoRoot)
+    ? normalizedFilePath.slice(normalizedRepoRoot.length).replace(/^\/+/, '')
+    : normalizedFilePath
+
+  if (!workspace.repoRelativePath) {
+    return repoRelativePath
+  }
+
+  const workspacePrefix = workspace.repoRelativePath.replace(/\\/g, '/')
+  if (!repoRelativePath.startsWith(`${workspacePrefix}/`)) {
+    return null
+  }
+
+  return repoRelativePath.slice(workspacePrefix.length + 1)
+}
+
 function renderMarkdown(markdown: string, headings: SpecDocumentHeading[]) {
   const headingAnchors = new Map(headings.map((heading) => [heading.title, heading.anchor]))
   const lines = markdown.split(/\r?\n/)
@@ -2114,6 +2200,280 @@ function ProjectPanel({
           ) : null}
         </article>
       </section>
+    </div>
+  )
+}
+
+function DiagnosticsPanel({
+  jobs,
+  selectedJobId,
+  selectedWorkspace,
+  onOpenEditorFile,
+  onSelectJob,
+}: {
+  jobs: JobRecord[]
+  selectedJobId: string | null
+  selectedWorkspace: WorkspaceSummary | null
+  onOpenEditorFile: (relativePath: string) => Promise<void>
+  onSelectJob: (jobId: string) => void
+}) {
+  const diagnostics = deriveDiagnosticsFromJobs(jobs)
+  const [familyFilter, setFamilyFilter] = useState<DiagnosticFamily | 'all'>('all')
+  const [selectedDiagnosticId, setSelectedDiagnosticId] = useState<string | null>(null)
+
+  const availableFamilies = diagnosticFamilyOrder.filter((family) =>
+    diagnostics.some((diagnostic) => diagnostic.family === family),
+  )
+  const effectiveFamilyFilter =
+    familyFilter !== 'all' && !availableFamilies.includes(familyFilter)
+      ? 'all'
+      : familyFilter
+  const visibleDiagnostics =
+    effectiveFamilyFilter === 'all'
+      ? diagnostics
+      : diagnostics.filter((diagnostic) => diagnostic.family === effectiveFamilyFilter)
+  const effectiveSelectedDiagnosticId =
+    selectedDiagnosticId && visibleDiagnostics.some((entry) => entry.id === selectedDiagnosticId)
+      ? selectedDiagnosticId
+      : visibleDiagnostics[0]?.id ?? null
+  const selectedDiagnostic =
+    visibleDiagnostics.find((diagnostic) => diagnostic.id === effectiveSelectedDiagnosticId) ??
+    visibleDiagnostics[0] ??
+    null
+
+  const diagnosticCounts = diagnosticFamilyOrder
+    .map((family) => ({
+      family,
+      count: diagnostics.filter((diagnostic) => diagnostic.family === family).length,
+    }))
+    .filter((entry) => entry.count > 0)
+
+  const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'error').length
+  const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'warning').length
+  const jobsWithDiagnostics = new Set(diagnostics.map((diagnostic) => diagnostic.jobId)).size
+  const openableRelativePath =
+    selectedDiagnostic && selectedWorkspace
+      ? resolveDiagnosticWorkspacePath(selectedDiagnostic.filePath, selectedWorkspace)
+      : null
+
+  return (
+    <div className="screen-stack">
+      <section className="diagnostics-summary-grid">
+        <article className="screen-card">
+          <p className="card-kicker">Diagnostics summary</p>
+          <h3>Derived from real `smc` / `svm` output</h3>
+          <div className="diagnostics-metrics">
+            <div className="diagnostics-metric">
+              <strong>{diagnostics.length}</strong>
+              <span>Total diagnostics</span>
+            </div>
+            <div className="diagnostics-metric">
+              <strong>{errorCount}</strong>
+              <span>Errors</span>
+            </div>
+            <div className="diagnostics-metric">
+              <strong>{warningCount}</strong>
+              <span>Warnings</span>
+            </div>
+            <div className="diagnostics-metric">
+              <strong>{jobsWithDiagnostics}</strong>
+              <span>Jobs with diagnostics</span>
+            </div>
+          </div>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Family filters</p>
+          <h3>Parse, type, module, verify, runtime</h3>
+          <div className="diagnostics-filter-row">
+            <button
+              type="button"
+              className={`diagnostics-filter-button ${effectiveFamilyFilter === 'all' ? 'diagnostics-filter-button-active' : ''}`}
+              onClick={() => setFamilyFilter('all')}
+            >
+              All
+            </button>
+            {diagnosticCounts.map((entry) => (
+              <button
+                key={entry.family}
+                type="button"
+                className={`diagnostics-filter-button ${effectiveFamilyFilter === entry.family ? 'diagnostics-filter-button-active' : ''}`}
+                onClick={() => setFamilyFilter(entry.family)}
+              >
+                {diagnosticFamilyLabel(entry.family)} <span>{entry.count}</span>
+              </button>
+            ))}
+          </div>
+          <p className="screen-summary">
+            Workbench groups diagnostics from command output, but preserves the original code, line, column, job, and raw message block when those fields exist.
+          </p>
+        </article>
+      </section>
+
+      {visibleDiagnostics.length === 0 ? (
+        <article className="screen-card">
+          <p className="card-kicker">No diagnostics yet</p>
+          <p className="empty-state">
+            Run `smc check`, `smc compile`, `svm run`, or `svm disasm` from the cockpit or current-file actions to populate this panel.
+          </p>
+        </article>
+      ) : (
+        <section className="diagnostics-shell">
+          <article className="screen-card diagnostics-list-panel">
+            <p className="card-kicker">Diagnostics ledger</p>
+            <h3>Grouped by public failure family</h3>
+            <div className="diagnostics-groups">
+              {diagnosticFamilyOrder
+                .filter((family) =>
+                  visibleDiagnostics.some((diagnostic) => diagnostic.family === family),
+                )
+                .map((family) => {
+                  const familyDiagnostics = visibleDiagnostics.filter(
+                    (diagnostic) => diagnostic.family === family,
+                  )
+
+                  return (
+                    <section key={family} className="diagnostics-group">
+                      <div className="diagnostics-group-header">
+                        <h4>{diagnosticFamilyLabel(family)}</h4>
+                        <span className="status-pill stable">{familyDiagnostics.length}</span>
+                      </div>
+                      <div className="diagnostics-group-list">
+                        {familyDiagnostics.map((diagnostic) => (
+                          <button
+                            key={diagnostic.id}
+                            type="button"
+                            className={`diagnostic-card ${selectedDiagnostic?.id === diagnostic.id ? 'diagnostic-card-active' : ''}`}
+                            onClick={() => {
+                              setSelectedDiagnosticId(diagnostic.id)
+                              onSelectJob(diagnostic.jobId)
+                            }}
+                          >
+                            <div className="diagnostic-card-topline">
+                              <span className={`status-pill ${severityPillClass(diagnostic.severity)}`}>
+                                {diagnostic.severity}
+                              </span>
+                              {diagnostic.code ? (
+                                <code className="diagnostic-code">{diagnostic.code}</code>
+                              ) : null}
+                            </div>
+                            <strong>{diagnostic.message}</strong>
+                            <p className="job-meta">{diagnostic.jobLabel}</p>
+                            <p className="job-meta">
+                              {formatDiagnosticLocation(diagnostic)}
+                            </p>
+                          </button>
+                        ))}
+                      </div>
+                    </section>
+                  )
+                })}
+            </div>
+          </article>
+
+          <article className="screen-card diagnostics-detail-panel">
+            <p className="card-kicker">Selected diagnostic</p>
+            {selectedDiagnostic ? (
+              <div className="diagnostics-detail-stack">
+                <div className="diagnostic-detail-header">
+                  <div>
+                    <h3>{selectedDiagnostic.message}</h3>
+                    <p className="job-meta">
+                      {diagnosticFamilyLabel(selectedDiagnostic.family)} from {selectedDiagnostic.jobLabel}
+                    </p>
+                  </div>
+                  <div className="status-cluster">
+                    <span className={`status-pill ${severityPillClass(selectedDiagnostic.severity)}`}>
+                      {selectedDiagnostic.severity}
+                    </span>
+                    {selectedDiagnostic.code ? (
+                      <code className="diagnostic-code">{selectedDiagnostic.code}</code>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="diagnostic-meta-grid">
+                  <div>
+                    <span className="diagnostic-meta-label">Location</span>
+                    <code>{formatDiagnosticLocation(selectedDiagnostic)}</code>
+                  </div>
+                  <div>
+                    <span className="diagnostic-meta-label">Job</span>
+                    <code>{selectedDiagnostic.commandLine}</code>
+                  </div>
+                  <div>
+                    <span className="diagnostic-meta-label">Working directory</span>
+                    <code>{selectedDiagnostic.cwd}</code>
+                  </div>
+                  <div>
+                    <span className="diagnostic-meta-label">Output channel</span>
+                    <code>{selectedDiagnostic.sourceChannel}</code>
+                  </div>
+                  {selectedDiagnostic.functionName ? (
+                    <div>
+                      <span className="diagnostic-meta-label">Function</span>
+                      <code>{selectedDiagnostic.functionName}</code>
+                    </div>
+                  ) : null}
+                  {selectedDiagnostic.offsetHex ? (
+                    <div>
+                      <span className="diagnostic-meta-label">Byte offset</span>
+                      <code>{selectedDiagnostic.offsetHex}</code>
+                    </div>
+                  ) : null}
+                  {selectedDiagnostic.instruction !== null ? (
+                    <div>
+                      <span className="diagnostic-meta-label">Instruction</span>
+                      <code>{selectedDiagnostic.instruction}</code>
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="field-actions">
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    onClick={() => onSelectJob(selectedDiagnostic.jobId)}
+                  >
+                    Focus job in history
+                  </button>
+                  {openableRelativePath ? (
+                    <button
+                      type="button"
+                      className="action-button"
+                      onClick={() => void onOpenEditorFile(openableRelativePath)}
+                    >
+                      Open source file
+                    </button>
+                  ) : null}
+                </div>
+
+                {selectedDiagnostic.helpText ? (
+                  <div className="diagnostic-callout">
+                    <span className="diagnostic-meta-label">Why this error?</span>
+                    <p>{selectedDiagnostic.helpText}</p>
+                  </div>
+                ) : null}
+
+                <div>
+                  <span className="diagnostic-meta-label">Raw diagnostic block</span>
+                  <pre className="terminal-output terminal-output-error">
+                    {selectedDiagnostic.rawBlock}
+                  </pre>
+                </div>
+
+                {selectedJobId === selectedDiagnostic.jobId ? (
+                  <p className="job-meta">
+                    This diagnostic already points at the currently selected job in the cockpit ledger.
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="empty-state">Select a diagnostic to inspect its preserved fields.</p>
+            )}
+          </article>
+        </section>
+      )}
     </div>
   )
 }

--- a/apps/workbench/src/diagnostics.ts
+++ b/apps/workbench/src/diagnostics.ts
@@ -1,0 +1,356 @@
+import type { JobKind } from './workbench-api'
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info'
+
+export type DiagnosticFamily =
+  | 'parse'
+  | 'policy'
+  | 'type'
+  | 'module'
+  | 'verify'
+  | 'runtime'
+  | 'other'
+
+export type DiagnosticSourceJob = {
+  id: string
+  kind: JobKind
+  label: string
+  status: 'running' | 'success' | 'failed'
+  commandLine: string
+  cwd: string
+  resolvedCommand: string[]
+  stdout: string
+  stderr: string
+}
+
+export type WorkbenchDiagnostic = {
+  id: string
+  jobId: string
+  jobKind: JobKind
+  jobLabel: string
+  family: DiagnosticFamily
+  severity: DiagnosticSeverity
+  code: string | null
+  message: string
+  filePath: string | null
+  line: number | null
+  column: number | null
+  functionName: string | null
+  instruction: number | null
+  offsetHex: string | null
+  helpText: string | null
+  rawBlock: string
+  sourceChannel: 'stdout' | 'stderr'
+  commandLine: string
+  cwd: string
+}
+
+const sourceDiagnosticPattern =
+  /^(Error|Warning)\s+\[([A-Z]\d{4})\]:\s*(.*?)(?:\s+at line\s+(\d+):(\d+))?$/i
+const verifyDiagnosticPattern =
+  /^verify error \[([^\]]+)\](?: in '([^']+)')?(?: @(0x[0-9a-fA-F]+))?:\s*(.*)$/i
+const runtimeDiagnosticPattern =
+  /^runtime error(?: at instruction (\d+))?:\s*(.*)$/i
+const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g')
+
+export const diagnosticFamilyOrder: DiagnosticFamily[] = [
+  'parse',
+  'policy',
+  'type',
+  'module',
+  'verify',
+  'runtime',
+  'other',
+]
+
+export function deriveDiagnosticsFromJobs(
+  jobs: DiagnosticSourceJob[],
+): WorkbenchDiagnostic[] {
+  const diagnostics: WorkbenchDiagnostic[] = []
+
+  jobs.forEach((job) => {
+    diagnostics.push(...parseChannel(job, 'stderr', job.stderr))
+    diagnostics.push(...parseChannel(job, 'stdout', job.stdout))
+  })
+
+  return diagnostics
+}
+
+export function diagnosticFamilyLabel(family: DiagnosticFamily) {
+  switch (family) {
+    case 'parse':
+      return 'Parse'
+    case 'policy':
+      return 'Policy'
+    case 'type':
+      return 'Type'
+    case 'module':
+      return 'Module'
+    case 'verify':
+      return 'Verify'
+    case 'runtime':
+      return 'Runtime'
+    default:
+      return 'Other'
+  }
+}
+
+function parseChannel(
+  job: DiagnosticSourceJob,
+  sourceChannel: 'stdout' | 'stderr',
+  rawText: string,
+): WorkbenchDiagnostic[] {
+  const text = stripAnsi(rawText)
+  const lines = text.split(/\r?\n/)
+  const diagnostics: WorkbenchDiagnostic[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.trimEnd() ?? ''
+    const trimmed = line.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    const sourceMatch = sourceDiagnosticPattern.exec(trimmed)
+    if (sourceMatch) {
+      const block = collectDiagnosticBlock(lines, index)
+      index = block.nextIndex - 1
+      const code = sourceMatch[2].toUpperCase()
+      const message = sourceMatch[3].trim()
+      diagnostics.push({
+        id: `${job.id}-${sourceChannel}-${index}`,
+        jobId: job.id,
+        jobKind: job.kind,
+        jobLabel: job.label,
+        family: classifySourceFamily(code, message),
+        severity:
+          sourceMatch[1].toLowerCase() === 'warning' ? 'warning' : 'error',
+        code,
+        message,
+        filePath: inferJobPrimaryPath(job),
+        line: parseNumber(sourceMatch[4]),
+        column: parseNumber(sourceMatch[5]),
+        functionName: null,
+        instruction: null,
+        offsetHex: null,
+        helpText: block.helpText,
+        rawBlock: block.rawBlock,
+        sourceChannel,
+        commandLine: job.commandLine,
+        cwd: job.cwd,
+      })
+      continue
+    }
+
+    const verifyMatch = verifyDiagnosticPattern.exec(trimmed)
+    if (verifyMatch) {
+      diagnostics.push({
+        id: `${job.id}-${sourceChannel}-${index}`,
+        jobId: job.id,
+        jobKind: job.kind,
+        jobLabel: job.label,
+        family: 'verify',
+        severity: 'error',
+        code: verifyMatch[1].trim(),
+        message: verifyMatch[4].trim(),
+        filePath: inferJobPrimaryPath(job),
+        line: null,
+        column: null,
+        functionName: verifyMatch[2] ?? null,
+        instruction: null,
+        offsetHex: verifyMatch[3] ?? null,
+        helpText: null,
+        rawBlock: trimmed,
+        sourceChannel,
+        commandLine: job.commandLine,
+        cwd: job.cwd,
+      })
+      continue
+    }
+
+    const runtimeMatch = runtimeDiagnosticPattern.exec(trimmed)
+    if (runtimeMatch) {
+      diagnostics.push({
+        id: `${job.id}-${sourceChannel}-${index}`,
+        jobId: job.id,
+        jobKind: job.kind,
+        jobLabel: job.label,
+        family: 'runtime',
+        severity: 'error',
+        code: null,
+        message: runtimeMatch[2].trim(),
+        filePath: inferJobPrimaryPath(job),
+        line: null,
+        column: null,
+        functionName: null,
+        instruction: parseNumber(runtimeMatch[1]),
+        offsetHex: null,
+        helpText: null,
+        rawBlock: trimmed,
+        sourceChannel,
+        commandLine: job.commandLine,
+        cwd: job.cwd,
+      })
+      continue
+    }
+
+    if (job.status === 'failed' && shouldPromoteLine(job, trimmed)) {
+      diagnostics.push({
+        id: `${job.id}-${sourceChannel}-${index}`,
+        jobId: job.id,
+        jobKind: job.kind,
+        jobLabel: job.label,
+        family: job.kind === 'svm' ? 'runtime' : 'other',
+        severity: 'error',
+        code: extractInlineCode(trimmed),
+        message: trimmed,
+        filePath: inferJobPrimaryPath(job),
+        line: null,
+        column: null,
+        functionName: null,
+        instruction: null,
+        offsetHex: null,
+        helpText: null,
+        rawBlock: trimmed,
+        sourceChannel,
+        commandLine: job.commandLine,
+        cwd: job.cwd,
+      })
+    }
+  }
+
+  return diagnostics
+}
+
+function collectDiagnosticBlock(lines: string[], startIndex: number) {
+  const blockLines: string[] = []
+  let helpText: string | null = null
+  let index = startIndex
+
+  while (index < lines.length) {
+    const line = lines[index] ?? ''
+    const trimmed = line.trim()
+
+    if (index !== startIndex && isDiagnosticStart(trimmed)) {
+      break
+    }
+
+    if (!trimmed) {
+      blockLines.push(line)
+      index += 1
+      break
+    }
+
+    if (trimmed.startsWith('help:')) {
+      helpText = trimmed.slice('help:'.length).trim()
+    }
+
+    blockLines.push(line)
+    index += 1
+  }
+
+  return {
+    rawBlock: blockLines.join('\n').trimEnd(),
+    helpText,
+    nextIndex: index,
+  }
+}
+
+function isDiagnosticStart(line: string) {
+  return (
+    sourceDiagnosticPattern.test(line) ||
+    verifyDiagnosticPattern.test(line) ||
+    runtimeDiagnosticPattern.test(line)
+  )
+}
+
+function shouldPromoteLine(job: DiagnosticSourceJob, line: string) {
+  if (!line) {
+    return false
+  }
+
+  if (job.kind === 'cargo' || job.kind === 'release_bundle_verify') {
+    return false
+  }
+
+  return !line.startsWith('help:')
+}
+
+function classifySourceFamily(code: string, message: string): DiagnosticFamily {
+  const normalizedMessage = message.toLowerCase()
+
+  if (normalizedMessage.startsWith('policy violation:')) {
+    return 'policy'
+  }
+
+  if (code >= 'E0238' && code <= 'E0245') {
+    return 'module'
+  }
+
+  if (
+    normalizedMessage.includes('unknown variable') ||
+    normalizedMessage.includes('unknown function') ||
+    normalizedMessage.includes('argument count mismatch') ||
+    normalizedMessage.includes('argument type mismatch') ||
+    normalizedMessage.includes('let-binding type mismatch') ||
+    normalizedMessage.includes('return type mismatch') ||
+    normalizedMessage.includes('invalid `if` condition') ||
+    normalizedMessage.includes('invalid `match`') ||
+    normalizedMessage.includes('unsupported operator') ||
+    normalizedMessage.includes('main must have signature')
+  ) {
+    return 'type'
+  }
+
+  return 'parse'
+}
+
+function inferJobPrimaryPath(job: DiagnosticSourceJob) {
+  const args = job.resolvedCommand.slice(1)
+
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index]
+    const previous = args[index - 1]
+    if (!value || value === '--') {
+      continue
+    }
+
+    if (
+      previous === '-o' ||
+      previous === '--bin' ||
+      previous === '--manifest-path' ||
+      previous === '-ManifestPath' ||
+      previous === '-File'
+    ) {
+      continue
+    }
+
+    if (job.kind === 'smc' && value.toLowerCase().endsWith('.sm')) {
+      return value
+    }
+
+    if (job.kind === 'svm' && value.toLowerCase().endsWith('.smc')) {
+      return value
+    }
+  }
+
+  return null
+}
+
+function extractInlineCode(line: string) {
+  const match = /\b([A-Z]\d{4})\b/.exec(line)
+  return match?.[1] ?? null
+}
+
+function parseNumber(value?: string | null) {
+  if (!value) {
+    return null
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function stripAnsi(text: string) {
+  return text.replace(ansiEscapePattern, '')
+}


### PR DESCRIPTION
## Summary
- add a diagnostics model derived from real `smc` and `svm` output without inventing a second compiler protocol
- group diagnostics by parse, policy, type, module, verify, runtime, and fallback families while preserving code, severity, file, range, and raw blocks when present
- add a diagnostics route with family filters, detail view, job focus, and safe source-file open from the selected workspace

## Includes
- `apps/workbench/src/diagnostics.ts` parser and model for job-derived diagnostics
- diagnostics panel in the Workbench UI with grouped ledger and detail inspector
- `.semantic-cache/` ignored in git so current-file actions do not dirty the repo locally

## Excludes
- no spec/error-code deep links yet
- no inline editor annotations yet
- no new backend diagnostics protocol beyond existing process output

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #20
