### PR TITLE
WB-BH-14 beta release notes and known-limits alignment

### DIFF
--- a/apps/workbench/README.md
+++ b/apps/workbench/README.md
@@ -37,6 +37,16 @@ This builds the release executable, creates a portable beta zip, launches the
 packaged app for a short smoke window, and records evidence under
 `artifacts/workbench/beta-smoke/`.
 
+## Beta Notes
+
+See:
+
+- `docs/workbench/beta_release_notes.md`
+- `docs/workbench/beta_packaging.md`
+
+These pages distinguish stable-now versus experimental workflows and document
+the current beta known limits without promising behavior beyond `main`.
+
 ## Scope Guard
 
 The first implementation waves must continue to respect the repository rule that

--- a/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-03-15T21:22:41.9740735Z",
+  "generatedAtUtc": "2026-03-15T21:30:01.3974544Z",
   "productName": "Semantic Workbench",
   "version": "0.1.0",
   "packageFormat": "portable-zip",
@@ -7,18 +7,18 @@
     "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target\\release\\semantic-workbench-app.exe",
     "fileName": "semantic-workbench-app.exe",
     "sizeBytes": 9077248,
-    "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
+    "sha256": "59e6840834c20d3d995c8011fc8314a725622dd58f57febb78e0695ce370b95f"
   },
   "portableZip": {
     "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
     "fileName": "semantic-workbench-beta-portable.zip",
-    "sizeBytes": 2895803,
-    "sha256": "9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820"
+    "sizeBytes": 2895799,
+    "sha256": "e979dec3618fda6ca8425cbe283fb78b2818de7ee779be6fb3b26469bb2a042e"
   },
   "extractedExecutable": {
     "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
     "fileName": "semantic-workbench-app.exe",
     "sizeBytes": 9077248,
-    "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
+    "sha256": "59e6840834c20d3d995c8011fc8314a725622dd58f57febb78e0695ce370b95f"
   }
 }

--- a/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_release_bundle_manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-16T02:22:41+05:00",
+  "generated_at": "2026-03-16T02:30:00+05:00",
   "documentation_bundle": [
     "docs/architecture",
     "docs/spec",

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.json
@@ -1,11 +1,11 @@
 {
-  "generatedAtUtc": "2026-03-15T21:22:42.0734627Z",
+  "generatedAtUtc": "2026-03-15T21:30:01.4975699Z",
   "gitBranch": "codex/wb-bh-14-beta-release-notes",
-  "gitCommit": "2ea476e3f8c554daa958fccaf88096b1c4583bd8",
+  "gitCommit": "a39a01f30e03f1031dfb9cf095987b5ed1bad5ea",
   "outputRoot": "artifacts/workbench/beta-smoke",
   "workspaceRoot": "artifacts/workbench/beta-smoke/workspace",
   "portablePackage": {
-    "generatedAtUtc": "2026-03-15T21:22:41.9740735Z",
+    "generatedAtUtc": "2026-03-15T21:30:01.3974544Z",
     "productName": "Semantic Workbench",
     "version": "0.1.0",
     "packageFormat": "portable-zip",
@@ -13,25 +13,25 @@
       "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\tauri-target\\release\\semantic-workbench-app.exe",
       "fileName": "semantic-workbench-app.exe",
       "sizeBytes": 9077248,
-      "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
+      "sha256": "59e6840834c20d3d995c8011fc8314a725622dd58f57febb78e0695ce370b95f"
     },
     "portableZip": {
       "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package\\semantic-workbench-beta-portable.zip",
       "fileName": "semantic-workbench-beta-portable.zip",
-      "sizeBytes": 2895803,
-      "sha256": "9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820"
+      "sizeBytes": 2895799,
+      "sha256": "e979dec3618fda6ca8425cbe283fb78b2818de7ee779be6fb3b26469bb2a042e"
     },
     "extractedExecutable": {
       "absolutePath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\package-extract\\semantic-workbench-app.exe",
       "fileName": "semantic-workbench-app.exe",
       "sizeBytes": 9077248,
-      "sha256": "ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8"
+      "sha256": "59e6840834c20d3d995c8011fc8314a725622dd58f57febb78e0695ce370b95f"
     }
   },
   "launchSmoke": {
     "launched": true,
     "launchSmokeSeconds": 8,
-    "durationMs": 8116,
+    "durationMs": 8126,
     "executable": "artifacts/workbench/beta-smoke/package-extract/semantic-workbench-app.exe",
     "exitCodeBeforeStop": null
   },
@@ -48,7 +48,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 6048,
+      "durationMs": 7062,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-lint.stderr.txt"
     },
@@ -64,7 +64,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 6024,
+      "durationMs": 6021,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-build.stderr.txt"
     },
@@ -81,7 +81,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 2035,
+      "durationMs": 2028,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-tauri-tests.stderr.txt"
     },
@@ -101,7 +101,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1022,
+      "durationMs": 1030,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\semantic-release-binaries.stderr.txt"
     },
