### PR TITLE
D20-C05 destructuring assignment

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -199,6 +199,14 @@ impl<'a> Parser<'a> {
                 return Ok(self.arena.alloc_stmt(Stmt::Assign { name, value }));
             }
         }
+        if self.looks_like_tuple_assign_stmt() {
+            self.expect(TokenKind::LParen, "expected '('")?;
+            let items = self.parse_tuple_bind_items_after_lparen()?;
+            self.expect(TokenKind::Assign, "expected '='")?;
+            let value = self.parse_expr()?;
+            self.expect(TokenKind::Semi, "expected ';'")?;
+            return Ok(self.arena.alloc_stmt(Stmt::AssignTuple { items, value }));
+        }
         if self.eat(TokenKind::KwGuard) {
             let condition = self.parse_expr()?;
             if !self.eat(TokenKind::KwElse) {
@@ -258,6 +266,38 @@ impl<'a> Parser<'a> {
         let expr = self.parse_expr()?;
         self.expect(TokenKind::Semi, "expected ';'")?;
         Ok(self.arena.alloc_stmt(Stmt::Expr(expr)))
+    }
+
+    fn looks_like_tuple_assign_stmt(&self) -> bool {
+        let mut i = self.next_non_layout_idx();
+        if self.tokens.get(i).map(|t| t.kind) != Some(TokenKind::LParen) {
+            return false;
+        }
+        let mut depth = 0usize;
+        while i < self.tokens.len() {
+            let kind = self.tokens[i].kind;
+            if !Self::is_layout(kind) {
+                match kind {
+                    TokenKind::LParen => depth += 1,
+                    TokenKind::RParen => {
+                        if depth == 0 {
+                            return false;
+                        }
+                        depth -= 1;
+                        if depth == 0 {
+                            i += 1;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
+        while i < self.tokens.len() && Self::is_layout(self.tokens[i].kind) {
+            i += 1;
+        }
+        self.tokens.get(i).map(|t| t.kind) == Some(TokenKind::Assign)
     }
 
     fn parse_tuple_bind_items_after_lparen(&mut self) -> Result<Vec<Option<SymbolId>>, FrontendError> {
@@ -2317,6 +2357,35 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_tuple_destructuring_assignment() {
+        let src = r#"
+fn pair() -> (i32, bool) = (1, true);
+
+fn main() {
+    let count: i32 = 0;
+    let ready: bool = false;
+    (count, ready) = pair();
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("tuple destructuring assignment should parse");
+        let func = &program.functions[1];
+        let Stmt::AssignTuple { items, value } = program.arena.stmt(func.body[2]) else {
+            panic!("expected tuple destructuring assignment");
+        };
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].map(|name| program.arena.symbol_name(name)), Some("count"));
+        assert_eq!(items[1].map(|name| program.arena.symbol_name(name)), Some("ready"));
+        let Expr::Call(name, args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "pair");
+        assert!(args.is_empty());
+    }
+
+    #[test]
     fn rustlike_parser_rejects_nested_tuple_destructuring_bind() {
         let src = r#"
 fn main() {
@@ -2327,6 +2396,25 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("nested tuple destructuring must reject");
+        assert!(err
+            .message
+            .contains("tuple destructuring bind v0 currently supports only flat"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_nested_tuple_destructuring_assignment() {
+        let src = r#"
+fn main() {
+    let x: i32 = 0;
+    let y: bool = false;
+    let z: bool = false;
+    ((x, y), z) = ((1, true), false);
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("nested tuple destructuring assignment must reject");
         assert!(err
             .message
             .contains("tuple destructuring bind v0 currently supports only flat"));

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -238,6 +238,57 @@ fn check_stmt(
                 format!("assignment to '{}'", resolve_symbol_name(arena, *name)?),
             )
         }
+        Stmt::AssignTuple { items, value } => {
+            let value_ty = infer_expr_type(*value, arena, env, table, ret_ty.clone())?;
+            let Type::Tuple(item_tys) = value_ty else {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "tuple destructuring assignment requires tuple value".to_string(),
+                });
+            };
+            if item_tys.len() != items.len() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "tuple destructuring assignment arity mismatch: expected {}, got {}",
+                        items.len(),
+                        item_tys.len()
+                    ),
+                });
+            }
+            for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+                let Some(name) = item else {
+                    continue;
+                };
+                let target_ty = env.get(*name).ok_or(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "unknown tuple assignment target '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
+                })?;
+                if env.is_const(*name) {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "cannot assign to const binding '{}' in tuple destructuring assignment",
+                            resolve_symbol_name(arena, *name)?
+                        ),
+                    });
+                }
+                ensure_binding_value_type(
+                    target_ty,
+                    item_ty,
+                    *value,
+                    arena,
+                    format!(
+                        "tuple assignment to '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
+                )?;
+            }
+            Ok(())
+        }
         Stmt::Guard {
             condition,
             else_return,
@@ -1304,6 +1355,42 @@ mod tests {
 
         let err = typecheck_source(src).expect_err("non-tuple destructuring must reject");
         assert!(err.message.contains("tuple destructuring bind requires tuple value"));
+    }
+
+    #[test]
+    fn tuple_destructuring_assignment_typechecks() {
+        let src = r#"
+            fn pair(flag: bool) -> (i32, bool) = (1, flag);
+
+            fn main() {
+                let count: i32 = 0;
+                let ready: bool = false;
+                (count, ready) = pair(true);
+                assert(count == 1);
+                assert(ready == true);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("tuple destructuring assignment should typecheck");
+    }
+
+    #[test]
+    fn tuple_destructuring_assignment_rejects_unknown_target() {
+        let src = r#"
+            fn pair(flag: bool) -> (i32, bool) = (1, flag);
+
+            fn main() {
+                let count: i32 = 0;
+                (count, ready) = pair(true);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("unknown tuple assignment target must reject");
+        assert!(err
+            .message
+            .contains("unknown tuple assignment target 'ready'"));
     }
 }
 

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -99,6 +99,10 @@ pub enum Stmt {
         name: SymbolId,
         value: ExprId,
     },
+    AssignTuple {
+        items: Vec<Option<SymbolId>>,
+        value: ExprId,
+    },
     Guard {
         condition: ExprId,
         else_return: Option<ExprId>,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1475,6 +1475,80 @@ fn bind_tuple_items(
     Ok(())
 }
 
+fn assign_tuple_items(
+    items: &[Option<SymbolId>],
+    tuple_reg: u16,
+    tuple_ty: &Type,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+) -> Result<(), FrontendError> {
+    let Type::Tuple(item_tys) = tuple_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: "tuple destructuring assignment requires tuple value".to_string(),
+        });
+    };
+    if item_tys.len() != items.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "tuple destructuring assignment arity mismatch: expected {}, got {}",
+                items.len(),
+                item_tys.len()
+            ),
+        });
+    }
+    for (index, (item, item_ty)) in items.iter().zip(item_tys.iter()).enumerate() {
+        let Some(name) = item else {
+            continue;
+        };
+        let target_ty = env.get(*name).ok_or(FrontendError {
+            pos: 0,
+            message: format!(
+                "unknown tuple assignment target '{}'",
+                resolve_symbol_name(arena, *name)?
+            ),
+        })?;
+        if env.is_const(*name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "cannot assign to const binding '{}' in tuple destructuring assignment",
+                    resolve_symbol_name(arena, *name)?
+                ),
+            });
+        }
+        if target_ty != *item_ty {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "type mismatch in tuple assignment to '{}': {:?} vs {:?}",
+                    resolve_symbol_name(arena, *name)?,
+                    target_ty,
+                    item_ty
+                ),
+            });
+        }
+        let reg = alloc(next);
+        let index = u16::try_from(index).map_err(|_| FrontendError {
+            pos: 0,
+            message: "tuple destructuring assignment index exceeds v0 limit".to_string(),
+        })?;
+        out.push(IrInstr::TupleGet {
+            dst: reg,
+            src: tuple_reg,
+            index,
+        });
+        out.push(IrInstr::StoreVar {
+            name: resolve_symbol_name(arena, *name)?.to_string(),
+            src: reg,
+        });
+    }
+    Ok(())
+}
+
 fn lower_stmt(
     stmt_id: StmtId,
     arena: &AstArena,
@@ -1590,6 +1664,26 @@ fn lower_stmt(
                 src: reg,
             });
             Ok(())
