### PR TITLE
D20-A03 match as expression

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -18,8 +18,8 @@ pub mod types;
 pub use types::{
     AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, FrontendErrorKind, Function,
     IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
-    LogosSystem, LogosWhen, MatchArm, Program, QuadVal, Stmt, StmtId, SymbolId, Token,
-    TokenKind, Type, UnaryOp,
+    LogosSystem, LogosWhen, MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt, StmtId,
+    SymbolId, Token, TokenKind, Type, UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -7,7 +7,8 @@ use crate::CompilePolicyView;
 use crate::types::{
     AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, Function, IfExpr, LogosEntity,
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
-    MatchArm, Program, QuadVal, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
+    MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt, StmtId, SymbolId, Token,
+    TokenKind, Type, UnaryOp,
 };
 use sm_profile::{CompatibilityMode, ParserProfile};
 use ton618_core::diagnostics::{
@@ -145,41 +146,7 @@ impl<'a> Parser<'a> {
             }));
         }
         if self.eat(TokenKind::KwMatch) {
-            let scrutinee = self.parse_expr()?;
-            self.expect(TokenKind::LBrace, "expected '{' after match expr")?;
-            let mut arms = Vec::new();
-            let mut default: Option<Vec<StmtId>> = None;
-            while !self.check(TokenKind::RBrace) {
-                if self.eat(TokenKind::Underscore) {
-                    self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
-                    let block = self.parse_block()?;
-                    default = Some(block);
-                    continue;
-                }
-                let pat = if self.eat(TokenKind::QuadN) {
-                    QuadVal::N
-                } else if self.eat(TokenKind::QuadF) {
-                    QuadVal::F
-                } else if self.eat(TokenKind::QuadT) {
-                    QuadVal::T
-                } else if self.eat(TokenKind::QuadS) {
-                    QuadVal::S
-                } else {
-                    return Err(FrontendError {
-                        pos: self.pos(),
-                        message: "expected match pattern N|F|T|S|_".to_string(),
-                    });
-                };
-                self.expect(TokenKind::FatArrow, "expected '=>' after match pattern")?;
-                let block = self.parse_block()?;
-                arms.push(MatchArm { pat, block });
-            }
-            self.expect(TokenKind::RBrace, "expected '}' after match arms")?;
-            return Ok(self.arena.alloc_stmt(Stmt::Match {
-                scrutinee,
-                arms,
-                default: default.unwrap_or_default(),
-            }));
+            return self.parse_match_stmt_after_kw_match();
         }
         if self.eat(TokenKind::KwReturn) {
             if self.eat(TokenKind::Semi) {
@@ -323,6 +290,9 @@ impl<'a> Parser<'a> {
         if self.eat(TokenKind::KwIf) {
             return self.parse_if_expr_after_kw_if();
         }
+        if self.eat(TokenKind::KwMatch) {
+            return self.parse_match_expr_after_kw_match();
+        }
         if self.check(TokenKind::LBrace) {
             return self.parse_block_expr();
         }
@@ -422,6 +392,73 @@ impl<'a> Parser<'a> {
         })))
     }
 
