### PR TITLE
REC1-04 record pass return and safe equality comparisons

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1007,15 +1007,15 @@ fn infer_expr_type(
                         return Err(FrontendError {
                             pos: 0,
                             message:
-                                "range equality is not part of the stable v0 range surface"
+                                    "range equality is not part of the stable v0 range surface"
                                     .to_string(),
                         });
                     }
-                    if contains_stage1_record_carrier(&lt) && contains_stage1_record_carrier(&rt) {
+                    if !supports_stable_equality_type(&lt, record_table)? {
                         return Err(FrontendError {
                             pos: 0,
                             message:
-                                "record equality is not part of the stage-1 canonical record surface"
+                                "record equality is allowed only when every field type already supports stable equality"
                                     .to_string(),
                         });
                     }
@@ -2255,25 +2255,25 @@ mod tests {
     }
 
     #[test]
-    fn record_type_rejects_executable_function_signature_use() {
+    fn record_type_allows_executable_function_signature_use() {
         let src = r#"
             record DecisionContext {
                 camera: quad,
             }
 
-            fn describe(ctx: DecisionContext) {
-                return;
+            fn echo(ctx: DecisionContext) -> DecisionContext {
+                return ctx;
             }
 
             fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T };
+                let mirror: DecisionContext = echo(ctx);
+                let _ = mirror;
                 return;
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("record param should reject before carrier lands");
-        assert!(err
-            .message
-            .contains("record type 'DecisionContext' is declared but not yet available in executable parameter 'ctx'"));
+        typecheck_source(src).expect("record params and returns should typecheck");
     }
 
     #[test]
@@ -2335,7 +2335,7 @@ mod tests {
     }
 
     #[test]
-    fn record_literal_rejects_record_equality() {
+    fn record_literal_allows_equality_for_stable_field_subset() {
         let src = r#"
             record DecisionContext {
                 camera: quad,
@@ -2349,8 +2349,30 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("record equality must remain gated");
-        assert!(err.message.contains("record equality is not part of the stage-1 canonical record surface"));
+        typecheck_source(src).expect("record equality should typecheck for stable field subset");
+    }
+
+    #[test]
+    fn record_equality_rejects_unsupported_field_subset() {
+        let src = r#"
+            record SensorFrame {
+                mask: qvec,
+            }
+
+            fn compare(left: SensorFrame, right: SensorFrame) {
+                assert(left == right);
+                return;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("record equality subset must reject unsupported fields");
+        assert!(err
+            .message
+            .contains("record equality is allowed only when every field type already supports stable equality"));
     }
 
     #[test]
@@ -2978,14 +3000,11 @@ fn ensure_executable_type_supported(
             }
             Ok(())
         }
-        Type::Record(name) => Err(FrontendError {
-            pos: 0,
-            message: format!(
-                "record type '{}' is declared but not yet available in executable {} until the canonical record carrier lands",
-                resolve_symbol_name(arena, *name)?,
-                context
-            ),
-        }),
+        Type::Record(name) => {
+            let _ = resolve_symbol_name(arena, *name)?;
+            let _ = context;
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -3010,11 +3029,54 @@ fn ensure_storage_type_supported(
     }
 }
 
-fn contains_stage1_record_carrier(ty: &Type) -> bool {
+fn supports_stable_equality_type(
+    ty: &Type,
+    record_table: &RecordTable,
+) -> Result<bool, FrontendError> {
+    let mut active = BTreeSet::new();
+    supports_stable_equality_type_inner(ty, record_table, &mut active)
+}
+
+fn supports_stable_equality_type_inner(
+    ty: &Type,
+    record_table: &RecordTable,
+    active: &mut BTreeSet<SymbolId>,
+) -> Result<bool, FrontendError> {
     match ty {
-        Type::Record(_) => true,
-        Type::Tuple(items) => items.iter().any(contains_stage1_record_carrier),
-        _ => false,
+        Type::Quad
+        | Type::Bool
+        | Type::I32
+        | Type::U32
+        | Type::Fx
+        | Type::F64
+        | Type::Unit => Ok(true),
+        Type::QVec(_) => Ok(false),
+        Type::RangeI32 => Ok(false),
+        Type::Tuple(items) => {
+            for item in items {
+                if !supports_stable_equality_type_inner(item, record_table, active)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        Type::Record(name) => {
+            if !active.insert(*name) {
+                return Ok(false);
+            }
+            let record = record_table.get(name).ok_or(FrontendError {
+                pos: 0,
+                message: "record equality subset references unknown record type".to_string(),
+            })?;
+            for field in &record.fields {
+                if !supports_stable_equality_type_inner(&field.ty, record_table, active)? {
+                    active.remove(name);
+                    return Ok(false);
+                }
+            }
+            active.remove(name);
+            Ok(true)
+        }
     }
 }
 

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -4259,26 +4259,35 @@ mod opt_tests {
     }
 
     #[test]
-    fn lowering_rejects_executable_record_signature_before_carrier_lands() {
+    fn lower_record_param_return_and_safe_equality_path() {
         let src = r#"
             record DecisionContext {
                 camera: quad,
             }
 
-            fn describe(ctx: DecisionContext) {
-                return;
+            fn echo(ctx: DecisionContext) -> DecisionContext {
+                return ctx;
             }
 
             fn main() {
+                let left: DecisionContext = DecisionContext { camera: T };
+                let right: DecisionContext = echo(left);
+                assert(right == right);
                 return;
             }
         "#;
 
-        let err = compile_program_to_ir(src)
-            .expect_err("executable record type should reject before carrier lands");
-        assert!(err
-            .message
-            .contains("record type 'DecisionContext' is declared but not yet available in executable parameter 'ctx'"));
+        let ir = compile_program_to_ir(src).expect("record params/returns should lower");
+        assert!(ir.iter().any(|func| func.name == "echo"));
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Call { name, .. } if name == "echo"
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::CmpEq { .. }
+        )));
     }
 
     #[test]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -823,6 +823,30 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_pass_return_and_safe_equality_semcode() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn echo(ctx: DecisionContext) -> DecisionContext {
+                return ctx;
+            }
+
+            fn main() {
+                let left: DecisionContext = DecisionContext { quality: 0.75, camera: T };
+                let right: DecisionContext = echo(left);
+                assert(right == right);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 2);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1228,9 +1228,20 @@ fn value_eq(a: &Value, b: &Value) -> Result<bool, RuntimeError> {
             }
             Ok(true)
         }
-        (Value::Record(_), Value::Record(_)) => Err(RuntimeError::TypeMismatchRuntime(
-            "record equality is not part of the stage-1 canonical record surface".to_string(),
-        )),
+        (Value::Record(xs), Value::Record(ys)) => {
+            if xs.type_name != ys.type_name {
+                return Ok(false);
+            }
+            if xs.slots.len() != ys.slots.len() {
+                return Ok(false);
+            }
+            for (x, y) in xs.slots.iter().zip(ys.slots.iter()) {
+                if !value_eq(x, y)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
         (Value::Unit, Value::Unit) => Ok(true),
         _ => Err(RuntimeError::TypeMismatchRuntime(
             "CmpEq/CmpNe operands must have same runtime type".to_string(),
@@ -1659,6 +1670,29 @@ mod tests {
         let disasm = disasm_semcode(&bytes).expect("disasm");
         assert!(disasm.contains("RECORD_GET"));
         run_semcode(&bytes).expect("run");
+    }
+
+    #[test]
+    fn vm_runs_record_pass_return_and_safe_equality_path() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn echo(ctx: DecisionContext) -> DecisionContext {
+                return ctx;
+            }
+
+            fn main() {
+                let left: DecisionContext = DecisionContext { quality: 0.75, camera: T };
+                let right: DecisionContext = echo(left);
+                assert(right == right);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        run_semcode(&bytes).expect("record pass/return/equality should run");
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -121,7 +121,7 @@ Current message families include:
 - missing field in record literal
 - unknown field in record field access
 - record field access on non-record value
-- record equality is not part of the stage-1 canonical record surface
+- record equality requested outside the stable field-equality subset
 - invalid tuple arity
 - tuple type mismatch
 - tuple destructuring bind requires tuple value

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -43,10 +43,10 @@ Current v0 record declaration semantics:
 - record literal fields are validated by declared field names and types
 - record literal evaluation is deterministic left-to-right in source field order
 - the canonical runtime carrier stores slots in declaration order, not source order
-- stage-1 record values may flow through executable local and const bindings
+- stage-1 record values may flow through executable locals, parameters, and returns
 - stage-1 field access uses `record_value.field_name` and resolves against the canonical record declaration
 - stage-1 field access lowers through deterministic declaration-slot reads
-- executable parameters, returns, and record equality remain deferred to later slices
+- record equality is allowed only when every field type already supports stable equality
 
 ## Deterministic Evaluation Order
 
@@ -398,10 +398,9 @@ Current stage-1 record semantics:
 
 Current v0 limit:
 
-- record values are not yet part of executable parameter or return contracts
 - record field access is read-only and resolves by canonical declaration-slot order
 - record destructuring, update, and punning are not yet part of the stable source contract
-- record equality is intentionally rejected
+- record equality remains gated to the stable field-equality subset
 - record values are not part of the PROMETHEUS host ABI surface
 
 ### Guard

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -95,10 +95,9 @@ Current v0 record limits:
 - `record_value.field_name` is the current stage-1 read-only field access form
 - record literal fields must appear exactly once by name
 - lowering preserves declaration-slot order rather than source-field order
-- record types are currently allowed only in executable local/const binding positions
-- record types are not yet part of stable executable function signatures or returns
+- record types may now appear in executable local bindings, parameters, and returns
 - record destructuring and record update are not yet part of the stable source contract
-- record equality is not yet part of the stable source contract
+- record equality is allowed only when every field type already supports stable equality
 - record values are not part of the PROMETHEUS host ABI surface
 - record destructuring, record punning, mutation, methods, and inheritance are not part of this slice
 


### PR DESCRIPTION
Closes #154

Stage-1 executable record use.

Scope:
- record params and returns
- stable-subset record equality only
- recursive nominal VM equality on canonical slots
- still no host ABI support

Validation:
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --test public_api_contracts
- cargo test --workspace