### PR TITLE
D20-A05 guard clause

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -242,6 +242,7 @@ fn tokenize_line(
                 let kind = match text {
                     "fn" => TokenKind::KwFn,
                     "let" => TokenKind::KwLet,
+                    "guard" => TokenKind::KwGuard,
                     "if" => TokenKind::KwIf,
                     "else" => TokenKind::KwElse,
                     "return" => TokenKind::KwReturn,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -126,6 +126,32 @@ impl<'a> Parser<'a> {
             self.expect(TokenKind::Semi, "expected ';'")?;
             return Ok(self.arena.alloc_stmt(Stmt::Let { name, ty, value }));
         }
+        if self.eat(TokenKind::KwGuard) {
+            let condition = self.parse_expr()?;
+            if !self.eat(TokenKind::KwElse) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message: "guard clause requires else return branch".to_string(),
+                });
+            }
+            if !self.eat(TokenKind::KwReturn) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message: "guard clause currently supports only else return".to_string(),
+                });
+            }
+            let else_return = if self.eat(TokenKind::Semi) {
+                None
+            } else {
+                let expr = self.parse_expr()?;
+                self.expect(TokenKind::Semi, "expected ';'")?;
+                Some(expr)
+            };
+            return Ok(self.arena.alloc_stmt(Stmt::Guard {
+                condition,
+                else_return,
+            }));
+        }
         if self.eat(TokenKind::KwIf) {
             let condition = self.parse_expr()?;
             let then_block = self.parse_block()?;
@@ -498,7 +524,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            if self.check(TokenKind::KwReturn) {
+            if self.check(TokenKind::KwGuard) || self.check(TokenKind::KwReturn) {
                 return Err(FrontendError {
                     pos: self.pos(),
                     message:
@@ -1191,6 +1217,42 @@ fn main() {
         assert!(err
             .message
             .contains("default '_' arm in match currently cannot have guard"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_guard_clause() {
+        let src = r#"
+fn main() {
+    guard true else return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("guard clause should parse");
+        let func = &program.functions[0];
+        let Stmt::Guard {
+            condition,
+            else_return,
+        } = program.arena.stmt(func.body[0]) else {
+            panic!("expected guard statement");
+        };
+        assert!(matches!(program.arena.expr(*condition), Expr::BoolLiteral(true)));
+        assert!(else_return.is_none());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_guard_without_else_return() {
+        let src = r#"
+fn main() {
+    guard true else { return; }
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("guard clause without else return should reject");
+        assert!(err
+            .message
+            .contains("guard clause currently supports only else return"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -131,6 +131,21 @@ fn check_stmt(
             env.insert(*name, final_ty);
             Ok(())
         }
+        Stmt::Guard {
+            condition,
+            else_return,
+        } => {
+            let condition_ty = infer_expr_type(*condition, arena, env, table, ret_ty)?;
+            if condition_ty != Type::Bool {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "guard clause condition must be bool; explicit compare is required for quad"
+                            .to_string(),
+                });
+            }
+            check_return_payload(*else_return, arena, env, table, ret_ty)
+        }
         Stmt::If {
             condition,
             then_block,
@@ -198,32 +213,7 @@ fn check_stmt(
             Ok(())
         }
         Stmt::Return(v) => {
-            let got = if let Some(e) = v {
-                infer_expr_type(*e, arena, env, table, ret_ty)?
-            } else {
-                Type::Unit
-            };
-            if got != ret_ty {
-                if ret_ty == Type::Fx && is_numeric_for_fx_gap(got) {
-                    if let Some(expr_id) = v {
-                        if is_fx_literal_expr(*expr_id, arena) {
-                            return Ok(());
-                        }
-                    }
-                    return Err(FrontendError {
-                        pos: 0,
-                        message: format!(
-                            "{}; function return currently requires an fx literal or an existing fx-typed value",
-                            fx_coercion_gap_message(),
-                        ),
-                    });
-                }
-                return Err(FrontendError {
-                    pos: 0,
-                    message: format!("return type mismatch: expected {:?}, got {:?}", ret_ty, got),
-                });
-            }
-            Ok(())
+            check_return_payload(*v, arena, env, table, ret_ty)
         }
         Stmt::Expr(e) => {
             let _ = infer_expr_type(*e, arena, env, table, ret_ty)?;
@@ -644,6 +634,43 @@ mod tests {
         let err = typecheck_source(src).expect_err("non-bool guard must reject");
         assert!(err.message.contains("match guard condition must be bool"));
     }
+
+    #[test]
+    fn guard_clause_typechecks_with_unit_return() {
+        let src = r#"
+            fn main() {
+                guard true else return;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("guard clause should typecheck");
+    }
+
+    #[test]
+    fn guard_clause_requires_bool_condition() {
+        let src = r#"
+            fn main() {
+                guard T else return;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-bool guard clause must reject");
+        assert!(err.message.contains("guard clause condition must be bool"));
+    }
+
+    #[test]
+    fn guard_clause_reuses_return_type_contract() {
+        let src = r#"
+            fn main() {
+                guard true else return true;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("guard return payload must typecheck");
+        assert!(err.message.contains("return type mismatch"));
+    }
 }
 
 fn infer_value_block_type(
@@ -744,6 +771,41 @@ fn check_match_guard(
                     .to_string(),
             });
         }
+    }
+    Ok(())
+}
+
+fn check_return_payload(
+    value: Option<ExprId>,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    let got = if let Some(expr_id) = value {
+        infer_expr_type(expr_id, arena, env, table, ret_ty)?
+    } else {
+        Type::Unit
+    };
+    if got != ret_ty {
+        if ret_ty == Type::Fx && is_numeric_for_fx_gap(got) {
+            if let Some(expr_id) = value {
+                if is_fx_literal_expr(expr_id, arena) {
+                    return Ok(());
+                }
+            }
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "{}; function return currently requires an fx literal or an existing fx-typed value",
+                    fx_coercion_gap_message(),
+                ),
+            });
+        }
+        return Err(FrontendError {
+            pos: 0,
+            message: format!("return type mismatch: expected {:?}, got {:?}", ret_ty, got),
+        });
     }
     Ok(())
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -66,6 +66,10 @@ pub enum Stmt {
         ty: Option<Type>,
         value: ExprId,
     },
+    Guard {
+        condition: ExprId,
+        else_return: Option<ExprId>,
+    },
     If {
         condition: ExprId,
         then_block: Vec<StmtId>,
@@ -185,6 +189,7 @@ pub struct Token {
 pub enum TokenKind {
     KwFn,
     KwLet,
+    KwGuard,
     KwIf,
     KwElse,
     KwReturn,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1312,48 +1312,60 @@ fn lower_stmt(
             });
             Ok(())
         }
+        Stmt::Guard {
+            condition,
+            else_return,
+        } => {
+            let (cond_reg, cond_ty) = lower_expr(
+                *condition,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                ret_ty,
+            )?;
+            if cond_ty != Type::Bool {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "guard clause condition must be bool".to_string(),
+                });
+            }
+
+            let id = ctx.next_if_id();
+            let continue_label = format!("guard_{}_continue", id);
+            ctx.instrs.push(IrInstr::JmpIf {
+                cond: cond_reg,
+                label: continue_label.clone(),
+            });
+            lower_return_payload(
+                *else_return,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                ret_ty,
+            )?;
+            ctx.instrs.push(IrInstr::Label {
+                name: continue_label,
+            });
+            Ok(())
+        }
         Stmt::Expr(expr) => {
             lower_expr_stmt(*expr, arena, ctx, env, fn_table, ret_ty)?;
             Ok(())
         }
         Stmt::Return(v) => {
-            match v {
-                Some(e) => {
-                    let (reg, ty) = lower_expr_with_expected(
-                        *e,
-                        arena,
-                        &mut ctx.next_reg,
-                        &mut ctx.instrs,
-                        env,
-                        fn_table,
-                        Some(ret_ty),
-                        ret_ty,
-                    )?;
-                    if ty != ret_ty {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message: format!(
-                                "return type mismatch in lowering: expected {:?}, got {:?}",
-                                ret_ty, ty
-                            ),
-                        });
-                    }
-                    ctx.instrs.push(IrInstr::Ret { src: Some(reg) });
-                }
-                None => {
-                    if ret_ty != Type::Unit {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message: format!(
-                                "return without value in non-unit function ({:?})",
-                                ret_ty
-                            ),
-                        });
-                    }
-                    ctx.instrs.push(IrInstr::Ret { src: None });
-                }
-            }
-            Ok(())
+            lower_return_payload(
+                *v,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                ret_ty,
+            )
         }
         Stmt::If {
             condition,
@@ -1645,6 +1657,52 @@ fn lower_match_guard(
         });
     }
     Ok(Some(guard_reg))
+}
+
+fn lower_return_payload(
+    value: Option<ExprId>,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    fn_table: &FnTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    match value {
+        Some(expr_id) => {
+            let (reg, ty) = lower_expr_with_expected(
+                expr_id,
+                arena,
+                next,
+                out,
+                env,
+                fn_table,
+                Some(ret_ty),
+                ret_ty,
+            )?;
+            if ty != ret_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "return type mismatch in lowering: expected {:?}, got {:?}",
+                        ret_ty, ty
+                    ),
+                });
+            }
+            out.push(IrInstr::Ret { src: Some(reg) });
+            Ok(())
+        }
+        None => {
+            if ret_ty != Type::Unit {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!("return without value in non-unit function ({:?})", ret_ty),
+                });
+            }
+            out.push(IrInstr::Ret { src: None });
+            Ok(())
+        }
+    }
 }
 
 fn lower_match_expr(
@@ -2051,6 +2109,29 @@ mod opt_tests {
             instr,
             IrInstr::LoadVar { name, .. } if name.starts_with("__match_expr_")
         )));