+    fn parse_match_stmt_after_kw_match(&mut self) -> Result<StmtId, FrontendError> {
+        let scrutinee = self.parse_expr()?;
+        self.expect(TokenKind::LBrace, "expected '{' after match expr")?;
+        let mut arms = Vec::new();
+        let mut default: Option<Vec<StmtId>> = None;
+        while !self.check(TokenKind::RBrace) {
+            if self.eat(TokenKind::Underscore) {
+                self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
+                let block = self.parse_block()?;
+                default = Some(block);
+                continue;
+            }
+            let pat = self.parse_quad_match_pattern()?;
+            self.expect(TokenKind::FatArrow, "expected '=>' after match pattern")?;
+            let block = self.parse_block()?;
+            arms.push(MatchArm { pat, block });
+        }
+        self.expect(TokenKind::RBrace, "expected '}' after match arms")?;
+        Ok(self.arena.alloc_stmt(Stmt::Match {
+            scrutinee,
+            arms,
+            default: default.unwrap_or_default(),
+        }))
+    }
+
+    fn parse_match_expr_after_kw_match(&mut self) -> Result<ExprId, FrontendError> {
+        let scrutinee = self.parse_expr()?;
+        self.expect(TokenKind::LBrace, "expected '{' after match expr")?;
+        let mut arms = Vec::new();
+        let mut default: Option<BlockExpr> = None;
+        while !self.check(TokenKind::RBrace) {
+            if self.eat(TokenKind::Underscore) {
+                self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
+                let block = self.parse_value_block()?;
+                default = Some(block);
+                continue;
+            }
+            let pat = self.parse_quad_match_pattern()?;
+            self.expect(TokenKind::FatArrow, "expected '=>' after match pattern")?;
+            let block = self.parse_value_block()?;
+            arms.push(MatchExprArm { pat, block });
+        }
+        self.expect(TokenKind::RBrace, "expected '}' after match arms")?;
+        Ok(self.arena.alloc_expr(Expr::Match(MatchExpr {
+            scrutinee,
+            arms,
+            default,
+        })))
+    }
+
+    fn parse_quad_match_pattern(&mut self) -> Result<QuadVal, FrontendError> {
+        if self.eat(TokenKind::QuadN) {
+            Ok(QuadVal::N)
+        } else if self.eat(TokenKind::QuadF) {
+            Ok(QuadVal::F)
+        } else if self.eat(TokenKind::QuadT) {
+            Ok(QuadVal::T)
+        } else if self.eat(TokenKind::QuadS) {
+            Ok(QuadVal::S)
+        } else {
+            Err(FrontendError {
+                pos: self.pos(),
+                message: "expected match pattern N|F|T|S|_".to_string(),
+            })
+        }
+    }
+
     fn parse_value_block(&mut self) -> Result<BlockExpr, FrontendError> {
         self.expect(TokenKind::LBrace, "expected '{'")?;
         let mut statements = Vec::new();
@@ -440,7 +477,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if self.check(TokenKind::KwMatch) || self.check(TokenKind::KwReturn) {
+            if self.check(TokenKind::KwReturn) {
                 return Err(FrontendError {
                     pos: self.pos(),
                     message:
@@ -1085,6 +1122,35 @@ fn main() {
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("else-if sugar must reject in value position");
         assert!(err.message.contains("else-if sugar is not supported in if expressions yet"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_match_expression() {
+        let src = r#"
+fn main() {
+    let value: f64 = match T {
+        T => { 1.0 }
+        _ => { 2.0 }
+    };
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("match expression should parse");
+        let func = &program.functions[0];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading let statement");
+        };
+        let Expr::Match(match_expr) = program.arena.expr(*value) else {
+            panic!("expected match expression");
+        };
+        assert!(matches!(
+            program.arena.expr(match_expr.scrutinee),
+            Expr::QuadLiteral(QuadVal::T)
+        ));
+        assert_eq!(match_expr.arms.len(), 1);
+        assert!(match_expr.default.is_some());
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -272,6 +272,7 @@ fn infer_expr_type(
             }
             Ok(then_ty)
         }
+        Expr::Match(match_expr) => infer_match_expr_type(match_expr, arena, env, table, ret_ty),
         Expr::Call(name, args) => {
             let sig = if let Some(s) = table.get(name) {
                 s.clone()
@@ -555,6 +556,77 @@ mod tests {
             .message
             .contains("if expression condition must be bool"));
     }
+
+    #[test]
+    fn match_expression_typechecks_when_arms_match() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T => { 1.0 }
+                    F => { 2.0 }
+                    _ => { 3.0 }
+                };
+                let same = total == total;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("match expression should typecheck");
+    }
+
+    #[test]
+    fn match_expression_requires_quad_scrutinee() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match true {
+                    T => { 1.0 }
+                    _ => { 2.0 }
+                };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-quad match expression must reject");
+        assert!(err
+            .message
+            .contains("match expression is allowed only for quad scrutinee"));
+    }
+
+    #[test]
+    fn match_expression_requires_default_arm() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T => { 1.0 }
+                };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("match expression without default must reject");
+        assert!(err
+            .message
+            .contains("match expression requires default arm '_'"));
+    }
+
+    #[test]
+    fn match_expression_rejects_branch_type_mismatch() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T => { 1.0 }
+                    _ => { true }
+                };
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("mismatched match expression branches must reject");
+        assert!(err
+            .message
+            .contains("match expression branch type mismatch"));
+    }
 }
 
 fn infer_value_block_type(
@@ -582,4 +654,58 @@ fn infer_value_block_type(
     let tail_ty = infer_expr_type(block.tail, arena, &block_env, table, ret_ty)?;
     block_env.pop_scope();
     Ok(tail_ty)
+}
+
+fn infer_match_expr_type(
+    match_expr: &MatchExpr,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    ret_ty: Type,
+) -> Result<Type, FrontendError> {
+    let scrutinee_ty = infer_expr_type(match_expr.scrutinee, arena, env, table, ret_ty)?;
+    if scrutinee_ty != Type::Quad {
+        return Err(FrontendError {
+            pos: 0,
+            message: "match expression is allowed only for quad scrutinee".to_string(),
+        });
+    }
+    let default = match_expr.default.as_ref().ok_or(FrontendError {
+        pos: 0,
+        message: "match expression requires default arm '_'".to_string(),
+    })?;
+
+    let mut result_ty = None;
+    for arm in &match_expr.arms {
+        let arm_ty = infer_value_block_type(&arm.block, arena, env, table, ret_ty)?;
+        if let Some(expected) = result_ty {
+            if expected != arm_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "match expression branch type mismatch: expected {:?}, got {:?}",
+                        expected, arm_ty
+                    ),
+                });
+            }
+        } else {
+            result_ty = Some(arm_ty);
+        }
+    }
+
+    let default_ty = infer_value_block_type(default, arena, env, table, ret_ty)?;
+    if let Some(expected) = result_ty {
+        if expected != default_ty {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "match expression branch type mismatch: expected {:?}, got {:?}",
+                    expected, default_ty
+                ),
+            });
+        }
+        Ok(expected)
+    } else {
+        Ok(default_ty)
+    }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -56,6 +56,7 @@ pub enum Expr {
     Binary(ExprId, BinaryOp, ExprId),
     Block(BlockExpr),
     If(IfExpr),
+    Match(MatchExpr),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -90,6 +91,19 @@ pub struct IfExpr {
     pub condition: ExprId,
     pub then_block: BlockExpr,
     pub else_block: BlockExpr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchExpr {
+    pub scrutinee: ExprId,
+    pub arms: Vec<MatchExprArm>,
+    pub default: Option<BlockExpr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchExprArm {
+    pub pat: QuadVal,
+    pub block: BlockExpr,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -934,7 +934,9 @@ fn lower_expr_with_expected(
             });
             Ok((r, ty))
         }
-        Expr::Block(block) => lower_value_block_expr(block, arena, next, out, env, fn_table, expected, ret_ty),
+        Expr::Block(block) => {
+            lower_value_block_expr(block, arena, next, out, env, fn_table, expected, ret_ty)
+        }
         Expr::If(if_expr) => {
             let (cond_reg, cond_ty) =
                 lower_expr(if_expr.condition, arena, next, out, env, fn_table, ret_ty)?;
@@ -1013,6 +1015,9 @@ fn lower_expr_with_expected(
                 name: result_name,
             });
             Ok((dst, then_ty))
+        }
+        Expr::Match(match_expr) => {
+            lower_match_expr(match_expr, arena, next, out, env, fn_table, expected, ret_ty)
         }
         Expr::Call(name, args) => {
             let sig = if let Some(s) = fn_table.get(name) {
@@ -1555,6 +1560,121 @@ fn lower_value_block_expr(
     Ok(tail)
 }
 
+fn lower_match_expr(
+    match_expr: &MatchExpr,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    fn_table: &FnTable,
+    expected: Option<Type>,
+    ret_ty: Type,
+) -> Result<(u16, Type), FrontendError> {
+    let (scr_reg, scr_ty) = lower_expr(match_expr.scrutinee, arena, next, out, env, fn_table, ret_ty)?;
+    if scr_ty != Type::Quad {
+        return Err(FrontendError {
+            pos: 0,
+            message: "match expression scrutinee must be quad".to_string(),
+        });
+    }
+    let default = match_expr.default.as_ref().ok_or(FrontendError {
+        pos: 0,
+        message: "match expression requires default arm '_'".to_string(),
+    })?;
+
+    let id = alloc_match_expr_id(next);
+    let end_label = format!("match_expr_{}_end", id);
+    let default_label = format!("match_expr_{}_default", id);
+    let arm_labels: Vec<String> = (0..match_expr.arms.len())
+        .map(|i| format!("match_expr_{}_arm_{}", id, i))
+        .collect();
+    let result_name = format!("__match_expr_{}_result", id);
+
+    for (i, arm) in match_expr.arms.iter().enumerate() {
+        let lit_reg = alloc(next);
+        out.push(IrInstr::LoadQ {
+            dst: lit_reg,
+            val: arm.pat,
+        });
+        let cmp_reg = alloc(next);
+        out.push(IrInstr::CmpEq {
+            dst: cmp_reg,
+            lhs: scr_reg,
+            rhs: lit_reg,
+        });
+        out.push(IrInstr::JmpIf {
+            cond: cmp_reg,
+            label: arm_labels[i].clone(),
+        });
+    }
+    out.push(IrInstr::Jmp {
+        label: default_label.clone(),
+    });
+
+    let mut result_ty = None;
+    for (i, arm) in match_expr.arms.iter().enumerate() {
+        out.push(IrInstr::Label {
+            name: arm_labels[i].clone(),
+        });
+        let (arm_reg, arm_ty) =
+            lower_value_block_expr(&arm.block, arena, next, out, env, fn_table, expected, ret_ty)?;
+        if let Some(expected_ty) = result_ty {
+            if expected_ty != arm_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "match expression branch type mismatch in lowering: expected {:?}, got {:?}",
+                        expected_ty, arm_ty
+                    ),
+                });
+            }
+        } else {
+            result_ty = Some(arm_ty);
+        }
+        out.push(IrInstr::StoreVar {
+            name: result_name.clone(),
+            src: arm_reg,
+        });
+        out.push(IrInstr::Jmp {
+            label: end_label.clone(),
+        });
+    }
+
+    out.push(IrInstr::Label {
+        name: default_label,
+    });
+    let (default_reg, default_ty) =
+        lower_value_block_expr(default, arena, next, out, env, fn_table, expected, ret_ty)?;
+    if let Some(expected_ty) = result_ty {
+        if expected_ty != default_ty {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "match expression branch type mismatch in lowering: expected {:?}, got {:?}",
+                    expected_ty, default_ty
+                ),
+            });
+        }
+    } else {
+        result_ty = Some(default_ty);
+    }
+    out.push(IrInstr::StoreVar {
+        name: result_name.clone(),
+        src: default_reg,
+    });
+    out.push(IrInstr::Jmp {
+        label: end_label.clone(),
+    });
+
+    out.push(IrInstr::Label { name: end_label });
+    let dst = alloc(next);
+    out.push(IrInstr::LoadVar {
+        dst,
+        name: result_name,
+    });
+    Ok((dst, result_ty.expect("default arm guarantees result type")))
+}
+
 fn lower_expr_stmt(
     expr_id: ExprId,
     arena: &AstArena,
@@ -1575,6 +1695,12 @@ fn lower_expr_stmt(
 }
 
 fn alloc_if_expr_id(next: &mut u16) -> u16 {
+    let id = *next;
+    *next += 1;
+    id
+}
+
+fn alloc_match_expr_id(next: &mut u16) -> u16 {
     let id = *next;
     *next += 1;
     id
@@ -1773,6 +1899,53 @@ mod opt_tests {
         assert!(err
             .message
             .contains("if expression branch type mismatch"));
+    }
+
+    #[test]
+    fn lower_match_expression_to_ir() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T => { 1.0 }
+                    _ => { 2.0 }
+                };
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("match expression should lower");
+        let main = &ir[0];
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("match_expr_")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name.starts_with("__match_expr_")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::LoadVar { name, .. } if name.starts_with("__match_expr_")
+        )));
+    }
+
+    #[test]
+    fn lowering_match_expression_rejects_branch_type_mismatch() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T => { 1.0 }
+                    _ => { true }
+                };
+                return;
+            }
+        "#;
+
+        let err =
+            compile_program_to_ir(src).expect_err("mismatched match expression branches must reject");
+        assert!(err
+            .message
+            .contains("match expression branch type mismatch"));
     }
 
     #[test]

