### PR TITLE
D20-C02 default parameters

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -38,6 +38,7 @@ pub use typecheck::{type_check_function, type_check_function_with_table, type_ch
 pub struct FnSig {
     pub params: Vec<Type>,
     pub param_names: Option<Vec<SymbolId>>,
+    pub param_defaults: Option<Vec<Option<ExprId>>>,
     pub ret: Type,
 }
 
@@ -146,6 +147,7 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
             FnSig {
                 params: f.params.iter().map(|(_, t)| *t).collect(),
                 param_names: Some(f.params.iter().map(|(name, _)| *name).collect()),
+                param_defaults: Some(f.param_defaults.clone()),
                 ret: f.ret,
             },
         );
@@ -159,11 +161,13 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
         "sin" | "cos" | "tan" | "sqrt" | "abs" => Some(FnSig {
             params: vec![Type::F64],
             param_names: None,
+            param_defaults: None,
             ret: Type::F64,
         }),
         "pow" => Some(FnSig {
             params: vec![Type::F64, Type::F64],
             param_names: None,
+            param_defaults: None,
             ret: Type::F64,
         }),
         _ => None,
@@ -179,7 +183,7 @@ pub fn reorder_call_args(
 ) -> Result<Vec<ExprId>, FrontendError> {
     let has_named = args.iter().any(|arg| arg.name.is_some());
     if !has_named {
-        if sig.params.len() != args.len() {
+        if args.len() > sig.params.len() {
             return Err(FrontendError {
                 pos: 0,
                 message: format!(
@@ -190,7 +194,11 @@ pub fn reorder_call_args(
                 ),
             });
         }
-        return Ok(args.iter().map(|arg| arg.value).collect());
+        let mut ordered = vec![None; sig.params.len()];
+        for (idx, arg) in args.iter().enumerate() {
+            ordered[idx] = Some(arg.value);
+        }
+        return finalize_ordered_call_args(call_name, ordered, sig, arena, args.len());
     }
 
     let Some(param_names) = sig.param_names.as_ref() else {
@@ -253,18 +261,51 @@ pub fn reorder_call_args(
         }
     }
 
-    if ordered.iter().any(|slot| slot.is_none()) {
-        let missing_index = ordered.iter().position(|slot| slot.is_none()).unwrap_or(0);
+    finalize_ordered_call_args(call_name, ordered, sig, arena, args.len())
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn finalize_ordered_call_args(
+    call_name: SymbolId,
+    mut ordered: Vec<Option<ExprId>>,
+    sig: &FnSig,
+    arena: &AstArena,
+    provided_count: usize,
+) -> Result<Vec<ExprId>, FrontendError> {
+    let param_names = sig.param_names.as_ref();
+    let param_defaults = sig.param_defaults.as_ref();
+    for idx in 0..ordered.len() {
+        if ordered[idx].is_some() {
+            continue;
+        }
+        let default_expr = param_defaults
+            .and_then(|defaults| defaults.get(idx))
+            .copied()
+            .flatten();
+        if let Some(default_expr) = default_expr {
+            ordered[idx] = Some(default_expr);
+            continue;
+        }
+        if let Some(param_names) = param_names {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "function '{}' is missing argument for parameter '{}'",
+                    resolve_symbol_name(arena, call_name)?,
+                    resolve_symbol_name(arena, param_names[idx])?
+                ),
+            });
+        }
         return Err(FrontendError {
             pos: 0,
             message: format!(
-                "function '{}' is missing argument for parameter '{}'",
+                "function '{}' expects {} args, got {}",
                 resolve_symbol_name(arena, call_name)?,
-                resolve_symbol_name(arena, param_names[missing_index])?
+                sig.params.len(),
+                provided_count
             ),
         });
     }
-
     Ok(ordered.into_iter().flatten().collect())
 }
 

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -76,12 +76,29 @@ impl<'a> Parser<'a> {
         let name = self.expect_symbol()?;
         self.expect(TokenKind::LParen, "expected '('")?;
         let mut params = Vec::new();
+        let mut param_defaults = Vec::new();
+        let mut default_seen = false;
         if !self.check(TokenKind::RParen) {
             loop {
                 let pname = self.expect_symbol()?;
                 self.expect(TokenKind::Colon, "expected ':'")?;
                 let pty = self.parse_type()?;
+                let default = if self.eat(TokenKind::Assign) {
+                    default_seen = true;
+                    Some(self.parse_expr()?)
+                } else {
+                    if default_seen {
+                        return Err(FrontendError {
+                            pos: self.pos(),
+                            message:
+                                "required parameter cannot follow parameter with default value"
+                                    .to_string(),
+                        });
+                    }
+                    None
+                };
                 params.push((pname, pty));
+                param_defaults.push(default);
                 if self.eat(TokenKind::Comma) {
                     continue;
                 }
@@ -107,6 +124,7 @@ impl<'a> Parser<'a> {
         Ok(Function {
             name,
             params,
+            param_defaults,
             ret,
             body,
         })
@@ -1725,6 +1743,29 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_default_parameters() {
+        let src = r#"
+fn scale(x: f64, factor: f64 = 2.0) -> f64 = x * factor;
+fn main() {
+    let value: f64 = scale(3.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("default parameters should parse");
+        let scale = &program.functions[0];
+        assert_eq!(scale.params.len(), 2);
+        assert_eq!(scale.param_defaults.len(), 2);
+        assert!(scale.param_defaults[0].is_none());
+        let default_expr = scale.param_defaults[1].expect("expected trailing default");
+        assert!(matches!(
+            program.arena.expr(default_expr),
+            Expr::NumericLiteral(NumericLiteral::F64(v)) if (*v - 2.0).abs() < f64::EPSILON
+        ));
+    }
+
+    #[test]
     fn rustlike_parser_accepts_pipeline_named_arguments_after_prefix() {
         let src = r#"
 fn scale(x: f64, factor: f64) -> f64 = x * factor;
@@ -1869,6 +1910,22 @@ fn main() {
         assert!(err
             .message
             .contains("positional arguments cannot follow named arguments"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_required_parameter_after_default() {
+        let src = r#"
+fn scale(x: f64 = 2.0, factor: f64) -> f64 = x * factor;
+fn main() {
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("required parameter after default must reject");
+        assert!(err
+            .message
+            .contains("required parameter cannot follow parameter with default value"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -42,6 +42,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
         FnSig {
             params: func.params.iter().map(|(_, t)| *t).collect(),
             param_names: Some(func.params.iter().map(|(name, _)| *name).collect()),
+            param_defaults: Some(func.param_defaults.clone()),
             ret: func.ret,
         },
     );
@@ -80,6 +81,35 @@ pub fn type_check_function_with_table(
     arena: &AstArena,
     table: &FnTable,
 ) -> Result<(), FrontendError> {
+    if func.params.len() != func.param_defaults.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: "function parameter/default metadata length mismatch".to_string(),
+        });
+    }
+    let empty_env = ScopeEnv::new();
+    for ((name, ty), default_expr) in func.params.iter().zip(func.param_defaults.iter()) {
+        if let Some(default_expr) = default_expr {
+            let default_ty = infer_expr_type(*default_expr, arena, &empty_env, table, Type::Unit)?;
+            if let Err(err) = ensure_const_initializer_safe(*default_expr, arena, &empty_env) {
+                return Err(FrontendError {
+                    pos: err.pos,
+                    message: format!(
+                        "default parameter '{}' {}",
+                        resolve_symbol_name(arena, *name)?,
+                        err.message
+                    ),
+                });
+            }
+            ensure_binding_value_type(
+                *ty,
+                default_ty,
+                *default_expr,
+                arena,
+                format!("default parameter '{}'", resolve_symbol_name(arena, *name)?),
+            )?;
+        }
+    }
     let mut env = ScopeEnv::with_params(&func.params);
     for stmt in &func.body {
         check_stmt(*stmt, arena, &mut env, func.ret, table)?;
@@ -812,6 +842,36 @@ mod tests {
     }
 
     #[test]
+    fn default_parameters_fill_omitted_trailing_arguments() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = 2.0) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale(3.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("default parameters should fill omitted trailing arguments");
+    }
+
+    #[test]
+    fn named_arguments_can_override_remaining_default_parameters() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = 2.0) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale(x = 3.0, factor = 4.0);
+                let ok = total == total;
+                if ok { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("named arguments should override defaulted parameters");
+    }
+
+    #[test]
     fn builtin_named_arguments_are_rejected() {
         let src = r#"
             fn main() {
@@ -858,6 +918,54 @@ mod tests {
         assert!(err
             .message
             .contains("is missing argument for parameter 'factor'"));
+    }
+
+    #[test]
+    fn required_parameter_still_rejects_when_default_is_missing() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = 2.0) -> f64 = x * factor;
+
+            fn main() {
+                let total: f64 = scale();
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("required non-default parameter must reject");
+        assert!(err
+            .message
+            .contains("is missing argument for parameter 'x'"));
+    }
+
+    #[test]
+    fn default_parameter_initializer_must_be_const_safe() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = sqrt(4.0)) -> f64 = x * factor;
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-const-safe default parameter must reject");
+        assert!(err
+            .message
+            .contains("default parameter 'factor'"));
+    }
+
+    #[test]
+    fn default_parameter_initializer_cannot_reference_previous_parameter() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = x) -> f64 = x * factor;
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("default parameter cannot reference earlier param");
+        assert!(err.message.contains("'x'"));
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -148,6 +148,7 @@ pub struct MatchArm {
 pub struct Function {
     pub name: SymbolId,
     pub params: Vec<(SymbolId, Type)>,
+    pub param_defaults: Vec<Option<ExprId>>,
     pub ret: Type,
     pub body: Vec<StmtId>,
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2357,6 +2357,48 @@ mod opt_tests {
     }
 
     #[test]
+    fn lower_default_parameters_to_ordinary_call_order() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = 2.0) -> f64 = x * factor;
+            fn main() {
+                let total: f64 = scale(3.0);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("default parameters should lower");
+        let main = &ir[1];
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::Call { name, args, .. } if name == "scale" && args.len() == 2)));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 2.0).abs() < f64::EPSILON)));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 3.0).abs() < f64::EPSILON)));
+    }
+
+    #[test]
+    fn lowering_rejects_non_const_safe_default_parameter_initializer() {
+        let src = r#"
+            fn scale(x: f64, factor: f64 = sqrt(4.0)) -> f64 = x * factor;
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err =
+            compile_program_to_ir(src).expect_err("non-const-safe default parameter must reject");
+        assert!(err
+            .message
+            .contains("default parameter 'factor'"));
+    }
+
+    #[test]
     fn lower_immediate_short_lambda_without_indirect_call_path() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -95,6 +95,9 @@ Current message families include:
 - unknown named parameter
 - duplicate named argument
 - missing named argument for a declared parameter
