### PR TITLE
WB-BH-13 beta packaging and smoke pass

### DIFF
--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -27,6 +27,16 @@ npm run build
 npm run tauri:build -- --debug --no-bundle
 ```
 
+## Beta Packaging
+
+```powershell
+pwsh -File ..\..\scripts\package_workbench_beta.ps1
+```
+
+This builds the release executable, creates a portable beta zip, launches the
+packaged app for a short smoke window, and records evidence under
+`artifacts/workbench/beta-smoke/`.
+
 ## Scope Guard
 
 The first implementation waves must continue to respect the repository rule that

--- a/artifacts/workbench/beta-smoke/.gitignore
+++ b/artifacts/workbench/beta-smoke/.gitignore
@@ -1,0 +1,4 @@
+logs/
+workspace/
+package/
+package-extract/

--- a/artifacts/workbench/beta-smoke/.gitignore
+++ b/artifacts/workbench/beta-smoke/.gitignore
@@ -2,3 +2,4 @@ logs/
 workspace/
 package/
 package-extract/
+tauri-target/

--- a/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
@@ -1,24 +1,24 @@
 {
-  "generatedAtUtc": "2026-03-15T20:55:56.6623669Z",
+  "generatedAtUtc": "2026-03-15T21:22:41.9740735Z",
   "productName": "Semantic Workbench",
   "version": "0.1.0",
   "packageFormat": "portable-zip",
   "releaseExecutable": {
-    "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench\\src-tauri\\target\\release\\semantic-workbench-app.exe",
+    "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target\\release\\semantic-workbench-app.exe",
     "fileName": "semantic-workbench-app.exe",
     "sizeBytes": 9077248,
-    "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+    "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
   },
   "portableZip": {
     "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
     "fileName": "semantic-workbench-beta-portable.zip",
-    "sizeBytes": 2895680,
-    "sha256": "73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75"
+    "sizeBytes": 2895803,
+    "sha256": "9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820"
   },
   "extractedExecutable": {
     "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
     "fileName": "semantic-workbench-app.exe",
     "sizeBytes": 9077248,
-    "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+    "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
   }
 }

--- a/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
@@ -1,0 +1,24 @@
+{
+  "generatedAtUtc": "2026-03-15T20:55:56.6623669Z",
+  "productName": "Semantic Workbench",
+  "version": "0.1.0",
+  "packageFormat": "portable-zip",
+  "releaseExecutable": {
+    "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench\\src-tauri\\target\\release\\semantic-workbench-app.exe",
+    "fileName": "semantic-workbench-app.exe",
+    "sizeBytes": 9077248,
+    "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+  },
+  "portableZip": {
+    "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
+    "fileName": "semantic-workbench-beta-portable.zip",
+    "sizeBytes": 2895680,
+    "sha256": "73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75"
+  },
+  "extractedExecutable": {
+    "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
+    "fileName": "semantic-workbench-app.exe",
+    "sizeBytes": 9077248,
+    "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+  }
+}

--- a/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
@@ -1,0 +1,25 @@
+{
+  "generated_at": "2026-03-16T01:55:56+05:00",
+  "documentation_bundle": [
+    "docs/architecture",
+    "docs/spec",
+    "docs/roadmap/v1_readiness.md",
+    "docs/roadmap/runtime_validation_policy.md",
+    "docs/roadmap/release_bundle_checklist.md",
+    "docs/roadmap/compatibility_statement.md"
+  ],
+  "validation_tests": [
+    "cargo test --workspace",
+    "cargo test --test public_api_contracts",
+    "cargo test --test golden_semcode",
+    "cargo test --test prometheus_runtime_matrix",
+    "cargo test --test prometheus_runtime_goldens",
+    "cargo test --test prometheus_runtime_negative_goldens",
+    "cargo test --test prometheus_runtime_compat_matrix"
+  ],
+  "snapshot_directories": [
+    "tests/golden_snapshots/public_api",
+    "tests/golden_snapshots/runtime"
+  ],
+  "current_scope": "Semantic v1 narrow PROMETHEUS boundary"
+}

--- a/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-16T01:55:56+05:00",
+  "generated_at": "2026-03-16T02:22:41+05:00",
   "documentation_bundle": [
     "docs/architecture",
     "docs/spec",

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
@@ -1,0 +1,277 @@
+{
+  "generatedAtUtc": "2026-03-15T20:55:56.7653411Z",
+  "gitBranch": "codex/wb-bh-13-beta-packaging-smoke",
+  "gitCommit": "4f42588a46249f4861b23fcc3a022c21f533365f",
+  "outputRoot": "artifacts/workbench/beta-smoke",
+  "workspaceRoot": "artifacts/workbench/beta-smoke/workspace",
+  "portablePackage": {
+    "generatedAtUtc": "2026-03-15T20:55:56.6623669Z",
+    "productName": "Semantic Workbench",
+    "version": "0.1.0",
+    "packageFormat": "portable-zip",
+    "releaseExecutable": {
+      "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench\\src-tauri\\target\\release\\semantic-workbench-app.exe",
+      "fileName": "semantic-workbench-app.exe",
+      "sizeBytes": 9077248,
+      "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+    },
+    "portableZip": {
+      "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
+      "fileName": "semantic-workbench-beta-portable.zip",
+      "sizeBytes": 2895680,
+      "sha256": "73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75"
+    },
+    "extractedExecutable": {
+      "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
+      "fileName": "semantic-workbench-app.exe",
+      "sizeBytes": 9077248,
+      "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+    }
+  },
+  "launchSmoke": {
+    "launched": true,
+    "launchSmokeSeconds": 8,
+    "durationMs": 8120,
+    "executable": "artifacts/workbench/beta-smoke/package-extract/semantic-workbench-app.exe",
+    "exitCodeBeforeStop": null
+  },
+  "steps": [
+    {
+      "name": "workbench lint",
+      "filePath": "npm.cmd",
+      "arguments": [
+        "run",
+        "lint"
+      ],
+      "commandLine": "npm.cmd run lint",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 6031,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stderr.txt"
+    },
+    {
+      "name": "workbench build",
+      "filePath": "npm.cmd",
+      "arguments": [
+        "run",
+        "build"
+      ],
+      "commandLine": "npm.cmd run build",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 6028,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stderr.txt"
+    },
+    {
+      "name": "workbench tauri tests",
+      "filePath": "cargo",
+      "arguments": [
+        "test",
+        "--manifest-path",
+        "apps/workbench/src-tauri/Cargo.toml"
+      ],
+      "commandLine": "cargo test --manifest-path apps/workbench/src-tauri/Cargo.toml",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 2030,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stderr.txt"
+    },
+    {
+      "name": "semantic release binaries",
+      "filePath": "cargo",
+      "arguments": [
+        "build",
+        "--release",
+        "--bin",
+        "smc",
+        "--bin",
+        "svm"
+      ],
+      "commandLine": "cargo build --release --bin smc --bin svm",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1039,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stderr.txt"
+    },
+    {
+      "name": "workbench release build",
+      "filePath": "npm.cmd",
+      "arguments": [
+        "run",
+        "tauri:build",
+        "--",
+        "--no-bundle"
+      ],
+      "commandLine": "npm.cmd run tauri:build -- --no-bundle",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 79015,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stderr.txt"
+    },
+    {
+      "name": "smoke diagnostics check",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "check",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe check C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 1,
+      "expectFailure": true,
+      "succeeded": true,
+      "durationMs": 1024,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-diagnostics-check.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-diagnostics-check.stderr.txt"
+    },
+    {
+      "name": "smoke format check before write",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "fmt",
+        "--check",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe fmt --check C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 1,
+      "expectFailure": true,
+      "succeeded": true,
+      "durationMs": 1021,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stderr.txt"
+    },
+    {
+      "name": "smoke format write",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "fmt",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe fmt C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1023,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stderr.txt"
+    },
+    {
+      "name": "smoke format check after write",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "fmt",
+        "--check",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe fmt --check C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1024,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stderr.txt"
+    },
+    {
+      "name": "smoke compile",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "compile",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm",
+        "-o",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe compile C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\src\\main.sm -o C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1018,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stderr.txt"
+    },
+    {
+      "name": "smoke verify",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe",
+      "arguments": [
+        "verify",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\smc.exe verify C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1025,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stderr.txt"
+    },
+    {
+      "name": "smoke disasm",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\svm.exe",
+      "arguments": [
+        "disasm",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\svm.exe disasm C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1013,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stderr.txt"
+    },
+    {
+      "name": "smoke run",
+      "filePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\svm.exe",
+      "arguments": [
+        "run",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc"
+      ],
+      "commandLine": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\target\\release\\svm.exe run C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workspace\\build\\main.smc",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1026,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-run.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-run.stderr.txt"
+    },
+    {
+      "name": "release bundle verify",
+      "filePath": "pwsh",
+      "arguments": [
+        "-File",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\scripts\\verify_release_bundle.ps1",
+        "-ManifestPath",
+        "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workbench_beta_release_bundle_manifest.json"
+      ],
+      "commandLine": "pwsh -File C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\scripts\\verify_release_bundle.ps1 -ManifestPath C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\workbench_beta_release_bundle_manifest.json",
+      "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode",
+      "exitCode": 0,
+      "expectFailure": false,
+      "succeeded": true,
+      "durationMs": 1027,
+      "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stdout.txt",
+      "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stderr.txt"
+    }
+  ]
+}

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
@@ -1,37 +1,37 @@
 {
-  "generatedAtUtc": "2026-03-15T20:55:56.7653411Z",
-  "gitBranch": "codex/wb-bh-13-beta-packaging-smoke",
-  "gitCommit": "4f42588a46249f4861b23fcc3a022c21f533365f",
+  "generatedAtUtc": "2026-03-15T21:22:42.0734627Z",
+  "gitBranch": "codex/wb-bh-14-beta-release-notes",
+  "gitCommit": "2ea476e3f8c554daa958fccaf88096b1c4583bd8",
   "outputRoot": "artifacts/workbench/beta-smoke",
   "workspaceRoot": "artifacts/workbench/beta-smoke/workspace",
   "portablePackage": {
-    "generatedAtUtc": "2026-03-15T20:55:56.6623669Z",
+    "generatedAtUtc": "2026-03-15T21:22:41.9740735Z",
     "productName": "Semantic Workbench",
     "version": "0.1.0",
     "packageFormat": "portable-zip",
     "releaseExecutable": {
-      "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench\\src-tauri\\target\\release\\semantic-workbench-app.exe",
+      "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target\\release\\semantic-workbench-app.exe",
       "fileName": "semantic-workbench-app.exe",
       "sizeBytes": 9077248,
-      "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+      "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
     },
     "portableZip": {
       "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
       "fileName": "semantic-workbench-beta-portable.zip",
-      "sizeBytes": 2895680,
-      "sha256": "73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75"
+      "sizeBytes": 2895803,
+      "sha256": "9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820"
     },
     "extractedExecutable": {
       "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
       "fileName": "semantic-workbench-app.exe",
       "sizeBytes": 9077248,
-      "sha256": "70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff"
+      "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
     }
   },
   "launchSmoke": {
     "launched": true,
     "launchSmokeSeconds": 8,
-    "durationMs": 8120,
+    "durationMs": 8116,
     "executable": "artifacts/workbench/beta-smoke/package-extract/semantic-workbench-app.exe",
     "exitCodeBeforeStop": null
   },
@@ -48,7 +48,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 6031,
+      "durationMs": 6048,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stderr.txt"
     },
@@ -64,7 +64,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 6028,
+      "durationMs": 6024,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stderr.txt"
     },
@@ -81,7 +81,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 2030,
+      "durationMs": 2035,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stderr.txt"
     },
@@ -101,25 +101,24 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1039,
+      "durationMs": 1022,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stderr.txt"
     },
     {
       "name": "workbench release build",
-      "filePath": "npm.cmd",
+      "filePath": "pwsh",
       "arguments": [
-        "run",
-        "tauri:build",
-        "--",
-        "--no-bundle"
+        "-NoProfile",
+        "-Command",
+        "$env:CARGO_TARGET_DIR='C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target'; npm.cmd run tauri:build -- --no-bundle"
       ],
-      "commandLine": "npm.cmd run tauri:build -- --no-bundle",
+      "commandLine": "pwsh -NoProfile -Command $env:CARGO_TARGET_DIR='C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target'; npm.cmd run tauri:build -- --no-bundle",
       "workingDirectory": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\apps\\workbench",
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 79015,
+      "durationMs": 358029,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stderr.txt"
     },
@@ -135,7 +134,7 @@
       "exitCode": 1,
       "expectFailure": true,
       "succeeded": true,
-      "durationMs": 1024,
+      "durationMs": 1020,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-diagnostics-check.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-diagnostics-check.stderr.txt"
     },
@@ -152,7 +151,7 @@
       "exitCode": 1,
       "expectFailure": true,
       "succeeded": true,
-      "durationMs": 1021,
+      "durationMs": 1023,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stderr.txt"
     },
@@ -168,7 +167,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1023,
+      "durationMs": 1022,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stderr.txt"
     },
@@ -185,7 +184,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1024,
+      "durationMs": 1019,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stderr.txt"
     },
@@ -203,7 +202,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1018,
+      "durationMs": 1024,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stderr.txt"
     },
@@ -219,7 +218,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1025,
+      "durationMs": 1017,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stderr.txt"
     },
@@ -235,7 +234,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1013,
+      "durationMs": 1018,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stderr.txt"
     },
@@ -251,7 +250,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1026,
+      "durationMs": 1015,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-run.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-run.stderr.txt"
     },
@@ -269,7 +268,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1027,
+      "durationMs": 1013,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stderr.txt"
     }

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
@@ -1,13 +1,13 @@
 # Workbench Beta Smoke Report
 
-- Generated: 2026-03-15T20:55:56.7653411Z
-- Branch: codex/wb-bh-13-beta-packaging-smoke
-- Commit: 4f42588a46249f4861b23fcc3a022c21f533365f
+- Generated: 2026-03-15T21:22:42.0734627Z
+- Branch: codex/wb-bh-14-beta-release-notes
+- Commit: 2ea476e3f8c554daa958fccaf88096b1c4583bd8
 - Output root: artifacts/workbench/beta-smoke
 - Workspace root: artifacts/workbench/beta-smoke/workspace
 - Package format: portable-zip
 - Portable zip: artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip
-- Release executable: apps/workbench/src-tauri/target/release/semantic-workbench-app.exe
+- Release executable: artifacts/workbench/beta-smoke/tauri-target/release/semantic-workbench-app.exe
 - Launch smoke: passed (8 s window)
 
 ## Acceptance Coverage
@@ -20,24 +20,24 @@
 
 | Step | Expectation | Exit | Duration (ms) | Stdout | Stderr |
 | --- | --- | ---: | ---: | --- | --- |
-| workbench lint | success | 0 | 6031 | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stderr.txt' |
-| workbench build | success | 0 | 6028 | 'artifacts/workbench/beta-smoke/logs/workbench-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-build.stderr.txt' |
-| workbench tauri tests | success | 0 | 2030 | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stderr.txt' |
-| semantic release binaries | success | 0 | 1039 | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stderr.txt' |
-| workbench release build | success | 0 | 79015 | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stderr.txt' |
-| smoke diagnostics check | expected failure | 1 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stderr.txt' |
-| smoke format check before write | expected failure | 1 | 1021 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stderr.txt' |
-| smoke format write | success | 0 | 1023 | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stderr.txt' |
-| smoke format check after write | success | 0 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stderr.txt' |
-| smoke compile | success | 0 | 1018 | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stderr.txt' |
-| smoke verify | success | 0 | 1025 | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stderr.txt' |
-| smoke disasm | success | 0 | 1013 | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stderr.txt' |
-| smoke run | success | 0 | 1026 | 'artifacts/workbench/beta-smoke/logs/smoke-run.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-run.stderr.txt' |
-| release bundle verify | success | 0 | 1027 | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stderr.txt' |
+| workbench lint | success | 0 | 6048 | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stderr.txt' |
+| workbench build | success | 0 | 6024 | 'artifacts/workbench/beta-smoke/logs/workbench-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-build.stderr.txt' |
+| workbench tauri tests | success | 0 | 2035 | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stderr.txt' |
+| semantic release binaries | success | 0 | 1022 | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stderr.txt' |
+| workbench release build | success | 0 | 358029 | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stderr.txt' |
+| smoke diagnostics check | expected failure | 1 | 1020 | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stderr.txt' |
+| smoke format check before write | expected failure | 1 | 1023 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stderr.txt' |
+| smoke format write | success | 0 | 1022 | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stderr.txt' |
+| smoke format check after write | success | 0 | 1019 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stderr.txt' |
+| smoke compile | success | 0 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stderr.txt' |
+| smoke verify | success | 0 | 1017 | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stderr.txt' |
+| smoke disasm | success | 0 | 1018 | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stderr.txt' |
+| smoke run | success | 0 | 1015 | 'artifacts/workbench/beta-smoke/logs/smoke-run.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-run.stderr.txt' |
+| release bundle verify | success | 0 | 1013 | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stderr.txt' |
 
 ## Bundle Inventory
 
 | Artifact | Size (bytes) | SHA256 |
 | --- | ---: | --- |
-| apps/workbench/src-tauri/target/release/semantic-workbench-app.exe | 9077248 | '70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff' |
-| artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip | 2895680 | '73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75' |
+| artifacts/workbench/beta-smoke/tauri-target/release/semantic-workbench-app.exe | 9077248 | 'ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8' |
+| artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip | 2895803 | '9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820' |

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
@@ -1,0 +1,43 @@
+# Workbench Beta Smoke Report
+
+- Generated: 2026-03-15T20:55:56.7653411Z
+- Branch: codex/wb-bh-13-beta-packaging-smoke
+- Commit: 4f42588a46249f4861b23fcc3a022c21f533365f
+- Output root: artifacts/workbench/beta-smoke
+- Workspace root: artifacts/workbench/beta-smoke/workspace
+- Package format: portable-zip
+- Portable zip: artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip
+- Release executable: apps/workbench/src-tauri/target/release/semantic-workbench-app.exe
+- Launch smoke: passed (8 s window)
+
+## Acceptance Coverage
+
+- Packaged app launched from the extracted portable beta package.
+- Smoke loop covered diagnostics, format check/write, compile, verify, disasm, run, and release bundle verification.
+- Full command captures are preserved under 'artifacts/workbench/beta-smoke/logs/'.
+
+## Step Summary
+
+| Step | Expectation | Exit | Duration (ms) | Stdout | Stderr |
+| --- | --- | ---: | ---: | --- | --- |
+| workbench lint | success | 0 | 6031 | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stderr.txt' |
+| workbench build | success | 0 | 6028 | 'artifacts/workbench/beta-smoke/logs/workbench-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-build.stderr.txt' |
+| workbench tauri tests | success | 0 | 2030 | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stderr.txt' |
+| semantic release binaries | success | 0 | 1039 | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stderr.txt' |
+| workbench release build | success | 0 | 79015 | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stderr.txt' |
+| smoke diagnostics check | expected failure | 1 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stderr.txt' |
+| smoke format check before write | expected failure | 1 | 1021 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stderr.txt' |
+| smoke format write | success | 0 | 1023 | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stderr.txt' |
+| smoke format check after write | success | 0 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stderr.txt' |
+| smoke compile | success | 0 | 1018 | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stderr.txt' |
+| smoke verify | success | 0 | 1025 | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stderr.txt' |
+| smoke disasm | success | 0 | 1013 | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stderr.txt' |
+| smoke run | success | 0 | 1026 | 'artifacts/workbench/beta-smoke/logs/smoke-run.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-run.stderr.txt' |
+| release bundle verify | success | 0 | 1027 | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stderr.txt' |
+
+## Bundle Inventory
+
+| Artifact | Size (bytes) | SHA256 |
+| --- | ---: | --- |
+| apps/workbench/src-tauri/target/release/semantic-workbench-app.exe | 9077248 | '70126083f3868942d09f8855ba793db13396f2da96f6e8012274e769ab81c4ff' |
+| artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip | 2895680 | '73c67c6af525fd8b18132f0847121858f3220602c754c7f7a9038e4216177a75' |

--- a/docs/workbench/beta_packaging.md
+++ b/docs/workbench/beta_packaging.md
@@ -1,0 +1,53 @@
+# Workbench Beta Packaging
+
+Workbench beta packaging is intentionally a thin release layer over the
+integrated desktop shell. It does not introduce a second installer-specific
+workflow or alternate runtime model.
+
+## Current Beta Package
+
+The current beta-facing package is a portable zip built from the Tauri release
+executable:
+
+- release build: `npm run tauri:build -- --no-bundle`
+- portable package: zip of the produced `semantic-workbench-app.exe`
+- smoke evidence: generated under `artifacts/workbench/beta-smoke/`
+
+This keeps the packaging path reproducible on Windows machines that do not have
+installer toolchains such as NSIS or WiX.
+
+## Evidence Command
+
+Run:
+
+```powershell
+pwsh -File scripts/package_workbench_beta.ps1
+```
+
+The script captures three evidence layers:
+
+1. portable package inventory with file hashes
+2. launch smoke for the packaged Workbench executable
+3. representative command-loop smoke for diagnostics, format, compile, verify,
+   disasm, run, and release bundle verification
+
+## Evidence Outputs
+
+The command writes:
+
+- `artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json`
+- `artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json`
+- `artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md`
+
+It also preserves full stdout and stderr captures under
+`artifacts/workbench/beta-smoke/logs/`.
+
+## Scope Boundary
+
+This beta packaging path does not claim a second source of truth for Workbench
+readiness.
+
+- package launch evidence comes from the packaged executable
+- command-loop evidence comes from real `smc`, `svm`, and release-script runs
+- canonical release truth remains in repository docs, release artifacts, and
+  recorded validation outputs

--- a/scripts/package_workbench_beta.ps1
+++ b/scripts/package_workbench_beta.ps1
@@ -133,6 +133,7 @@ $logsDirectory = Join-Path $outputDirectory "logs"
 $workspaceDirectory = Join-Path $outputDirectory "workspace"
 $packageDirectory = Join-Path $outputDirectory "package"
 $extractedDirectory = Join-Path $outputDirectory "package-extract"
+$tauriTargetDirectory = Join-Path $outputDirectory "tauri-target"
 $bundleManifestPath = Join-Path $outputDirectory "workbench_beta_package_manifest.json"
 $releaseManifestPath = Join-Path $outputDirectory "workbench_beta_release_bundle_manifest.json"
 $jsonReportPath = Join-Path $outputDirectory "workbench_beta_smoke_latest.json"
@@ -144,13 +145,15 @@ New-Directory $logsDirectory
 Remove-IfExists $workspaceDirectory
 Remove-IfExists $packageDirectory
 Remove-IfExists $extractedDirectory
+Remove-IfExists $tauriTargetDirectory
 New-Directory $workspaceDirectory
 New-Directory $packageDirectory
 New-Directory $extractedDirectory
+New-Directory $tauriTargetDirectory
 
 $workbenchDirectory = Join-Path $repoRoot "apps/workbench"
 $tauriDirectory = Join-Path $workbenchDirectory "src-tauri"
-$workbenchReleaseDirectory = Join-Path $tauriDirectory "target/release"
+$workbenchReleaseDirectory = Join-Path $tauriTargetDirectory "release"
 $workbenchExePath = Join-Path $workbenchReleaseDirectory "semantic-workbench-app.exe"
 $smcReleasePath = Join-Path $repoRoot "target/release/smc.exe"
 $svmReleasePath = Join-Path $repoRoot "target/release/svm.exe"
@@ -163,7 +166,8 @@ $steps.Add((Invoke-CapturedStep -Name "workbench lint" -FilePath "npm.cmd" -Argu
 $steps.Add((Invoke-CapturedStep -Name "workbench build" -FilePath "npm.cmd" -ArgumentList @("run", "build") -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
 $steps.Add((Invoke-CapturedStep -Name "workbench tauri tests" -FilePath "cargo" -ArgumentList @("test", "--manifest-path", "apps/workbench/src-tauri/Cargo.toml") -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
 $steps.Add((Invoke-CapturedStep -Name "semantic release binaries" -FilePath "cargo" -ArgumentList @("build", "--release", "--bin", "smc", "--bin", "svm") -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
-$steps.Add((Invoke-CapturedStep -Name "workbench release build" -FilePath "npm.cmd" -ArgumentList @("run", "tauri:build", "--", "--no-bundle") -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
+$tauriBuildCommand = "`$env:CARGO_TARGET_DIR='$tauriTargetDirectory'; npm.cmd run tauri:build -- --no-bundle"
+$steps.Add((Invoke-CapturedStep -Name "workbench release build" -FilePath "pwsh" -ArgumentList @("-NoProfile", "-Command", $tauriBuildCommand) -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
 
 if (-not (Test-Path -LiteralPath $workbenchExePath)) {
     throw "expected packaged Workbench executable at '$workbenchExePath'"

--- a/scripts/package_workbench_beta.ps1
+++ b/scripts/package_workbench_beta.ps1
@@ -1,0 +1,283 @@
+param(
+    [string]$OutputRoot = "artifacts/workbench/beta-smoke",
+    [int]$LaunchSmokeSeconds = 8
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-Directory([string]$Path) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+}
+
+function Remove-IfExists([string]$Path) {
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+    }
+}
+
+function Get-RepoRelativePath([string]$RepoRoot, [string]$AbsolutePath) {
+    $repoUri = [System.Uri]((Resolve-Path $RepoRoot).Path.TrimEnd('\') + '\')
+    $targetUri = [System.Uri]((Resolve-Path $AbsolutePath).Path)
+    $relative = $repoUri.MakeRelativeUri($targetUri).ToString()
+    return [System.Uri]::UnescapeDataString($relative).Replace('\', '/')
+}
+
+function Invoke-CapturedStep {
+    param(
+        [string]$Name,
+        [string]$FilePath,
+        [string[]]$ArgumentList,
+        [string]$WorkingDirectory,
+        [string]$LogsDirectory,
+        [bool]$ExpectFailure = $false
+    )
+
+    $safeName = ($Name.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+    $stdoutPath = Join-Path $LogsDirectory "$safeName.stdout.txt"
+    $stderrPath = Join-Path $LogsDirectory "$safeName.stderr.txt"
+    Remove-IfExists $stdoutPath
+    Remove-IfExists $stderrPath
+
+    $startedAt = Get-Date
+    $process = Start-Process `
+        -FilePath $FilePath `
+        -ArgumentList $ArgumentList `
+        -WorkingDirectory $WorkingDirectory `
+        -NoNewWindow `
+        -Wait `
+        -PassThru `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath
+    $finishedAt = Get-Date
+
+    $succeeded = if ($ExpectFailure) {
+        $process.ExitCode -ne 0
+    } else {
+        $process.ExitCode -eq 0
+    }
+
+    if (-not $succeeded) {
+        $expectation = if ($ExpectFailure) { "non-zero" } else { "zero" }
+        throw "step '$Name' exited with code $($process.ExitCode), expected $expectation"
+    }
+
+    [pscustomobject]@{
+        name = $Name
+        filePath = $FilePath
+        arguments = @($ArgumentList)
+        commandLine = (@($FilePath) + $ArgumentList) -join ' '
+        workingDirectory = $WorkingDirectory
+        exitCode = $process.ExitCode
+        expectFailure = $ExpectFailure
+        succeeded = $true
+        durationMs = [int][Math]::Round(($finishedAt - $startedAt).TotalMilliseconds)
+        stdoutPath = $stdoutPath
+        stderrPath = $stderrPath
+    }
+}
+
+function Get-FileSummary([string]$Path) {
+    $item = Get-Item -LiteralPath $Path
+    $hash = Get-FileHash -LiteralPath $Path -Algorithm SHA256
+    [pscustomobject]@{
+        absolutePath = $item.FullName
+        fileName = $item.Name
+        sizeBytes = [int64]$item.Length
+        sha256 = $hash.Hash.ToLowerInvariant()
+    }
+}
+
+function Write-SmokeWorkspace([string]$WorkspaceRoot, [bool]$Invalid) {
+    New-Directory (Join-Path $WorkspaceRoot "src")
+    New-Directory (Join-Path $WorkspaceRoot "build")
+    $manifest = @'
+[package]
+name = "workbench-beta-smoke"
+version = "0.1.0"
+edition = "v1"
+entry = "src/main.sm"
+'@
+    Set-Content -LiteralPath (Join-Path $WorkspaceRoot "Semantic.toml") -Value $manifest -NoNewline
+
+    $source = if ($Invalid) {
+@'
+fn main() {
+    let broken: i32 =
+}
+'@
+    } else {
+@'
+fn allow()->quad{    
+    return T;
+}
+
+fn main(){
+let state: quad = allow();
+if state == T {
+return;
+} else {
+return;
+}
+}
+'@
+    }
+
+    Set-Content -LiteralPath (Join-Path $WorkspaceRoot "src/main.sm") -Value $source -NoNewline
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "..")).Path
+$outputDirectory = Join-Path $repoRoot $OutputRoot
+$logsDirectory = Join-Path $outputDirectory "logs"
+$workspaceDirectory = Join-Path $outputDirectory "workspace"
+$packageDirectory = Join-Path $outputDirectory "package"
+$extractedDirectory = Join-Path $outputDirectory "package-extract"
+$bundleManifestPath = Join-Path $outputDirectory "workbench_beta_package_manifest.json"
+$releaseManifestPath = Join-Path $outputDirectory "workbench_beta_release_bundle_manifest.json"
+$jsonReportPath = Join-Path $outputDirectory "workbench_beta_smoke_latest.json"
+$markdownReportPath = Join-Path $outputDirectory "workbench_beta_smoke_latest.md"
+$zipPath = Join-Path $packageDirectory "semantic-workbench-beta-portable.zip"
+
+New-Directory $outputDirectory
+New-Directory $logsDirectory
+Remove-IfExists $workspaceDirectory
+Remove-IfExists $packageDirectory
+Remove-IfExists $extractedDirectory
+New-Directory $workspaceDirectory
+New-Directory $packageDirectory
+New-Directory $extractedDirectory
+
+$workbenchDirectory = Join-Path $repoRoot "apps/workbench"
+$tauriDirectory = Join-Path $workbenchDirectory "src-tauri"
+$workbenchReleaseDirectory = Join-Path $tauriDirectory "target/release"
+$workbenchExePath = Join-Path $workbenchReleaseDirectory "semantic-workbench-app.exe"
+$smcReleasePath = Join-Path $repoRoot "target/release/smc.exe"
+$svmReleasePath = Join-Path $repoRoot "target/release/svm.exe"
+$smokeSourcePath = Join-Path $workspaceDirectory "src/main.sm"
+$smokeBytecodePath = Join-Path $workspaceDirectory "build/main.smc"
+
+$steps = [System.Collections.Generic.List[object]]::new()
+
+$steps.Add((Invoke-CapturedStep -Name "workbench lint" -FilePath "npm.cmd" -ArgumentList @("run", "lint") -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "workbench build" -FilePath "npm.cmd" -ArgumentList @("run", "build") -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "workbench tauri tests" -FilePath "cargo" -ArgumentList @("test", "--manifest-path", "apps/workbench/src-tauri/Cargo.toml") -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "semantic release binaries" -FilePath "cargo" -ArgumentList @("build", "--release", "--bin", "smc", "--bin", "svm") -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "workbench release build" -FilePath "npm.cmd" -ArgumentList @("run", "tauri:build", "--", "--no-bundle") -WorkingDirectory $workbenchDirectory -LogsDirectory $logsDirectory))
+
+if (-not (Test-Path -LiteralPath $workbenchExePath)) {
+    throw "expected packaged Workbench executable at '$workbenchExePath'"
+}
+
+Copy-Item -LiteralPath $workbenchExePath -Destination (Join-Path $packageDirectory "semantic-workbench-app.exe")
+Copy-Item -LiteralPath (Join-Path $workbenchDirectory "README.md") -Destination (Join-Path $packageDirectory "README.md")
+Compress-Archive -Path (Join-Path $packageDirectory "*") -DestinationPath $zipPath -Force
+Expand-Archive -LiteralPath $zipPath -DestinationPath $extractedDirectory -Force
+
+$launchedExePath = Join-Path $extractedDirectory "semantic-workbench-app.exe"
+if (-not (Test-Path -LiteralPath $launchedExePath)) {
+    throw "portable package is missing '$launchedExePath'"
+}
+
+$launchStartedAt = Get-Date
+$launchProcess = Start-Process -FilePath $launchedExePath -WorkingDirectory $extractedDirectory -PassThru
+Start-Sleep -Seconds $LaunchSmokeSeconds
+$launchProcess.Refresh()
+$launchRunning = -not $launchProcess.HasExited
+$launchExitCode = if ($launchProcess.HasExited) { $launchProcess.ExitCode } else { $null }
+if ($launchRunning) {
+    Stop-Process -Id $launchProcess.Id -Force
+}
+$launchFinishedAt = Get-Date
+if (-not $launchRunning) {
+    throw "portable Workbench package exited before the launch smoke window completed"
+}
+
+Write-SmokeWorkspace -WorkspaceRoot $workspaceDirectory -Invalid $true
+$steps.Add((Invoke-CapturedStep -Name "smoke diagnostics check" -FilePath $smcReleasePath -ArgumentList @("check", $smokeSourcePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory -ExpectFailure $true))
+
+Write-SmokeWorkspace -WorkspaceRoot $workspaceDirectory -Invalid $false
+$steps.Add((Invoke-CapturedStep -Name "smoke format check before write" -FilePath $smcReleasePath -ArgumentList @("fmt", "--check", $smokeSourcePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory -ExpectFailure $true))
+$steps.Add((Invoke-CapturedStep -Name "smoke format write" -FilePath $smcReleasePath -ArgumentList @("fmt", $smokeSourcePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "smoke format check after write" -FilePath $smcReleasePath -ArgumentList @("fmt", "--check", $smokeSourcePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "smoke compile" -FilePath $smcReleasePath -ArgumentList @("compile", $smokeSourcePath, "-o", $smokeBytecodePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "smoke verify" -FilePath $smcReleasePath -ArgumentList @("verify", $smokeBytecodePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "smoke disasm" -FilePath $svmReleasePath -ArgumentList @("disasm", $smokeBytecodePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "smoke run" -FilePath $svmReleasePath -ArgumentList @("run", $smokeBytecodePath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+$steps.Add((Invoke-CapturedStep -Name "release bundle verify" -FilePath "pwsh" -ArgumentList @("-File", (Join-Path $repoRoot "scripts/verify_release_bundle.ps1"), "-ManifestPath", $releaseManifestPath) -WorkingDirectory $repoRoot -LogsDirectory $logsDirectory))
+
+$bundleManifest = [pscustomobject]@{
+    generatedAtUtc = (Get-Date).ToUniversalTime().ToString("o")
+    productName = "Semantic Workbench"
+    version = "0.1.0"
+    packageFormat = "portable-zip"
+    releaseExecutable = Get-FileSummary -Path $workbenchExePath
+    portableZip = Get-FileSummary -Path $zipPath
+    extractedExecutable = Get-FileSummary -Path $launchedExePath
+}
+$bundleManifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $bundleManifestPath
+
+$report = [pscustomobject]@{
+    generatedAtUtc = (Get-Date).ToUniversalTime().ToString("o")
+    gitBranch = (git branch --show-current)
+    gitCommit = (git rev-parse HEAD)
+    outputRoot = (Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $outputDirectory)
+    workspaceRoot = (Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $workspaceDirectory)
+    portablePackage = $bundleManifest
+    launchSmoke = [pscustomobject]@{
+        launched = $launchRunning
+        launchSmokeSeconds = $LaunchSmokeSeconds
+        durationMs = [int][Math]::Round(($launchFinishedAt - $launchStartedAt).TotalMilliseconds)
+        executable = (Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $launchedExePath)
+        exitCodeBeforeStop = $launchExitCode
+    }
+    steps = $steps
+}
+$report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $jsonReportPath
+
+$markdown = @(
+    "# Workbench Beta Smoke Report"
+    ""
+    "- Generated: $($report.generatedAtUtc)"
+    "- Branch: $($report.gitBranch)"
+    "- Commit: $($report.gitCommit)"
+    "- Output root: $($report.outputRoot)"
+    "- Workspace root: $($report.workspaceRoot)"
+    "- Package format: portable-zip"
+    "- Portable zip: $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $zipPath)"
+    "- Release executable: $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $workbenchExePath)"
+    "- Launch smoke: passed ($LaunchSmokeSeconds s window)"
+    ""
+    "## Acceptance Coverage"
+    ""
+    "- Packaged app launched from the extracted portable beta package."
+    "- Smoke loop covered diagnostics, format check/write, compile, verify, disasm, run, and release bundle verification."
+    "- Full command captures are preserved under 'artifacts/workbench/beta-smoke/logs/'."
+    ""
+    "## Step Summary"
+    ""
+    "| Step | Expectation | Exit | Duration (ms) | Stdout | Stderr |"
+    "| --- | --- | ---: | ---: | --- | --- |"
+)
+
+foreach ($step in $steps) {
+    $expectation = if ($step.expectFailure) { "expected failure" } else { "success" }
+    $stdoutRelative = Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $step.stdoutPath
+    $stderrRelative = Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $step.stderrPath
+    $markdown += "| $($step.name) | $expectation | $($step.exitCode) | $($step.durationMs) | '$stdoutRelative' | '$stderrRelative' |"
+}
+
+$markdown += ""
+$markdown += "## Bundle Inventory"
+$markdown += ""
+$markdown += "| Artifact | Size (bytes) | SHA256 |"
+$markdown += "| --- | ---: | --- |"
+$markdown += "| $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $bundleManifest.releaseExecutable.absolutePath) | $($bundleManifest.releaseExecutable.sizeBytes) | '$($bundleManifest.releaseExecutable.sha256)' |"
+$markdown += "| $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $bundleManifest.portableZip.absolutePath) | $($bundleManifest.portableZip.sizeBytes) | '$($bundleManifest.portableZip.sha256)' |"
+
+$markdown -join "`n" | Set-Content -LiteralPath $markdownReportPath
+
+Write-Host "Workbench beta smoke evidence written to:"
+Write-Host "  $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $jsonReportPath)"
+Write-Host "  $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $markdownReportPath)"
+Write-Host "  $(Get-RepoRelativePath -RepoRoot $repoRoot -AbsolutePath $bundleManifestPath)"


### PR DESCRIPTION
WB-BH-13 adds a reproducible beta packaging path and commits the resulting smoke evidence.

## What changed
- add `scripts/package_workbench_beta.ps1` to build a portable Workbench beta zip and capture smoke evidence
- document the beta packaging contract in `docs/workbench/beta_packaging.md`
- record the latest package manifest, release bundle manifest, and smoke reports under `artifacts/workbench/beta-smoke/`
- update the Workbench README with the packaging command

## Smoke coverage
- packaged app launch from extracted portable package
- diagnostics failure capture
- formatter check/write/check loop
- compile, verify, disasm, run
- release bundle verification

## Validation
- pwsh -File scripts/package_workbench_beta.ps1

Refs #62