--- a/crates/sm-ir/src/lib.rs
+++ b/crates/sm-ir/src/lib.rs
@@ -9,8 +9,8 @@ mod frontend {
         build_fn_table, builtin_sig, parse_logos_program_with_profile,
         parse_program_with_profile, resolve_symbol_name,
         type_check_function_with_table, type_check_program, AstArena, BinaryOp, BlockExpr,
-        CompileProfile, Expr, ExprId, FnTable, FrontendError, Function, LogosProgram, OptLevel,
-        QuadVal, ScopeEnv, Stmt, StmtId, SymbolId, Type, UnaryOp,
+        CompileProfile, Expr, ExprId, FnTable, FrontendError, Function, LogosProgram, MatchExpr,
+        OptLevel, QuadVal, ScopeEnv, Stmt, StmtId, SymbolId, Type, UnaryOp,
     };
     pub use sm_profile::ParserProfile;
 }

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -37,6 +37,7 @@ Current examples include:
 - block-expression parse failures such as missing trailing tail values
 - `if`-expression parse failures such as missing `else` or rejected `else if`
   sugar in value position
+- `match`-expression parse failures such as invalid literal arm patterns
 
 Current guarantees:
 
@@ -81,6 +82,7 @@ Current message families include:
 - return type mismatch
 - invalid `if` condition type
 - `if`-expression branch type mismatch
