### PR TITLE
D20P-B02 UFCS and method-call sugar

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -560,6 +560,29 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_primary(&mut self) -> Result<ExprId, FrontendError> {
+        let mut expr = self.parse_primary_atom()?;
+        while self.eat(TokenKind::Dot) {
+            let name = self.expect_symbol()?;
+            if !self.eat(TokenKind::LParen) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message:
+                        "UFCS method-call sugar currently requires explicit parentheses '.name(...)'"
+                            .to_string(),
+                });
+            }
+            let mut args = vec![CallArg {
+                name: None,
+                value: expr,
+            }];
+            args.extend(self.parse_call_args()?);
+            self.expect(TokenKind::RParen, "expected ')' after UFCS method call")?;
+            expr = self.arena.alloc_expr(Expr::Call(name, args));
+        }
+        Ok(expr)
+    }
+
+    fn parse_primary_atom(&mut self) -> Result<ExprId, FrontendError> {
         if self.eat(TokenKind::KwIf) {
             return self.parse_if_expr_after_kw_if();
         }
@@ -2640,6 +2663,76 @@ fn main() {
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("break without value must reject");
         assert!(err.message.contains("requires break value"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_ufcs_method_call_sugar() {
+        let src = r#"
+fn scale(value: f64, factor: f64) -> f64 = value * factor;
+
+fn main() {
+    let total: f64 = 2.0.scale(3.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("UFCS method-call sugar should parse");
+        let func = &program.functions[1];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected let statement");
+        };
+        let Expr::Call(name, args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "scale");
+        assert_eq!(args.len(), 2);
+        assert!(matches!(
+            program.arena.expr(args[0].value),
+            Expr::NumericLiteral(NumericLiteral::F64(_))
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_ufcs_method_call_with_named_arguments() {
+        let src = r#"
+fn clamp(value: f64, min: f64, max: f64) -> f64 = value;
+
+fn main() {
+    let total: f64 = 2.0.clamp(min = 0.0, max = 10.0);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("UFCS named-argument call should parse");
+        let func = &program.functions[1];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected let statement");
+        };
+        let Expr::Call(_, args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(args.len(), 3);
+        assert!(args[0].name.is_none());
+        assert!(args[1].name.is_some());
+        assert!(args[2].name.is_some());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_ufcs_without_parentheses() {
+        let src = r#"
+fn abs(value: f64) -> f64 = value;
+
+fn main() {
+    let total: f64 = 2.0.abs;
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("UFCS without parentheses must reject");
+        assert!(err.message.contains("requires explicit parentheses"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1554,6 +1554,49 @@ mod tests {
             .message
             .contains("loop expression body currently does not allow guard clause or return"));
     }
+
+    #[test]
+    fn ufcs_method_call_typechecks_via_ordinary_call_contract() {
+        let src = r#"
+            fn scale(value: f64, factor: f64) -> f64 = value * factor;
+
+            fn main() {
+                let total: f64 = 2.0.scale(3.0);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("UFCS method-call sugar should typecheck");
+    }
+
+    #[test]
+    fn ufcs_named_arguments_reuse_parameter_reorder_rules() {
+        let src = r#"
+            fn clamp(value: f64, min: f64, max: f64) -> f64 = value;
+
+            fn main() {
+                let total: f64 = 2.0.clamp(min = 0.0, max = 10.0);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("UFCS named arguments should typecheck");
+    }
+
+    #[test]
+    fn ufcs_builtin_named_arguments_still_reject() {
+        let src = r#"
+            fn main() {
+                let total: f64 = 2.0.pow(exp = 3.0);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("builtin named arguments must still reject");
+        assert!(err
+            .message
+            .contains("named arguments are not supported for builtin 'pow'"));
+    }
 }
 
 fn is_builtin_assert_name(

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3504,6 +3504,33 @@ mod opt_tests {
     }
 
     #[test]
+    fn lower_ufcs_method_call_to_ordinary_call_order() {
+        let method_src = r#"
+            fn scale(value: f64, factor: f64) -> f64 = value * factor;
+
+            fn main() {
+                let total: f64 = 2.0.scale(3.0);
+                return;
+            }
+        "#;
+
+        let plain_src = r#"
+            fn scale(value: f64, factor: f64) -> f64 = value * factor;
+
+            fn main() {
+                let total: f64 = scale(2.0, 3.0);
+                return;
+            }
+        "#;
+
+        let method_ir = compile_program_to_ir(method_src).expect("UFCS method call should lower");
+        let plain_ir = compile_program_to_ir(plain_src).expect("plain call should lower");
+        let method_main = method_ir.iter().find(|func| func.name == "main").expect("main fn");
+        let plain_main = plain_ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert_eq!(method_main.instrs, plain_main.instrs);
+    }
+
+    #[test]
     fn lowering_match_expression_rejects_branch_type_mismatch() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -114,6 +114,7 @@ Current message families include:
 - malformed or empty `where` binding lists
 - `break expr;` outside `loop` expression context
 - loop-expression bodies that currently use unsupported `guard` / `return`
+- UFCS method-call sugar written without explicit `(...)`
 - return type mismatch
 - invalid `guard` condition type
 - invalid `if` condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -217,6 +217,22 @@ Current v0 limit:
 - `where` bindings currently reuse ordinary local-bind semantics; richer
   destructuring and control-flow forms are not yet part of the stable contract
 
+## UFCS / Method-Call Sugar
+
+Current UFCS semantics:
+
+- `receiver.name(args...)` is postfix sugar over the ordinary call form
+  `name(receiver, args...)`
+- after desugaring, ordinary parameter ordering, named-argument reordering, and
+  lowering rules apply unchanged
+- UFCS chaining remains ordinary nested-call structure after desugaring
+
+Current v0 limit:
+
+- UFCS currently requires explicit call parentheses
+- UFCS does not define field access or member lookup
+- UFCS does not introduce method declarations or object-oriented dispatch
+
 ## Loop Expression
 
 Current `loop` expression semantics:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -137,6 +137,9 @@ Current expression forms:
 - named-argument calls:
   - `open(path = main_path, mode = read_only)`
   - `value |> stage(limit = 10)`
+- UFCS / method-call sugar:
+  - `value.scale(10.0)`
+  - `sensor.clamp(min = 0.0, max = 1.0)`
 - pipeline chains:
   - `value |> stage()`
   - `value |> stage(arg)`
@@ -233,6 +236,16 @@ Current named-argument rules:
 - named arguments reorder to the declared parameter order before ordinary
   type-checking and lowering
 - named arguments are not yet part of the builtin-call surface
+
+Current UFCS / method-call rules:
+
+- `receiver.name(args...)` is accepted as postfix call sugar
+- UFCS currently desugars to ordinary call order: `name(receiver, args...)`
+- UFCS may chain because it remains ordinary expression/call surface after
+  desugaring
+- UFCS currently requires explicit parentheses; `.name` without `(...)` is not
+  part of the contract
+- UFCS does not introduce field access, object members, or method declarations
 
 Current where-clause rules:
 


### PR DESCRIPTION
Implements #101 as postfix call sugar over existing free-function calls.\n\nScope:\n- receiver.name(args...) surface\n- ordinary call desugaring\n- no field access or object model\n- docs/tests sync\n\nValidation:\n- cargo test -p sm-front\n- cargo test -p sm-ir\n- cargo test --workspace