### PR TITLE
REC1-05 stage-1 record contract freeze and scenario validation

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -847,6 +847,80 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_access_policy_scenario() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                badge: quad,
+                override_state: quad,
+                tamper: quad,
+                quality: f64,
+            }
+
+            fn allow(ctx: DecisionContext) -> quad {
+                if ctx.tamper == T || ctx.tamper == S {
+                    return S;
+                }
+                if ctx.override_state == T {
+                    return T;
+                }
+                if ctx.camera == T && ctx.badge == T {
+                    return T;
+                }
+                return N;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext {
+                    quality: 0.50,
+                    tamper: F,
+                    override_state: N,
+                    badge: T,
+                    camera: T,
+                };
+                let decision: quad = allow(ctx);
+                assert(decision == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 2);
+    }
+
+    #[test]
+    fn verifier_accepts_record_runtime_config_scenario() {
+        let src = r#"
+            record RuntimeConfig {
+                max_steps: u32,
+                debug_mode: bool,
+                fallback_state: quad,
+            }
+
+            fn fallback(cfg: RuntimeConfig) -> quad {
+                if cfg.debug_mode == true {
+                    return cfg.fallback_state;
+                }
+                return N;
+            }
+
+            fn main() {
+                let cfg: RuntimeConfig = RuntimeConfig {
+                    fallback_state: S,
+                    debug_mode: true,
+                    max_steps: 16u32,
+                };
+                let state: quad = fallback(cfg);
+                assert(state == S);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 2);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1696,6 +1696,47 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_record_access_policy_scenario() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                badge: quad,
+                override_state: quad,
+                tamper: quad,
+                quality: f64,
+            }
+
+            fn allow(ctx: DecisionContext) -> quad {
+                if ctx.tamper == T || ctx.tamper == S {
+                    return S;
+                }
+                if ctx.override_state == T {
+                    return T;
+                }
+                if ctx.camera == T && ctx.badge == T {
+                    return T;
+                }
+                return N;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext {
+                    quality: 0.50,
+                    tamper: F,
+                    override_state: N,
+                    badge: T,
+                    camera: T,
+                };
+                let decision: quad = allow(ctx);
+                assert(decision == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        run_semcode(&bytes).expect("record access-policy scenario should run");
+    }
+
+    #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
             fn main() {

--- a/docs/roadmap/language_maturity/record_data_model.md
+++ b/docs/roadmap/language_maturity/record_data_model.md
@@ -1,14 +1,14 @@
 # Record Data Model
 
-Status: proposed v0
+Status: implemented stage-1 v0
 
 ## Purpose
 
-This document defines the first intentional aggregate family proposed for the
-Semantic executable language surface: nominal records.
+This document defines the first stabilized aggregate family currently available
+in the Semantic executable language surface: nominal records.
 
-It is a design target for the user-data-model workstream, not a claim that the
-current parser or VM already implements this feature.
+It is no longer only a design target. It records the narrow stage-1 contract
+that now exists across parser, sema, IR, verifier, and VM.
 
 ## Why Records First
 
@@ -20,7 +20,7 @@ Records are the right first aggregate family because they:
 - do not require hidden dynamic dispatch
 - compose naturally with existing `quad` and numeric values
 
-## Proposed Surface
+## Canonical Stage-1 Surface
 
 The proposed source form is a nominal `record` declaration:
 
@@ -53,29 +53,30 @@ ctx.quality
 
 ## Type Identity
 
-Proposed rules:
+Current rules:
 
 - record types are nominal, not structural
 - record field order is part of layout, but not the public identity of the
   type
 - field names must be unique within one record declaration
-- an empty record type should not be part of the first stabilized surface
+- an empty record type is not part of the stabilized stage-1 surface
 
 ## Value Semantics
 
-Proposed phase-1 rules:
+Current stage-1 rules:
 
 - record values are immutable after construction
 - record construction requires every declared field exactly once
 - no implicit default field values
 - no field mutation syntax in the first stage
-- passing a record to a function passes the value as one logical source object
+- passing a record to a function passes one nominal logical value through the
+  verified execution path
 
 ## Equality
 
-Phase-1 equality should be explicit and narrow.
+Stage-1 equality is explicit and narrow.
 
-Proposed rules:
+Current rules:
 
 - record equality is allowed only when every field type already supports
   stable equality
@@ -84,9 +85,9 @@ Proposed rules:
 
 ## Pattern And Match Scope
 
-Records should not immediately force a full pattern system.
+Records do not yet reopen a full pattern system.
 
-Phase-1 rule:
+Current stage-1 rule:
 
 - record destructuring and record-pattern matching are out of scope
 - users access fields explicitly rather than through destructuring syntax
@@ -118,42 +119,41 @@ and should not reopen pattern/destructuring ergonomics by accident.
 
 ## Lowering Strategy
 
-The first record implementation should preserve the current deterministic VM
-story.
+The current stage-1 record implementation preserves the deterministic VM story.
 
-Preferred initial strategy:
+Current strategy:
 
 - lower each record value into a fixed compile-time field layout
-- flatten field storage during IR lowering rather than introducing a general
-  heap object model
+- rewrite source field order into canonical declaration-slot order
 - keep record layout statically known to the compiler
+- avoid introducing a general heap object model
 
-That means the first record family should behave more like a named product type
-than like a dynamic object.
+That means the first record family behaves more like a named product type than
+like a dynamic object.
 
 ## IR Implications
 
-The first implementation should aim for the smallest IR change compatible with
-clear semantics.
+The stage-1 implementation keeps the IR change set narrow.
 
-Preferred direction:
+Current direction:
 
-- add explicit record-type metadata in the frontend and sema layers
-- lower field access into deterministic field-slot operations
-- avoid generic dictionary-like runtime operations
+- explicit record-type metadata exists in the frontend and sema layers
+- record construction lowers through canonical `MakeRecord`
+- field access lowers through deterministic `RecordGet`
+- generic dictionary-like runtime operations remain out of scope
 
-The exact IR opcode strategy is intentionally left open, but the contract goal
-is clear: records should lower to predictable slots, not opaque runtime blobs.
+The contract goal remains explicit: records lower to predictable slots, not
+opaque runtime blobs.
 
 ## VM And Verifier Implications
 
-Phase-1 records should not require abandoning the verified execution model.
+Stage-1 records do not abandon the verified execution model.
 
-Expected rules:
+Current rules:
 
-- verifier must be able to validate record-related layout references
-- VM should execute record access through deterministic, bounded operations
-- records must not become a hidden escape hatch around SemCode validation
+- verifier validates record-related layout references
+- VM executes record access through deterministic, bounded operations
+- records do not become a hidden escape hatch around SemCode validation
 
 ## Quad Composition
 
@@ -191,25 +191,26 @@ This phase does not attempt to provide:
 - record-specific generics
 - heap allocation semantics as a user-visible contract
 
-## Example Workload
+## Example Workloads
 
-The record family should unlock examples like:
+The record family already supports stage-1 scenarios such as:
 
 - access-policy contexts
 - structured sensor snapshots
 - semantic decision envelopes
 - grouped runtime configuration inputs
 
-These are more representative of real user data than today's scalar-only local
-packs.
+These are more representative of real user data than scalar-only local packs,
+while staying within the current verified-path contract.
 
 ## Acceptance Criteria
 
-The Stage 1 record family should be considered properly designed when the
+The Stage-1 record family should be considered properly frozen for v0 when the
 repository has:
 
-- a stable proposed source form
+- a stable canonical source form
 - explicit construction and access rules
 - explicit equality and non-goals
 - a documented deterministic lowering direction
 - examples showing why records are better than scalar-only decomposition
+- scenario workloads that compile through the verified path

--- a/docs/roadmap/language_maturity/record_scenarios.md
+++ b/docs/roadmap/language_maturity/record_scenarios.md
@@ -1,17 +1,19 @@
 # Record Scenarios
 
-Status: proposed v0
+Status: validated against stage-1 v0
 
 ## Purpose
 
 This document gives concrete user-data scenarios that justify records as the
-first aggregate family for Semantic.
+first aggregate family for Semantic and tracks which parts are already covered
+by the current stage-1 implementation.
 
 The goal is to show real workloads that are awkward in the current scalar-only
 surface and become clearer with nominal records.
 
-These examples are design targets rather than claims that the current parser
-already implements `record`.
+These examples are no longer only design targets. The stage-1 contract now
+supports nominal record declarations, construction, field access, pass/return,
+and equality inside the stable field-equality subset.
 
 ## Why Scenarios Matter
 
@@ -40,7 +42,7 @@ let quality: f64 = 0.50;
 This works, but the source no longer has one named value that represents "the
 current decision context".
 
-The proposed record form is clearer:
+The stage-1 record form is clearer:
 
 ```sm
 record DecisionContext {
@@ -70,6 +72,11 @@ Why this matters:
 - the policy takes one domain object instead of five unrelated parameters
 - field names remain explicit
 - `quad`-oriented semantics stay first-class inside the aggregate
+
+Stage-1 validation status:
+
+- compiles through the verified path
+- runs through the VM with explicit field access and ordinary control flow
 
 ## Scenario 2: Sensor Snapshot
 
@@ -105,12 +112,17 @@ Why this matters:
 - helper functions can accept one meaningful argument
 - later field additions do not explode parameter lists immediately
 
+Stage-1 validation status:
+
+- compiles through the verified path
+- field access resolves deterministically by declaration-slot order
+
 ## Scenario 3: Rule Input Envelope
 
 Semantic is good at deterministic reasoning, but today rule inputs still need
 to be unpacked manually.
 
-A record should allow a clean input envelope:
+A record allows a clean input envelope:
 
 ```sm
 record RuleInput {
@@ -136,6 +148,11 @@ Why this matters:
 - grouped policy inputs read like one contract
 - the code documents intent without relying on naming conventions alone
 
+Stage-1 validation status:
+
+- supported as a nominal input object
+- compatible with pass/return through the verified execution path
+
 ## Scenario 4: Runtime Configuration Bundle
 
 Not every structured value is a policy object. Some are just grouped execution
@@ -157,6 +174,11 @@ Why this matters:
 - users need a source-level way to group config values without pretending they
   are semantic declarations
 
+Current limit:
+
+- record values are still not part of the PROMETHEUS host ABI surface
+- config bundles may participate in verified-local execution, not host calls
+
 ## Comparison With Logos Entities
 
 It is important not to confuse records with `Entity`.
@@ -167,7 +189,7 @@ It is important not to confuse records with `Entity`.
 - domain metadata for the Logos surface
 - part of the system/rule description layer
 
-Records should become:
+Records are currently:
 
 - ordinary executable values
 - usable in Rust-like functions
@@ -177,7 +199,7 @@ That distinction keeps the executable language model cleaner.
 
 ## First-Stage Success Criteria
 
-The first record stage becomes worthwhile when users can stop writing
+The first record stage is worthwhile when users can stop writing
 policy-shaped scalar packs like:
 
 - `camera_state`
@@ -187,6 +209,16 @@ policy-shaped scalar packs like:
 - `quality`
 
 and instead pass one explicit domain value with named fields.
+
+## Explicit Non-Goals Still In Force
+
+The current stage-1 implementation still does not include:
+
+- record destructuring
+- record update / copy-with
+- record punning
+- methods, inheritance, or dynamic dispatch
+- host ABI passage for record values
 
 ## Cross-References
 

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -34,6 +34,7 @@ Semantic already has a strong execution contract. What it still lacks is a fully
 Related staged design-target notes:
 
 - `docs/roadmap/language_maturity/record_data_model.md`
+- `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`
 
 Current gated follow-up:


### PR DESCRIPTION
Closes #155

Stage-1 record freeze only.

Scope:
- align roadmap docs with implemented record contract
- validate motivating record scenarios through verified path
- keep record punning explicitly gated for a later ergonomics wave
- no new record runtime features in this slice

Validation:
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --workspace