+        }
+        Stmt::AssignTuple { items, value } => {
+            let (tuple_reg, tuple_ty) = lower_expr(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                fn_table,
+                ret_ty,
+            )?;
+            assign_tuple_items(
+                items,
+                tuple_reg,
+                &tuple_ty,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+            )
         }
         Stmt::Guard {
             condition,
@@ -2818,6 +2912,34 @@ mod opt_tests {
         "#;
 
         let ir = compile_program_to_ir(src).expect("tuple destructuring bind should lower");
+        let main = ir
+            .iter()
+            .find(|func| func.name == "main")
+            .expect("main fn");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::TupleGet { index: 0, .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::TupleGet { index: 1, .. })));
+    }
+
+    #[test]
+    fn lower_tuple_destructuring_assignment_to_tuple_get_ir() {
+        let src = r#"
+            fn pair(flag: bool) -> (i32, bool) = (1, flag);
+
+            fn main() {
+                let count: i32 = 0;
+                let ready: bool = false;
+                (count, ready) = pair(true);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("tuple destructuring assignment should lower");
         let main = ir
             .iter()
             .find(|func| func.name == "main")

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -107,6 +107,10 @@ Current message families include:
 - tuple destructuring bind requires tuple value
 - tuple destructuring bind arity mismatch
 - nested tuple destructuring bind rejected in v0
+- tuple destructuring assignment requires tuple value
+- tuple destructuring assignment arity mismatch
+- unknown tuple assignment target
+- tuple destructuring assignment to const target
 - return type mismatch
 - invalid `guard` condition type
 - invalid `if` condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -153,6 +153,8 @@ Current statement meaning:
 - `let` evaluates the right-hand side before binding the name
 - tuple destructuring bind evaluates the right-hand side once before projecting
   tuple items into named bindings
+- tuple destructuring assignment evaluates the right-hand side once before
+  projecting tuple items into existing assignment targets
 - discard bind evaluates the right-hand side and then drops the produced value
 - `name op= expr;` evaluates as read-modify-write over the existing binding
 - the current v0 compound forms are `+=`, `-=`, `*=`, `/=`, `&&=`, and `||=`
@@ -210,11 +212,18 @@ Current tuple-destructuring semantics:
 - an optional whole-binding annotation, such as
   `let (a, b): (i32, bool) = expr;`, constrains the full tuple value before
   item bindings are introduced
+- `(a, b) = expr;` assigns projected tuple items into already existing mutable
+  bindings
+- `_` items in tuple destructuring assignment discard the corresponding tuple
+  element without requiring a target binding
 
 Current v0 limit:
 
 - tuple destructuring bind is currently statement-level only
+- tuple destructuring assignment is currently statement-level only
 - only flat name-or-`_` item lists are supported
+- tuple destructuring assignment does not introduce new bindings; every named
+  item must already resolve to an existing non-const local
 - nested tuple patterns, tuple field access, and general tuple pattern matching
   are not yet part of the stable source contract
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -86,6 +86,7 @@ Current statement forms:
 - `name /= expr;`
 - `name &&= expr;`
 - `name ||= expr;`
+- `(a, b) = expr;`
 - `guard condition else return;`
 - `guard condition else return expr;`
 - `assert(condition);`
@@ -103,6 +104,7 @@ Current statement rules:
 - `const` initializer syntax mirrors `let` but uses a narrower compile-time-safe expression subset
 - `let _ = expr;` is the current discard-bind surface
 - tuple destructuring bind is currently flat only and accepts only names or `_`
+- tuple destructuring assignment is currently flat only and accepts only names or `_`
 - compound assignment is statement-level sugar only
 - `guard` currently supports only the `else return` form
 - `assert(condition);` is a statement-level builtin contract form
@@ -185,6 +187,8 @@ Current v0 tuple limits:
 - tuple destructuring bind is currently statement-level only
 - tuple destructuring bind currently supports only flat name-or-`_` item lists
 - tuple destructuring bind currently requires arity at least 2
+- tuple destructuring assignment is currently statement-level only
+- tuple destructuring assignment currently supports only flat name-or-`_` item lists
 - tuple equality follows ordinary `==` / `!=` when both operands have the same
   tuple type
 - tuple field access and tuple pattern matching beyond flat destructuring bind


### PR DESCRIPTION
Implements #93 as a separate tuple-assignment slice.\n\nScope:\n- flat tuple destructuring assignment\n- discard item support\n- no plain assignment surface\n- docs/tests sync\n\nValidation:\n- cargo test -p sm-front\n- cargo test -p sm-ir\n- cargo test --workspace