@@ -118,7 +118,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 358029,
+      "durationMs": 318014,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\workbench-release-build.stderr.txt"
     },
@@ -151,7 +151,7 @@
       "exitCode": 1,
       "expectFailure": true,
       "succeeded": true,
-      "durationMs": 1023,
+      "durationMs": 1014,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-before-write.stderr.txt"
     },
@@ -167,7 +167,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1022,
+      "durationMs": 1014,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-write.stderr.txt"
     },
@@ -184,7 +184,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1019,
+      "durationMs": 1013,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-format-check-after-write.stderr.txt"
     },
@@ -202,7 +202,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1024,
+      "durationMs": 1025,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-compile.stderr.txt"
     },
@@ -218,7 +218,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1017,
+      "durationMs": 1020,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-verify.stderr.txt"
     },
@@ -234,7 +234,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1018,
+      "durationMs": 1032,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\smoke-disasm.stderr.txt"
     },
@@ -268,7 +268,7 @@
       "exitCode": 0,
       "expectFailure": false,
       "succeeded": true,
-      "durationMs": 1013,
+      "durationMs": 1015,
       "stdoutPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stdout.txt",
       "stderrPath": "C:\\Users\\said3\\Desktop\\EXOcode\\EXOcode\\artifacts\\workbench\\beta-smoke\\logs\\release-bundle-verify.stderr.txt"
     }

--- a/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
+++ b/artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md
@@ -1,8 +1,8 @@
 # Workbench Beta Smoke Report
 
-- Generated: 2026-03-15T21:22:42.0734627Z
+- Generated: 2026-03-15T21:30:01.4975699Z
 - Branch: codex/wb-bh-14-beta-release-notes
-- Commit: 2ea476e3f8c554daa958fccaf88096b1c4583bd8
+- Commit: a39a01f30e03f1031dfb9cf095987b5ed1bad5ea
 - Output root: artifacts/workbench/beta-smoke
 - Workspace root: artifacts/workbench/beta-smoke/workspace
 - Package format: portable-zip
@@ -20,24 +20,24 @@
 
 | Step | Expectation | Exit | Duration (ms) | Stdout | Stderr |
 | --- | --- | ---: | ---: | --- | --- |
-| workbench lint | success | 0 | 6048 | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stderr.txt' |
-| workbench build | success | 0 | 6024 | 'artifacts/workbench/beta-smoke/logs/workbench-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-build.stderr.txt' |
-| workbench tauri tests | success | 0 | 2035 | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stderr.txt' |
-| semantic release binaries | success | 0 | 1022 | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stderr.txt' |
-| workbench release build | success | 0 | 358029 | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stderr.txt' |
+| workbench lint | success | 0 | 7062 | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-lint.stderr.txt' |
+| workbench build | success | 0 | 6021 | 'artifacts/workbench/beta-smoke/logs/workbench-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-build.stderr.txt' |
+| workbench tauri tests | success | 0 | 2028 | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-tauri-tests.stderr.txt' |
+| semantic release binaries | success | 0 | 1030 | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/semantic-release-binaries.stderr.txt' |
+| workbench release build | success | 0 | 318014 | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/workbench-release-build.stderr.txt' |
 | smoke diagnostics check | expected failure | 1 | 1020 | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-diagnostics-check.stderr.txt' |
-| smoke format check before write | expected failure | 1 | 1023 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stderr.txt' |
-| smoke format write | success | 0 | 1022 | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stderr.txt' |
-| smoke format check after write | success | 0 | 1019 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stderr.txt' |
-| smoke compile | success | 0 | 1024 | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stderr.txt' |
-| smoke verify | success | 0 | 1017 | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stderr.txt' |
-| smoke disasm | success | 0 | 1018 | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stderr.txt' |
+| smoke format check before write | expected failure | 1 | 1014 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-before-write.stderr.txt' |
+| smoke format write | success | 0 | 1014 | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-write.stderr.txt' |
+| smoke format check after write | success | 0 | 1013 | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-format-check-after-write.stderr.txt' |
+| smoke compile | success | 0 | 1025 | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-compile.stderr.txt' |
+| smoke verify | success | 0 | 1020 | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-verify.stderr.txt' |
+| smoke disasm | success | 0 | 1032 | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-disasm.stderr.txt' |
 | smoke run | success | 0 | 1015 | 'artifacts/workbench/beta-smoke/logs/smoke-run.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/smoke-run.stderr.txt' |
-| release bundle verify | success | 0 | 1013 | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stderr.txt' |
+| release bundle verify | success | 0 | 1015 | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stdout.txt' | 'artifacts/workbench/beta-smoke/logs/release-bundle-verify.stderr.txt' |
 
 ## Bundle Inventory
 
 | Artifact | Size (bytes) | SHA256 |
 | --- | ---: | --- |