+- required parameter after default parameter
+- non-const-safe default parameter initializer
+- default parameter type mismatch
 - let-binding type mismatch
 - discard-binding type mismatch
 - non-const-safe initializer in const declaration

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -79,14 +79,30 @@ Current named-argument call semantics:
 - positional arguments may appear only before the first named argument
 - after resolution, named arguments reorder to the declared parameter order
   before ordinary argument type-checking and lowering
-- each declared parameter must receive exactly one argument in the current
-  contract
+- each required non-default parameter must receive exactly one argument in the
+  current contract
+
+Current default-parameter limits:
+
+- builtin calls do not yet accept named arguments
+- named arguments do not imply overload resolution or keyword-only parameters
+
+Current default-parameter semantics:
+
+- default parameters are currently supported only for ordinary user-defined
+  functions
+- only trailing parameters may declare defaults in the stable v0 surface
+- when an argument is omitted for a trailing defaulted parameter, the declared
+  default initializer is substituted before ordinary argument type-checking and
+  lowering
+- default initializers must remain within the current const-safe expression
+  subset and may not depend on function parameters or local runtime bindings
 
 Current v0 limits:
 
-- builtin calls do not yet accept named arguments
-- default parameters are not yet part of the source contract
-- named arguments do not imply overload resolution or keyword-only parameters
+- builtin calls do not yet expose default parameters
+- default parameters do not imply optional positional holes, keyword-only
+  parameters, or overload resolution
 
 ## Numeric Literal Meaning
 
