### PR TITLE
D20-C01 named arguments

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -16,8 +16,8 @@ use alloc::vec::Vec;
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use types::{
-    AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, FrontendErrorKind, Function,
-    IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
+    AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId, FrontendError, FrontendErrorKind,
+    Function, IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
     LogosSystem, LogosWhen, MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt, StmtId,
     SymbolId, Token, TokenKind, Type, UnaryOp,
 };
@@ -37,6 +37,7 @@ pub use typecheck::{type_check_function, type_check_function_with_table, type_ch
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FnSig {
     pub params: Vec<Type>,
+    pub param_names: Option<Vec<SymbolId>>,
     pub ret: Type,
 }
 
@@ -144,6 +145,7 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
             f.name,
             FnSig {
                 params: f.params.iter().map(|(_, t)| *t).collect(),
+                param_names: Some(f.params.iter().map(|(name, _)| *name).collect()),
                 ret: f.ret,
             },
         );
@@ -156,14 +158,114 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
     match name {
         "sin" | "cos" | "tan" | "sqrt" | "abs" => Some(FnSig {
             params: vec![Type::F64],
+            param_names: None,
             ret: Type::F64,
         }),
         "pow" => Some(FnSig {
             params: vec![Type::F64, Type::F64],
+            param_names: None,
             ret: Type::F64,
         }),
         _ => None,
     }
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn reorder_call_args(
+    call_name: SymbolId,
+    args: &[CallArg],
+    sig: &FnSig,
+    arena: &AstArena,
+) -> Result<Vec<ExprId>, FrontendError> {
+    let has_named = args.iter().any(|arg| arg.name.is_some());
+    if !has_named {
+        if sig.params.len() != args.len() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "function '{}' expects {} args, got {}",
+                    resolve_symbol_name(arena, call_name)?,
+                    sig.params.len(),
+                    args.len()
+                ),
+            });
+        }
+        return Ok(args.iter().map(|arg| arg.value).collect());
+    }
+
+    let Some(param_names) = sig.param_names.as_ref() else {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "named arguments are not supported for builtin '{}'",
+                resolve_symbol_name(arena, call_name)?
+            ),
+        });
+    };
+
+    let mut ordered = vec![None; sig.params.len()];
+    let mut positional_index = 0usize;
+    let mut named_seen = false;
+    for arg in args {
+        if let Some(arg_name) = arg.name {
+            named_seen = true;
+            let Some(param_index) = param_names.iter().position(|name| *name == arg_name) else {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "function '{}' has no parameter named '{}'",
+                        resolve_symbol_name(arena, call_name)?,
+                        resolve_symbol_name(arena, arg_name)?
+                    ),
+                });
+            };
+            if ordered[param_index].is_some() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "duplicate named argument '{}' in call to '{}'",
+                        resolve_symbol_name(arena, arg_name)?,
+                        resolve_symbol_name(arena, call_name)?
+                    ),
+                });
+            }
+            ordered[param_index] = Some(arg.value);
+        } else {
+            if named_seen {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "positional arguments cannot follow named arguments".to_string(),
+                });
+            }
+            if positional_index >= ordered.len() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "function '{}' expects {} args, got {}",
+                        resolve_symbol_name(arena, call_name)?,
+                        sig.params.len(),
+                        args.len()
+                    ),
+                });
+            }
+            ordered[positional_index] = Some(arg.value);
+            positional_index += 1;
+        }
+    }
+
+    if ordered.iter().any(|slot| slot.is_none()) {
+        let missing_index = ordered.iter().position(|slot| slot.is_none()).unwrap_or(0);
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "function '{}' is missing argument for parameter '{}'",
+                resolve_symbol_name(arena, call_name)?,
+                resolve_symbol_name(arena, param_names[missing_index])?
+            ),
+        });
+    }
+
+    Ok(ordered.into_iter().flatten().collect())
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1,9 +1,9 @@
 use crate::lexer::lex_tokens;
 use crate::types::{
-    AstArena, BinaryOp, BlockExpr, Expr, ExprId, FrontendError, Function, IfExpr, LogosEntity,
-    LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
-    MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal, Stmt, StmtId, SymbolId,
-    Token, TokenKind, Type, UnaryOp,
+    AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId, FrontendError, Function, IfExpr,
+    LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem,
+    LogosWhen, MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal, Stmt, StmtId,
+    SymbolId, Token, TokenKind, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -407,17 +407,12 @@ impl<'a> Parser<'a> {
         }
 
         let name = self.expect_symbol()?;
-        let mut args = vec![input];
+        let mut args = vec![CallArg {
+            name: None,
+            value: input,
+        }];
         if self.eat(TokenKind::LParen) {
-            if !self.check(TokenKind::RParen) {
-                loop {
-                    args.push(self.parse_expr()?);
-                    if self.eat(TokenKind::Comma) {
-                        continue;
-                    }
-                    break;
-                }
-            }
+            args.extend(self.parse_call_args()?);
             self.expect(TokenKind::RParen, "expected ')'")?;
         }
         Ok(self.arena.alloc_expr(Expr::Call(name, args)))
@@ -466,16 +461,7 @@ impl<'a> Parser<'a> {
         if self.check(TokenKind::Ident) {
             let name = self.expect_symbol()?;
             if self.eat(TokenKind::LParen) {
-                let mut args = Vec::new();
-                if !self.check(TokenKind::RParen) {
-                    loop {
-                        args.push(self.parse_expr()?);
-                        if self.eat(TokenKind::Comma) {
-                            continue;
-                        }
-                        break;
-                    }
-                }
+                let args = self.parse_call_args()?;
                 self.expect(TokenKind::RParen, "expected ')'")?;
                 return Ok(self.arena.alloc_expr(Expr::Call(name, args)));
             }
@@ -489,6 +475,45 @@ impl<'a> Parser<'a> {
 
     fn starts_short_lambda_head(&self) -> bool {
         self.check(TokenKind::Ident) && self.peek_next_kind() == Some(TokenKind::FatArrow)
+    }
+
+    fn parse_call_args(&mut self) -> Result<Vec<CallArg>, FrontendError> {
+        let mut args = Vec::new();
+        let mut named_seen = false;
+        if self.check(TokenKind::RParen) {
+            return Ok(args);
+        }
+        loop {
+            let arg = if self.check(TokenKind::Ident)
+                && self.peek_next_kind() == Some(TokenKind::Assign)
+            {
+                named_seen = true;
+                let name = self.expect_symbol()?;
+                self.expect(TokenKind::Assign, "expected '=' in named argument")?;
+                let value = self.parse_expr()?;
+                CallArg {
+                    name: Some(name),
+                    value,
+                }
+            } else {
+                if named_seen {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "positional arguments cannot follow named arguments".to_string(),
+                    });
+                }
+                CallArg {
+                    name: None,
+                    value: self.parse_expr()?,
+                }
+            };
+            args.push(arg);
+            if self.eat(TokenKind::Comma) {
+                continue;
+            }
+            break;
+        }
+        Ok(args)
     }
 
     fn parse_short_lambda_apply_after_lparen(
@@ -595,7 +620,7 @@ impl<'a> Parser<'a> {
             }
             Expr::Call(_, args) => {
                 for arg in args {
-                    self.ensure_short_lambda_expr_capture_free(*arg, scopes)?;
+                    self.ensure_short_lambda_expr_capture_free(arg.value, scopes)?;
                 }
                 Ok(())
             }
@@ -1655,11 +1680,77 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*scale_name), "scale");
         assert_eq!(scale_args.len(), 2);
-        let Expr::Call(inc_name, inc_args) = program.arena.expr(scale_args[0]) else {
+        assert!(scale_args[0].name.is_none());
+        let Expr::Call(inc_name, inc_args) = program.arena.expr(scale_args[0].value) else {
             panic!("expected nested pipeline call");
         };
         assert_eq!(program.arena.symbol_name(*inc_name), "inc");
         assert_eq!(inc_args.len(), 1);
+        assert!(inc_args[0].name.is_none());
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_named_arguments() {
+        let src = r#"
+fn scale(x: f64, factor: f64) -> f64 = x * factor;
+fn main() {
+    let value: f64 = scale(factor = 3.0, x = 1.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("named arguments should parse");
+        let func = &program.functions[1];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading let statement");
+        };
+        let Expr::Call(scale_name, scale_args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(program.arena.symbol_name(*scale_name), "scale");
+        assert_eq!(scale_args.len(), 2);
+        assert_eq!(
+            scale_args[0]
+                .name
+                .map(|name| program.arena.symbol_name(name)),
+            Some("factor")
+        );
+        assert_eq!(
+            scale_args[1]
+                .name
+                .map(|name| program.arena.symbol_name(name)),
+            Some("x")
+        );
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_pipeline_named_arguments_after_prefix() {
+        let src = r#"
+fn scale(x: f64, factor: f64) -> f64 = x * factor;
+fn main() {
+    let value: f64 = 1.0 |> scale(factor = 3.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("pipeline named arguments should parse");
+        let func = &program.functions[1];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected leading let statement");
+        };
+        let Expr::Call(_, scale_args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(scale_args.len(), 2);
+        assert!(scale_args[0].name.is_none());
+        assert_eq!(
+            scale_args[1]
+                .name
+                .map(|name| program.arena.symbol_name(name)),
+            Some("factor")
+        );
     }
 
     #[test]
@@ -1761,6 +1852,23 @@ fn main() {
         assert!(err
             .message
             .contains("pipeline stage must start with function name or call"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_positional_after_named_arguments() {
+        let src = r#"
+fn scale(x: f64, factor: f64) -> f64 = x * factor;
+fn main() {
+    let value: f64 = scale(x = 1.0, 3.0);
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("positional after named must reject");
+        assert!(err
+            .message
+            .contains("positional arguments cannot follow named arguments"));
     }
 
     #[test]
@@ -2019,7 +2127,7 @@ fn main() {
         assert_eq!(program.arena.symbol_name(*name), "assert");
         assert_eq!(args.len(), 1);
         assert!(matches!(
-            program.arena.expr(args[0]),
+            program.arena.expr(args[0].value),
             Expr::BoolLiteral(true)
         ));
     }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -41,6 +41,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
         func.name,
         FnSig {
             params: func.params.iter().map(|(_, t)| *t).collect(),
+            param_names: Some(func.params.iter().map(|(name, _)| *name).collect()),
             ret: func.ret,
         },
     );
@@ -320,18 +321,8 @@ fn infer_expr_type(
                     message: format!("unknown function '{}'", resolve_symbol_name(arena, *name)?),
                 });
             };
-            if sig.params.len() != args.len() {
-                return Err(FrontendError {
-                    pos: 0,
-                    message: format!(
-                        "function '{}' expects {} args, got {}",
-                        resolve_symbol_name(arena, *name)?,
-                        sig.params.len(),
-                        args.len()
-                    ),
-                });
-            }
-            for (i, arg) in args.iter().enumerate() {
+            let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
+            for (i, arg) in ordered_args.iter().enumerate() {
                 let at = infer_expr_type(*arg, arena, env, table, ret_ty)?;
                 if at != sig.params[i] {
                     if sig.params[i] == Type::Fx && is_numeric_for_fx_gap(at) {
@@ -791,6 +782,85 @@ mod tests {
     }
 
     #[test]
+    fn named_arguments_typecheck_via_parameter_reorder() {
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale(factor = 3.0, x = 2.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("named arguments should typecheck");
+    }
+
+    #[test]
+    fn pipeline_named_arguments_typecheck_after_positional_prefix() {
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = 2.0 |> scale(factor = 3.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("pipeline named arguments should typecheck");
+    }
+
+    #[test]
+    fn builtin_named_arguments_are_rejected() {
+        let src = r#"
+            fn main() {
+                let total: f64 = sqrt(x = 4.0);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("builtin named arguments must reject");
+        assert!(err
+            .message
+            .contains("named arguments are not supported for builtin 'sqrt'"));
+    }
+
+    #[test]
+    fn duplicate_named_arguments_are_rejected() {
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale(x = 2.0, x = 3.0);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("duplicate named arguments must reject");
+        assert!(err
+            .message
+            .contains("duplicate named argument 'x'"));
+    }
+
+    #[test]
+    fn missing_named_argument_is_rejected() {
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale(x = 2.0);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("missing named argument must reject");
+        assert!(err
+            .message
+            .contains("is missing argument for parameter 'factor'"));
+    }
+
+    #[test]
     fn immediate_short_lambda_typechecks_via_block_desugaring() {
         let src = r#"
             fn main() {
@@ -1056,7 +1126,7 @@ fn check_builtin_assert_stmt(
             message: format!("assert builtin expects 1 arg, got {}", args.len()),
         });
     }
-    let cond_ty = infer_expr_type(args[0], arena, env, table, ret_ty)?;
+    let cond_ty = infer_expr_type(args[0].value, arena, env, table, ret_ty)?;
     if cond_ty != Type::Bool {
         return Err(FrontendError {
             pos: 0,

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -53,12 +53,18 @@ pub enum NumericLiteral {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct CallArg {
+    pub name: Option<SymbolId>,
+    pub value: ExprId,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     QuadLiteral(QuadVal),
     BoolLiteral(bool),
     NumericLiteral(NumericLiteral),
     Var(SymbolId),
-    Call(SymbolId, Vec<ExprId>),
+    Call(SymbolId, Vec<CallArg>),
     Unary(UnaryOp, ExprId),
     Binary(ExprId, BinaryOp, ExprId),
     Block(BlockExpr),

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1101,19 +1101,9 @@ fn lower_expr_with_expected(
                     message: format!("unknown function '{}'", resolve_symbol_name(arena, *name)?),
                 });
             };
-            if sig.params.len() != args.len() {
-                return Err(FrontendError {
-                    pos: 0,
-                    message: format!(
-                        "function '{}' expects {} args, got {}",
-                        resolve_symbol_name(arena, *name)?,
-                        sig.params.len(),
-                        args.len()
-                    ),
-                });
-            }
+            let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
             let mut regs = Vec::new();
-            for (i, arg) in args.iter().enumerate() {
+            for (i, arg) in ordered_args.iter().enumerate() {
                 let (r, t) = lower_expr_with_expected(
                     *arg,
                     arena,
@@ -2048,7 +2038,7 @@ fn lower_expr_stmt_with_parts(
                 });
             }
             let (cond, cond_ty) = lower_expr_with_expected(
-                args[0],
+                args[0].value,
                 arena,
                 next,
                 out,
@@ -2076,19 +2066,9 @@ fn lower_expr_stmt_with_parts(
                 message: format!("unknown function '{}'", resolve_symbol_name(arena, *name)?),
             });
         };
-        if sig.params.len() != args.len() {
-            return Err(FrontendError {
-                pos: 0,
-                message: format!(
-                    "function '{}' expects {} args, got {}",
-                    resolve_symbol_name(arena, *name)?,
-                    sig.params.len(),
-                    args.len()
-                ),
-            });
-        }
+        let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
         let mut regs = Vec::new();
-        for (i, arg) in args.iter().enumerate() {
+        for (i, arg) in ordered_args.iter().enumerate() {
             let (r, t) = lower_expr_with_expected(
                 *arg,
                 arena,
@@ -2332,6 +2312,48 @@ mod opt_tests {
             .collect();
         assert!(call_names.contains(&"inc"));
         assert!(call_names.contains(&"scale"));
+    }
+
+    #[test]
+    fn lower_named_arguments_to_ordinary_call_order() {
+        let src = r#"
+            fn scale(x: f64, factor: f64) -> f64 = x * factor;
+            fn main() {
+                let total: f64 = scale(factor = 3.0, x = 2.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("named arguments should lower");
+        let main = &ir[1];
+        let call = main
+            .instrs
+            .iter()
+            .find(|instr| matches!(instr, IrInstr::Call { name, .. } if name == "scale"));
+        assert!(call.is_some());
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 2.0).abs() < f64::EPSILON)));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 3.0).abs() < f64::EPSILON)));
+    }
+
+    #[test]
+    fn lowering_rejects_builtin_named_arguments() {
+        let src = r#"
+            fn main() {
+                let total: f64 = sqrt(x = 4.0);
+                return;
+            }
+        "#;
+
+        let err = compile_program_to_ir(src).expect_err("builtin named arguments must reject");
+        assert!(err
+            .message
+            .contains("named arguments are not supported for builtin 'sqrt'"));
     }
 
     #[test]

--- a/crates/sm-ir/src/lib.rs
+++ b/crates/sm-ir/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 mod frontend {
     pub use sm_front::{
         build_fn_table, builtin_sig, parse_logos_program_with_profile,
-        parse_program_with_profile, resolve_symbol_name,
+        parse_program_with_profile, reorder_call_args, resolve_symbol_name,
         type_check_function_with_table, type_check_program, AstArena, BinaryOp, BlockExpr,
         CompileProfile, Expr, ExprId, FnTable, FrontendError, Function, LogosProgram, MatchExpr,
         OptLevel, QuadVal, ScopeEnv, Stmt, StmtId, SymbolId, Type, UnaryOp,

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -90,6 +90,11 @@ Current message families include:
 - invalid `assert` argument count
 - invalid `assert` condition type
 - statement-only `assert` used in value position
+- positional arguments after named arguments
+- named arguments on builtin calls
+- unknown named parameter
+- duplicate named argument
+- missing named argument for a declared parameter
 - let-binding type mismatch
 - discard-binding type mismatch
 - non-const-safe initializer in const declaration

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -60,6 +60,7 @@ Current rules:
   same name exists
 - there is no overload resolution
 - there is no dynamic dispatch
+- named arguments reorder only after the target function resolves successfully
 
 Current builtin names in the Rust-like surface are:
 
@@ -70,6 +71,22 @@ Current builtin names in the Rust-like surface are:
 - `abs`
 - `pow`
 - `assert`
+
+Current named-argument call semantics:
+
+- named arguments are currently supported only for ordinary user-defined
+  functions
+- positional arguments may appear only before the first named argument
+- after resolution, named arguments reorder to the declared parameter order
+  before ordinary argument type-checking and lowering
+- each declared parameter must receive exactly one argument in the current
+  contract
+
+Current v0 limits:
+
+- builtin calls do not yet accept named arguments
+- default parameters are not yet part of the source contract
+- named arguments do not imply overload resolution or keyword-only parameters
 
 ## Numeric Literal Meaning
 
@@ -289,6 +306,7 @@ Current `|>` semantics:
 
 - `input |> stage()` is equivalent to `stage(input)`
 - `input |> stage(arg1, arg2)` is equivalent to `stage(input, arg1, arg2)`
+- `input |> stage(name = arg1)` is equivalent to `stage(input, name = arg1)`
 - pipeline stages are currently restricted to bare function names or ordinary
   call syntax
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -120,6 +120,9 @@ Current expression forms:
     - explicit `fx` forms `1.25fx`, `100fx`
 - variables
 - function calls
+- named-argument calls:
+  - `open(path = main_path, mode = read_only)`
+  - `value |> stage(limit = 10)`
 - pipeline chains:
   - `value |> stage()`
   - `value |> stage(arg)`
@@ -179,6 +182,16 @@ Current short-lambda rules:
   bindings
 - typed lambda parameters and multi-argument lambda forms are not yet part of
   the stable source contract
+
+Current named-argument rules:
+
+- ordinary user-defined calls may use named arguments
+- positional arguments are allowed only as a leading prefix before any named
+  argument
+- every declared parameter must still be supplied exactly once in v0
+- named arguments reorder to the declared parameter order before ordinary
+  type-checking and lowering
+- named arguments are not yet part of the builtin-call surface
 
 ## Quad-Specific Surface Rules
 


### PR DESCRIPTION
Refs #89.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
