### PR TITLE
PR-WB-16 feat(workbench): release console

### DIFF
--- a/apps/workbench/src-tauri/src/snapshot.rs
+++ b/apps/workbench/src-tauri/src/snapshot.rs
@@ -1,5 +1,5 @@
 use crate::adapter::repo_root;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -28,8 +28,47 @@ pub struct OverviewSnapshot {
   pub baseline_tag_points_at_head: bool,
   pub baseline_manifest_path: String,
   pub baseline_manifest_exists: bool,
+  pub release_manifest: Option<ReleaseBundleManifest>,
+  pub asset_smoke: Option<AssetSmokeSnapshot>,
   pub release_docs: Vec<OverviewDocument>,
   pub known_limits: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseBundleManifest {
+  pub generated_at: String,
+  pub documentation_bundle: Vec<String>,
+  pub validation_tests: Vec<String>,
+  pub snapshot_directories: Vec<String>,
+  pub current_scope: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetSmokeSnapshot {
+  pub validated_tag: Option<String>,
+  pub validated_assets: Vec<String>,
+  pub scenarios: Vec<AssetSmokeScenario>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetSmokeScenario {
+  pub scenario: String,
+  pub source: String,
+  pub validation: String,
+  pub expected_signal: String,
+  pub current_result: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseBundleManifestFile {
+  generated_at: String,
+  documentation_bundle: Vec<String>,
+  validation_tests: Vec<String>,
+  snapshot_directories: Vec<String>,
+  current_scope: String,
 }
 
 pub fn read_overview_snapshot() -> Result<OverviewSnapshot, String> {
@@ -51,6 +90,11 @@ pub fn read_overview_snapshot() -> Result<OverviewSnapshot, String> {
 
   let readiness_path = repo_root.join("docs").join("roadmap").join("v1_readiness.md");
   let readiness_body = read_markdown(&readiness_path)?;
+  let asset_smoke_path = repo_root
+    .join("docs")
+    .join("roadmap")
+    .join("release_asset_smoke_matrix.md");
+  let asset_smoke_body = read_markdown(&asset_smoke_path)?;
 
   Ok(OverviewSnapshot {
     repo_root: repo_root.to_string_lossy().into_owned(),
@@ -62,6 +106,8 @@ pub fn read_overview_snapshot() -> Result<OverviewSnapshot, String> {
     baseline_tag_points_at_head,
     baseline_manifest_path: baseline_manifest.to_string_lossy().into_owned(),
     baseline_manifest_exists: baseline_manifest.exists(),
+    release_manifest: read_release_manifest(&baseline_manifest).ok(),
+    asset_smoke: parse_asset_smoke(&asset_smoke_body),
     release_docs: vec![
       read_overview_document(&repo_root, "readiness", "docs/roadmap/v1_readiness.md", None)?,
       read_overview_document(
@@ -90,6 +136,21 @@ pub fn read_overview_snapshot() -> Result<OverviewSnapshot, String> {
       )?,
     ],
     known_limits: extract_section_bullets(&readiness_body, "Current Known Limits"),
+  })
+}
+
+fn read_release_manifest(path: &Path) -> Result<ReleaseBundleManifest, String> {
+  let text = fs::read_to_string(path)
+    .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+  let manifest: ReleaseBundleManifestFile = serde_json::from_str(&text)
+    .map_err(|error| format!("failed to parse '{}': {error}", path.display()))?;
+
+  Ok(ReleaseBundleManifest {
+    generated_at: manifest.generated_at,
+    documentation_bundle: manifest.documentation_bundle,
+    validation_tests: manifest.validation_tests,
+    snapshot_directories: manifest.snapshot_directories,
+    current_scope: manifest.current_scope,
   })
 }
 
@@ -176,6 +237,78 @@ fn extract_section_bullets(markdown: &str, heading: &str) -> Vec<String> {
 
 fn first_bullet_in_section(markdown: &str, heading: &str) -> Option<String> {
   extract_section_bullets(markdown, heading).into_iter().next()
+}
+
+fn parse_asset_smoke(markdown: &str) -> Option<AssetSmokeSnapshot> {
+  let validated_assets = extract_section_bullets(markdown, "Validated Assets");
+  let scenarios = extract_markdown_table(markdown, "Current Smoke Matrix")
+    .into_iter()
+    .filter_map(|row| {
+      if row.len() < 5 {
+        return None;
+      }
+
+      Some(AssetSmokeScenario {
+        scenario: row[0].clone(),
+        source: row[1].clone(),
+        validation: row[2].clone(),
+        expected_signal: row[3].clone(),
+        current_result: row[4].clone(),
+      })
+    })
+    .collect::<Vec<_>>();
+
+  if validated_assets.is_empty() && scenarios.is_empty() {
+    return None;
+  }
+
+  Some(AssetSmokeSnapshot {
+    validated_tag: first_bullet_in_section(markdown, "Current Validated Tag"),
+    validated_assets,
+    scenarios,
+  })
+}
+
+fn extract_markdown_table(markdown: &str, heading: &str) -> Vec<Vec<String>> {
+  let mut in_section = false;
+  let mut rows = Vec::new();
+
+  for line in markdown.lines() {
+    if let Some(title) = line.strip_prefix("## ") {
+      if in_section {
+        break;
+      }
+      in_section = title.trim() == heading;
+      continue;
+    }
+
+    if !in_section {
+      continue;
+    }
+
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') {
+      continue;
+    }
+
+    let cells = trimmed
+      .trim_matches('|')
+      .split('|')
+      .map(|cell| cell.trim().to_owned())
+      .collect::<Vec<_>>();
+
+    if cells.iter().all(|cell| cell.chars().all(|ch| ch == '-' || ch == ':' || ch == ' ')) {
+      continue;
+    }
+
+    rows.push(cells);
+  }
+
+  if rows.len() <= 1 {
+    return Vec::new();
+  }
+
+  rows.into_iter().skip(1).collect()
 }
 
 fn relative_repo_path(repo_root: &Path, relative_path: &str) -> PathBuf {

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -1070,6 +1070,33 @@
   font: 0.88rem/1.45 "Cascadia Code", "Fira Code", Consolas, monospace;
 }
 
+.release-console-grid,
+.release-gate-list,
+.release-checklist,
+.smoke-scenario-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.release-console-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.release-gate-list,
+.release-checklist,
+.smoke-scenario-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.release-gate-card,
+.release-check-card,
+.smoke-scenario-card {
+  padding: 0.95rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(15, 23, 32, 0.1);
+  background: rgba(255, 255, 255, 0.72);
+}
+
 @media (max-width: 1180px) {
   .workbench-shell {
     grid-template-columns: 1fr;
@@ -1083,6 +1110,10 @@
   .hero-grid,
   .screen-grid,
   .overview-grid,
+  .release-console-grid,
+  .release-gate-list,
+  .release-checklist,
+  .smoke-scenario-list,
   .inspect-summary-grid,
   .inspect-shell,
   .inspect-metrics,

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1536,13 +1536,71 @@ function ReleasePanel({
   const latestSmc = latestJobOfKind(jobs, 'smc')
   const latestSvm = latestJobOfKind(jobs, 'svm')
   const latestBundle = latestJobOfKind(jobs, 'release_bundle_verify')
+  const latestTrace = latestJobMatching(
+    jobs,
+    (job) => job.kind === 'smc' && effectiveResolvedCommand(job).includes('--trace-cache'),
+  )
+  const releaseManifest = overviewSnapshot?.releaseManifest ?? null
+  const assetSmoke = overviewSnapshot?.assetSmoke ?? null
+  const releaseDocuments = releaseSection?.documents ?? []
+  const docsAlignment = [
+    {
+      label: 'Baseline manifest present',
+      ok: overviewSnapshot?.baselineManifestExists ?? false,
+      detail: overviewSnapshot?.baselineManifestPath ?? 'No baseline manifest path resolved.',
+    },
+    {
+      label: 'Release docs indexed',
+      ok: releaseDocuments.length >= 5,
+      detail: `${releaseDocuments.length} release document(s) indexed in the canonical navigator.`,
+    },
+    {
+      label: 'Stable policy doc present',
+      ok: releaseDocuments.some((document) =>
+        document.relativePath.endsWith('stable_release_policy.md'),
+      ),
+      detail: 'The release console expects stable_release_policy.md to remain in the indexed release bundle.',
+    },
+    {
+      label: 'Asset smoke tag recorded',
+      ok: Boolean(assetSmoke?.validatedTag),
+      detail: assetSmoke?.validatedTag ?? 'No validated asset tag found in release_asset_smoke_matrix.md.',
+    },
+  ]
+  const gateRows = [
+    {
+      label: 'Workspace tests',
+      detail: 'cargo test --workspace',
+      job: latestCargo,
+    },
+    {
+      label: 'CLI workflows',
+      detail: 'latest smc compile/check/verify/fmt action',
+      job: latestSmc,
+    },
+    {
+      label: 'Bytecode workflows',
+      detail: 'latest svm run/disasm action',
+      job: latestSvm,
+    },
+    {
+      label: 'Trace workflow',
+      detail: 'smc check --trace-cache',
+      job: latestTrace,
+    },
+    {
+      label: 'Bundle verification',
+      detail: 'verify_release_bundle.ps1',
+      job: latestBundle,
+    },
+  ]
 
   return (
     <div className="screen-stack">
-      <section className="overview-grid">
+      <section className="release-console-grid">
         <article className="screen-card">
           <p className="card-kicker">Release identity</p>
-          <h3>What the current line is anchored to</h3>
+          <h3>Current release line anchor</h3>
           <dl className="facts-grid">
             <div>
               <dt>Branch</dt>
@@ -1582,27 +1640,62 @@ function ReleasePanel({
                 <code>{selectedWorkspace?.resolvedPath ?? overviewSnapshot?.repoRoot ?? 'Loading...'}</code>
               </dd>
             </div>
+            {releaseManifest ? (
+              <>
+                <div>
+                  <dt>Manifest generated</dt>
+                  <dd>{releaseManifest.generatedAt}</dd>
+                </div>
+                <div className="facts-grid-wide">
+                  <dt>Current scope</dt>
+                  <dd>{releaseManifest.currentScope}</dd>
+                </div>
+              </>
+            ) : null}
           </dl>
         </article>
 
         <article className="screen-card">
-          <p className="card-kicker">Release-critical jobs</p>
-          <h3>Signals from actual command history</h3>
-          <div className="activity-list">
-            <ValidationRow label="Workspace tests" job={latestCargo} />
-            <ValidationRow label="smc workflows" job={latestSmc} />
-            <ValidationRow label="svm workflows" job={latestSvm} />
-            <ValidationRow label="Bundle verification" job={latestBundle} />
+          <p className="card-kicker">Release gates</p>
+          <h3>Status from actual jobs only</h3>
+          <div className="release-gate-list">
+            {gateRows.map((gate) => (
+              <section key={gate.label} className="release-gate-card">
+                <div className="document-topline">
+                  <strong>{gate.label}</strong>
+                  <span className={`status-pill ${gate.job?.status ?? 'draft'}`}>
+                    {gate.job?.status ?? 'not run'}
+                  </span>
+                </div>
+                <p className="job-meta">{gate.detail}</p>
+                <p className="job-meta">
+                  {gate.job ? gate.job.commandLine : 'No local job recorded for this gate yet.'}
+                </p>
+              </section>
+            ))}
           </div>
         </article>
       </section>
 
-      <section className="command-grid">
+      <section className="release-console-grid">
         <article className="screen-card">
-          <p className="card-kicker">Release-facing docs</p>
-          <h3>Source paths and freshness from repository files</h3>
+          <p className="card-kicker">Docs alignment</p>
+          <h3>Canonical release docs remain the truth</h3>
+          <div className="release-checklist">
+            {docsAlignment.map((item) => (
+              <section key={item.label} className="release-check-card">
+                <div className="document-topline">
+                  <strong>{item.label}</strong>
+                  <span className={`status-pill ${item.ok ? 'stable' : 'draft'}`}>
+                    {item.ok ? 'aligned' : 'attention'}
+                  </span>
+                </div>
+                <p className="job-meta">{item.detail}</p>
+              </section>
+            ))}
+          </div>
           <div className="document-list">
-            {(releaseSection?.documents ?? []).map((document) => (
+            {releaseDocuments.map((document) => (
               <section key={document.relativePath} className="document-card">
                 <div className="document-topline">
                   <strong>{document.title}</strong>
@@ -1622,9 +1715,78 @@ function ReleasePanel({
         </article>
 
         <article className="screen-card">
-          <p className="card-kicker">Readiness truths</p>
-          <h3>Known limits and validated tag callouts</h3>
+          <p className="card-kicker">Artifacts and asset smoke</p>
+          <h3>Release inventory from manifest and smoke matrix</h3>
           <div className="screen-stack">
+            {releaseManifest ? (
+              <section className="document-card">
+                <div className="document-topline">
+                  <strong>Baseline artifact inventory</strong>
+                  <span className="status-pill stable">manifest</span>
+                </div>
+                <p className="job-meta">documentation bundle</p>
+                <ul className="bullet-list">
+                  {releaseManifest.documentationBundle.map((path) => (
+                    <li key={path}>
+                      <code>{path}</code>
+                    </li>
+                  ))}
+                </ul>
+                <p className="job-meta">validation tests</p>
+                <ul className="bullet-list">
+                  {releaseManifest.validationTests.map((command) => (
+                    <li key={command}>
+                      <code>{command}</code>
+                    </li>
+                  ))}
+                </ul>
+                <p className="job-meta">snapshot directories</p>
+                <ul className="bullet-list">
+                  {releaseManifest.snapshotDirectories.map((path) => (
+                    <li key={path}>
+                      <code>{path}</code>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+
+            <section className="document-card">
+              <div className="document-topline">
+                <strong>Asset smoke status</strong>
+                <span className={`status-pill ${assetSmoke?.validatedTag ? 'stable' : 'draft'}`}>
+                  {assetSmoke?.validatedTag ? 'recorded' : 'missing'}
+                </span>
+              </div>
+              <p className="job-meta">
+                validated tag: <code>{assetSmoke?.validatedTag ?? 'not recorded'}</code>
+              </p>
+              <ul className="bullet-list">
+                {(assetSmoke?.validatedAssets ?? []).map((asset) => (
+                  <li key={asset}>
+                    <code>{asset}</code>
+                  </li>
+                ))}
+              </ul>
+              <div className="smoke-scenario-list">
+                {(assetSmoke?.scenarios ?? []).map((scenario) => (
+                  <section key={scenario.scenario} className="smoke-scenario-card">
+                    <div className="document-topline">
+                      <strong>{scenario.scenario}</strong>
+                      <span
+                        className={`status-pill ${scenario.currentResult.toLowerCase() === 'pass' ? 'stable' : 'draft'}`}
+                      >
+                        {scenario.currentResult}
+                      </span>
+                    </div>
+                    <p className="job-meta">source: {scenario.source}</p>
+                    <p className="job-meta">validation: {scenario.validation}</p>
+                    <p className="job-meta">expected: {scenario.expectedSignal}</p>
+                  </section>
+                ))}
+              </div>
+            </section>
+
             <section className="document-card">
               <div className="document-topline">
                 <strong>Known limits</strong>
@@ -1635,33 +1797,25 @@ function ReleasePanel({
                   <li key={limit}>{limit}</li>
                 ))}
               </ul>
-            </section>
-            <section className="document-card">
-              <div className="document-topline">
-                <strong>Current validated tag</strong>
-                <span className="status-pill stable">derived</span>
-              </div>
-              <div className="document-list">
-                {(overviewSnapshot?.releaseDocs ?? [])
-                  .filter((document) => document.highlight)
-                  .map((document) => (
-                    <div key={document.key}>
-                      <p className="job-meta">
-                        <code>{document.path}</code>
-                      </p>
-                      <p className="document-highlight">{document.highlight}</p>
-                    </div>
-                  ))}
-              </div>
+              {(overviewSnapshot?.releaseDocs ?? [])
+                .filter((document) => document.highlight)
+                .map((document) => (
+                  <div key={document.key}>
+                    <p className="job-meta">
+                      <code>{document.path}</code>
+                    </p>
+                    <p className="document-highlight">{document.highlight}</p>
+                  </div>
+                ))}
             </section>
           </div>
         </article>
       </section>
 
-      <section className="command-grid">
+      <section className="release-console-grid">
         <article className="screen-card">
-          <p className="card-kicker">No second release model</p>
-          <h3>What the UI must not do</h3>
+          <p className="card-kicker">Release honesty guard</p>
+          <h3>What the console must not do</h3>
           <ul className="bullet-list">
             <li>Do not invent a release score that is not backed by repository docs or job output.</li>
             <li>Do not hide known limits behind green local commands.</li>
@@ -1673,9 +1827,9 @@ function ReleasePanel({
           <p className="card-kicker">Next operate slices</p>
           <h3>What still belongs to later PRs</h3>
           <ul className="bullet-list">
-            <li>`WB-16` will formalize the release console around gate views and artifact lists.</li>
-            <li>`WB-17` will add one-click validation runs and report export.</li>
-            <li>This slice stays presentation-only over current release artifacts.</li>
+            <li>`WB-17` adds one-click validation runs and report export.</li>
+            <li>`WB-18` and `WB-19` stay downstream from the release contract and should not reopen scope.</li>
+            <li>This slice remains read-only over current release artifacts, docs, and job history.</li>
           </ul>
         </article>
       </section>
@@ -3251,6 +3405,13 @@ function SettingsPanel({
 
 function latestJobOfKind(jobs: JobRecord[], kind: JobKind) {
   return jobs.find((job) => job.kind === kind)
+}
+
+function latestJobMatching(
+  jobs: JobRecord[],
+  predicate: (job: JobRecord) => boolean,
+) {
+  return jobs.find(predicate)
 }
 
 export default App

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -71,6 +71,28 @@ export type OverviewDocument = {
   highlight: string | null
 }
 
+export type ReleaseBundleManifest = {
+  generatedAt: string
+  documentationBundle: string[]
+  validationTests: string[]
+  snapshotDirectories: string[]
+  currentScope: string
+}
+
+export type AssetSmokeScenario = {
+  scenario: string
+  source: string
+  validation: string
+  expectedSignal: string
+  currentResult: string
+}
+
+export type AssetSmokeSnapshot = {
+  validatedTag: string | null
+  validatedAssets: string[]
+  scenarios: AssetSmokeScenario[]
+}
+
 export type OverviewSnapshot = {
   repoRoot: string
   branch: string
@@ -81,6 +103,8 @@ export type OverviewSnapshot = {
   baselineTagPointsAtHead: boolean
   baselineManifestPath: string
   baselineManifestExists: boolean
+  releaseManifest: ReleaseBundleManifest | null
+  assetSmoke: AssetSmokeSnapshot | null
   releaseDocs: OverviewDocument[]
   knownLimits: string[]
 }


### PR DESCRIPTION
## Summary\n- extend the release snapshot with parsed baseline-manifest and asset-smoke metadata\n- replace the release placeholder with a real release console: gate grid, docs-alignment checklist, artifact inventory, and asset-smoke status\n- keep every console status derived from canonical docs, baseline artifacts, or real jobs\n\n## Guardrails\n- no second release scoring model is introduced\n- no new release automation command is added in this slice\n- release console remains read-only over docs, manifest, smoke matrix, and job history\n\n## Validation\n- 
pm run lint\n- 
pm run build\n- cargo check --manifest-path src-tauri/Cargo.toml\n- cargo tauri build --debug --no-bundle\n\nRefs #25