+    }
+
+    #[test]
+    fn lower_guard_clause_to_ir() {
+        let src = r#"
+            fn main() {
+                guard true else return;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("guard clause should lower");
+        let main = &ir[0];
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::JmpIf { label, .. } if label.starts_with("guard_")
+        )));
+        assert!(main
+            .instrs
+            .iter()
+            .filter(|instr| matches!(instr, IrInstr::Ret { .. }))
+            .count()
+            >= 2);
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -37,6 +37,7 @@ Current examples include:
 - block-expression parse failures such as missing trailing tail values
 - `if`-expression parse failures such as missing `else` or rejected `else if`
   sugar in value position
+- `guard`-clause parse failures such as missing `else return`
 - `match`-expression parse failures such as invalid literal arm patterns
 
 Current guarantees:
@@ -80,6 +81,7 @@ Current message families include:
 - argument type mismatch
 - let-binding type mismatch
 - return type mismatch
+- invalid `guard` condition type
 - invalid `if` condition type
 - `if`-expression branch type mismatch
 - invalid `match` guard condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -86,6 +86,9 @@ Current honest limit:
 Current statement meaning:
 
 - `let` evaluates the right-hand side before binding the name
+- `guard condition else return ...;` continues when the condition is `true`
+- when the guard condition is `false`, the `else return` path terminates the
+  current function immediately
 - expression statements evaluate for effect and then discard any produced value
 - `return expr;` terminates the current function with that value
 - `return;` terminates a `unit`-returning function