-| artifacts/workbench/beta-smoke/tauri-target/release/semantic-workbench-app.exe | 9077248 | 'ce6076ac0a173301c63960c05410a1036799317e5d609966987a3aad41d9c2a8' |
-| artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip | 2895803 | '9850e18d3a83037e272642796b2333aa6dd44d81ddc1bf71abaa3d5964dd6820' |
+| artifacts/workbench/beta-smoke/tauri-target/release/semantic-workbench-app.exe | 9077248 | '59e6840834c20d3d995c8011fc8314a725622dd58f57febb78e0695ce370b95f' |
+| artifacts/workbench/beta-smoke/package/semantic-workbench-beta-portable.zip | 2895799 | 'e979dec3618fda6ca8425cbe283fb78b2818de7ee779be6fb3b26469bb2a042e' |

--- a/docs/workbench/beta_packaging.md
+++ b/docs/workbench/beta_packaging.md
@@ -4,6 +4,9 @@ Workbench beta packaging is intentionally a thin release layer over the
 integrated desktop shell. It does not introduce a second installer-specific
 workflow or alternate runtime model.
 
+Release posture, stable-versus-experimental workflow labels, and known limits
+for the beta line are tracked in `docs/workbench/beta_release_notes.md`.
+
 ## Current Beta Package
 
 The current beta-facing package is a portable zip built from the Tauri release

--- a/docs/workbench/beta_release_notes.md
+++ b/docs/workbench/beta_release_notes.md
@@ -1,0 +1,108 @@
+# Semantic Workbench Beta Release Notes
+
+Semantic Workbench is currently published as a beta-facing desktop shell over
+the Semantic repository. These notes describe only the workflows that exist on
+the current `main` line.
+
+## Current Beta Posture
+
+- package format: portable Windows zip
+- desktop shell: Tauri + React
+- command orchestration: `smc`, `svm`, `cargo`, and release scripts only
+- repository truth: `docs/spec/*`, `docs/roadmap/*`, release artifacts, and
+  captured validation outputs
+
+These notes do not claim a second source of truth for compiler, verifier, VM,
+runtime, or release semantics.
+
+## Setup
+
+### Development setup
+
+```powershell
+cd apps\workbench
+npm install
+npm run dev
+```
+
+### Local validation
+
+```powershell
+cd apps\workbench
+npm run lint
+npm run build
+cargo check --manifest-path src-tauri/Cargo.toml
+cargo test --manifest-path src-tauri/Cargo.toml
+npm run tauri:build -- --debug --no-bundle
+```
+
+### Portable beta packaging
+
+```powershell
+pwsh -File scripts/package_workbench_beta.ps1
+```
+
+Packaging evidence is recorded under `artifacts/workbench/beta-smoke/`.
+
+## Stable Now
+
+The following Workbench workflows are considered beta-ready on the current
+mainline:
+
+- open repository or canonical sub-workspace
+- recent workspaces and local settings restore
+- overview and operations cockpit
+- jobs panel and command output
+- spec navigator and release/readiness panels
+- project explorer and editor shell
+- current-file `check` and `compile`
+- diagnostics grouping and source navigation
+- formatter integration through canonical `smc fmt`
+- disasm / verify / trace / runtime inspectors
+- release console and clean validation report export
+- project scaffolding through canonical `Semantic.toml` / `src/main.sm`
+- docs entry and package metadata preview
+
+## Experimental
+
+The following path remains explicitly experimental:
+
+- `smlsp` protocol bridge
+
+Experimental means:
+
+- it stays behind the Workbench experimental toggle
+- it is not required for the primary beta authoring loop
+- failures in this path must remain local to the experimental panel
+- it must not be described as stable editor semantics
+
+## Known Limits
+
+Current beta known limits:
+
+- packaging is a portable zip, not a full installer
+- package smoke evidence is currently Windows-first
+- `smlsp` is optional and experimental
+- Workbench is not a full IDE and does not claim complete editor-protocol
+  coverage
+- Workbench does not own compiler, verifier, VM, PROMETHEUS, or runtime logic
+- release status is derived from canonical docs and recorded validation outputs,
+  not from a hidden UI-only score
+
+## What These Notes Do Not Promise
+
+These notes do not promise:
+
+- a full stable installer pipeline
+- a public guarantee for `smlsp`
+- richer editor semantics beyond the current bridge
+- any capability beyond the current `main` branch implementation
+- ownership transfer of Semantic internals into Workbench
+
+## Evidence Pointers
+
+- packaging contract: `docs/workbench/beta_packaging.md`
+- latest beta smoke report:
+  `artifacts/workbench/beta-smoke/workbench_beta_smoke_latest.md`
+- latest beta package manifest:
+  `artifacts/workbench/beta-smoke/workbench_beta_package_manifest.json`


### PR DESCRIPTION
WB-BH-14 aligns public-facing beta notes with the current Workbench mainline.

## What changed
- add canonical beta release notes for Workbench
- document setup, stable-now workflows, experimental workflows, and known limits
- link packaging documentation and README back to the canonical beta notes
- avoid promising behavior beyond the current `main` implementation

## Validation
- docs-only change; no code or build behavior changed

Refs #63
