### PR TITLE
D20-D01 const declarations

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -272,6 +272,7 @@ fn tokenize_line(
                 let text = &line_text[start..i];
                 let kind = match text {
                     "fn" => TokenKind::KwFn,
+                    "const" => TokenKind::KwConst,
                     "let" => TokenKind::KwLet,
                     "guard" => TokenKind::KwGuard,
                     "if" => TokenKind::KwIf,

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -44,9 +44,16 @@ pub struct FnSig {
 pub type FnTable = BTreeMap<SymbolId, FnSig>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeBinding {
+    pub ty: Type,
+    pub is_const: bool,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeEnv {
-    scopes: Vec<BTreeMap<SymbolId, Type>>,
+    scopes: Vec<BTreeMap<SymbolId, ScopeBinding>>,
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -76,15 +83,37 @@ impl ScopeEnv {
     }
 
     pub fn insert(&mut self, name: SymbolId, ty: Type) {
+        self.insert_binding(
+            name,
+            ScopeBinding {
+                ty,
+                is_const: false,
+            },
+        );
+    }
+
+    pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
+        self.insert_binding(name, ScopeBinding { ty, is_const: true });
+    }
+
+    fn insert_binding(&mut self, name: SymbolId, binding: ScopeBinding) {
         if let Some(last) = self.scopes.last_mut() {
-            last.insert(name, ty);
+            last.insert(name, binding);
         }
     }
 
     pub fn get(&self, name: SymbolId) -> Option<Type> {
+        self.binding(name).map(|binding| binding.ty)
+    }
+
+    pub fn is_const(&self, name: SymbolId) -> bool {
+        self.binding(name).map(|binding| binding.is_const).unwrap_or(false)
+    }
+
+    fn binding(&self, name: SymbolId) -> Option<ScopeBinding> {
         for scope in self.scopes.iter().rev() {
-            if let Some(t) = scope.get(&name) {
-                return Some(*t);
+            if let Some(binding) = scope.get(&name) {
+                return Some(*binding);
             }
         }
         None

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -123,6 +123,18 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_stmt(&mut self) -> Result<StmtId, FrontendError> {
+        if self.eat(TokenKind::KwConst) {
+            let name = self.expect_symbol()?;
+            let ty = if self.eat(TokenKind::Colon) {
+                Some(self.parse_type()?)
+            } else {
+                None
+            };
+            self.expect(TokenKind::Assign, "expected '='")?;
+            let value = self.parse_expr()?;
+            self.expect(TokenKind::Semi, "expected ';'")?;
+            return Ok(self.arena.alloc_stmt(Stmt::Const { name, ty, value }));
+        }
         if self.eat(TokenKind::KwLet) {
             if self.eat(TokenKind::Underscore) {
                 let ty = if self.eat(TokenKind::Colon) {
@@ -648,6 +660,13 @@ impl<'a> Parser<'a> {
         scopes: &mut Vec<Vec<SymbolId>>,
     ) -> Result<(), FrontendError> {
         match self.arena.stmt(stmt_id) {
+            Stmt::Const { name, value, .. } => {
+                self.ensure_short_lambda_expr_capture_free(*value, scopes)?;
+                if let Some(scope) = scopes.last_mut() {
+                    scope.push(*name);
+                }
+                Ok(())
+            }
             Stmt::Let { name, value, .. } => {
                 self.ensure_short_lambda_expr_capture_free(*value, scopes)?;
                 if let Some(scope) = scopes.last_mut() {
@@ -680,7 +699,7 @@ impl<'a> Parser<'a> {
     }
 
     fn starts_stmt_only_in_block_expr(&self) -> bool {
-        self.check(TokenKind::KwLet)
+        self.check(TokenKind::KwLet) || self.check(TokenKind::KwConst)
     }
 
     fn parse_if_expr_after_kw_if(&mut self) -> Result<ExprId, FrontendError> {
@@ -818,7 +837,7 @@ impl<'a> Parser<'a> {
                 return Err(FrontendError {
                     pos: self.pos(),
                     message:
-                        "value-producing block currently supports only let-bindings and expression statements before the tail value"
+                        "value-producing block currently supports only const-bindings, let-bindings, discard binds, and expression statements before the tail value"
                             .to_string(),
                 });
             }
@@ -1432,6 +1451,26 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_const_declaration() {
+        let src = r#"
+fn main() {
+    const total: f64 = 1.0 + 2.0;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("const declaration should parse");
+        let func = &program.functions[0];
+        let Stmt::Const { name, ty, value } = program.arena.stmt(func.body[0]) else {
+            panic!("expected const statement");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "total");
+        assert_eq!(*ty, Some(Type::F64));
+        assert!(matches!(program.arena.expr(*value), Expr::Binary(_, BinaryOp::Add, _)));
+    }
+
+    #[test]
     fn rustlike_parser_accepts_pipeline_chain() {
         let src = r#"
 fn inc(x: f64) -> f64 = x + 1.0;
@@ -1563,8 +1602,9 @@ fn main() {
         let src = r#"
 fn main() {
     let value: f64 = {
+        const offset: f64 = 2.0;
         let base: f64 = 1.0;
-        base + 2.0
+        base + offset
     };
     return;
 }
@@ -1579,7 +1619,7 @@ fn main() {
         let Expr::Block(block) = program.arena.expr(*value) else {
             panic!("expected block expression");
         };
-        assert_eq!(block.statements.len(), 1);
+        assert_eq!(block.statements.len(), 2);
         match program.arena.expr(block.tail) {
             Expr::Binary(_, BinaryOp::Add, _) => {}
             other => panic!("expected additive tail expression, got {:?}", other),

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -94,6 +94,24 @@ fn check_stmt(
 ) -> Result<(), FrontendError> {
     let stmt = arena.stmt(stmt_id);
     match stmt {
+        Stmt::Const { name, ty, value } => {
+            let vt = infer_expr_type(*value, arena, env, table, ret_ty)?;
+            ensure_const_initializer_safe(*value, arena, env)?;
+            let final_ty = if let Some(ann) = ty {
+                ensure_binding_value_type(
+                    *ann,
+                    vt,
+                    *value,
+                    arena,
+                    format!("const '{}'", resolve_symbol_name(arena, *name)?),
+                )?;
+                *ann
+            } else {
+                vt
+            };
+            env.insert_const(*name, final_ty);
+            Ok(())
+        }
         Stmt::Let { name, ty, value } => {
             let vt = infer_expr_type(*value, arena, env, table, ret_ty)?;
             let final_ty = if let Some(ann) = ty {
@@ -126,6 +144,15 @@ fn check_stmt(
                     resolve_symbol_name(arena, *name)?
                 ),
             })?;
+            if env.is_const(*name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "cannot assign to const binding '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
+                });
+            }
             let value_ty = infer_expr_type(*value, arena, env, table, ret_ty)?;
             ensure_binding_value_type(
                 target_ty,
@@ -753,6 +780,64 @@ mod tests {
     }
 
     #[test]
+    fn const_declaration_typechecks_for_literal_expression_subset() {
+        let src = r#"
+            fn main() {
+                const two: f64 = 1.0 + 1.0;
+                const four: f64 = two + two;
+                let ok = four == four;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("const declarations should typecheck");
+    }
+
+    #[test]
+    fn const_declaration_rejects_non_const_initializer() {
+        let src = r#"
+            fn main() {
+                let base: f64 = 1.0;
+                const total: f64 = base + 1.0;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("const initializer must reject runtime binding");
+        assert!(err.message.contains("is not const"));
+    }
+
+    #[test]
+    fn const_binding_rejects_assignment_target() {
+        let src = r#"
+            fn main() {
+                const total: f64 = 1.0;
+                total += 2.0;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("assignment to const must reject");
+        assert!(err.message.contains("cannot assign to const binding 'total'"));
+    }
+
+    #[test]
+    fn const_declaration_is_allowed_inside_value_block_body() {
+        let src = r#"
+            fn main() {
+                let total: f64 = {
+                    const offset: f64 = 2.0;
+                    1.0 + offset
+                };
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("const should be accepted in value block body");
+    }
+
+    #[test]
     fn captureful_short_lambda_is_rejected() {
         let src = r#"
             fn main() {
@@ -955,13 +1040,13 @@ fn infer_value_block_type(
     block_env.push_scope();
     for stmt in &block.statements {
         match arena.stmt(*stmt) {
-            Stmt::Let { .. } | Stmt::Discard { .. } | Stmt::Expr(_) => {
+            Stmt::Const { .. } | Stmt::Let { .. } | Stmt::Discard { .. } | Stmt::Expr(_) => {
                 check_stmt(*stmt, arena, &mut block_env, ret_ty, table)?;
             }
             _ => {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "value-producing block currently supports only let-bindings and expression statements before the tail value".to_string(),
+                    message: "value-producing block currently supports only const-bindings, let-bindings, discard binds, and expression statements before the tail value".to_string(),
                 });
             }
         }
@@ -1112,4 +1197,37 @@ fn ensure_binding_value_type(
             context, expected, actual
         ),
     })
+}
+
+fn ensure_const_initializer_safe(
+    expr_id: ExprId,
+    arena: &AstArena,
+    env: &ScopeEnv,
+) -> Result<(), FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::QuadLiteral(_) | Expr::BoolLiteral(_) | Expr::Num(_) | Expr::Float(_) => Ok(()),
+        Expr::Var(name) => {
+            if env.is_const(*name) {
+                Ok(())
+            } else {
+                Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "const initializer currently allows only literals, unary/binary operations, and references to earlier const bindings; '{}' is not const",
+                        resolve_symbol_name(arena, *name)?
+                    ),
+                })
+            }
+        }
+        Expr::Unary(_, inner) => ensure_const_initializer_safe(*inner, arena, env),
+        Expr::Binary(lhs, _, rhs) => {
+            ensure_const_initializer_safe(*lhs, arena, env)?;
+            ensure_const_initializer_safe(*rhs, arena, env)
+        }
+        _ => Err(FrontendError {
+            pos: 0,
+            message: "const initializer currently supports only pure literal/const expression forms"
+                .to_string(),
+        }),
+    }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -61,6 +61,11 @@ pub enum Expr {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Stmt {
+    Const {
+        name: SymbolId,
+        ty: Option<Type>,
+        value: ExprId,
+    },
     Let {
         name: SymbolId,
         ty: Option<Type>,
@@ -196,6 +201,7 @@ pub struct Token {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     KwFn,
+    KwConst,
     KwLet,
     KwGuard,
     KwIf,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1321,6 +1321,25 @@ fn lower_stmt(
 ) -> Result<(), FrontendError> {
     let stmt = arena.stmt(stmt_id);
     match stmt {
+        Stmt::Const { name, ty, value } => {
+            let (reg, vty) = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                *ty,
+                ret_ty,
+            )?;
+            let final_ty = if let Some(ann) = ty { *ann } else { vty };
+            env.insert_const(*name, final_ty);
+            ctx.instrs.push(IrInstr::StoreVar {
+                name: resolve_symbol_name(arena, *name)?.to_string(),
+                src: reg,
+            });
+            Ok(())
+        }
         Stmt::Let { name, ty, value } => {
             let (reg, vty) = lower_expr_with_expected(
                 *value,
@@ -1361,6 +1380,15 @@ fn lower_stmt(
                     resolve_symbol_name(arena, *name)?
                 ),
             })?;
+            if env.is_const(*name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "cannot assign to const binding '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
+                });
+            }
             let (reg, _) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -1657,6 +1685,24 @@ fn lower_value_block_expr(
     block_env.push_scope();
     for stmt in &block.statements {
         match arena.stmt(*stmt) {
+            Stmt::Const { name, ty, value } => {
+                let (reg, vty) = lower_expr_with_expected(
+                    *value,
+                    arena,
+                    next,
+                    out,
+                    &block_env,
+                    fn_table,
+                    *ty,
+                    ret_ty,
+                )?;
+                let final_ty = if let Some(ann) = ty { *ann } else { vty };
+                block_env.insert_const(*name, final_ty);
+                out.push(IrInstr::StoreVar {
+                    name: resolve_symbol_name(arena, *name)?.to_string(),
+                    src: reg,
+                });
+            }
             Stmt::Let { name, ty, value } => {
                 let (reg, vty) = lower_expr_with_expected(
                     *value, arena, next, out, &block_env, fn_table, *ty, ret_ty,
@@ -1679,7 +1725,7 @@ fn lower_value_block_expr(
             _ => {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "value-producing block currently supports only let-bindings and expression statements before the tail value".to_string(),
+                    message: "value-producing block currently supports only const-bindings, let-bindings, discard binds, and expression statements before the tail value".to_string(),
                 });
             }
         }
@@ -2119,7 +2165,7 @@ mod opt_tests {
 
         let err = compile_program_to_ir(src).expect_err("control statements must reject");
         assert!(err.message.contains(
-            "value-producing block currently supports only let-bindings and expression statements before the tail value"
+            "value-producing block currently supports only const-bindings, let-bindings, discard binds, and expression statements before the tail value"
         ));
     }
 
@@ -2292,6 +2338,41 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::Call { .. })));
+    }
+
+    #[test]
+    fn lower_const_declaration_to_existing_store_path() {
+        let src = r#"
+            fn main() {
+                const total: f64 = 1.0 + 2.0;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("const declaration should lower");
+        let main = &ir[0];
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "total")));
+    }
+
+    #[test]
+    fn lowering_rejects_assignment_to_const_binding() {
+        let src = r#"
+            fn main() {
+                const total: f64 = 1.0;
+                total += 2.0;
+                return;
+            }
+        "#;
+
+        let err = compile_program_to_ir(src).expect_err("assignment to const must reject");
+        assert!(err.message.contains("cannot assign to const binding 'total'"));
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -81,6 +81,7 @@ Current message families include:
 
 - unknown variable
 - unknown assignment target
+- assignment to const binding
 - unknown function
 - argument count mismatch
 - argument type mismatch
@@ -89,6 +90,7 @@ Current message families include:
 - statement-only `assert` used in value position
 - let-binding type mismatch
 - discard-binding type mismatch
+- non-const-safe initializer in const declaration
 - return type mismatch
 - invalid `guard` condition type
 - invalid `if` condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -78,6 +78,7 @@ The executable Rust-like surface uses lexical block scoping.
 Current rules:
 
 - function parameters are bound in function scope before body execution
+- `const` introduces an immutable source-visible local binding
 - `let` introduces a source-visible local binding
 - `let _ = expr;` evaluates the right-hand side but introduces no source-visible binding
 - `if` branches and `match` arms are checked in branch-local scopes
@@ -93,6 +94,8 @@ Current honest limit:
 
 Current statement meaning:
 
+- `const` evaluates a compile-time-safe initializer expression before binding the name
+- const bindings are immutable in the current source contract
 - `let` evaluates the right-hand side before binding the name
 - discard bind evaluates the right-hand side and then drops the produced value
 - `name op= expr;` evaluates as read-modify-write over the existing binding
@@ -114,6 +117,13 @@ Current non-goal:
 - `guard` does not yet support arbitrary `else { ... }` recovery blocks
 - plain reassignment `name = expr;` is not yet part of the public surface
 
+Current v0 const limit:
+
+- `const` is statement-level only in the current source contract
+- const initializers currently support only pure literal/const expression forms
+- ordinary function calls, control-flow expressions, and references to
+  non-const locals are not yet part of the stable const initializer subset
+
 ## Block Expressions
 
 Current block-expression semantics:
@@ -126,7 +136,8 @@ Current block-expression semantics:
 Current v0 limit:
 
 - block-expression bodies currently accept only named `let` bindings,
-  discard binds, and expression statements before the tail value
+  `const` bindings, discard binds, and expression statements before the tail
+  value
 - discard bind is accepted in value-producing block bodies, but richer pattern
   destructuring is not yet part of the stable block-expression contract
 - `return` is not yet supported inside value-producing block bodies as a

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -63,6 +63,8 @@ Current rules:
 
 Current statement forms:
 
+- `const name = expr;`
+- `const name: type = expr;`
 - `let name = expr;`
 - `let name: type = expr;`
 - `let _ = expr;`
@@ -86,6 +88,8 @@ Current statement forms:
 Current statement rules:
 
 - semicolons terminate executable statements
+- `const` is currently statement-level only
+- `const` initializer syntax mirrors `let` but uses a narrower compile-time-safe expression subset
 - `let _ = expr;` is the current discard-bind surface
 - compound assignment is statement-level sugar only
 - `guard` currently supports only the `else return` form


### PR DESCRIPTION
Refs #95.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
