### PR TITLE
D20P-C01 let-else

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -19,7 +19,7 @@ pub use types::{
     AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId, FrontendError, FrontendErrorKind,
     Function, IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
     LogosSystem, LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, Program, QuadVal, Stmt,
-    StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
+    StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -3,7 +3,7 @@ use crate::types::{
     AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId, FrontendError, Function, IfExpr,
     LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem,
     LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal,
-    Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
+    Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -162,11 +162,19 @@ impl<'a> Parser<'a> {
                 };
                 self.expect(TokenKind::Assign, "expected '='")?;
                 let value = self.parse_expr()?;
+                if self.check(TokenKind::KwElse) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "let-else currently requires tuple destructuring target; discard target is not supported"
+                                .to_string(),
+                    });
+                }
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::Discard { ty, value }));
             }
             if self.eat(TokenKind::LParen) {
-                let items = self.parse_tuple_bind_items_after_lparen()?;
+                let items = self.parse_tuple_pattern_items_after_lparen()?;
                 let ty = if self.eat(TokenKind::Colon) {
                     Some(self.parse_type()?)
                 } else {
@@ -174,6 +182,16 @@ impl<'a> Parser<'a> {
                 };
                 self.expect(TokenKind::Assign, "expected '='")?;
                 let value = self.parse_expr()?;
+                if self.eat(TokenKind::KwElse) {
+                    let else_return = self.parse_else_return_payload("let-else")?;
+                    return Ok(self.arena.alloc_stmt(Stmt::LetElseTuple {
+                        items,
+                        ty,
+                        value,
+                        else_return,
+                    }));
+                }
+                let items = self.lower_tuple_pattern_items_to_bind(items)?;
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::LetTuple { items, ty, value }));
             }
@@ -185,6 +203,14 @@ impl<'a> Parser<'a> {
             };
             self.expect(TokenKind::Assign, "expected '='")?;
             let value = self.parse_expr()?;
+            if self.check(TokenKind::KwElse) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message:
+                        "let-else currently requires tuple destructuring target; plain binding target is not supported"
+                            .to_string(),
+                });
+            }
             self.expect(TokenKind::Semi, "expected ';'")?;
             return Ok(self.arena.alloc_stmt(Stmt::Let { name, ty, value }));
         }
