### PR TITLE
D20-B03 pipeline operator

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -162,13 +162,16 @@ fn tokenize_line(
                 if i + 1 < bytes.len() && bytes[i + 1] == b'|' {
                     push_tok(out, TokenKind::OrOr, "||", abs_pos, line_no, col);
                     i += 2;
+                } else if i + 1 < bytes.len() && bytes[i + 1] == b'>' {
+                    push_tok(out, TokenKind::PipeForward, "|>", abs_pos, line_no, col);
+                    i += 2;
                 } else {
                     return Err(fmt_mark_error(
                         "E0003",
                         line_no,
                         col,
                         line_text,
-                        "expected '||'",
+                        "expected '||' or '|>'",
                         abs_pos,
                     ));
                 }

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -217,7 +217,15 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_expr(&mut self) -> Result<ExprId, FrontendError> {
-        self.parse_impl()
+        self.parse_pipe()
+    }
+
+    fn parse_pipe(&mut self) -> Result<ExprId, FrontendError> {
+        let mut left = self.parse_impl()?;
+        while self.eat(TokenKind::PipeForward) {
+            left = self.parse_pipeline_stage(left)?;
+        }
+        Ok(left)
     }
 
     fn parse_impl(&mut self) -> Result<ExprId, FrontendError> {
@@ -319,6 +327,31 @@ impl<'a> Parser<'a> {
             return Ok(self.arena.alloc_expr(Expr::Unary(UnaryOp::Neg, inner)));
         }
         self.parse_primary()
+    }
+
+    fn parse_pipeline_stage(&mut self, input: ExprId) -> Result<ExprId, FrontendError> {
+        if !self.check(TokenKind::Ident) {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: "pipeline stage must start with function name or call".to_string(),
+            });
+        }
+
+        let name = self.expect_symbol()?;
+        let mut args = vec![input];
+        if self.eat(TokenKind::LParen) {
+            if !self.check(TokenKind::RParen) {
+                loop {
+                    args.push(self.parse_expr()?);
+                    if self.eat(TokenKind::Comma) {
+                        continue;
+                    }
+                    break;
+                }
+            }
+            self.expect(TokenKind::RParen, "expected ')'")?;
+        }
+        Ok(self.arena.alloc_expr(Expr::Call(name, args)))
     }
 
     fn parse_primary(&mut self) -> Result<ExprId, FrontendError> {
@@ -1112,6 +1145,51 @@ fn main() { return; }
         assert!(err
             .message
             .contains("expected ';' after expression-bodied function"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_pipeline_chain() {
+        let src = r#"
+fn inc(x: f64) -> f64 = x + 1.0;
+fn scale(x: f64, factor: f64) -> f64 = x * factor;
+fn main() {
+    let value: f64 = 1.0 |> inc() |> scale(3.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("pipeline chain should parse");
+        let func = &program.functions[2];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading let statement");
+        };
+        let Expr::Call(scale_name, scale_args) = program.arena.expr(*value) else {
+            panic!("expected outer desugared call");
+        };
+        assert_eq!(program.arena.symbol_name(*scale_name), "scale");
+        assert_eq!(scale_args.len(), 2);
+        let Expr::Call(inc_name, inc_args) = program.arena.expr(scale_args[0]) else {
+            panic!("expected nested pipeline call");
+        };
+        assert_eq!(program.arena.symbol_name(*inc_name), "inc");
+        assert_eq!(inc_args.len(), 1);
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_pipeline_without_call_target() {
+        let src = r#"
+fn main() {
+    let value: f64 = 1.0 |> true;
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("pipeline stage without function target must reject");
+        assert!(err
+            .message
+            .contains("pipeline stage must start with function name or call"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -700,6 +700,22 @@ mod tests {
         let err = typecheck_source(src).expect_err("expression-bodied return mismatch must reject");
         assert!(err.message.contains("return type mismatch"));
     }
+
+    #[test]
+    fn pipeline_chain_typechecks_via_existing_call_rules() {
+        let src = r#"
+            fn inc(x: f64) -> f64 = x + 1.0;
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = 1.0 |> inc() |> scale(3.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("pipeline desugaring should typecheck");
+    }
 }
 
 fn infer_value_block_type(

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -218,6 +218,7 @@ pub enum TokenKind {
     String,
     AndAnd,
     OrOr,
+    PipeForward,
     Plus,
     Minus,
     Star,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2135,6 +2135,33 @@ mod opt_tests {
     }
 
     #[test]
+    fn lower_pipeline_expression_to_ordinary_calls() {
+        let src = r#"
+            fn inc(x: f64) -> f64 = x + 1.0;
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = 1.0 |> inc() |> scale(3.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("pipeline should lower through ordinary calls");
+        let main = &ir[2];
+        let call_names: Vec<_> = main
+            .instrs
+            .iter()
+            .filter_map(|instr| match instr {
+                IrInstr::Call { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(call_names.contains(&"inc"));
+        assert!(call_names.contains(&"scale"));
+    }
+
+    #[test]
     fn lowering_match_expression_rejects_branch_type_mismatch() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -38,6 +38,7 @@ Current examples include:
 - `if`-expression parse failures such as missing `else` or rejected `else if`
   sugar in value position
 - expression-bodied function parse failures such as missing trailing `;`
+- pipeline parse failures such as missing function-stage targets after `|>`
 - `guard`-clause parse failures such as missing `else return`
 - `match`-expression parse failures such as invalid literal arm patterns
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -41,6 +41,8 @@ Current rules:
 - call arguments are evaluated left-to-right
 - control-flow conditions are evaluated before branch selection
 - `match` scrutinee is evaluated once before arm dispatch
+- pipeline stages evaluate left-to-right and pass the previous stage value as
+  the first argument of the next call
 
 The source contract does not currently claim short-circuit laziness beyond the
 observable deterministic behavior of the current lowering path.
@@ -213,6 +215,20 @@ Current builtin signatures:
 - `sqrt(f64) -> f64`
 - `abs(f64) -> f64`
 - `pow(f64, f64) -> f64`
+
+## Pipeline
+
+Current `|>` semantics:
+
+- `input |> stage()` is equivalent to `stage(input)`
+- `input |> stage(arg1, arg2)` is equivalent to `stage(input, arg1, arg2)`
+- pipeline stages are currently restricted to bare function names or ordinary
+  call syntax
+
+Current v0 limit:
+
+- placeholder-based pipeline forms are not part of the current contract
+- arbitrary right-hand expressions after `|>` are not yet supported
 
 ## Logos Semantics Boundary
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -94,6 +94,9 @@ Current expression forms:
   - floating literals
 - variables
 - function calls
+- pipeline chains:
+  - `value |> stage()`
+  - `value |> stage(arg)`
 - block expressions with a trailing tail value:
   - `{ let x = 1; x }`
 - `if` expressions with explicit `else` blocks:
@@ -123,6 +126,7 @@ Current precedence, from tighter to looser:
 6. `&&`
 7. `||`
 8. `->`
+9. `|>`
 
 ## Quad-Specific Surface Rules
 


### PR DESCRIPTION
Refs #86.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
