### PR TITLE
D20-B04 expression-bodied functions

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -94,7 +94,16 @@ impl<'a> Parser<'a> {
         } else {
             Type::Unit
         };
-        let body = self.parse_block()?;
+        let body = if self.eat(TokenKind::Assign) {
+            let expr = self.parse_expr()?;
+            self.expect(
+                TokenKind::Semi,
+                "expected ';' after expression-bodied function",
+            )?;
+            vec![self.arena.alloc_stmt(Stmt::Return(Some(expr)))]
+        } else {
+            self.parse_block()?
+        };
         Ok(Function {
             name,
             params,
@@ -1073,6 +1082,36 @@ fn main() { let x: quad = idq(T); return; }
         let a = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect("frontend rustlike");
         assert_eq!(a.functions.len(), 2);
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_expression_bodied_function() {
+        let src = r#"
+fn idq(q: quad) -> quad = q;
+fn main() { return; }
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("expression-bodied function should parse");
+        let func = &program.functions[0];
+        let Stmt::Return(Some(value)) = program.arena.stmt(func.body[0]) else {
+            panic!("expected desugared return statement");
+        };
+        assert!(matches!(program.arena.expr(*value), Expr::Var(_)));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_expression_bodied_function_without_semi() {
+        let src = r#"
+fn idq(q: quad) -> quad = q
+fn main() { return; }
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("missing semicolon must reject");
+        assert!(err
+            .message
+            .contains("expected ';' after expression-bodied function"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -671,6 +671,35 @@ mod tests {
         let err = typecheck_source(src).expect_err("guard return payload must typecheck");
         assert!(err.message.contains("return type mismatch"));
     }
+
+    #[test]
+    fn expression_bodied_function_reuses_return_typing() {
+        let src = r#"
+            fn id(x: f64) -> f64 = x;
+
+            fn main() {
+                let same: f64 = id(1.0);
+                let ok = same == same;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("expression-bodied function should typecheck");
+    }
+
+    #[test]
+    fn expression_bodied_function_reports_return_mismatch() {
+        let src = r#"
+            fn bad() -> f64 = true;
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("expression-bodied return mismatch must reject");
+        assert!(err.message.contains("return type mismatch"));
+    }
 }
 
 fn infer_value_block_type(

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -37,6 +37,7 @@ Current examples include:
 - block-expression parse failures such as missing trailing tail values
 - `if`-expression parse failures such as missing `else` or rejected `else if`
   sugar in value position
+- expression-bodied function parse failures such as missing trailing `;`
 - `guard`-clause parse failures such as missing `else return`
 - `match`-expression parse failures such as invalid literal arm patterns
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -28,6 +28,8 @@ Current rules:
 - execution begins at `fn main()`
 - `main` must currently have signature `fn main()`
 - there is no dynamic entrypoint discovery or module-level executable code
+- `fn name(...) -> ret = expr;` is semantically equivalent to a body containing
+  only `return expr;`
 
 ## Deterministic Evaluation Order
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -44,12 +44,19 @@ fn name(arg: type, ...) -> ret_type {
 }
 ```
 
+Expression-bodied sugar is also part of the current v0 surface:
+
+```sm
+fn name(arg: type, ...) -> ret_type = expr;
+```
+
 Current rules:
 
 - `fn` introduces a function
 - parameters are named and typed explicitly
 - the return type is optional; omitted return type means `unit`
 - function bodies are block-delimited with `{ ... }`
+- `fn ... = expr;` is accepted as shorthand for a single returned expression
 - the public program entrypoint is `fn main()`
 
 ## Statements


### PR DESCRIPTION
Refs #87.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
