### PR TITLE
D20-C06 compound assignment

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -145,8 +145,13 @@ fn tokenize_line(
             }
             b'&' => {
                 if i + 1 < bytes.len() && bytes[i + 1] == b'&' {
-                    push_tok(out, TokenKind::AndAnd, "&&", abs_pos, line_no, col);
-                    i += 2;
+                    if i + 2 < bytes.len() && bytes[i + 2] == b'=' {
+                        push_tok(out, TokenKind::AndAndAssign, "&&=", abs_pos, line_no, col);
+                        i += 3;
+                    } else {
+                        push_tok(out, TokenKind::AndAnd, "&&", abs_pos, line_no, col);
+                        i += 2;
+                    }
                 } else {
                     return Err(fmt_mark_error(
                         "E0002",
@@ -160,8 +165,13 @@ fn tokenize_line(
             }
             b'|' => {
                 if i + 1 < bytes.len() && bytes[i + 1] == b'|' {
-                    push_tok(out, TokenKind::OrOr, "||", abs_pos, line_no, col);
-                    i += 2;
+                    if i + 2 < bytes.len() && bytes[i + 2] == b'=' {
+                        push_tok(out, TokenKind::OrOrAssign, "||=", abs_pos, line_no, col);
+                        i += 3;
+                    } else {
+                        push_tok(out, TokenKind::OrOr, "||", abs_pos, line_no, col);
+                        i += 2;
+                    }
                 } else if i + 1 < bytes.len() && bytes[i + 1] == b'>' {
                     push_tok(out, TokenKind::PipeForward, "|>", abs_pos, line_no, col);
                     i += 2;
@@ -177,20 +187,38 @@ fn tokenize_line(
                 }
             }
             b'+' => {
-                push_tok(out, TokenKind::Plus, "+", abs_pos, line_no, col);
-                i += 1;
+                if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
+                    push_tok(out, TokenKind::PlusAssign, "+=", abs_pos, line_no, col);
+                    i += 2;
+                } else {
+                    push_tok(out, TokenKind::Plus, "+", abs_pos, line_no, col);
+                    i += 1;
+                }
             }
             b'*' => {
-                push_tok(out, TokenKind::Star, "*", abs_pos, line_no, col);
-                i += 1;
+                if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
+                    push_tok(out, TokenKind::StarAssign, "*=", abs_pos, line_no, col);
+                    i += 2;
+                } else {
+                    push_tok(out, TokenKind::Star, "*", abs_pos, line_no, col);
+                    i += 1;
+                }
             }
             b'/' => {
-                push_tok(out, TokenKind::Slash, "/", abs_pos, line_no, col);
-                i += 1;
+                if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
+                    push_tok(out, TokenKind::SlashAssign, "/=", abs_pos, line_no, col);
+                    i += 2;
+                } else {
+                    push_tok(out, TokenKind::Slash, "/", abs_pos, line_no, col);
+                    i += 1;
+                }
             }
             b'-' => {
                 if i + 1 < bytes.len() && bytes[i + 1] == b'>' {
                     push_tok(out, TokenKind::Implies, "->", abs_pos, line_no, col);
+                    i += 2;
+                } else if i + 1 < bytes.len() && bytes[i + 1] == b'=' {
+                    push_tok(out, TokenKind::MinusAssign, "-=", abs_pos, line_no, col);
                     i += 2;
                 } else {
                     push_tok(out, TokenKind::Minus, "-", abs_pos, line_no, col);

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -135,6 +135,17 @@ impl<'a> Parser<'a> {
             self.expect(TokenKind::Semi, "expected ';'")?;
             return Ok(self.arena.alloc_stmt(Stmt::Let { name, ty, value }));
         }
+        if self.check(TokenKind::Ident) {
+            if let Some(op) = self.peek_compound_assign_op() {
+                let name = self.expect_symbol()?;
+                let _ = self.advance();
+                let rhs = self.parse_expr()?;
+                self.expect(TokenKind::Semi, "expected ';'")?;
+                let lhs = self.arena.alloc_expr(Expr::Var(name));
+                let value = self.arena.alloc_expr(Expr::Binary(lhs, op, rhs));
+                return Ok(self.arena.alloc_stmt(Stmt::Assign { name, value }));
+            }
+        }
         if self.eat(TokenKind::KwGuard) {
             let condition = self.parse_expr()?;
             if !self.eat(TokenKind::KwElse) {
@@ -194,6 +205,24 @@ impl<'a> Parser<'a> {
         let expr = self.parse_expr()?;
         self.expect(TokenKind::Semi, "expected ';'")?;
         Ok(self.arena.alloc_stmt(Stmt::Expr(expr)))
+    }
+
+    fn peek_compound_assign_op(&self) -> Option<BinaryOp> {
+        let current = self.next_non_layout_idx();
+        let mut next_idx = current + 1;
+        while next_idx < self.tokens.len() && Self::is_layout(self.tokens[next_idx].kind) {
+            next_idx += 1;
+        }
+        let next = self.tokens.get(next_idx)?;
+        match next.kind {
+            TokenKind::PlusAssign => Some(BinaryOp::Add),
+            TokenKind::MinusAssign => Some(BinaryOp::Sub),
+            TokenKind::StarAssign => Some(BinaryOp::Mul),
+            TokenKind::SlashAssign => Some(BinaryOp::Div),
+            TokenKind::AndAndAssign => Some(BinaryOp::AndAnd),
+            TokenKind::OrOrAssign => Some(BinaryOp::OrOr),
+            _ => None,
+        }
     }
 
     fn parse_if_after_kw_if(&mut self) -> Result<Stmt, FrontendError> {
@@ -1145,6 +1174,30 @@ fn main() { return; }
         assert!(err
             .message
             .contains("expected ';' after expression-bodied function"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_compound_assignment() {
+        let src = r#"
+fn main() {
+    let total: f64 = 1.0;
+    total += 2.0;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("compound assignment should parse");
+        let func = &program.functions[0];
+        let Stmt::Assign { name, value } = program.arena.stmt(func.body[1]) else {
+            panic!("expected compound assignment statement");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "total");
+        let Expr::Binary(lhs, BinaryOp::Add, rhs) = program.arena.expr(*value) else {
+            panic!("expected desugared additive assignment");
+        };
+        assert!(matches!(program.arena.expr(*lhs), Expr::Var(_)));
+        assert!(matches!(program.arena.expr(*rhs), Expr::Float(_)));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -97,39 +97,36 @@ fn check_stmt(
         Stmt::Let { name, ty, value } => {
             let vt = infer_expr_type(*value, arena, env, table, ret_ty)?;
             let final_ty = if let Some(ann) = ty {
-                if *ann != vt {
-                    if *ann == Type::Fx && is_numeric_for_fx_gap(vt) {
-                        if is_fx_literal_expr(*value, arena) {
-                            Type::Fx
-                        } else {
-                            return Err(FrontendError {
-                                pos: 0,
-                                message: format!(
-                                    "{}; let '{}' currently accepts only fx literals or existing fx-typed values",
-                                    fx_coercion_gap_message(),
-                                    resolve_symbol_name(arena, *name)?,
-                                ),
-                            });
-                        }
-                    } else {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message: format!(
-                                "type mismatch in let '{}': {:?} vs {:?}",
-                                resolve_symbol_name(arena, *name)?,
-                                ann,
-                                vt
-                            ),
-                        });
-                    }
-                } else {
-                    *ann
-                }
+                ensure_binding_value_type(
+                    *ann,
+                    vt,
+                    *value,
+                    arena,
+                    format!("let '{}'", resolve_symbol_name(arena, *name)?),
+                )?;
+                *ann
             } else {
                 vt
             };
             env.insert(*name, final_ty);
             Ok(())
+        }
+        Stmt::Assign { name, value } => {
+            let target_ty = env.get(*name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown assignment target '{}'",
+                    resolve_symbol_name(arena, *name)?
+                ),
+            })?;
+            let value_ty = infer_expr_type(*value, arena, env, table, ret_ty)?;
+            ensure_binding_value_type(
+                target_ty,
+                value_ty,
+                *value,
+                arena,
+                format!("assignment to '{}'", resolve_symbol_name(arena, *name)?),
+            )
         }
         Stmt::Guard {
             condition,
@@ -716,6 +713,49 @@ mod tests {
 
         typecheck_source(src).expect("pipeline desugaring should typecheck");
     }
+
+    #[test]
+    fn compound_assignment_typechecks_for_existing_scalar_rules() {
+        let src = r#"
+            fn main() {
+                let total: f64 = 1.0;
+                total += 2.0;
+                let ready: bool = true;
+                ready &&= false;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("compound assignment should typecheck");
+    }
+
+    #[test]
+    fn compound_assignment_requires_existing_binding() {
+        let src = r#"
+            fn main() {
+                total += 1.0;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("unknown assignment target must reject");
+        assert!(err.message.contains("unknown assignment target 'total'"));
+    }
+
+    #[test]
+    fn compound_assignment_reuses_operator_type_rules() {
+        let src = r#"
+            fn main() {
+                let total: f64 = 1.0;
+                total += true;
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("compound assignment operator mismatch must reject");
+        assert!(err.message.contains("f64 arithmetic requires f64 operands"));
+    }
 }
 
 fn infer_value_block_type(
@@ -853,4 +893,33 @@ fn check_return_payload(
         });
     }
     Ok(())
+}
+
+fn ensure_binding_value_type(
+    expected: Type,
+    actual: Type,
+    value_expr: ExprId,
+    arena: &AstArena,
+    context: String,
+) -> Result<(), FrontendError> {
+    if expected == actual {
+        return Ok(());
+    }
+    if expected == Type::Fx && is_numeric_for_fx_gap(actual) {
+        if is_fx_literal_expr(value_expr, arena) {
+            return Ok(());
+        }
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "{}; {} currently accepts only fx literals or existing fx-typed values",
+                fx_coercion_gap_message(),
+                context,
+            ),
+        });
+    }
+    Err(FrontendError {
+        pos: 0,
+        message: format!("type mismatch in {}: {:?} vs {:?}", context, expected, actual),
+    })
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -66,6 +66,10 @@ pub enum Stmt {
         ty: Option<Type>,
         value: ExprId,
     },
+    Assign {
+        name: SymbolId,
+        value: ExprId,
+    },
     Guard {
         condition: ExprId,
         else_return: Option<ExprId>,
@@ -219,6 +223,12 @@ pub enum TokenKind {
     AndAnd,
     OrOr,
     PipeForward,
+    AndAndAssign,
+    OrOrAssign,
+    PlusAssign,
+    MinusAssign,
+    StarAssign,
+    SlashAssign,
     Plus,
     Minus,
     Star,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1312,6 +1312,30 @@ fn lower_stmt(
             });
             Ok(())
         }
+        Stmt::Assign { name, value } => {
+            let target_ty = env.get(*name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown assignment target '{}'",
+                    resolve_symbol_name(arena, *name)?
+                ),
+            })?;
+            let (reg, _) = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                Some(target_ty),
+                ret_ty,
+            )?;
+            ctx.instrs.push(IrInstr::StoreVar {
+                name: resolve_symbol_name(arena, *name)?.to_string(),
+                src: reg,
+            });
+            Ok(())
+        }
         Stmt::Guard {
             condition,
             else_return,
@@ -2159,6 +2183,34 @@ mod opt_tests {
             .collect();
         assert!(call_names.contains(&"inc"));
         assert!(call_names.contains(&"scale"));
+    }
+
+    #[test]
+    fn lower_compound_assignment_to_read_modify_write() {
+        let src = r#"
+            fn main() {
+                let total: f64 = 1.0;
+                total += 2.0;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("compound assignment should lower");
+        let main = &ir[0];
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadVar { name, .. } if name == "total")));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "total"))
+            .count()
+            >= 2);
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -78,6 +78,7 @@ messages rather than as a stable numeric code family.
 Current message families include:
 
 - unknown variable
+- unknown assignment target
 - unknown function
 - argument count mismatch
 - argument type mismatch

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -90,6 +90,8 @@ Current honest limit:
 Current statement meaning:
 
 - `let` evaluates the right-hand side before binding the name
+- `name op= expr;` evaluates as read-modify-write over the existing binding
+- the current v0 compound forms are `+=`, `-=`, `*=`, `/=`, `&&=`, and `||=`
 - `guard condition else return ...;` continues when the condition is `true`
 - when the guard condition is `false`, the `else return` path terminates the
   current function immediately
@@ -102,6 +104,7 @@ Current non-goal:
 - the source contract does not claim deferred execution, generators, or
   coroutine-style statement behavior
 - `guard` does not yet support arbitrary `else { ... }` recovery blocks
+- plain reassignment `name = expr;` is not yet part of the public surface
 
 ## Block Expressions
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -65,6 +65,12 @@ Current statement forms:
 
 - `let name = expr;`
 - `let name: type = expr;`
+- `name += expr;`
+- `name -= expr;`
+- `name *= expr;`
+- `name /= expr;`
+- `name &&= expr;`
+- `name ||= expr;`
 - `guard condition else return;`
 - `guard condition else return expr;`
 - `if condition { ... } else { ... }`
@@ -77,6 +83,7 @@ Current statement forms:
 Current statement rules:
 
 - semicolons terminate executable statements
+- compound assignment is statement-level sugar only
 - `guard` currently supports only the `else return` form
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`


### PR DESCRIPTION
Refs #94.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
