### PR TITLE
PR-WB-20 feat(workbench): smlsp bridge

### DIFF
--- a/apps/workbench/src-tauri/src/lib.rs
+++ b/apps/workbench/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod adapter;
 mod docs;
+mod lsp_bridge;
 mod reports;
 mod scaffold;
 mod snapshot;
@@ -15,6 +16,7 @@ use adapter::{
   WorkspaceSummary,
 };
 use docs::{read_spec_catalog, read_spec_document, SpecCatalogSection, SpecDocumentView};
+use lsp_bridge::{run_smlsp_bridge, SmlspBridgeRequest, SmlspBridgeResult};
 use reports::{
   export_release_report, ReleaseReportExportRequest, ReleaseReportExportResult,
 };
@@ -93,6 +95,13 @@ fn scaffold_semantic_project(
   scaffold_project(request)
 }
 
+#[tauri::command]
+fn run_smlsp_protocol_bridge(
+  request: SmlspBridgeRequest,
+) -> Result<SmlspBridgeResult, String> {
+  run_smlsp_bridge(request)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -117,7 +126,8 @@ pub fn run() {
       get_workspace_file,
       save_workspace_file_contents,
       export_release_report_file,
-      scaffold_semantic_project
+      scaffold_semantic_project,
+      run_smlsp_protocol_bridge
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/workbench/src-tauri/src/lsp_bridge.rs
+++ b/apps/workbench/src-tauri/src/lsp_bridge.rs
@@ -1,0 +1,727 @@
+use crate::adapter::repo_root;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SmlspBridgeRequest {
+  pub workspace_root: String,
+  pub relative_path: String,
+  pub content: String,
+  pub line: u32,
+  pub character: u32,
+  pub command: String,
+  pub args: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SmlspBridgeResult {
+  pub transport: String,
+  pub command_line: Vec<String>,
+  pub capabilities: Vec<String>,
+  pub hover_markdown: Option<String>,
+  pub definition_path: Option<String>,
+  pub definition_line: Option<u32>,
+  pub definition_character: Option<u32>,
+  pub formatting_text: Option<String>,
+  pub diagnostics: Vec<SmlspDiagnostic>,
+  pub stderr: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SmlspDiagnostic {
+  pub severity: String,
+  pub code: Option<String>,
+  pub message: String,
+  pub line: u32,
+  pub character: u32,
+  pub end_line: u32,
+  pub end_character: u32,
+}
+
+struct BridgeState {
+  diagnostics: Vec<SmlspDiagnostic>,
+  pending_notifications: Vec<String>,
+}
+
+impl BridgeState {
+  fn new() -> Self {
+    Self {
+      diagnostics: Vec::new(),
+      pending_notifications: Vec::new(),
+    }
+  }
+}
+
+pub fn run_smlsp_bridge(
+  request: SmlspBridgeRequest,
+) -> Result<SmlspBridgeResult, String> {
+  let repo_root = repo_root()?;
+  let workspace_root = resolve_workspace_root(&repo_root, &request.workspace_root)?;
+  let document_path = resolve_document_path(&workspace_root, &request.relative_path)?;
+  let command_name = normalized_command(&request.command)?;
+  let mut command_line = vec![command_name.clone()];
+  command_line.extend(request.args.clone());
+
+  let mut child = Command::new(&command_name)
+    .args(&request.args)
+    .current_dir(&workspace_root)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .map_err(|error| format!("failed to start smlsp command '{}': {error}", command_name))?;
+
+  let mut stdin = child
+    .stdin
+    .take()
+    .ok_or_else(|| "failed to open smlsp stdin".to_string())?;
+  let stdout = child
+    .stdout
+    .take()
+    .ok_or_else(|| "failed to open smlsp stdout".to_string())?;
+  let stderr = child
+    .stderr
+    .take()
+    .ok_or_else(|| "failed to open smlsp stderr".to_string())?;
+
+  let message_rx = spawn_stdout_reader(stdout);
+  let stderr_rx = spawn_stderr_reader(stderr);
+  let mut state = BridgeState::new();
+
+  let root_uri = file_uri(&workspace_root);
+  let document_uri = file_uri(&document_path);
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {
+        "processId": serde_json::Value::Null,
+        "rootUri": root_uri,
+        "workspaceFolders": [{
+          "uri": file_uri(&workspace_root),
+          "name": workspace_root.file_name().and_then(|value| value.to_str()).unwrap_or("workspace")
+        }],
+        "capabilities": {
+          "textDocument": {
+            "hover": { "contentFormat": ["markdown", "plaintext"] },
+            "definition": { "linkSupport": true },
+            "formatting": {}
+          }
+        },
+        "clientInfo": {
+          "name": "semantic-workbench",
+          "version": env!("CARGO_PKG_VERSION")
+        }
+      }
+    }),
+  )?;
+
+  let initialize_result = wait_for_response(&message_rx, &mut state, 1, Duration::from_secs(3))?;
+  let capabilities = extract_capabilities(initialize_result.get("capabilities"));
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "method": "initialized",
+      "params": {}
+    }),
+  )?;
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "method": "textDocument/didOpen",
+      "params": {
+        "textDocument": {
+          "uri": document_uri,
+          "languageId": "semantic",
+          "version": 1,
+          "text": request.content
+        }
+      }
+    }),
+  )?;
+
+  let position = json!({
+    "line": request.line,
+    "character": request.character
+  });
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "textDocument/hover",
+      "params": {
+        "textDocument": { "uri": document_uri },
+        "position": position
+      }
+    }),
+  )?;
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "textDocument/definition",
+      "params": {
+        "textDocument": { "uri": document_uri },
+        "position": position
+      }
+    }),
+  )?;
+
+  write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "id": 4,
+      "method": "textDocument/formatting",
+      "params": {
+        "textDocument": { "uri": document_uri },
+        "options": {
+          "tabSize": 2,
+          "insertSpaces": true,
+          "trimTrailingWhitespace": true,
+          "insertFinalNewline": true,
+          "trimFinalNewlines": true
+        }
+      }
+    }),
+  )?;
+
+  let hover_result = wait_for_response(&message_rx, &mut state, 2, Duration::from_secs(3))?;
+  let definition_result = wait_for_response(&message_rx, &mut state, 3, Duration::from_secs(3))?;
+  let formatting_result = wait_for_response(&message_rx, &mut state, 4, Duration::from_secs(3))?;
+
+  drain_notifications(&message_rx, &mut state, Duration::from_millis(250))?;
+
+  let _ = write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "id": 99,
+      "method": "shutdown",
+      "params": serde_json::Value::Null
+    }),
+  );
+  let _ = wait_for_response(&message_rx, &mut state, 99, Duration::from_secs(1));
+  let _ = write_message(
+    &mut stdin,
+    &json!({
+      "jsonrpc": "2.0",
+      "method": "exit",
+      "params": serde_json::Value::Null
+    }),
+  );
+  drop(stdin);
+
+  let _ = child.wait();
+  let stderr_text = stderr_rx
+    .recv_timeout(Duration::from_secs(1))
+    .unwrap_or_default();
+
+  let hover_markdown = extract_hover_text(&hover_result);
+  let definition = extract_definition_location(&definition_result);
+  let formatting_text = apply_formatting_result(&request.content, &formatting_result)?;
+
+  Ok(SmlspBridgeResult {
+    transport: "stdio".into(),
+    command_line,
+    capabilities,
+    hover_markdown,
+    definition_path: definition
+      .as_ref()
+      .map(|location| location.path.to_string_lossy().replace('\\', "/")),
+    definition_line: definition.as_ref().map(|location| location.line),
+    definition_character: definition.as_ref().map(|location| location.character),
+    formatting_text,
+    diagnostics: state.diagnostics,
+    stderr: stderr_text,
+  })
+}
+
+fn resolve_workspace_root(repo_root: &Path, workspace_root: &str) -> Result<PathBuf, String> {
+  let requested = PathBuf::from(workspace_root);
+  let absolute = if requested.is_absolute() {
+    requested
+  } else {
+    repo_root.join(requested)
+  };
+
+  let canonical = absolute
+    .canonicalize()
+    .map_err(|error| format!("failed to resolve workspace root '{}': {error}", absolute.display()))?;
+
+  if !canonical.starts_with(repo_root) {
+    return Err("workspace root must stay inside the repository root".into());
+  }
+
+  Ok(canonical)
+}
+
+fn resolve_document_path(workspace_root: &Path, relative_path: &str) -> Result<PathBuf, String> {
+  let candidate = workspace_root.join(relative_path);
+  if !candidate.starts_with(workspace_root) {
+    return Err("smlsp document path must stay inside the workspace root".into());
+  }
+  Ok(candidate)
+}
+
+fn normalized_command(command: &str) -> Result<String, String> {
+  let value = command.trim();
+  if value.is_empty() {
+    return Err("smlsp command cannot be empty".into());
+  }
+  Ok(value.to_string())
+}
+
+fn spawn_stdout_reader(stdout: impl Read + Send + 'static) -> Receiver<Result<Value, String>> {
+  let (tx, rx) = mpsc::channel();
+  thread::spawn(move || {
+    let mut reader = BufReader::new(stdout);
+    loop {
+      match read_json_rpc_message(&mut reader) {
+        Ok(Some(message)) => {
+          if tx.send(Ok(message)).is_err() {
+            break;
+          }
+        }
+        Ok(None) => break,
+        Err(error) => {
+          let _ = tx.send(Err(error));
+          break;
+        }
+      }
+    }
+  });
+  rx
+}
+
+fn spawn_stderr_reader(stderr: impl Read + Send + 'static) -> Receiver<String> {
+  let (tx, rx) = mpsc::channel();
+  thread::spawn(move || {
+    let mut reader = BufReader::new(stderr);
+    let mut buffer = String::new();
+    let _ = reader.read_to_string(&mut buffer);
+    let _ = tx.send(buffer);
+  });
+  rx
+}
+
+fn read_json_rpc_message(reader: &mut impl BufRead) -> Result<Option<Value>, String> {
+  let mut headers = HashMap::new();
+
+  loop {
+    let mut line = String::new();
+    let bytes_read = reader
+      .read_line(&mut line)
+      .map_err(|error| format!("failed to read smlsp header: {error}"))?;
+
+    if bytes_read == 0 {
+      if headers.is_empty() {
+        return Ok(None);
+      }
+      return Err("unexpected EOF while reading smlsp headers".into());
+    }
+
+    let trimmed = line.trim_end_matches(['\r', '\n']);
+    if trimmed.is_empty() {
+      break;
+    }
+
+    if let Some((name, value)) = trimmed.split_once(':') {
+      headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+    }
+  }
+
+  let content_length = headers
+    .get("content-length")
+    .ok_or_else(|| "missing Content-Length header from smlsp".to_string())?
+    .parse::<usize>()
+    .map_err(|error| format!("invalid Content-Length header from smlsp: {error}"))?;
+
+  let mut body = vec![0u8; content_length];
+  reader
+    .read_exact(&mut body)
+    .map_err(|error| format!("failed to read smlsp body: {error}"))?;
+
+  serde_json::from_slice::<Value>(&body)
+    .map(Some)
+    .map_err(|error| format!("failed to parse smlsp JSON-RPC message: {error}"))
+}
+
+fn write_message(writer: &mut impl Write, payload: &Value) -> Result<(), String> {
+  let encoded = serde_json::to_vec(payload)
+    .map_err(|error| format!("failed to serialize smlsp JSON-RPC message: {error}"))?;
+  writer
+    .write_all(format!("Content-Length: {}\r\n\r\n", encoded.len()).as_bytes())
+    .and_then(|_| writer.write_all(&encoded))
+    .and_then(|_| writer.flush())
+    .map_err(|error| format!("failed to write smlsp message: {error}"))
+}
+
+fn wait_for_response(
+  rx: &Receiver<Result<Value, String>>,
+  state: &mut BridgeState,
+  request_id: i64,
+  timeout: Duration,
+) -> Result<Value, String> {
+  let deadline = Instant::now() + timeout;
+
+  loop {
+    let now = Instant::now();
+    if now >= deadline {
+      return Err(format!("timed out waiting for smlsp response id={request_id}"));
+    }
+
+    let remaining = deadline.saturating_duration_since(now);
+    let message = rx
+      .recv_timeout(remaining)
+      .map_err(|_| format!("timed out waiting for smlsp response id={request_id}"))??;
+
+    if handle_notification(&message, state)? {
+      continue;
+    }
+
+    if message.get("id").and_then(Value::as_i64) == Some(request_id) {
+      if let Some(error) = message.get("error") {
+        return Err(format!("smlsp request id={request_id} failed: {error}"));
+      }
+      return Ok(message
+        .get("result")
+        .cloned()
+        .unwrap_or(Value::Null));
+    }
+  }
+}
+
+fn drain_notifications(
+  rx: &Receiver<Result<Value, String>>,
+  state: &mut BridgeState,
+  timeout: Duration,
+) -> Result<(), String> {
+  let deadline = Instant::now() + timeout;
+
+  loop {
+    let now = Instant::now();
+    if now >= deadline {
+      return Ok(());
+    }
+
+    let remaining = deadline.saturating_duration_since(now);
+    match rx.recv_timeout(remaining) {
+      Ok(Ok(message)) => {
+        let _ = handle_notification(&message, state)?;
+      }
+      Ok(Err(error)) => return Err(error),
+      Err(_) => return Ok(()),
+    }
+  }
+}
+
+fn handle_notification(message: &Value, state: &mut BridgeState) -> Result<bool, String> {
+  let Some(method) = message.get("method").and_then(Value::as_str) else {
+    return Ok(false);
+  };
+
+  if method == "textDocument/publishDiagnostics" {
+    state.diagnostics = extract_diagnostics(message.get("params"));
+    return Ok(true);
+  }
+
+  state.pending_notifications.push(method.to_string());
+  Ok(true)
+}
+
+fn extract_capabilities(capabilities: Option<&Value>) -> Vec<String> {
+  let Some(capabilities) = capabilities else {
+    return Vec::new();
+  };
+
+  let mut values = Vec::new();
+  if capability_present(capabilities.get("hoverProvider")) {
+    values.push("hover".into());
+  }
+  if capability_present(capabilities.get("definitionProvider")) {
+    values.push("definition".into());
+  }
+  if capability_present(capabilities.get("documentFormattingProvider")) {
+    values.push("formatting".into());
+  }
+  if capability_present(capabilities.get("textDocumentSync")) {
+    values.push("diagnostics".into());
+  }
+  values
+}
+
+fn capability_present(value: Option<&Value>) -> bool {
+  match value {
+    Some(Value::Bool(flag)) => *flag,
+    Some(Value::Null) | None => false,
+    Some(_) => true,
+  }
+}
+
+fn extract_hover_text(result: &Value) -> Option<String> {
+  let contents = result.get("contents")?;
+
+  if let Some(text) = contents.as_str() {
+    return Some(text.to_string());
+  }
+
+  if let Some(value) = contents.get("value").and_then(Value::as_str) {
+    return Some(value.to_string());
+  }
+
+  if let Some(items) = contents.as_array() {
+    let joined = items
+      .iter()
+      .filter_map(|item| {
+        item
+          .as_str()
+          .map(|value| value.to_string())
+          .or_else(|| item.get("value").and_then(Value::as_str).map(|value| value.to_string()))
+      })
+      .collect::<Vec<_>>()
+      .join("\n\n");
+    if !joined.is_empty() {
+      return Some(joined);
+    }
+  }
+
+  None
+}
+
+struct DefinitionLocation {
+  path: PathBuf,
+  line: u32,
+  character: u32,
+}
+
+fn extract_definition_location(result: &Value) -> Option<DefinitionLocation> {
+  let location = if let Some(items) = result.as_array() {
+    items.first()?
+  } else {
+    result
+  };
+
+  let uri = location.get("uri").and_then(Value::as_str)?;
+  let range = location
+    .get("range")
+    .or_else(|| location.get("targetSelectionRange"))
+    .or_else(|| location.get("targetRange"))?;
+  let start = range.get("start")?;
+
+  Some(DefinitionLocation {
+    path: uri_to_path(uri)?,
+    line: start.get("line").and_then(Value::as_u64).unwrap_or(0) as u32,
+    character: start.get("character").and_then(Value::as_u64).unwrap_or(0) as u32,
+  })
+}
+
+fn extract_diagnostics(params: Option<&Value>) -> Vec<SmlspDiagnostic> {
+  params
+    .and_then(|value| value.get("diagnostics"))
+    .and_then(Value::as_array)
+    .map(|diagnostics| {
+      diagnostics
+        .iter()
+        .filter_map(|diagnostic| {
+          let range = diagnostic.get("range")?;
+          let start = range.get("start")?;
+          let end = range.get("end")?;
+          Some(SmlspDiagnostic {
+            severity: diagnostic_severity_label(diagnostic.get("severity")),
+            code: diagnostic
+              .get("code")
+              .map(|value| match value {
+                Value::String(text) => text.clone(),
+                other => other.to_string(),
+              }),
+            message: diagnostic
+              .get("message")
+              .and_then(Value::as_str)
+              .unwrap_or("unnamed diagnostic")
+              .to_string(),
+            line: start.get("line").and_then(Value::as_u64).unwrap_or(0) as u32,
+            character: start.get("character").and_then(Value::as_u64).unwrap_or(0) as u32,
+            end_line: end.get("line").and_then(Value::as_u64).unwrap_or(0) as u32,
+            end_character: end.get("character").and_then(Value::as_u64).unwrap_or(0) as u32,
+          })
+        })
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default()
+}
+
+fn diagnostic_severity_label(value: Option<&Value>) -> String {
+  match value.and_then(Value::as_u64) {
+    Some(1) => "error".into(),
+    Some(2) => "warning".into(),
+    Some(3) => "info".into(),
+    Some(4) => "hint".into(),
+    _ => "unknown".into(),
+  }
+}
+
+fn apply_formatting_result(content: &str, result: &Value) -> Result<Option<String>, String> {
+  let Some(edits) = result.as_array() else {
+    return Ok(None);
+  };
+  if edits.is_empty() {
+    return Ok(None);
+  }
+
+  let mut normalized = edits
+    .iter()
+    .filter_map(|edit| {
+      Some(TextEdit {
+        start_line: edit.get("range")?.get("start")?.get("line")?.as_u64()? as u32,
+        start_character: edit
+          .get("range")?
+          .get("start")?
+          .get("character")?
+          .as_u64()? as u32,
+        end_line: edit.get("range")?.get("end")?.get("line")?.as_u64()? as u32,
+        end_character: edit
+          .get("range")?
+          .get("end")?
+          .get("character")?
+          .as_u64()? as u32,
+        new_text: edit.get("newText")?.as_str()?.to_string(),
+      })
+    })
+    .collect::<Vec<_>>();
+
+  normalized.sort_by(|left, right| {
+    right
+      .start_line
+      .cmp(&left.start_line)
+      .then(right.start_character.cmp(&left.start_character))
+  });
+
+  let mut updated = content.to_string();
+  for edit in normalized {
+    let start = position_to_offset(&updated, edit.start_line, edit.start_character)?;
+    let end = position_to_offset(&updated, edit.end_line, edit.end_character)?;
+    updated.replace_range(start..end, &edit.new_text);
+  }
+
+  Ok(Some(updated))
+}
+
+struct TextEdit {
+  start_line: u32,
+  start_character: u32,
+  end_line: u32,
+  end_character: u32,
+  new_text: String,
+}
+
+fn position_to_offset(content: &str, line: u32, character: u32) -> Result<usize, String> {
+  let mut current_line = 0u32;
+  let mut current_character = 0u32;
+
+  for (offset, ch) in content.char_indices() {
+    if current_line == line && current_character == character {
+      return Ok(offset);
+    }
+
+    if ch == '\n' {
+      current_line += 1;
+      current_character = 0;
+    } else {
+      current_character += 1;
+    }
+  }
+
+  if current_line == line && current_character == character {
+    return Ok(content.len());
+  }
+
+  Err(format!(
+    "formatting edit references invalid position {line}:{character}"
+  ))
+}
+
+fn file_uri(path: &Path) -> String {
+  let normalized = path.to_string_lossy().replace('\\', "/");
+  if normalized.starts_with('/') {
+    format!("file://{normalized}")
+  } else {
+    format!("file:///{normalized}")
+  }
+}
+
+fn uri_to_path(uri: &str) -> Option<PathBuf> {
+  let value = uri.strip_prefix("file:///").or_else(|| uri.strip_prefix("file://"))?;
+  Some(PathBuf::from(value.replace('/', "\\")))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{apply_formatting_result, extract_capabilities, file_uri, position_to_offset};
+  use serde_json::json;
+  use std::path::PathBuf;
+
+  #[test]
+  fn file_uri_uses_windows_compatible_format() {
+    let uri = file_uri(&PathBuf::from(r"C:\repo\file.sm"));
+    assert_eq!(uri, "file:///C:/repo/file.sm");
+  }
+
+  #[test]
+  fn capabilities_are_summarized_from_initialize_result() {
+    let values = extract_capabilities(Some(&json!({
+      "hoverProvider": true,
+      "definitionProvider": { "workDoneProgress": false },
+      "documentFormattingProvider": true,
+      "textDocumentSync": 2
+    })));
+    assert_eq!(values, vec!["hover", "definition", "formatting", "diagnostics"]);
+  }
+
+  #[test]
+  fn formatting_edits_apply_to_document() {
+    let result = apply_formatting_result(
+      "fn main(){\nreturn;\n}\n",
+      &json!([
+        {
+          "range": {
+            "start": { "line": 0, "character": 9 },
+            "end": { "line": 1, "character": 0 }
+          },
+          "newText": " {\n    "
+        }
+      ]),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(result, "fn main() {\n    return;\n}\n");
+  }
+
+  #[test]
+  fn positions_resolve_to_offsets() {
+    let offset = position_to_offset("alpha\nbeta\n", 1, 2).unwrap();
+    assert_eq!(&"alpha\nbeta\n"[offset..], "ta\n");
+  }
+}

--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -821,6 +821,14 @@
   gap: 1rem;
 }
 
+.toggle-row-input {
+  grid-template-columns: 1fr;
+}
+
+.settings-text-field {
+  width: 100%;
+}
+
 .toggle-row input[type='checkbox'] {
   width: 1.2rem;
   height: 1.2rem;

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -10,6 +10,7 @@ import {
   fetchWorkspaceTree,
   resolveWorkspaceRoot,
   runCliJob,
+  runSmlspProtocolBridge,
   saveWorkspaceFile,
   scaffoldSemanticProject,
   type AdapterContract,
@@ -17,6 +18,7 @@ import {
   type JobKind,
   type JobResult,
   type OverviewSnapshot,
+  type SmlspBridgeResult,
   type ScaffoldProjectResult,
   type SpecCatalogSection,
   type SpecDocumentHeading,
@@ -99,6 +101,11 @@ type PackageManifestPreview = {
   version: string | null
   edition: string | null
   entry: string | null
+}
+
+type EditorCursorPosition = {
+  line: number
+  character: number
 }
 
 const initialWorkbenchState = loadWorkbenchState()
@@ -2625,11 +2632,28 @@ function ProjectPanel({
     'idle' | 'loading' | 'ready' | 'missing' | 'error'
   >('idle')
   const [packageManifestError, setPackageManifestError] = useState<string | null>(null)
+  const [editorCursor, setEditorCursor] = useState<EditorCursorPosition>({ line: 0, character: 0 })
+  const [smlspBusy, setSmlspBusy] = useState(false)
+  const [smlspResult, setSmlspResult] = useState<SmlspBridgeResult | null>(null)
+  const [smlspError, setSmlspError] = useState<string | null>(null)
+  const smlspDefinitionRelativePath =
+    smlspResult?.definitionPath && selectedWorkspace
+      ? resolveAbsoluteWorkspacePath(
+          smlspResult.definitionPath,
+          selectedWorkspace,
+        )
+      : null
 
   useEffect(() => {
     setScaffoldPackageName(deriveScaffoldPackageName(selectedWorkspace))
     setScaffoldMessage(null)
   }, [selectedWorkspace])
+
+  useEffect(() => {
+    setEditorCursor({ line: 0, character: 0 })
+    setSmlspResult(null)
+    setSmlspError(null)
+  }, [activeEditorPath])
 
   useEffect(() => {
     let cancelled = false
@@ -2799,6 +2823,46 @@ function ProjectPanel({
     } finally {
       setScaffoldBusy(false)
     }
+  }
+
+  async function runSmlspBridge() {
+    if (
+      !selectedWorkspace ||
+      !activeEditorTab ||
+      !isSemanticSource(activeEditorTab.relativePath) ||
+      smlspBusy
+    ) {
+      return
+    }
+
+    setSmlspBusy(true)
+    setSmlspError(null)
+
+    try {
+      const result = await runSmlspProtocolBridge({
+        workspaceRoot: selectedWorkspace.resolvedPath,
+        relativePath: activeEditorTab.relativePath,
+        content: activeEditorTab.content,
+        line: editorCursor.line,
+        character: editorCursor.character,
+        command: settings.smlspCommand,
+        args: [],
+      })
+      setSmlspResult(result)
+    } catch (error) {
+      setSmlspResult(null)
+      setSmlspError(String(error))
+    } finally {
+      setSmlspBusy(false)
+    }
+  }
+
+  function applySmlspFormatting() {
+    if (!activeEditorTab || !smlspResult?.formattingText) {
+      return
+    }
+
+    onUpdateEditorContent(activeEditorTab.relativePath, smlspResult.formattingText)
   }
 
   return (
@@ -3010,6 +3074,133 @@ function ProjectPanel({
             </dl>
           ) : null}
         </article>
+
+        {settings.showExperimental ? (
+          <article className="screen-card">
+            <p className="card-kicker">Experimental protocol bridge</p>
+            <h3>`smlsp` over stdio for the active editor buffer</h3>
+            <p className="screen-summary">
+              This bridge talks only to an external <code>{settings.smlspCommand}</code> process.
+              Workbench does not synthesize hover, definition, diagnostics, or formatting on its
+              own.
+            </p>
+            <div className="field-actions">
+              <button
+                type="button"
+                className="action-button"
+                onClick={() => void runSmlspBridge()}
+                disabled={
+                  !selectedWorkspace ||
+                  !activeEditorTab ||
+                  !isSemanticSource(activeEditorTab.relativePath) ||
+                  smlspBusy
+                }
+              >
+                {smlspBusy ? 'Running smlsp...' : 'Run smlsp bridge'}
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={() => applySmlspFormatting()}
+                disabled={!activeEditorTab || !smlspResult?.formattingText}
+              >
+                Apply formatted text
+              </button>
+            </div>
+            <p className="job-meta">
+              cursor: <code>{editorCursor.line}:{editorCursor.character}</code>
+            </p>
+            <p className="job-meta">
+              active file:{' '}
+              <code>{activeEditorTab?.relativePath ?? 'open a .sm file first'}</code>
+            </p>
+            {smlspError ? <p className="adapter-error">{smlspError}</p> : null}
+            {smlspResult ? (
+              <div className="screen-stack">
+                <div className="diagnostics-filter-row">
+                  <span className="status-pill draft">experimental</span>
+                  <span className="status-pill stable">{smlspResult.transport}</span>
+                  {smlspResult.capabilities.map((capability) => (
+                    <span key={capability} className="status-pill stable">
+                      {capability}
+                    </span>
+                  ))}
+                </div>
+                {smlspResult.hoverMarkdown ? (
+                  <section className="inspect-output-block">
+                    <span className="diagnostic-meta-label">Hover</span>
+                    <pre className="inspect-output-code">{smlspResult.hoverMarkdown}</pre>
+                  </section>
+                ) : null}
+                {smlspResult.definitionPath ? (
+                  <section className="inspect-signal-card">
+                    <div className="diagnostic-card-topline">
+                      <strong>Definition</strong>
+                      <span className="status-pill stable">linked</span>
+                    </div>
+                    <p className="job-meta">
+                      <code>{smlspResult.definitionPath}</code>
+                    </p>
+                    <p className="job-meta">
+                      line {smlspResult.definitionLine ?? 0}, character{' '}
+                      {smlspResult.definitionCharacter ?? 0}
+                    </p>
+                    {smlspDefinitionRelativePath ? (
+                      <button
+                        type="button"
+                        className="ghost-button"
+                        onClick={() => void onOpenEditorFile(smlspDefinitionRelativePath)}
+                      >
+                        Open definition file
+                      </button>
+                    ) : null}
+                  </section>
+                ) : null}
+                <section className="inspect-output-block">
+                  <span className="diagnostic-meta-label">
+                    Inline diagnostics ({smlspResult.diagnostics.length})
+                  </span>
+                  {smlspResult.diagnostics.length > 0 ? (
+                    <div className="diagnostics-group-list">
+                      {smlspResult.diagnostics.map((diagnostic, index) => (
+                        <section key={`${diagnostic.message}-${index}`} className="diagnostic-card">
+                          <div className="diagnostic-card-topline">
+                            <span className={`status-pill ${severityPillClass(diagnostic.severity as WorkbenchDiagnostic['severity'])}`}>
+                              {diagnostic.severity}
+                            </span>
+                            {diagnostic.code ? (
+                              <code>{diagnostic.code}</code>
+                            ) : null}
+                          </div>
+                          <strong>{diagnostic.message}</strong>
+                          <p className="job-meta">
+                            {diagnostic.line}:{diagnostic.character} → {diagnostic.endLine}:
+                            {diagnostic.endCharacter}
+                          </p>
+                        </section>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="empty-state">
+                      No diagnostics were published by the current `smlsp` session.
+                    </p>
+                  )}
+                </section>
+                {smlspResult.stderr.trim().length > 0 ? (
+                  <section className="inspect-output-block">
+                    <span className="diagnostic-meta-label">smlsp stderr</span>
+                    <pre className="inspect-output-code">{smlspResult.stderr}</pre>
+                  </section>
+                ) : null}
+              </div>
+            ) : (
+              <p className="empty-state">
+                Run the bridge to inspect hover, definition, formatting, and published diagnostics
+                for the current buffer.
+              </p>
+            )}
+          </article>
+        ) : null}
       </section>
 
       <section className="project-shell">
@@ -3164,6 +3355,14 @@ function ProjectPanel({
                 onChange={(event) =>
                   onUpdateEditorContent(activeEditorTab.relativePath, event.target.value)
                 }
+                onSelect={(event) =>
+                  setEditorCursor(
+                    deriveCursorPosition(
+                      event.currentTarget.value,
+                      event.currentTarget.selectionStart ?? 0,
+                    ),
+                  )
+                }
                 spellCheck={false}
               />
             </div>
@@ -3194,6 +3393,35 @@ function deriveScaffoldPackageName(selectedWorkspace: WorkspaceSummary | null) {
 
 function deriveScaffoldPackageNameFromResult(result: ScaffoldProjectResult) {
   return result.packageName
+}
+
+function deriveCursorPosition(content: string, selectionStart: number): EditorCursorPosition {
+  const safeOffset = Math.max(0, Math.min(selectionStart, content.length))
+  const prefix = content.slice(0, safeOffset)
+  const lines = prefix.split(/\r?\n/)
+  return {
+    line: Math.max(0, lines.length - 1),
+    character: lines[lines.length - 1]?.length ?? 0,
+  }
+}
+
+function resolveAbsoluteWorkspacePath(
+  absolutePath: string,
+  workspace: WorkspaceSummary,
+) {
+  const normalizedAbsolute = absolutePath.replace(/\\/g, '/').toLowerCase()
+  const normalizedWorkspace = workspace.resolvedPath.replace(/\\/g, '/').toLowerCase()
+
+  if (!normalizedAbsolute.startsWith(normalizedWorkspace)) {
+    return null
+  }
+
+  const relative = absolutePath
+    .replace(/\\/g, '/')
+    .slice(workspace.resolvedPath.replace(/\\/g, '/').length)
+    .replace(/^\/+/, '')
+
+  return relative || null
 }
 
 function parsePackageManifest(content: string): PackageManifestPreview {
@@ -3844,6 +4072,24 @@ function SettingsPanel({
               checked={settings.showExperimental}
               onChange={(event) =>
                 onUpdateSettings({ showExperimental: event.target.checked })
+              }
+            />
+          </label>
+
+          <label className="toggle-row toggle-row-input">
+            <span>
+              <strong>`smlsp` command</strong>
+              <p className="job-meta">
+                External editor-protocol bridge command. Workbench only shells out to this process;
+                it does not implement hover, definition, diagnostics, or formatting itself.
+              </p>
+            </span>
+            <input
+              type="text"
+              className="text-field settings-text-field"
+              value={settings.smlspCommand}
+              onChange={(event) =>
+                onUpdateSettings({ smlspCommand: event.target.value || 'smlsp' })
               }
             />
           </label>

--- a/apps/workbench/src/workbench-api.ts
+++ b/apps/workbench/src/workbench-api.ts
@@ -117,6 +117,39 @@ export type ScaffoldProjectResult = {
   entryRelativePath: string
 }
 
+export type SmlspBridgeRequest = {
+  workspaceRoot: string
+  relativePath: string
+  content: string
+  line: number
+  character: number
+  command: string
+  args: string[]
+}
+
+export type SmlspBridgeDiagnostic = {
+  severity: string
+  code: string | null
+  message: string
+  line: number
+  character: number
+  endLine: number
+  endCharacter: number
+}
+
+export type SmlspBridgeResult = {
+  transport: string
+  commandLine: string[]
+  capabilities: string[]
+  hoverMarkdown: string | null
+  definitionPath: string | null
+  definitionLine: number | null
+  definitionCharacter: number | null
+  formattingText: string | null
+  diagnostics: SmlspBridgeDiagnostic[]
+  stderr: string
+}
+
 export type OverviewSnapshot = {
   repoRoot: string
   branch: string
@@ -209,4 +242,8 @@ export async function exportReleaseReportFile(request: ReleaseReportExportReques
 
 export async function scaffoldSemanticProject(request: ScaffoldProjectRequest) {
   return invoke<ScaffoldProjectResult>('scaffold_semantic_project', { request })
+}
+
+export async function runSmlspProtocolBridge(request: SmlspBridgeRequest) {
+  return invoke<SmlspBridgeResult>('run_smlsp_protocol_bridge', { request })
 }

--- a/apps/workbench/src/workbench-state.ts
+++ b/apps/workbench/src/workbench-state.ts
@@ -16,6 +16,7 @@ export type WorkbenchSettings = {
   preferredShell: 'pwsh'
   formatOnSave: boolean
   showExperimental: boolean
+  smlspCommand: string
 }
 
 export type StoredWorkbenchState = {
@@ -32,6 +33,7 @@ const defaultState: StoredWorkbenchState = {
     preferredShell: 'pwsh',
     formatOnSave: false,
     showExperimental: false,
+    smlspCommand: 'smlsp',
   },
 }
 
@@ -59,6 +61,11 @@ export function loadWorkbenchState(): StoredWorkbenchState {
         preferredShell: 'pwsh',
         formatOnSave: Boolean(parsed.settings?.formatOnSave),
         showExperimental: Boolean(parsed.settings?.showExperimental),
+        smlspCommand:
+          typeof parsed.settings?.smlspCommand === 'string' &&
+          parsed.settings.smlspCommand.trim().length > 0
+            ? parsed.settings.smlspCommand
+            : 'smlsp',
       },
     }
   } catch {


### PR DESCRIPTION
## Summary
- add an experimental stdio JSON-RPC bridge to an external `smlsp` process from Workbench
- surface hover, go-to-definition, published diagnostics, and formatting results for the active `.sm` editor buffer
- keep the bridge behind Workbench settings so protocol data stays external and Workbench does not invent editor semantics

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Refs #29
