### PR TITLE
D20-A04 match guards

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -399,15 +399,22 @@ impl<'a> Parser<'a> {
         let mut default: Option<Vec<StmtId>> = None;
         while !self.check(TokenKind::RBrace) {
             if self.eat(TokenKind::Underscore) {
+                if self.check(TokenKind::KwIf) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "default '_' arm in match currently cannot have guard".to_string(),
+                    });
+                }
                 self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
                 let block = self.parse_block()?;
                 default = Some(block);
                 continue;
             }
             let pat = self.parse_quad_match_pattern()?;
+            let guard = self.parse_match_guard_opt()?;
             self.expect(TokenKind::FatArrow, "expected '=>' after match pattern")?;
             let block = self.parse_block()?;
-            arms.push(MatchArm { pat, block });
+            arms.push(MatchArm { pat, guard, block });
         }
         self.expect(TokenKind::RBrace, "expected '}' after match arms")?;
         Ok(self.arena.alloc_stmt(Stmt::Match {
@@ -424,15 +431,22 @@ impl<'a> Parser<'a> {
         let mut default: Option<BlockExpr> = None;
         while !self.check(TokenKind::RBrace) {
             if self.eat(TokenKind::Underscore) {
+                if self.check(TokenKind::KwIf) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "default '_' arm in match currently cannot have guard".to_string(),
+                    });
+                }
                 self.expect(TokenKind::FatArrow, "expected '=>' after '_'")?;
                 let block = self.parse_value_block()?;
                 default = Some(block);
                 continue;
             }
             let pat = self.parse_quad_match_pattern()?;
+            let guard = self.parse_match_guard_opt()?;
             self.expect(TokenKind::FatArrow, "expected '=>' after match pattern")?;
             let block = self.parse_value_block()?;
-            arms.push(MatchExprArm { pat, block });
+            arms.push(MatchExprArm { pat, guard, block });
         }
         self.expect(TokenKind::RBrace, "expected '}' after match arms")?;
         Ok(self.arena.alloc_expr(Expr::Match(MatchExpr {
@@ -457,6 +471,13 @@ impl<'a> Parser<'a> {
                 message: "expected match pattern N|F|T|S|_".to_string(),
             })
         }
+    }
+
+    fn parse_match_guard_opt(&mut self) -> Result<Option<ExprId>, FrontendError> {
+        if self.eat(TokenKind::KwIf) {
+            return Ok(Some(self.parse_expr()?));
+        }
+        Ok(None)
     }
 
     fn parse_value_block(&mut self) -> Result<BlockExpr, FrontendError> {
@@ -1129,7 +1150,7 @@ fn main() {
         let src = r#"
 fn main() {
     let value: f64 = match T {
-        T => { 1.0 }
+        T if true => { 1.0 }
         _ => { 2.0 }
     };
     return;
@@ -1150,7 +1171,26 @@ fn main() {
             Expr::QuadLiteral(QuadVal::T)
         ));
         assert_eq!(match_expr.arms.len(), 1);
+        assert!(match_expr.arms[0].guard.is_some());
         assert!(match_expr.default.is_some());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_guarded_default_match_arm() {
+        let src = r#"
+fn main() {
+    let value: f64 = match T {
+        _ if true => { 2.0 }
+    };
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("guarded default arm must reject");
+        assert!(err
+            .message
+            .contains("default '_' arm in match currently cannot have guard"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -182,6 +182,7 @@ fn check_stmt(
             for arm in arms {
                 let mut arm_env = env.clone();
                 arm_env.push_scope();
+                check_match_guard(arm.guard, arena, &arm_env, table, ret_ty)?;
                 for s in &arm.block {
                     check_stmt(*s, arena, &mut arm_env, ret_ty, table)?;
                 }
@@ -627,6 +628,22 @@ mod tests {
             .message
             .contains("match expression branch type mismatch"));
     }
+
+    #[test]
+    fn match_expression_guard_requires_bool() {
+        let src = r#"
+            fn main() {
+                let total: f64 = match T {
+                    T if T => { 1.0 }
+                    _ => { 2.0 }
+                };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-bool guard must reject");
+        assert!(err.message.contains("match guard condition must be bool"));
+    }
 }
 
 fn infer_value_block_type(
@@ -677,6 +694,7 @@ fn infer_match_expr_type(
 
     let mut result_ty = None;
     for arm in &match_expr.arms {
+        check_match_guard(arm.guard, arena, env, table, ret_ty)?;
         let arm_ty = infer_value_block_type(&arm.block, arena, env, table, ret_ty)?;
         if let Some(expected) = result_ty {
             if expected != arm_ty {
@@ -708,4 +726,24 @@ fn infer_match_expr_type(
     } else {
         Ok(default_ty)
     }
+}
+
+fn check_match_guard(
+    guard: Option<ExprId>,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    if let Some(expr_id) = guard {
+        let guard_ty = infer_expr_type(expr_id, arena, env, table, ret_ty)?;
+        if guard_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: "match guard condition must be bool; explicit compare is required for quad"
+                    .to_string(),
+            });
+        }
+    }
+    Ok(())
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -103,12 +103,14 @@ pub struct MatchExpr {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchExprArm {
     pub pat: QuadVal,
+    pub guard: Option<ExprId>,
     pub block: BlockExpr,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchArm {
     pub pat: QuadVal,
+    pub guard: Option<ExprId>,
     pub block: Vec<StmtId>,
 }
 

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1447,41 +1447,106 @@ fn lower_stmt(
             let arm_labels: Vec<String> = (0..arms.len())
                 .map(|i| format!("match_{}_arm_{}", mid, i))
                 .collect();
-
-            for (i, arm) in arms.iter().enumerate() {
-                let lit_reg = alloc(&mut ctx.next_reg);
-                ctx.instrs.push(IrInstr::LoadQ {
-                    dst: lit_reg,
-                    val: arm.pat,
-                });
-                let cmp_reg = alloc(&mut ctx.next_reg);
-                ctx.instrs.push(IrInstr::CmpEq {
-                    dst: cmp_reg,
-                    lhs: scr_reg,
-                    rhs: lit_reg,
-                });
-                ctx.instrs.push(IrInstr::JmpIf {
-                    cond: cmp_reg,
-                    label: arm_labels[i].clone(),
-                });
-            }
-            ctx.instrs.push(IrInstr::Jmp {
-                label: default_label.clone(),
-            });
-
-            for (i, arm) in arms.iter().enumerate() {
-                ctx.instrs.push(IrInstr::Label {
-                    name: arm_labels[i].clone(),
-                });
-                let mut arm_env = env.clone();
-                arm_env.push_scope();
-                for s in &arm.block {
-                    lower_stmt(*s, arena, ctx, &mut arm_env, ret_ty, fn_table)?;
+            if arms.iter().all(|arm| arm.guard.is_none()) {
+                for (i, arm) in arms.iter().enumerate() {
+                    let lit_reg = alloc(&mut ctx.next_reg);
+                    ctx.instrs.push(IrInstr::LoadQ {
+                        dst: lit_reg,
+                        val: arm.pat,
+                    });
+                    let cmp_reg = alloc(&mut ctx.next_reg);
+                    ctx.instrs.push(IrInstr::CmpEq {
+                        dst: cmp_reg,
+                        lhs: scr_reg,
+                        rhs: lit_reg,
+                    });
+                    ctx.instrs.push(IrInstr::JmpIf {
+                        cond: cmp_reg,
+                        label: arm_labels[i].clone(),
+                    });
                 }
-                arm_env.pop_scope();
                 ctx.instrs.push(IrInstr::Jmp {
-                    label: end_label.clone(),
+                    label: default_label.clone(),
                 });
+
+                for (i, arm) in arms.iter().enumerate() {
+                    ctx.instrs.push(IrInstr::Label {
+                        name: arm_labels[i].clone(),
+                    });
+                    let mut arm_env = env.clone();
+                    arm_env.push_scope();
+                    for s in &arm.block {
+                        lower_stmt(*s, arena, ctx, &mut arm_env, ret_ty, fn_table)?;
+                    }
+                    arm_env.pop_scope();
+                    ctx.instrs.push(IrInstr::Jmp {
+                        label: end_label.clone(),
+                    });
+                }
+            } else {
+                for (i, arm) in arms.iter().enumerate() {
+                    if i > 0 {
+                        ctx.instrs.push(IrInstr::Label {
+                            name: format!("match_{}_check_{}", mid, i),
+                        });
+                    }
+                    let next_label = if i + 1 < arms.len() {
+                        format!("match_{}_check_{}", mid, i + 1)
+                    } else {
+                        default_label.clone()
+                    };
+
+                    let lit_reg = alloc(&mut ctx.next_reg);
+                    ctx.instrs.push(IrInstr::LoadQ {
+                        dst: lit_reg,
+                        val: arm.pat,
+                    });
+                    let cmp_reg = alloc(&mut ctx.next_reg);
+                    ctx.instrs.push(IrInstr::CmpEq {
+                        dst: cmp_reg,
+                        lhs: scr_reg,
+                        rhs: lit_reg,
+                    });
+                    ctx.instrs.push(IrInstr::JmpIf {
+                        cond: cmp_reg,
+                        label: arm_labels[i].clone(),
+                    });
+                    ctx.instrs.push(IrInstr::Jmp {
+                        label: next_label.clone(),
+                    });
+
+                    ctx.instrs.push(IrInstr::Label {
+                        name: arm_labels[i].clone(),
+                    });
+                    let mut arm_env = env.clone();
+                    arm_env.push_scope();
+                    if let Some(guard_reg) = lower_match_guard(
+                        arm.guard,
+                        arena,
+                        &mut ctx.next_reg,
+                        &mut ctx.instrs,
+                        &arm_env,
+                        fn_table,
+                        ret_ty,
+                    )? {
+                        let guarded_body_label = format!("match_{}_body_{}", mid, i);
+                        ctx.instrs.push(IrInstr::JmpIf {
+                            cond: guard_reg,
+                            label: guarded_body_label.clone(),
+                        });
+                        ctx.instrs.push(IrInstr::Jmp { label: next_label });
+                        ctx.instrs.push(IrInstr::Label {
+                            name: guarded_body_label,
+                        });
+                    }
+                    for s in &arm.block {
+                        lower_stmt(*s, arena, ctx, &mut arm_env, ret_ty, fn_table)?;
+                    }
+                    arm_env.pop_scope();
+                    ctx.instrs.push(IrInstr::Jmp {
+                        label: end_label.clone(),
+                    });
+                }
             }
 
             ctx.instrs.push(IrInstr::Label {
@@ -1560,6 +1625,28 @@ fn lower_value_block_expr(
     Ok(tail)
 }
 
+fn lower_match_guard(
+    guard: Option<ExprId>,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    fn_table: &FnTable,
+    ret_ty: Type,
+) -> Result<Option<u16>, FrontendError> {
+    let Some(guard_expr) = guard else {
+        return Ok(None);
+    };
+    let (guard_reg, guard_ty) = lower_expr(guard_expr, arena, next, out, env, fn_table, ret_ty)?;
+    if guard_ty != Type::Bool {
+        return Err(FrontendError {
+            pos: 0,
+            message: "match guard condition must be bool".to_string(),
+        });
+    }
+    Ok(Some(guard_reg))
+}
+
 fn lower_match_expr(
     match_expr: &MatchExpr,
     arena: &AstArena,
@@ -1590,7 +1677,19 @@ fn lower_match_expr(
         .collect();
     let result_name = format!("__match_expr_{}_result", id);
 
+    let mut result_ty = None;
     for (i, arm) in match_expr.arms.iter().enumerate() {
+        if i > 0 {
+            out.push(IrInstr::Label {
+                name: format!("match_expr_{}_check_{}", id, i),
+            });
+        }
+        let next_label = if i + 1 < match_expr.arms.len() {
+            format!("match_expr_{}_check_{}", id, i + 1)
+        } else {
+            default_label.clone()
+        };
+
         let lit_reg = alloc(next);
         out.push(IrInstr::LoadQ {
             dst: lit_reg,
@@ -1606,18 +1705,39 @@ fn lower_match_expr(
             cond: cmp_reg,
             label: arm_labels[i].clone(),
         });
-    }
-    out.push(IrInstr::Jmp {
-        label: default_label.clone(),
-    });
+        out.push(IrInstr::Jmp {
+            label: next_label.clone(),
+        });
 
-    let mut result_ty = None;
-    for (i, arm) in match_expr.arms.iter().enumerate() {
         out.push(IrInstr::Label {
             name: arm_labels[i].clone(),
         });
-        let (arm_reg, arm_ty) =
-            lower_value_block_expr(&arm.block, arena, next, out, env, fn_table, expected, ret_ty)?;
+        let mut arm_env = env.clone();
+        arm_env.push_scope();
+        if let Some(guard_reg) =
+            lower_match_guard(arm.guard, arena, next, out, &arm_env, fn_table, ret_ty)?
+        {
+            let guarded_body_label = format!("match_expr_{}_body_{}", id, i);
+            out.push(IrInstr::JmpIf {
+                cond: guard_reg,
+                label: guarded_body_label.clone(),
+            });
+            out.push(IrInstr::Jmp { label: next_label });
+            out.push(IrInstr::Label {
+                name: guarded_body_label,
+            });
+        }
+        let (arm_reg, arm_ty) = lower_value_block_expr(
+            &arm.block,
+            arena,
+            next,
+            out,
+            &arm_env,
+            fn_table,
+            expected,
+            ret_ty,
+        )?;
+        arm_env.pop_scope();
         if let Some(expected_ty) = result_ty {
             if expected_ty != arm_ty {
                 return Err(FrontendError {
@@ -1906,7 +2026,7 @@ mod opt_tests {
         let src = r#"
             fn main() {
                 let total: f64 = match T {
-                    T => { 1.0 }
+                    T if true => { 1.0 }
                     _ => { 2.0 }
                 };
                 return;
@@ -1918,6 +2038,10 @@ mod opt_tests {
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,
             IrInstr::Label { name } if name.starts_with("match_expr_")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::LoadBool { .. }
         )));
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -82,6 +82,7 @@ Current message families include:
 - return type mismatch
 - invalid `if` condition type
 - `if`-expression branch type mismatch
+- invalid `match` guard condition type
 - `match`-expression branch type mismatch
 - invalid `match` scrutinee or missing `_` arm
 - unsupported statement forms inside a value-producing block

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -143,6 +143,7 @@ Current `match` semantics:
 
 - `match` is currently restricted to `quad`
 - arms match only the literal patterns `N`, `F`, `T`, `S`
+- non-default arms may attach a `bool` guard with `if guard_expr`
 - `_` is required as the default arm
 - the first matching arm is selected deterministically
 
@@ -150,6 +151,7 @@ Current `match` expression semantics:
 
 - `match scrutinee { ... }` may appear in value position
 - each non-default arm uses a value-producing block after `=>`
+- expression arms may use the same `if guard_expr` form as statement-side arms
 - `_` is required as the default arm for value-producing `match`
 - all arms, including `_`, must produce the same type
 
@@ -158,7 +160,7 @@ pattern-matching system.
 
 Current v0 limit:
 
-- `match` expression arms do not yet support guards
+- the default `_` arm does not yet support guards
 - only literal `quad` patterns and `_` are part of the stable source contract
 
 ## Operator Meaning

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -60,6 +60,7 @@ Current statement forms:
 - `let name: type = expr;`
 - `if condition { ... } else { ... }`
 - `match quad_expr { T => { ... } ... _ => { ... } }`
+- `match quad_expr { T if ready == true => { ... } ... _ => { ... } }`
 - `return;`
 - `return expr;`
 - expression statements: `expr;`
@@ -89,6 +90,7 @@ Current expression forms:
   - `if ready { 1.0 } else { 0.0 }`
 - `match` expressions with value-producing arms:
   - `match state { T => { 1.0 } _ => { 0.0 } }`
+  - `match state { T if ready == true => { 1.0 } _ => { 0.0 } }`
 - parenthesized expressions
 - unary operators:
   - `!`


### PR DESCRIPTION
Refs #82.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