@@ -94,6 +97,7 @@ Current non-goal:
 
 - the source contract does not claim deferred execution, generators, or
   coroutine-style statement behavior
+- `guard` does not yet support arbitrary `else { ... }` recovery blocks
 
 ## Block Expressions
 
@@ -136,6 +140,16 @@ Current v0 limit:
 
 - `else if` sugar is not yet supported for value-producing `if`; users must
   write `else { if ... }`
+
+### Guard
+
+Current `guard` semantics:
+
+- `guard condition else return;` is allowed in `unit`-returning functions
+- `guard condition else return expr;` is allowed when `expr` matches the
+  function return type
+- `guard` requires a `bool` condition
+- `guard` is purely statement-level in the current source contract
 
 ### Match
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -58,6 +58,8 @@ Current statement forms:
 
 - `let name = expr;`
 - `let name: type = expr;`
+- `guard condition else return;`
+- `guard condition else return expr;`
 - `if condition { ... } else { ... }`
 - `match quad_expr { T => { ... } ... _ => { ... } }`
 - `match quad_expr { T if ready == true => { ... } ... _ => { ... } }`
@@ -68,6 +70,7 @@ Current statement forms:
 Current statement rules:
 
 - semicolons terminate executable statements
+- `guard` currently supports only the `else return` form
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`
 - `match` requires an explicit default arm `_ => { ... }`


### PR DESCRIPTION
Refs #83.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
