### PR TITLE
WB-BH-07 Diagnostics spec-link truthfulness

### DIFF
--- a/apps/workbench/src/App.css
+++ b/apps/workbench/src/App.css
@@ -915,6 +915,15 @@
   background: rgba(255, 255, 255, 0.72);
 }
 
+.document-truth-callout {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.document-truth-callout code {
+  word-break: break-all;
+}
+
 .diagnostics-metric strong {
   display: block;
   font-size: 1.4rem;

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -36,6 +36,7 @@ import {
 } from './workbench-state'
 import {
   deriveDiagnosticsFromJobs,
+  diagnosticDocMapping,
   diagnosticDocLinks,
   diagnosticFamilyLabel,
   diagnosticFamilyOrder,
@@ -1882,9 +1883,23 @@ function SpecNavigatorPanel({
                   </span>
                 ) : null}
               </div>
-              <p className="job-meta">
-                source path: <code>{selectedSpecDocument.absolutePath}</code>
-              </p>
+              <section className="diagnostic-callout document-truth-callout">
+                <div className="document-topline">
+                  <span className="diagnostic-meta-label">Repository truth</span>
+                  <span
+                    className={`status-pill ${selectedSpecDocument.status ? statusTone(selectedSpecDocument.status) : 'draft'}`}
+                  >
+                    {selectedSpecDocument.status ?? 'status unlabelled'}
+                  </span>
+                </div>
+                <p className="job-meta">
+                  source path: <code>{selectedSpecDocument.absolutePath}</code>
+                </p>
+                <p className="job-meta">
+                  Workbench reads this document directly from the repository and does not keep an alternative spec
+                  mirror.
+                </p>
+              </section>
               <div className="spec-document-grid">
                 <aside className="spec-outline-panel">
                   <p className="card-kicker">Section navigator</p>
@@ -2306,6 +2321,17 @@ function statusTone(status: string) {
   }
 
   return 'draft'
+}
+
+function diagnosticDocMappingLabel(status: 'exact' | 'family' | 'generic') {
+  switch (status) {
+    case 'exact':
+      return 'exact mapping'
+    case 'family':
+      return 'family mapping'
+    default:
+      return 'generic only'
+  }
 }
 
 function formatFreshness(modifiedEpochMs: number | null) {
@@ -4210,6 +4236,7 @@ function DiagnosticsPanel({
     selectedDiagnostic && selectedWorkspace
       ? resolveDiagnosticWorkspacePath(selectedDiagnostic.filePath, selectedWorkspace)
       : null
+  const docMapping = selectedDiagnostic ? diagnosticDocMapping(selectedDiagnostic) : null
   const relatedDocs = selectedDiagnostic ? diagnosticDocLinks(selectedDiagnostic) : []
 
   return (
@@ -4413,9 +4440,29 @@ function DiagnosticsPanel({
                     ) : null}
                 </div>
 
+                {docMapping ? (
+                  <div className="diagnostic-callout">
+                    <div className="document-topline">
+                      <span className="diagnostic-meta-label">Canonical mapping status</span>
+                      <span
+                        className={`status-pill ${docMapping.status === 'generic' ? 'draft' : 'stable'}`}
+                      >
+                        {diagnosticDocMappingLabel(docMapping.status)}
+                      </span>
+                    </div>
+                    <p>{docMapping.detail}</p>
+                    {docMapping.status === 'generic' ? (
+                      <p className="job-meta">
+                        No exact code or family mapping is recorded yet, so Workbench does not guess additional
+                        spec links.
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+
                 {relatedDocs.length > 0 ? (
                   <div className="diagnostic-related-docs">
-                    <span className="diagnostic-meta-label">Related spec and error docs</span>
+                    <span className="diagnostic-meta-label">Canonical spec and error docs</span>
                     <div className="diagnostic-doc-links">
                       {relatedDocs.map((document) => (
                         <button

--- a/apps/workbench/src/diagnostics.ts
+++ b/apps/workbench/src/diagnostics.ts
@@ -50,6 +50,14 @@ export type DiagnosticDocLink = {
   relativePath: string
 }
 
+export type DiagnosticDocMappingStatus = 'exact' | 'family' | 'generic'
+
+export type DiagnosticDocMapping = {
+  links: DiagnosticDocLink[]
+  status: DiagnosticDocMappingStatus
+  detail: string
+}
+
 const sourceDiagnosticPattern =
   /^(Error|Warning)\s+\[([A-Z]\d{4})\]:\s*(.*?)(?:\s+at line\s+(\d+):(\d+))?$/i
 const verifyDiagnosticPattern =
@@ -100,50 +108,80 @@ export function diagnosticFamilyLabel(family: DiagnosticFamily) {
   }
 }
 
-export function diagnosticDocLinks(
+export function diagnosticDocMapping(
   diagnostic: WorkbenchDiagnostic,
-): DiagnosticDocLink[] {
+): DiagnosticDocMapping {
   const links = new Map<string, DiagnosticDocLink>()
+  let status: DiagnosticDocMappingStatus = 'generic'
+  let detail =
+    'No exact diagnostic-code or family-specific mapping exists yet. Workbench exposes only the generic diagnostics contract instead of guessing deeper links.'
 
   addDocLink(links, 'Language diagnostics spec', 'docs/spec/diagnostics.md')
 
   switch (diagnostic.family) {
     case 'parse':
+      status = 'family'
+      detail = 'Mapped from parse diagnostics to the canonical syntax and source-semantics documents.'
       addDocLink(links, 'Syntax spec', 'docs/spec/syntax.md')
       addDocLink(links, 'Source semantics', 'docs/spec/source_semantics.md')
       break
     case 'policy':
+      status = 'family'
+      detail = 'Mapped from policy diagnostics to the canonical logos and source-semantics documents.'
       addDocLink(links, 'Logos spec', 'docs/spec/logos.md')
       addDocLink(links, 'Source semantics', 'docs/spec/source_semantics.md')
       break
     case 'type':
+      status = 'family'
+      detail = 'Mapped from type diagnostics to the canonical types and source-semantics documents.'
       addDocLink(links, 'Types spec', 'docs/spec/types.md')
       addDocLink(links, 'Source semantics', 'docs/spec/source_semantics.md')
       break
     case 'module':
+      status = 'family'
+      detail = 'Mapped from module diagnostics to the canonical modules/imports/exports documents.'
       addDocLink(links, 'Modules spec', 'docs/spec/modules.md')
       addDocLink(links, 'Imports guide', 'docs/imports.md')
       addDocLink(links, 'Exports guide', 'docs/exports.md')
       addModuleErrorDocLink(links, diagnostic.code)
+      if (diagnostic.code && ['E0242', 'E0243', 'E0244', 'E0245'].includes(diagnostic.code)) {
+        status = 'exact'
+        detail = `Mapped from exact diagnostic code ${diagnostic.code} to its canonical error document and module-contract references.`
+      }
       break
     case 'verify':
+      status = 'family'
+      detail = 'Mapped from verifier diagnostics to the canonical verifier and SemCode specifications.'
       addDocLink(links, 'Verifier spec', 'docs/spec/verifier.md')
       addDocLink(links, 'SemCode spec', 'docs/spec/semcode.md')
       break
     case 'runtime':
+      status = 'family'
+      detail = 'Mapped from runtime diagnostics to the canonical VM contract.'
       addDocLink(links, 'VM spec', 'docs/spec/vm.md')
       if (
         diagnostic.code?.toLowerCase().includes('quota') ||
         diagnostic.message.toLowerCase().includes('quota')
       ) {
         addDocLink(links, 'Quotas spec', 'docs/spec/quotas.md')
+        detail = 'Mapped from a runtime quota signal to the canonical VM and quota specifications.'
       }
       break
     default:
       break
   }
 
-  return Array.from(links.values())
+  return {
+    links: Array.from(links.values()),
+    status,
+    detail,
+  }
+}
+
+export function diagnosticDocLinks(
+  diagnostic: WorkbenchDiagnostic,
+): DiagnosticDocLink[] {
+  return diagnosticDocMapping(diagnostic).links
 }
 
 function parseChannel(


### PR DESCRIPTION
## Summary
- add explicit canonical-mapping status for diagnostics links
- fail explicitly when only the generic diagnostics contract is available
- make opened spec documents show repository-truth source path and truth status more clearly

## Validation
- npm run lint
- npm run build
- cargo check --manifest-path apps/workbench/src-tauri/Cargo.toml
- cargo tauri build --debug --no-bundle

Closes #56