### PR TITLE
PR-WB-13 feat(workbench): formatter integration via smc fmt

### DIFF
--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -161,7 +161,7 @@ const routeSpecs: ScreenSpec[] = [
     stable: [
       'Workspace resolver over canonical repository paths',
       'Recent projects list and default workspace persistence',
-      'Workspace file tree, read/write text editor tabs, and current-file compile/check actions',
+      'Workspace file tree, read/write text editor tabs, current-file compile/check, and formatter actions through smc fmt',
     ],
     next: [
       'Route current-file command results into richer diagnostics views',
@@ -246,7 +246,7 @@ const routeSpecs: ScreenSpec[] = [
     stable: [
       'Settings route with persisted local preferences',
       'Scope guard against hidden runtime or language toggles',
-      'Formatter and shell preference toggles',
+      'Formatter and shell preference toggles wired only to canonical public surfaces',
     ],
     next: [
       'Route settings into later formatter and command surfaces',
@@ -438,7 +438,7 @@ function App() {
     })()
   }, [adapterContract, selectedWorkspace, settings.defaultWorkspacePath])
 
-  async function runJobAction(action: JobActionSpec) {
+  async function runJobAction(action: JobActionSpec): Promise<JobResult | null> {
     const id = crypto.randomUUID()
     const cwd =
       action.cwdMode === 'repo'
@@ -472,6 +472,7 @@ function App() {
       })
       setAdapterError(null)
       commitJob(id, action.label, result)
+      return result
     } catch (error) {
       const message = String(error)
       startTransition(() =>
@@ -488,6 +489,7 @@ function App() {
         ),
       )
       setAdapterError(message)
+      return null
     } finally {
       setActiveJob(null)
     }
@@ -612,12 +614,29 @@ function App() {
         relativePath,
         content: tab.content,
       })
+      let nextDocument = document
+
+      if (settings.formatOnSave && isSemanticSource(relativePath)) {
+        const repoRelativePath = toRepoRelativePath(relativePath, selectedWorkspace)
+        const formatResult = await runJobAction({
+          kind: 'smc',
+          label: `Format ${document.relativePath}`,
+          args: ['fmt', repoRelativePath],
+          notes: 'Format the current Semantic source file through the canonical smc fmt surface.',
+          cwdMode: 'repo',
+        })
+
+        if (formatResult?.success) {
+          nextDocument = await fetchWorkspaceFile({
+            workspaceRoot: selectedWorkspace.resolvedPath,
+            relativePath,
+          })
+        }
+      }
 
       setEditorTabs((current) =>
         current.map((entry) =>
-          entry.relativePath === relativePath
-            ? createEditorTab(document)
-            : entry,
+          entry.relativePath === relativePath ? createEditorTab(nextDocument) : entry,
         ),
       )
       setWorkspaceTreeError(null)
