### PR TITLE
D20P-A01 wildcard and discard patterns

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1,15 +1,15 @@
+use crate::lexer::lex_tokens;
+use crate::types::{
+    AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, Function, IfExpr, LogosEntity,
+    LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
+    MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt, StmtId, SymbolId, Token, TokenKind,
+    Type, UnaryOp,
+};
+use crate::CompilePolicyView;
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::lexer::lex_tokens;
-use crate::CompilePolicyView;
-use crate::types::{
-    AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, Function, IfExpr, LogosEntity,
-    LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
-    MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt, StmtId, SymbolId, Token,
-    TokenKind, Type, UnaryOp,
-};
 use sm_profile::{CompatibilityMode, ParserProfile};
 use ton618_core::diagnostics::{
     format_multiple_parser_errors, format_parser_error_at_input, suggest_closest_case_insensitive,
@@ -124,6 +124,17 @@ impl<'a> Parser<'a> {
 
     fn parse_stmt(&mut self) -> Result<StmtId, FrontendError> {
         if self.eat(TokenKind::KwLet) {
+            if self.eat(TokenKind::Underscore) {
+                let ty = if self.eat(TokenKind::Colon) {
+                    Some(self.parse_type()?)
+                } else {
+                    None
+                };
+                self.expect(TokenKind::Assign, "expected '='")?;
+                let value = self.parse_expr()?;
+                self.expect(TokenKind::Semi, "expected ';'")?;
+                return Ok(self.arena.alloc_stmt(Stmt::Discard { ty, value }));
+            }
             let name = self.expect_symbol()?;
             let ty = if self.eat(TokenKind::Colon) {
                 Some(self.parse_type()?)
@@ -272,7 +283,9 @@ impl<'a> Parser<'a> {
         let mut left = self.parse_and()?;
         while self.eat(TokenKind::OrOr) {
             let right = self.parse_and()?;
-            left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::OrOr, right));
+            left = self
+                .arena
+                .alloc_expr(Expr::Binary(left, BinaryOp::OrOr, right));
         }
         Ok(left)
     }
@@ -293,12 +306,16 @@ impl<'a> Parser<'a> {
         loop {
             if self.eat(TokenKind::EqEq) {
                 let right = self.parse_add()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Eq, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Eq, right));
                 continue;
             }
             if self.eat(TokenKind::Ne) {
                 let right = self.parse_add()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Ne, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Ne, right));
                 continue;
             }
             break;
@@ -311,12 +328,16 @@ impl<'a> Parser<'a> {
         loop {
             if self.eat(TokenKind::Plus) {
                 let right = self.parse_mul()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Add, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Add, right));
                 continue;
             }
             if self.eat(TokenKind::Minus) {
                 let right = self.parse_mul()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Sub, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Sub, right));
                 continue;
             }
             break;
@@ -329,12 +350,16 @@ impl<'a> Parser<'a> {
         loop {
             if self.eat(TokenKind::Star) {
                 let right = self.parse_unary()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Mul, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Mul, right));
                 continue;
             }
             if self.eat(TokenKind::Slash) {
                 let right = self.parse_unary()?;
-                left = self.arena.alloc_expr(Expr::Binary(left, BinaryOp::Div, right));
+                left = self
+                    .arena
+                    .alloc_expr(Expr::Binary(left, BinaryOp::Div, right));
                 continue;
             }
             break;