@@ -307,6 +323,8 @@ Current `|>` semantics:
 - `input |> stage()` is equivalent to `stage(input)`
 - `input |> stage(arg1, arg2)` is equivalent to `stage(input, arg1, arg2)`
 - `input |> stage(name = arg1)` is equivalent to `stage(input, name = arg1)`
+- `input |> stage(name = arg1)` may still omit later trailing defaulted
+  parameters
 - pipeline stages are currently restricted to bare function names or ordinary
   call syntax
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -44,6 +44,14 @@ fn name(arg: type, ...) -> ret_type {
 }
 ```
 
+Trailing default-parameter sugar is also part of the current v0 surface:
+
+```sm
+fn name(arg: type, optional_arg: type = expr) -> ret_type {
+    ...
+}
+```
+
 Expression-bodied sugar is also part of the current v0 surface:
 
 ```sm
@@ -54,6 +62,7 @@ Current rules:
 
 - `fn` introduces a function
 - parameters are named and typed explicitly
+- trailing parameters may attach a default initializer with `= expr`
 - the return type is optional; omitted return type means `unit`
 - function bodies are block-delimited with `{ ... }`
 - `fn ... = expr;` is accepted as shorthand for a single returned expression
@@ -188,10 +197,18 @@ Current named-argument rules:
 - ordinary user-defined calls may use named arguments
 - positional arguments are allowed only as a leading prefix before any named
   argument
-- every declared parameter must still be supplied exactly once in v0
+- required non-default parameters must still be supplied exactly once in v0
 - named arguments reorder to the declared parameter order before ordinary
   type-checking and lowering
 - named arguments are not yet part of the builtin-call surface
+
+Current default-parameter rules:
+
+- only trailing parameters may declare defaults in v0
+- omitted arguments may currently be filled only from those declared trailing
+  defaults
+- default initializers are part of ordinary user-defined function declarations
+- builtin calls do not expose default-parameter surface
 
 ## Quad-Specific Surface Rules
 


### PR DESCRIPTION
Refs #90.

Scope:
- narrow D20 slice only
- no broader language/runtime expansion beyond this feature
- stacked in validated dependency order

Validation:
- targeted crate tests for the touched layers
- cargo test --workspace
