### PR TITLE
PR-WB-18 feat(workbench): project scaffolding

### DIFF
--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod adapter;
 mod docs;
 mod reports;
+mod scaffold;
 mod snapshot;
 mod workspace_files;
 
@@ -17,6 +18,7 @@ use docs::{read_spec_catalog, read_spec_document, SpecCatalogSection, SpecDocume
 use reports::{
   export_release_report, ReleaseReportExportRequest, ReleaseReportExportResult,
 };
+use scaffold::{scaffold_project, ScaffoldProjectRequest, ScaffoldProjectResult};
 use snapshot::{read_overview_snapshot, OverviewSnapshot};
 use workspace_files::{
   list_workspace_tree,
@@ -84,6 +86,13 @@ fn export_release_report_file(
   export_release_report(request)
 }
 
+#[tauri::command]
+fn scaffold_semantic_project(
+  request: ScaffoldProjectRequest,
+) -> Result<ScaffoldProjectResult, String> {
+  scaffold_project(request)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -107,7 +116,8 @@ pub fn run() {
       get_workspace_tree,
       get_workspace_file,
       save_workspace_file_contents,
-      export_release_report_file
+      export_release_report_file,
+      scaffold_semantic_project
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/workbench/src-tauri/src/scaffold.rs
+++ b/apps/workbench/src-tauri/src/scaffold.rs
@@ -1,0 +1,217 @@
+use crate::adapter::repo_root;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScaffoldProjectRequest {
+  pub workspace_root: String,
+  pub mode: String,
+  pub package_name: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScaffoldProjectResult {
+  pub workspace_root: String,
+  pub repo_relative_path: String,
+  pub package_name: String,
+  pub created_paths: Vec<String>,
+  pub entry_relative_path: String,
+}
+
+pub fn scaffold_project(
+  request: ScaffoldProjectRequest,
+) -> Result<ScaffoldProjectResult, String> {
+  let repo_root = repo_root()?;
+  let package_name = normalize_package_name(&request.package_name)?;
+  let workspace_root = resolve_workspace_root(&repo_root, &request.workspace_root)?;
+  let mode = request.mode.trim().to_ascii_lowercase();
+
+  let target_root = match mode.as_str() {
+    "new" => workspace_root.join(&package_name),
+    "init" => workspace_root,
+    _ => return Err("project scaffold mode must be 'new' or 'init'".into()),
+  };
+
+  ensure_target_allowed(&repo_root, &target_root, mode.as_str())?;
+
+  let src_dir = target_root.join("src");
+  let examples_dir = target_root.join("examples");
+  fs::create_dir_all(&src_dir)
+    .map_err(|error| format!("failed to create '{}': {error}", src_dir.display()))?;
+  fs::create_dir_all(&examples_dir)
+    .map_err(|error| format!("failed to create '{}': {error}", examples_dir.display()))?;
+
+  let manifest_path = target_root.join("Semantic.toml");
+  let entry_path = src_dir.join("main.sm");
+  let smoke_path = examples_dir.join("smoke.sm");
+
+  let manifest_text = render_manifest(&package_name);
+  let main_text = render_main_source();
+  let smoke_text = render_smoke_source();
+
+  write_new_file(&manifest_path, &manifest_text)?;
+  write_new_file(&entry_path, &main_text)?;
+  write_new_file(&smoke_path, &smoke_text)?;
+
+  let created_paths = vec![manifest_path, entry_path, smoke_path]
+    .into_iter()
+    .map(|path| relative_to_repo(&repo_root, &path))
+    .collect::<Vec<_>>();
+  let repo_relative_path = relative_to_repo(&repo_root, &target_root);
+
+  Ok(ScaffoldProjectResult {
+    workspace_root: target_root.to_string_lossy().into_owned(),
+    repo_relative_path,
+    package_name,
+    created_paths,
+    entry_relative_path: "src/main.sm".into(),
+  })
+}
+
+fn resolve_workspace_root(repo_root: &Path, workspace_root: &str) -> Result<PathBuf, String> {
+  let requested = PathBuf::from(workspace_root);
+  let absolute = if requested.is_absolute() {
+    requested
+  } else {
+    repo_root.join(requested)
+  };
+
+  let canonical = absolute
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve workspace root '{}': {error}", absolute.display()))?;
+
+  if !canonical.starts_with(repo_root) {
+    return Err("workspace root must stay inside the repository root".into());
+  }
+
+  Ok(canonical)
+}
+
+fn ensure_target_allowed(repo_root: &Path, target_root: &Path, mode: &str) -> Result<(), String> {
+  if !target_root.starts_with(repo_root) {
+    return Err("project scaffold target must stay inside the repository root".into());
+  }
+
+  match mode {
+    "new" => {
+      if target_root.exists() {
+        let is_empty = fs::read_dir(target_root)
+          .map_err(|error| format!("failed to read '{}': {error}", target_root.display()))?
+          .next()
+          .is_none();
+        if !is_empty {
+          return Err(format!(
+            "new project target '{}' already exists and is not empty",
+            target_root.display()
+          ));
+        }
+      }
+      Ok(())
+    }
+    "init" => {
+      if !target_root.is_dir() {
+        return Err(format!(
+          "init target '{}' is not a directory",
+          target_root.display()
+        ));
+      }
+      for path in [
+        target_root.join("Semantic.toml"),
+        target_root.join("src").join("main.sm"),
+        target_root.join("examples").join("smoke.sm"),
+      ] {
+        if path.exists() {
+          return Err(format!(
+            "init target '{}' already contains '{}'",
+            target_root.display(),
+            path.file_name().and_then(|name| name.to_str()).unwrap_or("existing scaffold file")
+          ));
+        }
+      }
+      Ok(())
+    }
+    _ => Err("unsupported scaffold mode".into()),
+  }
+}
+
+fn write_new_file(path: &Path, contents: &str) -> Result<(), String> {
+  if path.exists() {
+    return Err(format!("refusing to overwrite existing '{}'", path.display()));
+  }
+
+  fs::write(path, contents)
+    .map_err(|error| format!("failed to write '{}': {error}", path.display()))
+}
+
+fn render_manifest(package_name: &str) -> String {
+  format!(
+    "[package]\nname = \"{package_name}\"\nversion = \"0.1.0\"\nedition = \"v1\"\nentry = \"src/main.sm\"\n"
+  )
+}
+
+fn render_main_source() -> &'static str {
+  "fn main() {\n    return;\n}\n"
+}
+
+fn render_smoke_source() -> &'static str {
+  "fn allow() -> quad {\n    return T;\n}\n\nfn main() -> quad {\n    return allow();\n}\n"
+}
+
+fn normalize_package_name(input: &str) -> Result<String, String> {
+  let mut normalized = String::with_capacity(input.len());
+  let mut last_was_dash = false;
+
+  for ch in input.trim().chars() {
+    if ch.is_ascii_alphanumeric() {
+      normalized.push(ch.to_ascii_lowercase());
+      last_was_dash = false;
+      continue;
+    }
+
+    if matches!(ch, ' ' | '_' | '-') && !last_was_dash {
+      normalized.push('-');
+      last_was_dash = true;
+    }
+  }
+
+  let normalized = normalized.trim_matches('-').to_string();
+  if normalized.is_empty() {
+    return Err("package name must contain at least one ASCII letter or digit".into());
+  }
+
+  Ok(normalized)
+}
+
+fn relative_to_repo(repo_root: &Path, path: &Path) -> String {
+  path
+    .strip_prefix(repo_root)
+    .ok()
+    .map(|value| value.to_string_lossy().replace('\\', "/"))
+    .unwrap_or_else(|| path.to_string_lossy().replace('\\', "/"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{normalize_package_name, render_manifest};
+
+  #[test]
+  fn normalize_package_name_collapses_spaces_and_case() {
+    assert_eq!(normalize_package_name("Access Policy").unwrap(), "access-policy");
+    assert_eq!(normalize_package_name("policy_core").unwrap(), "policy-core");
+  }
+
+  #[test]
+  fn normalize_package_name_rejects_empty_result() {
+    assert!(normalize_package_name("___").is_err());
+  }
+
+  #[test]
+  fn manifest_renders_expected_entry() {
+    let manifest = render_manifest("access-policy");
+    assert!(manifest.contains("name = \"access-policy\""));
+    assert!(manifest.contains("entry = \"src/main.sm\""));
+  }
+}

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -11,11 +11,13 @@ import {
   resolveWorkspaceRoot,
   runCliJob,
   saveWorkspaceFile,
+  scaffoldSemanticProject,
   type AdapterContract,
   type AdapterJobSpec,
   type JobKind,
   type JobResult,
   type OverviewSnapshot,
+  type ScaffoldProjectResult,
   type SpecCatalogSection,
   type SpecDocumentHeading,
   type SpecDocumentView,
@@ -237,6 +239,7 @@ const routeSpecs: ScreenSpec[] = [
     stable: [
       'Workspace resolver over canonical repository paths',
       'Recent projects list and default workspace persistence',
+      'Canonical project bootstrap for Semantic.toml, src/main.sm, and examples/smoke.sm',
       'Workspace file tree, read/write text editor tabs, current-file compile/check, and formatter actions through smc fmt',
     ],
     next: [
@@ -352,6 +355,7 @@ function App() {
     useState<SpecDocumentView | null>(null)
   const [workspaceTree, setWorkspaceTree] = useState<WorkspaceTreeNode[]>([])
   const [workspaceTreeError, setWorkspaceTreeError] = useState<string | null>(null)
+  const [workspaceTreeVersion, setWorkspaceTreeVersion] = useState(0)
   const [editorTabs, setEditorTabs] = useState<EditorTab[]>([])
   const [activeEditorPath, setActiveEditorPath] = useState<string | null>(null)
   const [workspaceInput, setWorkspaceInput] = useState('')
@@ -486,7 +490,7 @@ function App() {
     return () => {
       cancelled = true
     }
-  }, [selectedWorkspace?.resolvedPath])
+  }, [selectedWorkspace?.resolvedPath, workspaceTreeVersion])
 
   useEffect(() => {
     saveWorkbenchState({
@@ -621,6 +625,10 @@ function App() {
     } catch (error) {
       setWorkspaceError(String(error))
     }
+  }
+
+  async function refreshWorkspaceTree() {
+    startTransition(() => setWorkspaceTreeVersion((current) => current + 1))
   }
 
   async function openEditorFile(relativePath: string) {
@@ -886,6 +894,7 @@ function App() {
                   onOpenEditorFile={openEditorFile}
                   onSelectEditorPath={setActiveEditorPath}
                   onUpdateEditorContent={updateEditorContent}
+                  onRefreshWorkspace={refreshWorkspaceTree}
                   onSaveEditorFile={saveEditorFile}
                   onReloadEditorFile={reloadEditorFile}
                   onCloseEditorTab={closeEditorTab}
@@ -933,6 +942,7 @@ function WorkbenchScreen({
   onOpenEditorFile,
   onSelectEditorPath,
   onUpdateEditorContent,
+  onRefreshWorkspace,
   onSaveEditorFile,
   onReloadEditorFile,
   onCloseEditorTab,
@@ -970,6 +980,7 @@ function WorkbenchScreen({
   onOpenEditorFile: (relativePath: string) => Promise<void>
   onSelectEditorPath: (relativePath: string | null) => void
   onUpdateEditorContent: (relativePath: string, content: string) => void
+  onRefreshWorkspace: () => Promise<void>
   onSaveEditorFile: (relativePath: string) => Promise<void>
   onReloadEditorFile: (relativePath: string) => Promise<void>
   onCloseEditorTab: (relativePath: string) => void
@@ -1067,6 +1078,7 @@ function WorkbenchScreen({
           onSelectEditorPath={onSelectEditorPath}
           onUpdateEditorContent={onUpdateEditorContent}
           onRunAction={onRunAction}
+          onRefreshWorkspace={onRefreshWorkspace}
           onSaveEditorFile={onSaveEditorFile}
           onReloadEditorFile={onReloadEditorFile}
           onCloseEditorTab={onCloseEditorTab}
@@ -2513,6 +2525,7 @@ function ProjectPanel({
   onSelectEditorPath,
   onUpdateEditorContent,
   onRunAction,
+  onRefreshWorkspace,
   onSaveEditorFile,
   onReloadEditorFile,
   onCloseEditorTab,
@@ -2533,6 +2546,7 @@ function ProjectPanel({
   onSelectEditorPath: (relativePath: string | null) => void
   onUpdateEditorContent: (relativePath: string, content: string) => void
   onRunAction: (action: JobActionSpec) => Promise<JobResult | null>
+  onRefreshWorkspace: () => Promise<void>
   onSaveEditorFile: (relativePath: string) => Promise<void>
   onReloadEditorFile: (relativePath: string) => Promise<void>
   onCloseEditorTab: (relativePath: string) => void
@@ -2549,6 +2563,16 @@ function ProjectPanel({
   const hasDirtySemanticTabs = editorTabs.some(
     (tab) => isSemanticSource(tab.relativePath) && tab.status !== 'clean',
   )
+  const [scaffoldPackageName, setScaffoldPackageName] = useState(
+    deriveScaffoldPackageName(selectedWorkspace),
+  )
+  const [scaffoldBusy, setScaffoldBusy] = useState(false)
+  const [scaffoldMessage, setScaffoldMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    setScaffoldPackageName(deriveScaffoldPackageName(selectedWorkspace))
+    setScaffoldMessage(null)
+  }, [selectedWorkspace])
 
   async function runCurrentFileAction(mode: 'check' | 'compile') {
     if (!activeEditorTab || !selectedWorkspace || !adapterContract || !activeEditorRepoPath) {
@@ -2637,75 +2661,109 @@ function ProjectPanel({
     }
   }
 
+  async function runScaffold(mode: 'new' | 'init') {
+    if (!selectedWorkspace || scaffoldBusy) {
+      return
+    }
+
+    setScaffoldBusy(true)
+    setScaffoldMessage(null)
+
+    try {
+      const result = await scaffoldSemanticProject({
+        workspaceRoot: selectedWorkspace.resolvedPath,
+        mode,
+        packageName: scaffoldPackageName,
+      })
+
+      if (mode === 'new') {
+        await onOpenWorkspace(result.workspaceRoot, true)
+      } else {
+        await onRefreshWorkspace()
+        await onOpenEditorFile(result.entryRelativePath)
+      }
+
+      setScaffoldPackageName(deriveScaffoldPackageNameFromResult(result))
+      setScaffoldMessage(
+        `Created ${result.createdPaths.length} canonical files under ${result.repoRelativePath}: ${result.createdPaths.join(', ')}`,
+      )
+    } catch (error) {
+      setScaffoldMessage(String(error))
+    } finally {
+      setScaffoldBusy(false)
+    }
+  }
+
   return (
     <div className="screen-stack">
       <section className="command-grid">
         <article className="screen-card">
-        <p className="card-kicker">Open workspace</p>
-        <h3>Canonical root selection for every job</h3>
-        <p className="screen-summary">
-          Enter an absolute path or repository-relative path. The backend resolver canonicalizes it and refuses anything outside the repository boundary.
-        </p>
-        <label className="field-label" htmlFor="workspace-path">
-          Workspace path
-        </label>
-        <div className="field-row">
-          <input
-            id="workspace-path"
-            className="text-field"
-            type="text"
-            value={workspaceInput}
-            onChange={(event) => onWorkspaceInputChange(event.target.value)}
-            placeholder={adapterContract?.repoRoot ?? 'Loading repository root...'}
-          />
-          <button
-            type="button"
-            className="action-button"
-            onClick={() =>
-              void onOpenWorkspace(
-                workspaceInput.trim() || adapterContract?.repoRoot || '',
-              )
-            }
-            disabled={!adapterContract}
-          >
-            Open
-          </button>
-        </div>
-        <div className="field-actions">
-          <button
-            type="button"
-            className="ghost-button"
-            onClick={() => void onOpenWorkspace(adapterContract?.repoRoot ?? '')}
-            disabled={!adapterContract}
-          >
-            Use repository root
-          </button>
-          <button
-            type="button"
-            className="ghost-button"
-            onClick={() => void onOpenWorkspace('examples')}
-            disabled={!adapterContract}
-          >
-            Use `examples`
-          </button>
-          <button
-            type="button"
-            className="ghost-button"
-            onClick={() => void onOpenWorkspace('docs')}
-            disabled={!adapterContract}
-          >
-            Use `docs`
-          </button>
-        </div>
-        {workspaceError ? <p className="adapter-error">{workspaceError}</p> : null}
-        <div className="repo-root">
-          <span className="repo-root-label">Selected workspace</span>
-          <code>{selectedWorkspace?.resolvedPath ?? 'No workspace selected yet.'}</code>
-        </div>
-        <p className="job-meta">
-          repo-relative:{' '}
-          <code>{selectedWorkspace?.repoRelativePath ?? '(repository root)'}</code>
-        </p>
+          <p className="card-kicker">Open workspace</p>
+          <h3>Canonical root selection for every job</h3>
+          <p className="screen-summary">
+            Enter an absolute path or repository-relative path. The backend resolver
+            canonicalizes it and refuses anything outside the repository boundary.
+          </p>
+          <label className="field-label" htmlFor="workspace-path">
+            Workspace path
+          </label>
+          <div className="field-row">
+            <input
+              id="workspace-path"
+              className="text-field"
+              type="text"
+              value={workspaceInput}
+              onChange={(event) => onWorkspaceInputChange(event.target.value)}
+              placeholder={adapterContract?.repoRoot ?? 'Loading repository root...'}
+            />
+            <button
+              type="button"
+              className="action-button"
+              onClick={() =>
+                void onOpenWorkspace(
+                  workspaceInput.trim() || adapterContract?.repoRoot || '',
+                )
+              }
+              disabled={!adapterContract}
+            >
+              Open
+            </button>
+          </div>
+          <div className="field-actions">
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => void onOpenWorkspace(adapterContract?.repoRoot ?? '')}
+              disabled={!adapterContract}
+            >
+              Use repository root
+            </button>
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => void onOpenWorkspace('examples')}
+              disabled={!adapterContract}
+            >
+              Use `examples`
+            </button>
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => void onOpenWorkspace('docs')}
+              disabled={!adapterContract}
+            >
+              Use `docs`
+            </button>
+          </div>
+          {workspaceError ? <p className="adapter-error">{workspaceError}</p> : null}
+          <div className="repo-root">
+            <span className="repo-root-label">Selected workspace</span>
+            <code>{selectedWorkspace?.resolvedPath ?? 'No workspace selected yet.'}</code>
+          </div>
+          <p className="job-meta">
+            repo-relative:{' '}
+            <code>{selectedWorkspace?.repoRelativePath ?? '(repository root)'}</code>
+          </p>
         </article>
 
         <article className="screen-card">
@@ -2737,6 +2795,62 @@ function ProjectPanel({
               ))
             )}
           </div>
+        </article>
+
+        <article className="screen-card">
+          <p className="card-kicker">Project bootstrap</p>
+          <h3>Canonical Semantic project scaffold</h3>
+          <p className="screen-summary">
+            Workbench only creates the canonical layout: <code>Semantic.toml</code>,
+            <code> src/main.sm</code>, and <code>examples/smoke.sm</code>. No extra
+            package magic or hidden layout rules.
+          </p>
+          <label className="field-label" htmlFor="scaffold-package-name">
+            Package name
+          </label>
+          <div className="field-row">
+            <input
+              id="scaffold-package-name"
+              className="text-field"
+              type="text"
+              value={scaffoldPackageName}
+              onChange={(event) => setScaffoldPackageName(event.target.value)}
+              placeholder="semantic-project"
+              disabled={!selectedWorkspace || scaffoldBusy}
+            />
+          </div>
+          <div className="field-actions">
+            <button
+              type="button"
+              className="action-button"
+              onClick={() => void runScaffold('init')}
+              disabled={!selectedWorkspace || scaffoldBusy}
+            >
+              {scaffoldBusy ? 'Scaffolding...' : 'Init current workspace'}
+            </button>
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => void runScaffold('new')}
+              disabled={!selectedWorkspace || scaffoldBusy}
+            >
+              Create child project
+            </button>
+          </div>
+          <p className="job-meta">
+            target root:{' '}
+            <code>{selectedWorkspace?.resolvedPath ?? 'Select a workspace first.'}</code>
+          </p>
+          <p className="job-meta">
+            package mode:{' '}
+            <span className="status-pill stable">init</span>{' '}
+            <span className="status-pill draft">new child</span>
+          </p>
+          {scaffoldMessage ? (
+            <p className={scaffoldMessage.startsWith('Created ') ? 'job-meta' : 'adapter-error'}>
+              {scaffoldMessage}
+            </p>
+          ) : null}
         </article>
       </section>
 
@@ -2900,6 +3014,28 @@ function ProjectPanel({
       </section>
     </div>
   )
+}
+
+function deriveScaffoldPackageName(selectedWorkspace: WorkspaceSummary | null) {
+  if (!selectedWorkspace) {
+    return 'semantic-project'
+  }
+
+  const rawSource =
+    selectedWorkspace.repoRelativePath?.split('/').filter(Boolean).pop() ??
+    selectedWorkspace.resolvedPath.split(/[\\/]/).filter(Boolean).pop() ??
+    'semantic-project'
+
+  const normalized = rawSource
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'semantic-project'
+}
+
+function deriveScaffoldPackageNameFromResult(result: ScaffoldProjectResult) {
+  return result.packageName
 }
 
 function DiagnosticsPanel({

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -103,6 +103,20 @@ export type ReleaseReportExportResult = {
   repoRelativePath: string
 }
 
+export type ScaffoldProjectRequest = {
+  workspaceRoot: string
+  mode: 'new' | 'init'
+  packageName: string
+}
+
+export type ScaffoldProjectResult = {
+  workspaceRoot: string
+  repoRelativePath: string
+  packageName: string
+  createdPaths: string[]
+  entryRelativePath: string
+}
+
 export type OverviewSnapshot = {
   repoRoot: string
   branch: string
@@ -191,4 +205,8 @@ export async function saveWorkspaceFile(request: SaveWorkspaceFileRequest) {
 
 export async function exportReleaseReportFile(request: ReleaseReportExportRequest) {
   return invoke<ReleaseReportExportResult>('export_release_report_file', { request })
+}
+
+export async function scaffoldSemanticProject(request: ScaffoldProjectRequest) {
+  return invoke<ScaffoldProjectResult>('scaffold_semantic_project', { request })
 }


### PR DESCRIPTION
## Summary
- add canonical project scaffolding for Workbench through a new Tauri backend command
- support `init` and `new` modes for `Semantic.toml`, `src/main.sm`, and `examples/smoke.sm`
- wire project bootstrap into the Project screen without adding hidden layout logic

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Refs #27