@@ -201,7 +227,8 @@ impl<'a> Parser<'a> {
         }
         if self.looks_like_tuple_assign_stmt() {
             self.expect(TokenKind::LParen, "expected '('")?;
-            let items = self.parse_tuple_bind_items_after_lparen()?;
+            let items = self.parse_tuple_pattern_items_after_lparen()?;
+            let items = self.lower_tuple_pattern_items_to_bind(items)?;
             self.expect(TokenKind::Assign, "expected '='")?;
             let value = self.parse_expr()?;
             self.expect(TokenKind::Semi, "expected ';'")?;
@@ -311,39 +338,44 @@ impl<'a> Parser<'a> {
         self.tokens.get(i).map(|t| t.kind) == Some(TokenKind::Assign)
     }
 
-    fn parse_tuple_bind_items_after_lparen(&mut self) -> Result<Vec<Option<SymbolId>>, FrontendError> {
+    fn parse_tuple_pattern_items_after_lparen(&mut self) -> Result<Vec<TuplePatternItem>, FrontendError> {
         let mut items = Vec::new();
         loop {
             if self.check(TokenKind::LParen) {
                 return Err(FrontendError {
                     pos: self.pos(),
                     message:
-                        "tuple destructuring bind v0 currently supports only flat name/_ items"
+                        "tuple destructuring pattern v0 currently supports only flat name/_/quad-literal items"
                             .to_string(),
                 });
             }
             let item = if self.eat(TokenKind::Underscore) {
-                None
+                TuplePatternItem::Discard
+            } else if self.eat(TokenKind::QuadN) {
+                TuplePatternItem::QuadLiteral(QuadVal::N)
+            } else if self.eat(TokenKind::QuadF) {
+                TuplePatternItem::QuadLiteral(QuadVal::F)
+            } else if self.eat(TokenKind::QuadT) {
+                TuplePatternItem::QuadLiteral(QuadVal::T)
+            } else if self.eat(TokenKind::QuadS) {
+                TuplePatternItem::QuadLiteral(QuadVal::S)
             } else {
-                Some(self.expect_symbol()?)
+                TuplePatternItem::Bind(self.expect_symbol()?)
             };
-            if let Some(name) = item {
-                if items
-                    .iter()
-                    .any(|existing: &Option<SymbolId>| existing.as_ref().is_some_and(|existing| *existing == name))
-                {
+            if let TuplePatternItem::Bind(name) = item {
+                if items.iter().any(|existing| {
+                    matches!(existing, TuplePatternItem::Bind(existing_name) if *existing_name == name)
+                }) {
                     return Err(FrontendError {
                         pos: self.pos(),
                         message: format!(
-                            "tuple destructuring bind cannot repeat '{}'",
+                            "tuple destructuring pattern cannot repeat '{}'",
                             self.arena.symbol_name(name)
                         ),
                     });
                 }
-                items.push(Some(name));
-            } else {
-                items.push(None);
             }
+            items.push(item);
             if self.eat(TokenKind::Comma) {
                 if self.check(TokenKind::RParen) {
                     break;
@@ -352,14 +384,54 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        self.expect(TokenKind::RParen, "expected ')' after tuple destructuring bind")?;
+        self.expect(TokenKind::RParen, "expected ')' after tuple destructuring pattern")?;
         if items.len() < 2 {
             return Err(FrontendError {
                 pos: self.pos(),
-                message: "tuple destructuring bind requires at least 2 items".to_string(),
+                message: "tuple destructuring pattern requires at least 2 items".to_string(),
             });
         }
         Ok(items)
+    }
+
+    fn lower_tuple_pattern_items_to_bind(
+        &self,
+        items: Vec<TuplePatternItem>,
+    ) -> Result<Vec<Option<SymbolId>>, FrontendError> {
+        let mut bind_items = Vec::with_capacity(items.len());
+        for item in items {
+            match item {
+                TuplePatternItem::Bind(name) => bind_items.push(Some(name)),
+                TuplePatternItem::Discard => bind_items.push(None),
+                TuplePatternItem::QuadLiteral(_) => {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "quad literal tuple patterns currently require let-else; plain tuple destructuring bind supports only name/_ items"
+                                .to_string(),
+                    })
+                }
+            }
+        }
+        Ok(bind_items)
+    }
+
+    fn parse_else_return_payload(
+        &mut self,
+        feature_name: &str,
+    ) -> Result<Option<ExprId>, FrontendError> {
+        if !self.eat(TokenKind::KwReturn) {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: format!("{feature_name} currently supports only else return"),
+            });
+        }
+        if self.eat(TokenKind::Semi) {
+            return Ok(None);
+        }
+        let expr = self.parse_expr()?;
+        self.expect(TokenKind::Semi, "expected ';'")?;
+        Ok(Some(expr))
     }
 
     fn peek_compound_assign_op(&self) -> Option<BinaryOp> {
@@ -2503,6 +2575,75 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_tuple_let_else_surface() {
+        let src = r#"
+fn pair() -> (i32, quad) = (1, T);
+
+fn main() {
+    let (count, T): (i32, quad) = pair() else return;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("tuple let-else should parse");
+        let func = &program.functions[1];
+        let Stmt::LetElseTuple {
+            items,
+            ty,
+            value,
+            else_return,
+        } = program.arena.stmt(func.body[0])
+        else {
+            panic!("expected tuple let-else statement");
+        };
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0], TuplePatternItem::Bind(_)));
+        assert!(matches!(items[1], TuplePatternItem::QuadLiteral(QuadVal::T)));
+        assert_eq!(*ty, Some(Type::Tuple(vec![Type::I32, Type::Quad])));
+        assert!(else_return.is_none());
+        let Expr::Call(name, args) = program.arena.expr(*value) else {
+            panic!("expected call expression");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "pair");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_plain_bind_let_else_surface() {
+        let src = r#"
+fn main() {
+    let value = 1 else return;
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("plain let-else target must reject");
+        assert!(err
+            .message
+            .contains("let-else currently requires tuple destructuring target"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_non_return_tuple_let_else_surface() {
+        let src = r#"
+fn pair() -> (i32, quad) = (1, T);
+
+fn main() {
+    let (count, T) = pair() else guard true else return;
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("tuple let-else non-return branch must reject");
+        assert!(err
+            .message
+            .contains("let-else currently supports only else return"));
+    }
+
+    #[test]
     fn rustlike_parser_accepts_tuple_destructuring_assignment() {
         let src = r#"
 fn pair() -> (i32, bool) = (1, true);
@@ -2544,7 +2685,7 @@ fn main() {
             .expect_err("nested tuple destructuring must reject");
         assert!(err
             .message
-            .contains("tuple destructuring bind v0 currently supports only flat"));
+            .contains("tuple destructuring pattern v0 currently supports only flat"));
     }
 
     #[test]
@@ -2563,7 +2704,7 @@ fn main() {
             .expect_err("nested tuple destructuring assignment must reject");
         assert!(err
             .message
-            .contains("tuple destructuring bind v0 currently supports only flat"));
+            .contains("tuple destructuring pattern v0 currently supports only flat"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -214,6 +214,61 @@ fn check_stmt(
             }
             Ok(())
         }
+        Stmt::LetElseTuple {
+            items,
+            ty,
+            value,
+            else_return,
+        } => {
+            let vt = infer_expr_type(*value, arena, env, table, ret_ty.clone(), loop_stack)?;
+            let final_ty = if let Some(ann) = ty {
+                ensure_binding_value_type(
+                    ann.clone(),
+                    vt,
+                    *value,
+                    arena,
+                    "let-else tuple destructuring bind".to_string(),
+                )?;
+                ann.clone()
+            } else {
+                vt
+            };
+            let Type::Tuple(item_tys) = final_ty else {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "let-else tuple destructuring bind requires tuple value".to_string(),
+                });
+            };
+            if item_tys.len() != items.len() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "let-else tuple destructuring bind arity mismatch: expected {}, got {}",
+                        items.len(),
+                        item_tys.len()
+                    ),
+                });
+            }
+            check_return_payload(*else_return, arena, env, table, ret_ty, loop_stack)?;
+            for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+                match item {
+                    TuplePatternItem::Bind(name) => env.insert(*name, item_ty),
+                    TuplePatternItem::Discard => {}
+                    TuplePatternItem::QuadLiteral(_) => {
+                        if item_ty != Type::Quad {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: format!(
+                                    "let-else tuple literal pattern requires quad element, got {:?}",
+                                    item_ty
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
         Stmt::Discard { ty, value } => {
             let vt = infer_expr_type(*value, arena, env, table, ret_ty, loop_stack)?;
             if let Some(ann) = ty {
@@ -1408,6 +1463,70 @@ mod tests {
     }
 
     #[test]
+    fn tuple_let_else_typechecks() {
+        let src = r#"
+            fn pair() -> (i32, quad) = (1, T);
+
+            fn main() {
+                let (count, T): (i32, quad) = pair() else return;
+                assert(count == 1);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("tuple let-else should typecheck");
+    }
+
+    #[test]
+    fn tuple_let_else_rejects_non_tuple_value() {
+        let src = r#"
+            fn main() {
+                let (count, T) = 1 else return;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-tuple let-else must reject");
+        assert!(err
+            .message
+            .contains("let-else tuple destructuring bind requires tuple value"));
+    }
+
+    #[test]
+    fn tuple_let_else_rejects_non_quad_literal_position() {
+        let src = r#"
+            fn pair() -> (i32, bool) = (1, true);
+
+            fn main() {
+                let (count, T): (i32, bool) = pair() else return;
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("non-quad let-else literal pattern must reject");
+        assert!(err
+            .message
+            .contains("let-else tuple literal pattern requires quad element"));
+    }
+
+    #[test]
+    fn tuple_let_else_rejects_return_type_mismatch() {
+        let src = r#"
+            fn pair() -> (i32, quad) = (1, T);
+
+            fn main() {
+                let (count, T): (i32, quad) = pair() else return 1.0;
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("let-else return type mismatch must reject");
+        assert!(err.message.contains("return type mismatch"));
+    }
+
+    #[test]
     fn tuple_destructuring_bind_rejects_non_tuple_value() {
         let src = r#"
             fn main() {
@@ -1764,6 +1883,10 @@ fn check_loop_expr_stmt(
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<(), FrontendError> {
     match arena.stmt(stmt_id) {
+        Stmt::LetElseTuple { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow let-else".to_string(),
+        }),
         Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow guard clause or return"

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -92,6 +92,12 @@ pub enum Stmt {
         ty: Option<Type>,
         value: ExprId,
     },
+    LetElseTuple {
+        items: Vec<TuplePatternItem>,
+        ty: Option<Type>,
+        value: ExprId,
+        else_return: Option<ExprId>,
+    },
     Discard {
         ty: Option<Type>,
         value: ExprId,
@@ -153,6 +159,13 @@ pub struct MatchExprArm {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LoopExpr {
     pub body: Vec<StmtId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TuplePatternItem {
+    Bind(SymbolId),
+    Discard,
+    QuadLiteral(QuadVal),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::semcode_format::{
     write_f64_le, write_i32_le, write_u16_le, write_u32_le, Opcode, MAGIC0, MAGIC1, MAGIC2,
 };
-use sm_front::LoopExpr;
+use sm_front::{LoopExpr, TuplePatternItem};
 use sm_front::types::NumericLiteral;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1623,6 +1623,106 @@ fn assign_tuple_items(
     Ok(())
 }
 
+fn bind_let_else_tuple_items(
+    items: &[TuplePatternItem],
+    tuple_reg: u16,
+    tuple_ty: &Type,
+    else_return: Option<ExprId>,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &mut ScopeEnv,
+    loop_stack: &mut Vec<LoopLoweringFrame>,
+    fn_table: &FnTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    let Type::Tuple(item_tys) = tuple_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: "let-else tuple destructuring bind requires tuple value".to_string(),
+        });
+    };
+    if item_tys.len() != items.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "let-else tuple destructuring bind arity mismatch: expected {}, got {}",
+                items.len(),
+                item_tys.len()
+            ),
+        });
+    }
+
+    let pattern_id = alloc_loop_expr_id(next);
+    let mut deferred_binds = Vec::new();
+    for (index, (item, item_ty)) in items.iter().zip(item_tys.iter()).enumerate() {
+        let reg = alloc(next);
+        let index = u16::try_from(index).map_err(|_| FrontendError {
+            pos: 0,
+            message: "let-else tuple destructuring bind index exceeds v0 limit".to_string(),
+        })?;
+        out.push(IrInstr::TupleGet {
+            dst: reg,
+            src: tuple_reg,
+            index,
+        });
+        match item {
+            TuplePatternItem::Bind(name) => deferred_binds.push((*name, reg, item_ty.clone())),
+            TuplePatternItem::Discard => {}
+            TuplePatternItem::QuadLiteral(pat) => {
+                if *item_ty != Type::Quad {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "let-else tuple literal pattern requires quad element, got {:?}",
+                            item_ty
+                        ),
+                    });
+                }
+                let lit_reg = alloc(next);
+                out.push(IrInstr::LoadQ {
+                    dst: lit_reg,
+                    val: *pat,
+                });
+                let cmp_reg = alloc(next);
+                out.push(IrInstr::CmpEq {
+                    dst: cmp_reg,
+                    lhs: reg,
+                    rhs: lit_reg,
+                });
+                let continue_label =
+                    format!("let_else_tuple_{}_item_{}_ok", pattern_id, index);
+                out.push(IrInstr::JmpIf {
+                    cond: cmp_reg,
+                    label: continue_label.clone(),
+                });
+                lower_return_payload(
+                    else_return,
+                    arena,
+                    next,
+                    out,
+                    env,
+                    loop_stack,
+                    fn_table,
+                    ret_ty.clone(),
+                )?;
+                out.push(IrInstr::Label {
+                    name: continue_label,
+                });
+            }
+        }
+    }
+
+    for (name, reg, item_ty) in deferred_binds {
+        env.insert(name, item_ty);
+        out.push(IrInstr::StoreVar {
+            name: resolve_symbol_name(arena, name)?.to_string(),
+            src: reg,
+        });
+    }
+    Ok(())
+}
+
 fn lower_stmt(
     stmt_id: StmtId,
     arena: &AstArena,
@@ -1694,6 +1794,38 @@ fn lower_stmt(
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
                 env,
+            )
+        }
+        Stmt::LetElseTuple {
+            items,
+            ty,
+            value,
+            else_return,
+        } => {
+            let (tuple_reg, vty) = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                ty.clone(),
+                ret_ty.clone(),
+            )?;
+            let final_ty = if let Some(ann) = ty { ann.clone() } else { vty };
+            bind_let_else_tuple_items(
+                items,
+                tuple_reg,
+                &final_ty,
+                *else_return,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                ret_ty,
             )
         }
         Stmt::Discard { ty, value } => {
@@ -2356,6 +2488,10 @@ fn lower_loop_expr_stmt(
     ret_ty: Type,
 ) -> Result<(), FrontendError> {
     match arena.stmt(stmt_id) {
+        Stmt::LetElseTuple { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow let-else".to_string(),
+        }),
         Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow guard clause or return"
@@ -3436,6 +3572,55 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::TupleGet { index: 1, .. })));
+    }
+
+    #[test]
+    fn lower_tuple_let_else_to_tuple_get_and_early_return_ir() {
+        let src = r#"
+            fn pair() -> (i32, quad) = (1, T);
+
+            fn main() {
+                let (count, T): (i32, quad) = pair() else return;
+                assert(count == 1);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("tuple let-else should lower");
+        let main = ir
+            .iter()
+            .find(|func| func.name == "main")
+            .expect("main fn");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::TupleGet { index: 0, .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::TupleGet { index: 1, .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadQ { val: QuadVal::T, .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::CmpEq { .. })));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::JmpIf { label, .. } if label.starts_with("let_else_tuple_")
+        )));
+        assert!(main
+            .instrs
+            .iter()
+            .filter(|instr| matches!(instr, IrInstr::Ret { .. }))
+            .count()
+            >= 2);
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name == "count"
+        )));
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -42,6 +42,8 @@ Current examples include:
 - short-lambda parse failures such as standalone non-invoked lambdas
 - short-lambda surface failures such as rejected outer-local capture in v0
 - `guard`-clause parse failures such as missing `else return`
+- `let-else` parse failures such as plain binding targets, discard targets, or
+  non-`return` else branches in the current v0 surface
 - `match`-expression parse failures such as invalid literal arm patterns
 - extended numeric-literal parse failures such as invalid typed suffix/body
   combinations or decimal-only `f64`/`fx` requirements
@@ -106,6 +108,9 @@ Current message families include:
 - tuple type mismatch
 - tuple destructuring bind requires tuple value
 - tuple destructuring bind arity mismatch
+- let-else tuple destructuring bind requires tuple value
+- let-else tuple destructuring bind arity mismatch
+- let-else tuple literal pattern requires quad element
 - nested tuple destructuring bind rejected in v0
 - tuple destructuring assignment requires tuple value
 - tuple destructuring assignment arity mismatch

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -134,6 +134,9 @@ Current rules:
 - `let` introduces a source-visible local binding
 - `let (a, b) = expr;` evaluates the right-hand side once and then binds named
   items left-to-right from the produced tuple value
+- `let (a, T) = expr else return ...;` evaluates the right-hand side once,
+  projects flat tuple items, and returns immediately when any refutable
+  quad-literal item does not match
 - `let _ = expr;` evaluates the right-hand side but introduces no source-visible binding
 - `if` branches and `match` arms are checked in branch-local scopes
 - branch-local bindings do not escape to sibling branches
@@ -155,6 +158,8 @@ Current statement meaning:
   tuple items into named bindings
 - tuple destructuring assignment evaluates the right-hand side once before
   projecting tuple items into existing assignment targets
+- tuple `let-else` introduces named bindings only on the success path; failure
+  follows the explicit `else return` path
 - discard bind evaluates the right-hand side and then drops the produced value
 - `name op= expr;` evaluates as read-modify-write over the existing binding
 - the current v0 compound forms are `+=`, `-=`, `*=`, `/=`, `&&=`, and `||=`
@@ -196,6 +201,8 @@ Current v0 limit:
 - block-expression bodies currently accept only named `let` bindings,
   tuple destructuring binds, `const` bindings, discard binds, and expression
   statements before the tail value
+- tuple `let-else` is not yet part of the stable value-producing block-body
+  contract
 - discard bind is accepted in value-producing block bodies, but richer pattern
   destructuring is not yet part of the stable block-expression contract
 - `return` is not yet supported inside value-producing block bodies as a
@@ -246,7 +253,8 @@ Current v0 limit:
 
 - only expression-form `loop` is part of the contract
 - only `break expr;` is supported; bare `break;` is not
-- loop-expression bodies currently do not allow `guard` or `return`
+- loop-expression bodies currently do not allow `let-else`, `guard`, or
+  `return`
 - `continue`, statement-loop, and richer control interaction are deferred
 
 ## Tuple Destructuring Bind
@@ -268,12 +276,17 @@ Current tuple-destructuring semantics:
 Current v0 limit:
 
 - tuple destructuring bind is currently statement-level only
+- tuple `let-else` is currently statement-level only
 - tuple destructuring assignment is currently statement-level only
-- only flat name-or-`_` item lists are supported
+- only flat name-or-`_` item lists are supported for plain tuple destructuring
+- tuple `let-else` currently supports only flat name/`_`/quad-literal item
+  lists
 - tuple destructuring assignment does not introduce new bindings; every named
   item must already resolve to an existing non-const local
 - nested tuple patterns, tuple field access, and general tuple pattern matching
   are not yet part of the stable source contract
+- plain `let name = expr else ...` is not yet part of the stable source
+  contract
 
 ## Control Flow
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -78,6 +78,8 @@ Current statement forms:
 - `let name: type = expr;`
 - `let (a, b) = expr;`
 - `let (a, _): (type_a, type_b) = expr;`
+- `let (a, T) = expr else return;`
+- `let (a, T): (type_a, quad) = expr else return expr;`
 - `let _ = expr;`
 - `let _: type = expr;`
 - `name += expr;`
@@ -104,6 +106,9 @@ Current statement rules:
 - `const` initializer syntax mirrors `let` but uses a narrower compile-time-safe expression subset
 - `let _ = expr;` is the current discard-bind surface
 - tuple destructuring bind is currently flat only and accepts only names or `_`
+- `let-else` currently requires tuple destructuring target and `else return`
+- `let-else` tuple items are currently flat only and accept only names, `_`,
+  or `quad` literals `N/F/T/S`
 - tuple destructuring assignment is currently flat only and accepts only names or `_`
 - compound assignment is statement-level sugar only
 - `guard` currently supports only the `else return` form
@@ -195,6 +200,8 @@ Current v0 tuple limits:
 - tuple literals and tuple types are supported
 - tuple destructuring bind is currently statement-level only
 - tuple destructuring bind currently supports only flat name-or-`_` item lists
+- tuple `let-else` currently supports only flat name/`_`/quad-literal item
+  lists
 - tuple destructuring bind currently requires arity at least 2
 - tuple destructuring assignment is currently statement-level only
 - tuple destructuring assignment currently supports only flat name-or-`_` item lists


### PR DESCRIPTION
Implements #102 as a narrow tuple-target let-else slice.\n\nScope:\n- tuple-only let-else\n- else return only\n- flat name/_/quad-literal items\n- explicit TupleGet/CmpEq/Ret lowering\n- docs/tests sync\n\nValidation:\n- cargo test -p sm-front\n- cargo test -p sm-ir\n- cargo test --workspace