@@ -867,7 +886,7 @@ function WorkbenchScreen({
   jobs: JobRecord[]
   selectedJobId: string | null
   activeJob: JobKind | null
-  onRunAction: (action: JobActionSpec) => Promise<void>
+  onRunAction: (action: JobActionSpec) => Promise<JobResult | null>
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
   onSpecSearchChange: (value: string) => void
   onSelectSpecPath: (value: string) => void
@@ -963,6 +982,7 @@ function WorkbenchScreen({
           workspaceInput={workspaceInput}
           workspaceError={workspaceError}
           recentWorkspaces={recentWorkspaces}
+          settings={settings}
           onWorkspaceInputChange={onWorkspaceInputChange}
           onOpenWorkspace={onOpenWorkspace}
           onOpenEditorFile={onOpenEditorFile}
@@ -1017,7 +1037,7 @@ function CommandBusPanel({
   jobs: JobRecord[]
   selectedJobId: string | null
   activeJob: JobKind | null
-  onRunAction: (action: JobActionSpec) => Promise<void>
+  onRunAction: (action: JobActionSpec) => Promise<JobResult | null>
   onRunProbe: (spec: AdapterJobSpec) => Promise<void>
   onSelectJob: (jobId: string) => void
   selectedWorkspace: WorkspaceSummary | null
@@ -1908,6 +1928,7 @@ function ProjectPanel({
   workspaceInput,
   workspaceError,
   recentWorkspaces,
+  settings,
   onWorkspaceInputChange,
   onOpenWorkspace,
   onOpenEditorFile,
@@ -1927,12 +1948,13 @@ function ProjectPanel({
   workspaceInput: string
   workspaceError: string | null
   recentWorkspaces: RecentWorkspace[]
+  settings: WorkbenchSettings
   onWorkspaceInputChange: (value: string) => void
   onOpenWorkspace: (candidate: string, persist?: boolean) => Promise<void>
   onOpenEditorFile: (relativePath: string) => Promise<void>
   onSelectEditorPath: (relativePath: string | null) => void
   onUpdateEditorContent: (relativePath: string, content: string) => void
-  onRunAction: (action: JobActionSpec) => Promise<void>
+  onRunAction: (action: JobActionSpec) => Promise<JobResult | null>
   onSaveEditorFile: (relativePath: string) => Promise<void>
   onReloadEditorFile: (relativePath: string) => Promise<void>
   onCloseEditorTab: (relativePath: string) => void
@@ -1945,6 +1967,10 @@ function ProjectPanel({
       : null
   const canRunSemanticFileAction =
     !!activeEditorTab && !!activeEditorRepoPath && isSemanticSource(activeEditorTab.relativePath)
+  const workspaceFormatTarget = selectedWorkspace?.repoRelativePath ?? '.'
+  const hasDirtySemanticTabs = editorTabs.some(
+    (tab) => isSemanticSource(tab.relativePath) && tab.status !== 'clean',
+  )
 
   async function runCurrentFileAction(mode: 'check' | 'compile') {
     if (!activeEditorTab || !selectedWorkspace || !adapterContract || !activeEditorRepoPath) {
@@ -1973,6 +1999,64 @@ function ProjectPanel({
           : 'Compile the active .sm file through the canonical smc compile surface.',
       cwdMode: 'repo',
     })
+  }
+
+  async function runFormatterAction(mode: 'file' | 'workspace' | 'check') {
+    if (!selectedWorkspace || !adapterContract) {
+      return
+    }
+
+    if (mode === 'file') {
+      if (!activeEditorTab || !activeEditorRepoPath || !canRunSemanticFileAction) {
+        return
+      }
+
+      if (activeEditorTab.status !== 'clean') {
+        await onSaveEditorFile(activeEditorTab.relativePath)
+      }
+
+      const result = await onRunAction({
+        kind: 'smc',
+        label: `Format ${activeEditorTab.title}`,
+        args: ['fmt', activeEditorRepoPath],
+        notes: 'Format the active Semantic source file through the canonical smc fmt surface.',
+        cwdMode: 'repo',
+      })
+
+      if (result?.success) {
+        await onReloadEditorFile(activeEditorTab.relativePath)
+      }
+      return
+    }
+
+    if (hasDirtySemanticTabs) {
+      return
+    }
+
+    const result = await onRunAction({
+      kind: 'smc',
+      label:
+        mode === 'check'
+          ? `Format check ${selectedWorkspace.repoRelativePath ?? 'repository root'}`
+          : `Format ${selectedWorkspace.repoRelativePath ?? 'repository root'}`,
+      args:
+        mode === 'check'
+          ? ['fmt', '--check', workspaceFormatTarget]
+          : ['fmt', workspaceFormatTarget],
+      notes:
+        mode === 'check'
+          ? 'Run canonical formatter check for the selected workspace.'
+          : 'Format all Semantic source files under the selected workspace through smc fmt.',
+      cwdMode: 'repo',
+    })
+
+    if (mode === 'workspace' && result?.success) {
+      for (const tab of editorTabs) {
+        if (tab.status === 'clean' && isSemanticSource(tab.relativePath)) {
+          await onReloadEditorFile(tab.relativePath)
+        }
+      }
+    }
   }
 
   return (
@@ -2164,6 +2248,30 @@ function ProjectPanel({
                 <button
                   type="button"
                   className="ghost-button"
+                  onClick={() => void runFormatterAction('file')}
+                  disabled={!canRunSemanticFileAction || activeEditorTab.status === 'saving'}
+                >
+                  Format file
+                </button>
+                <button
+                  type="button"
+                  className="ghost-button"
+                  onClick={() => void runFormatterAction('workspace')}
+                  disabled={!selectedWorkspace || hasDirtySemanticTabs}
+                >
+                  Format workspace
+                </button>
+                <button
+                  type="button"
+                  className="ghost-button"
+                  onClick={() => void runFormatterAction('check')}
+                  disabled={!selectedWorkspace || hasDirtySemanticTabs}
+                >
+                  Format check
+                </button>
+                <button
+                  type="button"
+                  className="ghost-button"
                   onClick={() => void runCurrentFileAction('check')}
                   disabled={!canRunSemanticFileAction || activeEditorTab.status === 'saving'}
                 >
@@ -2185,9 +2293,19 @@ function ProjectPanel({
                 repo path:{' '}
                 <code>{activeEditorRepoPath ?? 'not a repository-scoped semantic source'}</code>
               </p>
+              <p className="job-meta">
+                formatter surface:{' '}
+                <span className="status-pill draft">smc fmt</span>{' '}
+                {settings.formatOnSave ? 'with format-on-save enabled' : 'format-on-save disabled'}
+              </p>
               {!isSemanticSource(activeEditorTab.relativePath) ? (
                 <p className="empty-state">
-                  Current-file compile and check are only enabled for `.sm` source files.
+                  Current-file compile, check, and format actions are only enabled for `.sm` source files.
+                </p>
+              ) : null}
+              {hasDirtySemanticTabs ? (
+                <p className="empty-state">
+                  Workspace format actions stay disabled while Semantic source tabs are dirty, so the formatter only runs against saved repository state.
                 </p>
               ) : null}
               <textarea
@@ -2542,7 +2660,7 @@ function SettingsPanel({
           <label className="toggle-row toggle-row-interactive">
             <span>
               <strong>Format on save</strong>
-              <p className="job-meta">Preference only. Formatter integration arrives in `WB-13`.</p>
+              <p className="job-meta">Uses the canonical `smc fmt` surface after saving `.sm` files.</p>
             </span>
             <input
               type="checkbox"

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -1,4 +1,5 @@
 use ton618_core::diagnostics::diagnostic_catalog;
+use crate::{format_path, FormatterMode};
 use sm_emit::{
     compile_program_to_semcode, compile_program_to_semcode_with_options_debug,
     CompileProfile, OptLevel,
@@ -50,6 +51,7 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
         "check" => cmd_check(&args[1..]),
         "lint" => cmd_lint(&args[1..]),
         "watch" => cmd_watch(&args[1..]),
+        "fmt" => cmd_fmt(&args[1..]),
         "dump-ast" => cmd_dump_ast(&args[1..]),
         "dump-ir" => cmd_dump_ir(&args[1..]),
         "dump-bytecode" => cmd_dump_bytecode(&args[1..]),
@@ -518,6 +520,79 @@ fn cmd_watch(args: &[String]) -> Result<(), String> {
         }
         thread::sleep(Duration::from_millis(600));
     }
+}
+
+fn cmd_fmt(args: &[String]) -> Result<(), String> {
+    if args.is_empty() {
+        return Err("usage: smc fmt [--check] <path>".to_string());
+    }
+
+    let mut check = false;
+    let mut target: Option<&str> = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--check" => check = true,
+            value if value.starts_with('-') => {
+                return Err(format!("unknown flag '{}'", value));
+            }
+            value => {
+                if target.is_some() {
+                    return Err("usage: smc fmt [--check] <path>".to_string());
+                }
+                target = Some(value);
+            }
+        }
+        i += 1;
+    }
+
+    let target = target.ok_or_else(|| "usage: smc fmt [--check] <path>".to_string())?;
+    let target_path = Path::new(target);
+    let mode = if check {
+        FormatterMode::Check
+    } else {
+        FormatterMode::Write
+    };
+    let summary = format_path(target_path, mode)?;
+    let display = target_path.display();
+
+    if check {
+        if summary.files_changed == 0 {
+            println!(
+                "format check passed: '{}' ({} file(s) scanned)",
+                display, summary.files_scanned
+            );
+            return Ok(());
+        }
+
+        let changed = summary
+            .changed_paths
+            .iter()
+            .map(|path| format!("  {}", path.display()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(format!(
+            "format check failed: {} file(s) need formatting under '{}'\n{}",
+            summary.files_changed, display, changed
+        ));
+    }
+
+    if summary.files_changed == 0 {
+        println!(
+            "already formatted: '{}' ({} file(s) scanned)",
+            display, summary.files_scanned
+        );
+    } else {
+        println!(
+            "formatted '{}' ({} file(s) changed out of {})",
+            display, summary.files_changed, summary.files_scanned
+        );
+        for path in summary.changed_paths {
+            println!("formatted: {}", path.display());
+        }
+    }
+
+    Ok(())
 }
 
 fn cmd_lint(args: &[String]) -> Result<(), String> {
@@ -2203,6 +2278,7 @@ fn usage() -> String {
         "  smc check <input.sm> [--no-cache] [--trace-cache] [--metrics] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc watch <input.sm> [--metrics] [--color auto|always|never]",
+        "  smc fmt [--check] <path>",
         "  smc dump-ast <input.sm>",
         "  smc dump-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
         "  smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",

--- a/crates/smc-cli/src/formatter.rs
+++ b/crates/smc-cli/src/formatter.rs
@@ -1,0 +1,177 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FormatterMode {
+    Write,
+    Check,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormatterSummary {
+    pub files_scanned: usize,
+    pub files_changed: usize,
+    pub changed_paths: Vec<PathBuf>,
+}
+
+pub fn format_path(path: &Path, mode: FormatterMode) -> Result<FormatterSummary, String> {
+    let mut files = Vec::new();
+    collect_semantic_files(path, &mut files)?;
+
+    if files.is_empty() {
+        return Err(format!(
+            "no Semantic source files found under '{}'",
+            path.display()
+        ));
+    }
+
+    let mut changed_paths = Vec::new();
+
+    for file in &files {
+        let original = fs::read_to_string(file)
+            .map_err(|e| format!("failed to read '{}': {}", file.display(), e))?;
+        let formatted = format_source_text(&original);
+        if formatted != original {
+            if mode == FormatterMode::Write {
+                fs::write(file, formatted.as_bytes())
+                    .map_err(|e| format!("failed to write '{}': {}", file.display(), e))?;
+            }
+            changed_paths.push(file.to_path_buf());
+        }
+    }
+
+    Ok(FormatterSummary {
+        files_scanned: files.len(),
+        files_changed: changed_paths.len(),
+        changed_paths,
+    })
+}
+
+pub fn format_source_text(input: &str) -> String {
+    let normalized = input.replace("\r\n", "\n").replace('\r', "\n");
+    let mut lines: Vec<String> = normalized
+        .split('\n')
+        .map(|line| trim_trailing_whitespace(line).to_string())
+        .collect();
+
+    while lines.last().is_some_and(|line| line.is_empty()) {
+        lines.pop();
+    }
+
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", lines.join("\n"))
+    }
+}
+
+fn collect_semantic_files(path: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    if path.is_file() {
+        if is_semantic_source(path) {
+            out.push(path.to_path_buf());
+        }
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(path)
+        .map_err(|e| format!("failed to read directory '{}': {}", path.display(), e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("failed to read directory entry: {}", e))?;
+        let entry_path = entry.path();
+        if entry_path.is_dir() {
+            if should_skip_dir(&entry_path) {
+                continue;
+            }
+            collect_semantic_files(&entry_path, out)?;
+        } else if is_semantic_source(&entry_path) {
+            out.push(entry_path);
+        }
+    }
+
+    out.sort();
+    Ok(())
+}
+
+fn is_semantic_source(path: &Path) -> bool {
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.eq_ignore_ascii_case("sm"))
+        .unwrap_or(false)
+}
+
+fn should_skip_dir(path: &Path) -> bool {
+    let name = path.file_name().and_then(|value| value.to_str()).unwrap_or_default();
+    matches!(
+        name,
+        ".git" | "target" | "node_modules" | "dist" | ".semantic-cache"
+    )
+}
+
+fn trim_trailing_whitespace(line: &str) -> &str {
+    line.trim_end_matches([' ', '\t'])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn mk_temp_dir(prefix: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "{}_{}_{}",
+            prefix,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&base).expect("mkdir");
+        base
+    }
+
+    #[test]
+    fn format_source_text_normalizes_whitespace_and_final_newline() {
+        let input = "fn main() {    \r\n    return;\t\r\n}\r\n\r\n";
+        let got = format_source_text(input);
+        assert_eq!(got, "fn main() {\n    return;\n}\n");
+    }
+
+    #[test]
+    fn format_path_check_reports_changes_without_writing() {
+        let dir = mk_temp_dir("smc_fmt_check");
+        let file = dir.join("main.sm");
+        fs::write(&file, "fn main() {  \n    return;\n}\n\n").expect("write");
+
+        let summary = format_path(&file, FormatterMode::Check).expect("check");
+        assert_eq!(summary.files_scanned, 1);
+        assert_eq!(summary.files_changed, 1);
+        assert_eq!(
+            fs::read_to_string(&file).expect("read"),
+            "fn main() {  \n    return;\n}\n\n"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn format_path_write_updates_recursive_tree() {
+        let dir = mk_temp_dir("smc_fmt_write");
+        let nested = dir.join("nested");
+        fs::create_dir_all(&nested).expect("nested");
+        let file = nested.join("main.sm");
+        fs::write(&file, "fn main() {  \n    return;\n}\n\n").expect("write");
+        fs::write(nested.join("note.txt"), "keep me").expect("write txt");
+
+        let summary = format_path(&dir, FormatterMode::Write).expect("write");
+        assert_eq!(summary.files_scanned, 1);
+        assert_eq!(summary.files_changed, 1);
+        assert_eq!(
+            fs::read_to_string(&file).expect("read"),
+            "fn main() {\n    return;\n}\n"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "std")]
 mod app;
+#[cfg(feature = "std")]
+mod formatter;
 
 #[cfg(feature = "std")]
 use ton618_core::diagnostics::diagnostic_catalog;
@@ -21,6 +23,8 @@ pub struct CliPipeline;
 
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
+#[cfg(feature = "std")]
+pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 
 #[cfg(feature = "std")]
 struct CliFsProvider;

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -3,9 +3,10 @@ source: crates/smc-cli/src/lib.rs
 pub struct CliPipeline;
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
+#[cfg(feature = "std")]
+pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 pub fn compile_source(
 pub fn build_ir(
 pub fn semantic_check_source(src: &str) -> Result<SemanticReport, String> {
 pub fn semantic_check_file(path: &Path) -> Result<SemanticReport, String> {
 pub fn explain(code: &str) -> Option<&'static str> {
-


### PR DESCRIPTION
## Summary\n- add a canonical smc fmt / smc fmt --check surface in smc-cli\n- wire Workbench Format file, Format workspace, Format check, and ormat-on-save through that public CLI path\n- update the public API snapshot for the intentional smc-cli formatter exports\n\n## Guardrails\n- Workbench does not own formatting logic; it only orchestrates smc fmt\n- no private crate internals are called from the UI\n- formatter scope is intentionally minimal and deterministic for this slice\n\n## Validation\n- cargo test -p smc-cli\n- 
pm run lint\n- 
pm run build\n- cargo check --manifest-path src-tauri/Cargo.toml\n- cargo tauri build --debug --no-bundle\n- cargo test --workspace\n- end-to-end smc fmt smoke on a temporary .sm file (--check fail -> mt write -> --check pass)\n\nRefs #22