+- `match`-expression branch type mismatch
 - invalid `match` scrutinee or missing `_` arm
 - unsupported statement forms inside a value-producing block
 - unsupported operator for a type family

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -108,8 +108,8 @@ Current v0 limit:
 
 - block-expression bodies currently accept only `let` bindings and expression
   statements before the tail value
-- `match` and `return` are not yet supported inside value-producing block
-  bodies as a stable source contract
+- `return` is not yet supported inside value-producing block bodies as a
+  stable source contract
 
 ## Control Flow
 
@@ -146,8 +146,20 @@ Current `match` semantics:
 - `_` is required as the default arm
 - the first matching arm is selected deterministically
 
+Current `match` expression semantics:
+
+- `match scrutinee { ... }` may appear in value position
+- each non-default arm uses a value-producing block after `=>`
+- `_` is required as the default arm for value-producing `match`
+- all arms, including `_`, must produce the same type
+
 This is a deliberately narrow source contract rather than a full general
 pattern-matching system.
+
+Current v0 limit:
+
+- `match` expression arms do not yet support guards
+- only literal `quad` patterns and `_` are part of the stable source contract
 
 ## Operator Meaning
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -87,6 +87,8 @@ Current expression forms:
   - `{ let x = 1; x }`
 - `if` expressions with explicit `else` blocks:
   - `if ready { 1.0 } else { 0.0 }`
+- `match` expressions with value-producing arms:
+  - `match state { T => { 1.0 } _ => { 0.0 } }`
 - parenthesized expressions
 - unary operators:
   - `!`
@@ -147,7 +149,6 @@ surface is part of the language contract and is specified in `modules.md`.
 
 The current source contract does not yet claim stable support for:
 
-- `match` as a value-producing expression
 - relational operators such as `>`, `<`, `>=`, `<=`
 - user-defined aggregate types
 - collections as first-class language forms


### PR DESCRIPTION
Refs #81.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