@@ -477,8 +502,9 @@ impl<'a> Parser<'a> {
         if self.check(TokenKind::KwIf) {
             return Err(FrontendError {
                 pos: self.pos(),
-                message: "else-if sugar is not supported in if expressions yet; use else { if ... }"
-                    .to_string(),
+                message:
+                    "else-if sugar is not supported in if expressions yet; use else { if ... }"
+                        .to_string(),
             });
         }
         let else_block = self.parse_value_block()?;
@@ -610,7 +636,10 @@ impl<'a> Parser<'a> {
                 continue;
             }
 
-            self.expect(TokenKind::RBrace, "expected '}' after value-producing block")?;
+            self.expect(
+                TokenKind::RBrace,
+                "expected '}' after value-producing block",
+            )?;
             return Ok(BlockExpr {
                 statements,
                 tail: expr,
@@ -942,7 +971,11 @@ impl<'a> Parser<'a> {
                 break;
             }
             if t.kind == TokenKind::Newline || t.kind == TokenKind::Dedent {
-                return Err(self.error_at_token(&t, "unexpected line break in expression", "E0235"));
+                return Err(self.error_at_token(
+                    &t,
+                    "unexpected line break in expression",
+                    "E0235",
+                ));
             }
             out.push(t);
             self.idx += 1;
@@ -986,7 +1019,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn expect_raw(&mut self, kind: TokenKind, msg: &str, code: &str) -> Result<Token, FrontendError> {
+    fn expect_raw(
+        &mut self,
+        kind: TokenKind,
+        msg: &str,
+        code: &str,
+    ) -> Result<Token, FrontendError> {
         if self.check_raw(kind) {
             let t = self.tokens[self.idx].clone();
             self.idx += 1;
@@ -1286,7 +1324,9 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("block expression without tail must reject");
-        assert!(err.message.contains("value-producing block requires trailing value expression"));
+        assert!(err
+            .message
+            .contains("value-producing block requires trailing value expression"));
     }
 
     #[test]
@@ -1324,7 +1364,9 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("if expression without else must reject");
-        assert!(err.message.contains("if expression requires explicit else branch"));
+        assert!(err
+            .message
+            .contains("if expression requires explicit else branch"));
     }
 
     #[test]
@@ -1338,7 +1380,9 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("else-if sugar must reject in value position");
-        assert!(err.message.contains("else-if sugar is not supported in if expressions yet"));
+        assert!(err
+            .message
+            .contains("else-if sugar is not supported in if expressions yet"));
     }
 
     #[test]
@@ -1403,10 +1447,14 @@ fn main() {
         let Stmt::Guard {
             condition,
             else_return,
-        } = program.arena.stmt(func.body[0]) else {
+        } = program.arena.stmt(func.body[0])
+        else {
             panic!("expected guard statement");
         };
-        assert!(matches!(program.arena.expr(*condition), Expr::BoolLiteral(true)));
+        assert!(matches!(
+            program.arena.expr(*condition),
+            Expr::BoolLiteral(true)
+        ));
         assert!(else_return.is_none());
     }
 
@@ -1423,6 +1471,44 @@ fn main() {
         assert!(err
             .message
             .contains("guard clause currently supports only else return"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_discard_bind() {
+        let src = r#"
+fn main() {
+    let _ = 1.0;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("discard bind should parse");
+        let func = &program.functions[0];
+        let Stmt::Discard { ty, value } = program.arena.stmt(func.body[0]) else {
+            panic!("expected discard statement");
+        };
+        assert!(ty.is_none());
+        assert!(matches!(program.arena.expr(*value), Expr::Float(_)));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_typed_discard_bind() {
+        let src = r#"
+fn main() {
+    let _: f64 = 1.0;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("typed discard bind should parse");
+        let func = &program.functions[0];
+        let Stmt::Discard { ty, value } = program.arena.stmt(func.body[0]) else {
+            panic!("expected discard statement");
+        };
+        assert_eq!(*ty, Some(Type::F64));
+        assert!(matches!(program.arena.expr(*value), Expr::Float(_)));
     }
 
     #[test]
@@ -1445,7 +1531,10 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*name), "assert");
         assert_eq!(args.len(), 1);
-        assert!(matches!(program.arena.expr(args[0]), Expr::BoolLiteral(true)));
+        assert!(matches!(
+            program.arena.expr(args[0]),
+            Expr::BoolLiteral(true)
+        ));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1,7 +1,7 @@
+use crate::*;
 use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::ToString;
-use crate::*;
 
 fn fx_coercion_gap_message() -> &'static str {
     "fx coercion from non-literal numeric expressions is not implemented in the canonical Rust-like path yet"
@@ -111,6 +111,13 @@ fn check_stmt(
             env.insert(*name, final_ty);
             Ok(())
         }
+        Stmt::Discard { ty, value } => {
+            let vt = infer_expr_type(*value, arena, env, table, ret_ty)?;
+            if let Some(ann) = ty {
+                ensure_binding_value_type(*ann, vt, *value, arena, "discard binding".to_string())?;
+            }
+            Ok(())
+        }
         Stmt::Assign { name, value } => {
             let target_ty = env.get(*name).ok_or(FrontendError {
                 pos: 0,
@@ -209,9 +216,7 @@ fn check_stmt(
             def_env.pop_scope();
             Ok(())
         }
-        Stmt::Return(v) => {
-            check_return_payload(*v, arena, env, table, ret_ty)
-        }
+        Stmt::Return(v) => check_return_payload(*v, arena, env, table, ret_ty),
         Stmt::Expr(e) => {
             if check_builtin_assert_stmt(*e, arena, env, table, ret_ty)? {
                 return Ok(());
@@ -268,8 +273,9 @@ fn infer_expr_type(
             if is_builtin_assert_name(*name, arena, table)? {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "assert builtin is statement-only and cannot be used as expression value"
-                        .to_string(),
+                    message:
+                        "assert builtin is statement-only and cannot be used as expression value"
+                            .to_string(),
                 });
             }
             let sig = if let Some(s) = table.get(name) {
@@ -535,9 +541,7 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("mismatched if expression branches must reject");
-        assert!(err
-            .message
-            .contains("if expression branch type mismatch"));
+        assert!(err.message.contains("if expression branch type mismatch"));
     }
 
     #[test]
@@ -550,9 +554,7 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("quad condition must reject");
-        assert!(err
-            .message
-            .contains("if expression condition must be bool"));
+        assert!(err.message.contains("if expression condition must be bool"));
     }
 
     #[test]
@@ -768,6 +770,48 @@ mod tests {
     }
 
     #[test]
+    fn repeated_discard_binds_typecheck_without_name_collisions() {
+        let src = r#"
+            fn main() {
+                let _ = 1.0;
+                let _ = 2.0;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("discard binds should not create conflicting visible names");
+    }
+
+    #[test]
+    fn typed_discard_bind_reuses_type_mismatch_rules() {
+        let src = r#"
+            fn main() {
+                let _: f64 = true;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("typed discard bind must check rhs type");
+        assert!(err.message.contains("discard binding"));
+    }
+
+    #[test]
+    fn discard_bind_is_allowed_inside_value_block_body() {
+        let src = r#"
+            fn main() {
+                let total: f64 = {
+                    let _ = 1.0;
+                    2.0
+                };
+                let same = total == total;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("discard bind should be accepted in value block body");
+    }
+
+    #[test]
     fn assert_builtin_statement_typechecks() {
         let src = r#"
             fn main() {
@@ -789,7 +833,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("assert builtin must require bool");
-        assert!(err.message.contains("assert builtin requires bool condition"));
+        assert!(err
+            .message
+            .contains("assert builtin requires bool condition"));
     }
 
     #[test]
@@ -852,10 +898,7 @@ fn check_builtin_assert_stmt(
     if cond_ty != Type::Bool {
         return Err(FrontendError {
             pos: 0,
-            message: format!(
-                "assert builtin requires bool condition, got {:?}",
-                cond_ty
-            ),
+            message: format!("assert builtin requires bool condition, got {:?}", cond_ty),
         });
     }
     Ok(true)
@@ -872,7 +915,7 @@ fn infer_value_block_type(
     block_env.push_scope();
     for stmt in &block.statements {
         match arena.stmt(*stmt) {
-            Stmt::Let { .. } | Stmt::Expr(_) => {
+            Stmt::Let { .. } | Stmt::Discard { .. } | Stmt::Expr(_) => {
                 check_stmt(*stmt, arena, &mut block_env, ret_ty, table)?;
             }
             _ => {
@@ -955,8 +998,9 @@ fn check_match_guard(
         if guard_ty != Type::Bool {
             return Err(FrontendError {
                 pos: 0,
-                message: "match guard condition must be bool; explicit compare is required for quad"
-                    .to_string(),
+                message:
+                    "match guard condition must be bool; explicit compare is required for quad"
+                        .to_string(),
             });
         }
     }
@@ -1023,6 +1067,9 @@ fn ensure_binding_value_type(
     }
     Err(FrontendError {
         pos: 0,
-        message: format!("type mismatch in {}: {:?} vs {:?}", context, expected, actual),
+        message: format!(
+            "type mismatch in {}: {:?} vs {:?}",
+            context, expected, actual
+        ),
     })
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -1,8 +1,8 @@
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use ton618_core::{SigTable, SourceMark};
 pub use ton618_core::{ExprId, StmtId, SymbolId};
+use ton618_core::{SigTable, SourceMark};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Type {
@@ -63,6 +63,10 @@ pub enum Expr {
 pub enum Stmt {
     Let {
         name: SymbolId,
+        ty: Option<Type>,
+        value: ExprId,
+    },
+    Discard {
         ty: Option<Type>,
         value: ExprId,
     },

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -180,7 +180,10 @@ fn encode_fx_literal(value: f64) -> Result<i32, FrontendError> {
     Ok(rounded as i32)
 }
 
-fn try_encode_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> Result<Option<i32>, FrontendError> {
+fn try_encode_fx_literal_expr(
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Result<Option<i32>, FrontendError> {
     match arena.expr(expr_id) {
         Expr::Num(n) => {
             let value = i32::try_from(*n).map_err(|_| FrontendError {
@@ -191,7 +194,8 @@ fn try_encode_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> Result<Optio
                 .checked_mul(FX_SCALE)
                 .ok_or(FrontendError {
                     pos: 0,
-                    message: "fx literal is out of range for the v1 fixed-point carrier".to_string(),
+                    message: "fx literal is out of range for the v1 fixed-point carrier"
+                        .to_string(),
                 })
                 .map(Some)
         }
@@ -205,7 +209,8 @@ fn try_encode_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> Result<Optio
                 .checked_neg()
                 .ok_or(FrontendError {
                     pos: 0,
-                    message: "fx literal is out of range for the v1 fixed-point carrier".to_string(),
+                    message: "fx literal is out of range for the v1 fixed-point carrier"
+                        .to_string(),
                 })
                 .map(Some)
         }
@@ -309,12 +314,9 @@ pub fn compile_program_to_immutable_ir(
     opt: OptLevel,
 ) -> Result<ImmutableIrProgram, FrontendError> {
     let parser_profile = ParserProfile::foundation_default();
-    Ok(ImmutableIrProgram::from_vec(compile_program_to_ir_with_options_and_profile(
-        input,
-        profile,
-        opt,
-        &parser_profile,
-    )?))
+    Ok(ImmutableIrProgram::from_vec(
+        compile_program_to_ir_with_options_and_profile(input, profile, opt, &parser_profile)?,
+    ))
 }
 
 pub fn compile_program_to_ir_with_options(
@@ -485,7 +487,10 @@ pub fn compile_program_to_semcode_with_options_debug(
     emit_semcode(ir.functions(), debug_symbols)
 }
 
-pub fn emit_ir_to_semcode(funcs: &[IrFunction], debug_symbols: bool) -> Result<Vec<u8>, FrontendError> {
+pub fn emit_ir_to_semcode(
+    funcs: &[IrFunction],
+    debug_symbols: bool,
+) -> Result<Vec<u8>, FrontendError> {
     emit_semcode(funcs, debug_symbols)
 }
 
@@ -813,11 +818,9 @@ fn has_v1_math_instr(funcs: &[IrFunction]) -> bool {
 }
 
 fn has_v2_fx_instr(funcs: &[IrFunction]) -> bool {
-    funcs.iter().any(|f| {
-        f.instrs
-            .iter()
-            .any(|i| matches!(i, IrInstr::LoadFx { .. }))
-    })
+    funcs
+        .iter()
+        .any(|f| f.instrs.iter().any(|i| matches!(i, IrInstr::LoadFx { .. })))
 }
 
 #[derive(Debug, Default)]
@@ -1032,15 +1035,16 @@ fn lower_expr_with_expected(
             });
             Ok((dst, then_ty))
         }
-        Expr::Match(match_expr) => {
-            lower_match_expr(match_expr, arena, next, out, env, fn_table, expected, ret_ty)
-        }
+        Expr::Match(match_expr) => lower_match_expr(
+            match_expr, arena, next, out, env, fn_table, expected, ret_ty,
+        ),
         Expr::Call(name, args) => {
             if is_builtin_assert_name(*name, arena, fn_table)? {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "assert builtin is statement-only and cannot be used as expression value"
-                        .to_string(),
+                    message:
+                        "assert builtin is statement-only and cannot be used as expression value"
+                            .to_string(),
                 });
             }
             let sig = if let Some(s) = fn_table.get(name) {
@@ -1066,17 +1070,16 @@ fn lower_expr_with_expected(
             }
             let mut regs = Vec::new();
             for (i, arg) in args.iter().enumerate() {
-                let (r, t) =
-                    lower_expr_with_expected(
-                        *arg,
-                        arena,
-                        next,
-                        out,
-                        env,
-                        fn_table,
-                        Some(sig.params[i]),
-                        ret_ty,
-                    )?;
+                let (r, t) = lower_expr_with_expected(
+                    *arg,
+                    arena,
+                    next,
+                    out,
+                    env,
+                    fn_table,
+                    Some(sig.params[i]),
+                    ret_ty,
+                )?;
                 if t != sig.params[i] {
                     return Err(FrontendError {
                         pos: 0,
@@ -1116,8 +1119,9 @@ fn lower_expr_with_expected(
                     return Ok((dst, Type::Fx));
                 }
             }
-            let (src, ty) =
-                lower_expr_with_expected(*inner, arena, next, out, env, fn_table, expected, ret_ty)?;
+            let (src, ty) = lower_expr_with_expected(
+                *inner, arena, next, out, env, fn_table, expected, ret_ty,
+            )?;
             match op {
                 UnaryOp::Not => {
                     let dst = alloc(next);
@@ -1168,8 +1172,9 @@ fn lower_expr_with_expected(
         Expr::Binary(left, op, right) => {
             let (lr, lt) =
                 lower_expr_with_expected(*left, arena, next, out, env, fn_table, expected, ret_ty)?;
-            let (rr, rt) =
-                lower_expr_with_expected(*right, arena, next, out, env, fn_table, expected, ret_ty)?;
+            let (rr, rt) = lower_expr_with_expected(
+                *right, arena, next, out, env, fn_table, expected, ret_ty,
+            )?;
             if lt != rt {
                 return Err(FrontendError {
                     pos: 0,
@@ -1335,6 +1340,19 @@ fn lower_stmt(
             });
             Ok(())
         }
+        Stmt::Discard { ty, value } => {
+            let _ = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                *ty,
+                ret_ty,
+            )?;
+            Ok(())
+        }
         Stmt::Assign { name, value } => {
             let target_ty = env.get(*name).ok_or(FrontendError {
                 pos: 0,
@@ -1403,17 +1421,15 @@ fn lower_stmt(
             lower_expr_stmt(*expr, arena, ctx, env, fn_table, ret_ty)?;
             Ok(())
         }
-        Stmt::Return(v) => {
-            lower_return_payload(
-                *v,
-                arena,
-                &mut ctx.next_reg,
-                &mut ctx.instrs,
-                env,
-                fn_table,
-                ret_ty,
-            )
-        }
+        Stmt::Return(v) => lower_return_payload(
+            *v,
+            arena,
+            &mut ctx.next_reg,
+            &mut ctx.instrs,
+            env,
+            fn_table,
+            ret_ty,
+        ),
         Stmt::If {
             condition,
             then_block,
@@ -1643,14 +1659,7 @@ fn lower_value_block_expr(
         match arena.stmt(*stmt) {
             Stmt::Let { name, ty, value } => {
                 let (reg, vty) = lower_expr_with_expected(
-                    *value,
-                    arena,
-                    next,
-                    out,
-                    &block_env,
-                    fn_table,
-                    *ty,
-                    ret_ty,
+                    *value, arena, next, out, &block_env, fn_table, *ty, ret_ty,
                 )?;
                 let final_ty = if let Some(ann) = ty { *ann } else { vty };
                 block_env.insert(*name, final_ty);
@@ -1658,6 +1667,11 @@ fn lower_value_block_expr(
                     name: resolve_symbol_name(arena, *name)?.to_string(),
                     src: reg,
                 });
+            }
+            Stmt::Discard { ty, value } => {
+                let _ = lower_expr_with_expected(
+                    *value, arena, next, out, &block_env, fn_table, *ty, ret_ty,
+                )?;
             }
             Stmt::Expr(expr) => {
                 lower_expr_stmt_with_parts(*expr, arena, next, out, &block_env, fn_table, ret_ty)?;
@@ -1671,14 +1685,7 @@ fn lower_value_block_expr(
         }
     }
     let tail = lower_expr_with_expected(
-        block.tail,
-        arena,
-        next,
-        out,
-        &block_env,
-        fn_table,
-        expected,
-        ret_ty,
+        block.tail, arena, next, out, &block_env, fn_table, expected, ret_ty,
     )?;
     block_env.pop_scope();
     Ok(tail)
@@ -1762,7 +1769,15 @@ fn lower_match_expr(
     expected: Option<Type>,
     ret_ty: Type,
 ) -> Result<(u16, Type), FrontendError> {
-    let (scr_reg, scr_ty) = lower_expr(match_expr.scrutinee, arena, next, out, env, fn_table, ret_ty)?;
+    let (scr_reg, scr_ty) = lower_expr(
+        match_expr.scrutinee,
+        arena,
+        next,
+        out,
+        env,
+        fn_table,
+        ret_ty,
+    )?;
     if scr_ty != Type::Quad {
         return Err(FrontendError {
             pos: 0,
@@ -1833,14 +1848,7 @@ fn lower_match_expr(
             });
         }
         let (arm_reg, arm_ty) = lower_value_block_expr(
-            &arm.block,
-            arena,
-            next,
-            out,
-            &arm_env,
-            fn_table,
-            expected,
-            ret_ty,
+            &arm.block, arena, next, out, &arm_env, fn_table, expected, ret_ty,
         )?;
         arm_env.pop_scope();
         if let Some(expected_ty) = result_ty {
@@ -1962,10 +1970,7 @@ fn lower_expr_stmt_with_parts(
             if cond_ty != Type::Bool {
                 return Err(FrontendError {
                     pos: 0,
-                    message: format!(
-                        "assert builtin requires bool condition, got {:?}",
-                        cond_ty
-                    ),
+                    message: format!("assert builtin requires bool condition, got {:?}", cond_ty),
                 });
             }
             out.push(IrInstr::Assert { cond });
@@ -2094,7 +2099,10 @@ mod opt_tests {
             instr,
             IrInstr::StoreVar { name, .. } if name == "total"
         )));
-        assert!(main.instrs.iter().any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
     }
 
     #[test]
@@ -2150,9 +2158,7 @@ mod opt_tests {
         "#;
 
         let err = compile_program_to_ir(src).expect_err("mismatched branch types must reject");
-        assert!(err
-            .message
-            .contains("if expression branch type mismatch"));
+        assert!(err.message.contains("if expression branch type mismatch"));
     }
 
     #[test]
@@ -2173,10 +2179,10 @@ mod opt_tests {
             instr,
             IrInstr::Label { name } if name.starts_with("match_expr_")
         )));
-        assert!(main.instrs.iter().any(|instr| matches!(
-            instr,
-            IrInstr::LoadBool { .. }
-        )));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadBool { .. })));
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,
             IrInstr::StoreVar { name, .. } if name.starts_with("__match_expr_")
@@ -2202,12 +2208,13 @@ mod opt_tests {
             instr,
             IrInstr::JmpIf { label, .. } if label.starts_with("guard_")
         )));
-        assert!(main
-            .instrs
-            .iter()
-            .filter(|instr| matches!(instr, IrInstr::Ret { .. }))
-            .count()
-            >= 2);
+        assert!(
+            main.instrs
+                .iter()
+                .filter(|instr| matches!(instr, IrInstr::Ret { .. }))
+                .count()
+                >= 2
+        );
     }
 
     #[test]
@@ -2257,12 +2264,34 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(
+            main.instrs
+                .iter()
+                .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "total"))
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn lower_discard_bind_evaluates_rhs_without_store() {
+        let src = r#"
+            fn main() {
+                let _ = 1.0 + 2.0;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("discard bind should lower");
+        let main = &ir[0];
         assert!(main
             .instrs
             .iter()
-            .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "total"))
-            .count()
-            >= 2);
+            .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(!main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name == "_"
+        )));
     }
 
     #[test]
@@ -2294,8 +2323,8 @@ mod opt_tests {
             }
         "#;
 
-        let err =
-            compile_program_to_ir(src).expect_err("mismatched match expression branches must reject");
+        let err = compile_program_to_ir(src)
+            .expect_err("mismatched match expression branches must reject");
         assert!(err
             .message
             .contains("match expression branch type mismatch"));
@@ -2378,13 +2407,10 @@ mod opt_tests {
         let report = crate::passes::run_default_opt_passes(&mut ir);
         assert!(report.changed);
         let f = &ir[0];
-        assert!(f.instrs.iter().any(|i| matches!(
-            i,
-            IrInstr::LoadBool {
-                dst: 2,
-                val: false
-            }
-        )));
+        assert!(f
+            .instrs
+            .iter()
+            .any(|i| matches!(i, IrInstr::LoadBool { dst: 2, val: false })));
         assert!(f.instrs.iter().any(|i| matches!(
             i,
             IrInstr::LoadF64 { dst: 5, val } if (*val - 5.0).abs() < f64::EPSILON

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -86,6 +86,7 @@ Current message families include:
 - invalid `assert` condition type
 - statement-only `assert` used in value position
 - let-binding type mismatch
+- discard-binding type mismatch
 - return type mismatch
 - invalid `guard` condition type
 - invalid `if` condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -77,6 +77,7 @@ Current rules:
 
 - function parameters are bound in function scope before body execution
 - `let` introduces a source-visible local binding
+- `let _ = expr;` evaluates the right-hand side but introduces no source-visible binding
 - `if` branches and `match` arms are checked in branch-local scopes
 - branch-local bindings do not escape to sibling branches
 
@@ -91,6 +92,7 @@ Current honest limit:
 Current statement meaning:
 
 - `let` evaluates the right-hand side before binding the name
+- discard bind evaluates the right-hand side and then drops the produced value
 - `name op= expr;` evaluates as read-modify-write over the existing binding
 - the current v0 compound forms are `+=`, `-=`, `*=`, `/=`, `&&=`, and `||=`
 - `guard condition else return ...;` continues when the condition is `true`
@@ -121,8 +123,10 @@ Current block-expression semantics:
 
 Current v0 limit:
 
-- block-expression bodies currently accept only `let` bindings and expression
-  statements before the tail value
+- block-expression bodies currently accept only named `let` bindings,
+  discard binds, and expression statements before the tail value
+- discard bind is accepted in value-producing block bodies, but richer pattern
+  destructuring is not yet part of the stable block-expression contract
 - `return` is not yet supported inside value-producing block bodies as a
   stable source contract
 
@@ -170,6 +174,8 @@ Current `match` semantics:
 - arms match only the literal patterns `N`, `F`, `T`, `S`
 - non-default arms may attach a `bool` guard with `if guard_expr`
 - `_` is required as the default arm
+- `_` currently means wildcard/default only in `match`, not a general rich
+  pattern system
 - the first matching arm is selected deterministically
 
 Current `match` expression semantics:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -65,6 +65,8 @@ Current statement forms:
 
 - `let name = expr;`
 - `let name: type = expr;`
+- `let _ = expr;`
+- `let _: type = expr;`
 - `name += expr;`
 - `name -= expr;`
 - `name *= expr;`
@@ -84,12 +86,14 @@ Current statement forms:
 Current statement rules:
 
 - semicolons terminate executable statements
+- `let _ = expr;` is the current discard-bind surface
 - compound assignment is statement-level sugar only
 - `guard` currently supports only the `else return` form
 - `assert(condition);` is a statement-level builtin contract form
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`
 - `match` requires an explicit default arm `_ => { ... }`
+- `_` in `match` remains the current wildcard/default arm spelling
 - unit-returning calls may be used as statements
 
 ## Expressions


### PR DESCRIPTION
Refs #99.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
