### PR TITLE
REC2-01 explicit record destructuring bind

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -4,7 +4,7 @@ use crate::types::{
     LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem,
     LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -233,6 +233,26 @@ impl<'a> Parser<'a> {
                 return Ok(self.arena.alloc_stmt(Stmt::LetTuple { items, ty, value }));
             }
             let name = self.expect_symbol()?;
+            if self.check(TokenKind::LBrace) {
+                self.expect(TokenKind::LBrace, "expected '{' after record pattern name")?;
+                let items = self.parse_record_pattern_items_after_lbrace()?;
+                self.expect(TokenKind::Assign, "expected '='")?;
+                let value = self.parse_expr()?;
+                if self.check(TokenKind::KwElse) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "let-else record pattern is not part of the stable contract in this slice"
+                                .to_string(),
+                    });
+                }
+                self.expect(TokenKind::Semi, "expected ';'")?;
+                return Ok(self.arena.alloc_stmt(Stmt::LetRecord {
+                    record_name: name,
+                    items,
+                    value,
+                }));
+            }
             let ty = if self.eat(TokenKind::Colon) {
                 Some(self.parse_type()?)
             } else {
@@ -458,6 +478,66 @@ impl<'a> Parser<'a> {
             }
         }
         Ok(bind_items)
+    }
+
+    fn parse_record_pattern_items_after_lbrace(
+        &mut self,
+    ) -> Result<Vec<RecordPatternItem>, FrontendError> {
+        let mut items = Vec::new();
+        loop {
+            let field = self.expect_symbol()?;
+            if items
+                .iter()
+                .any(|existing: &RecordPatternItem| existing.field == field)
+            {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message: format!(
+                        "record destructuring pattern cannot repeat field '{}'",
+                        self.arena.symbol_name(field)
+                    ),
+                });
+            }
+            self.expect(
+                TokenKind::Colon,
+                "expected ':' after record destructuring field name",
+            )?;
+            let target = if self.eat(TokenKind::Underscore) {
+                None
+            } else {
+                Some(self.expect_symbol()?)
+            };
+            if let Some(target_name) = target {
+                if items.iter().any(|existing| existing.target == Some(target_name)) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: format!(
+                            "record destructuring pattern cannot repeat binding '{}'",
+                            self.arena.symbol_name(target_name)
+                        ),
+                    });
+                }
+            }
+            items.push(RecordPatternItem { field, target });
+            if self.eat(TokenKind::Comma) {
+                if self.check(TokenKind::RBrace) {
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+        self.expect(
+            TokenKind::RBrace,
+            "expected '}' after record destructuring pattern",
+        )?;
+        if items.is_empty() {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: "record destructuring pattern requires at least 1 field".to_string(),
+            });
+        }
+        Ok(items)
     }
 
     fn parse_else_return_payload(
@@ -2947,6 +3027,109 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*base), "ctx");
         assert_eq!(program.arena.symbol_name(field_expr.field), "camera");
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_explicit_record_destructuring_bind() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let DecisionContext { camera: seen_camera, quality: _ } =
+        DecisionContext { camera: T, quality: 0.75 };
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record destructuring bind should parse");
+        let main = &program.functions[0];
+        let Stmt::LetRecord {
+            record_name,
+            items,
+            value,
+        } = program.arena.stmt(main.body[0])
+        else {
+            panic!("expected record destructuring let");
+        };
+        assert_eq!(program.arena.symbol_name(*record_name), "DecisionContext");
+        assert_eq!(items.len(), 2);
+        assert_eq!(program.arena.symbol_name(items[0].field), "camera");
+        assert_eq!(
+            items[0]
+                .target
+                .map(|symbol| program.arena.symbol_name(symbol).to_string()),
+            Some("seen_camera".to_string())
+        );
+        assert_eq!(program.arena.symbol_name(items[1].field), "quality");
+        assert!(items[1].target.is_none());
+        assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_duplicate_field_in_record_destructuring_bind() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+}
+
+fn main() {
+    let DecisionContext { camera: first, camera: second } =
+        DecisionContext { camera: T };
+    return;
+}
+        "#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("duplicate field should reject");
+        assert!(err
+            .message
+            .contains("record destructuring pattern cannot repeat field 'camera'"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_duplicate_binding_in_record_destructuring_bind() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    badge: quad,
+}
+
+fn main() {
+    let DecisionContext { camera: seen, badge: seen } =
+        DecisionContext { camera: T, badge: F };
+    return;
+}
+        "#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("duplicate binding should reject");
+        assert!(err
+            .message
+            .contains("record destructuring pattern cannot repeat binding 'seen'"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_record_destructuring_let_else_surface() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+}
+
+fn main() {
+    let DecisionContext { camera: seen } = DecisionContext { camera: T } else return;
+    return;
+}
+        "#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("record let-else must reject in this slice");
+        assert!(err
+            .message
+            .contains("let-else record pattern is not part of the stable contract in this slice"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -303,6 +303,54 @@ fn check_stmt(
             }
             Ok(())
         }
+        Stmt::LetRecord {
+            record_name,
+            items,
+            value,
+        } => {
+            let record = record_table.get(record_name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown record type '{}' in record destructuring bind",
+                    resolve_symbol_name(arena, *record_name)?
+                ),
+            })?;
+            let value_ty = infer_expr_type(
+                *value,
+                arena,
+                env,
+                table,
+                record_table,
+                ret_ty.clone(),
+                loop_stack,
+            )?;
+            if value_ty != Type::Record(*record_name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "record destructuring bind requires value of type '{}', got {:?}",
+                        resolve_symbol_name(arena, *record_name)?,
+                        value_ty
+                    ),
+                });
+            }
+            for item in items {
+                let field = record.fields.iter().find(|field| field.name == item.field).ok_or(
+                    FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "record type '{}' has no field named '{}' in destructuring bind",
+                            resolve_symbol_name(arena, *record_name)?,
+                            resolve_symbol_name(arena, item.field)?
+                        ),
+                    },
+                )?;
+                if let Some(target) = item.target {
+                    env.insert(target, field.ty.clone());
+                }
+            }
+            Ok(())
+        }
         Stmt::LetElseTuple {
             items,
             ty,
@@ -2426,6 +2474,69 @@ mod tests {
         assert!(err
             .message
             .contains("record field access requires record value before '.quality', got F64"));
+    }
+
+    #[test]
+    fn record_destructuring_bind_typechecks_for_explicit_field_subset() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: _ } =
+                    DecisionContext { camera: T, quality: 0.75 };
+                let same = seen_camera == T;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("record destructuring bind should typecheck");
+    }
+
+    #[test]
+    fn record_destructuring_bind_rejects_unknown_field() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+            }
+
+            fn main() {
+                let DecisionContext { badge: seen_badge } =
+                    DecisionContext { camera: T };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("unknown record field must reject");
+        assert!(err
+            .message
+            .contains("record type 'DecisionContext' has no field named 'badge' in destructuring bind"));
+    }
+
+    #[test]
+    fn record_destructuring_bind_rejects_wrong_record_value() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+            }
+
+            record RuntimeConfig {
+                debug_mode: bool,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera } =
+                    RuntimeConfig { debug_mode: true };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("wrong record value must reject");
+        assert!(err
+            .message
+            .contains("record destructuring bind requires value of type 'DecisionContext'"));
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -80,6 +80,12 @@ pub struct RecordFieldExpr {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct RecordPatternItem {
+    pub field: SymbolId,
+    pub target: Option<SymbolId>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     QuadLiteral(QuadVal),
     BoolLiteral(bool),
@@ -113,6 +119,11 @@ pub enum Stmt {
     LetTuple {
         items: Vec<Option<SymbolId>>,
         ty: Option<Type>,
+        value: ExprId,
+    },
+    LetRecord {
+        record_name: SymbolId,
+        items: Vec<RecordPatternItem>,
         value: ExprId,
     },
     LetElseTuple {

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3,7 +3,7 @@ use crate::semcode_format::{
     write_f64_le, write_i32_le, write_u16_le, write_u32_le, Opcode, MAGIC0, MAGIC1, MAGIC2,
 };
 use sm_front::{LoopExpr, TuplePatternItem};
-use sm_front::types::NumericLiteral;
+use sm_front::types::{NumericLiteral, RecordPatternItem};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IrInstr {
@@ -1819,6 +1819,71 @@ fn bind_tuple_items(
     Ok(())
 }
 
+fn bind_record_items(
+    record_name: SymbolId,
+    items: &[RecordPatternItem],
+    record_reg: u16,
+    record_ty: &Type,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &mut ScopeEnv,
+    record_table: &RecordTable,
+) -> Result<(), FrontendError> {
+    if *record_ty != Type::Record(record_name) {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "record destructuring bind requires value of type '{}', got {:?}",
+                resolve_symbol_name(arena, record_name)?,
+                record_ty
+            ),
+        });
+    }
+    let record = record_table.get(&record_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown record type '{}' in record destructuring bind",
+            resolve_symbol_name(arena, record_name)?
+        ),
+    })?;
+    for item in items {
+        let Some(target) = item.target else {
+            continue;
+        };
+        let (index, field) = record
+            .fields
+            .iter()
+            .enumerate()
+            .find(|(_, field)| field.name == item.field)
+            .ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "record type '{}' has no field named '{}' in destructuring bind",
+                    resolve_symbol_name(arena, record_name)?,
+                    resolve_symbol_name(arena, item.field)?
+                ),
+            })?;
+        let reg = alloc(next);
+        let index = u16::try_from(index).map_err(|_| FrontendError {
+            pos: 0,
+            message: "record destructuring bind index exceeds v0 limit".to_string(),
+        })?;
+        out.push(IrInstr::RecordGet {
+            dst: reg,
+            src: record_reg,
+            record_name: resolve_symbol_name(arena, record_name)?.to_string(),
+            index,
+        });
+        env.insert(target, field.ty.clone());
+        out.push(IrInstr::StoreVar {
+            name: resolve_symbol_name(arena, target)?.to_string(),
+            src: reg,
+        });
+    }
+    Ok(())
+}
+
 fn assign_tuple_items(
     items: &[Option<SymbolId>],
     tuple_reg: u16,
@@ -2244,6 +2309,35 @@ fn lower_stmt(
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
                 env,
+            )
+        }
+        Stmt::LetRecord {
+            record_name,
+            items,
+            value,
+        } => {
+            let (record_reg, record_ty) = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                Some(Type::Record(*record_name)),
+                ret_ty.clone(),
+            )?;
+            bind_record_items(
+                *record_name,
+                items,
+                record_reg,
+                &record_ty,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                record_table,
             )
         }
         Stmt::LetElseTuple {
@@ -2772,6 +2866,35 @@ fn lower_value_block_expr(
                 )?;
                 let final_ty = if let Some(ann) = ty { ann.clone() } else { vty };
                 bind_tuple_items(items, tuple_reg, &final_ty, arena, next, out, &mut block_env)?;
+            }
+            Stmt::LetRecord {
+                record_name,
+                items,
+                value,
+            } => {
+                let (record_reg, record_ty) = lower_expr_with_expected(
+                    *value,
+                    arena,
+                    next,
+                    out,
+                    &block_env,
+                    loop_stack,
+                    fn_table,
+                    record_table,
+                    Some(Type::Record(*record_name)),
+                    ret_ty.clone(),
+                )?;
+                bind_record_items(
+                    *record_name,
+                    items,
+                    record_reg,
+                    &record_ty,
+                    arena,
+                    next,
+                    out,
+                    &mut block_env,
+                    record_table,
+                )?;
             }
             Stmt::Discard { ty, value } => {
                 let _ = lower_expr_with_expected(
@@ -4339,6 +4462,35 @@ mod opt_tests {
             instr,
             IrInstr::RecordGet { record_name, index, .. }
                 if record_name == "DecisionContext" && *index == 0
+        )));
+    }
+
+    #[test]
+    fn lower_record_destructuring_bind_to_record_get_ir() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: _ } =
+                    DecisionContext { quality: 0.75, camera: T };
+                assert(seen_camera == T);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("record destructuring bind should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::RecordGet { record_name, index, .. }
+                if record_name == "DecisionContext" && *index == 0
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name == "seen_camera"
         )));
     }
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -921,6 +921,26 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_destructuring_bind_semcode() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: _ } =
+                    DecisionContext { quality: 0.75, camera: T };
+                assert(seen_camera == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1737,6 +1737,27 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_record_destructuring_bind_path() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: _ } =
+                    DecisionContext { quality: 0.75, camera: T };
+                assert(seen_camera == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disassemble");
+        assert!(disasm.contains("RECORD_GET"));
+        run_semcode(&bytes).expect("record destructuring bind path should run");
+    }
+
+    #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -121,6 +121,11 @@ Current message families include:
 - missing field in record literal
 - unknown field in record field access
 - record field access on non-record value
+- duplicate field in record destructuring bind pattern
+- duplicate binding in record destructuring bind pattern
+- unknown record type in record destructuring bind
+- unknown field in record destructuring bind
+- record destructuring bind on non-matching record value
 - record equality requested outside the stable field-equality subset
 - invalid tuple arity
 - tuple type mismatch

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -46,6 +46,9 @@ Current v0 record declaration semantics:
 - stage-1 record values may flow through executable locals, parameters, and returns
 - stage-1 field access uses `record_value.field_name` and resolves against the canonical record declaration
 - stage-1 field access lowers through deterministic declaration-slot reads
+- explicit record destructuring bind uses `let RecordName { field: target, ... } = value;`
+- explicit record destructuring bind currently projects only the named subset of declaration fields
+- `_` targets in explicit record destructuring bind discard the projected field value without creating a source binding
 - record equality is allowed only when every field type already supports stable equality
 
 ## Deterministic Evaluation Order
@@ -209,6 +212,8 @@ Current statement meaning:
 - `let` evaluates the right-hand side before binding the name
 - tuple destructuring bind evaluates the right-hand side once before projecting
   tuple items into named bindings
+- record destructuring bind evaluates the right-hand side once before projecting
+  the requested record fields into named bindings
 - tuple destructuring assignment evaluates the right-hand side once before
   projecting tuple items into existing assignment targets
 - tuple `let-else` introduces named bindings only on the success path; failure
@@ -399,7 +404,10 @@ Current stage-1 record semantics:
 Current v0 limit:
 
 - record field access is read-only and resolves by canonical declaration-slot order
-- record destructuring, update, and punning are not yet part of the stable source contract
+- record destructuring bind currently supports only statement-level explicit
+  `RecordName { field: target }` patterns
+- record destructuring bind does not yet open `let-else`, nested patterns,
+  literal field patterns, update, or punning
 - record equality remains gated to the stable field-equality subset
 - record values are not part of the PROMETHEUS host ABI surface
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -111,6 +111,7 @@ Current statement forms:
 - `let name: type = expr;`
 - `let (a, b) = expr;`
 - `let (a, _): (type_a, type_b) = expr;`
+- `let RecordName { field_name: local_name, other_field: _ } = expr;`
 - `let (a, T) = expr else return;`
 - `let (a, T): (type_a, quad) = expr else return expr;`
 - `let _ = expr;`
@@ -141,6 +142,10 @@ Current statement rules:
 - `const` initializer syntax mirrors `let` but uses a narrower compile-time-safe expression subset
 - `let _ = expr;` is the current discard-bind surface
 - tuple destructuring bind is currently flat only and accepts only names or `_`
+- record destructuring bind is currently statement-level only
+- record destructuring bind currently requires explicit `RecordName { field: target }` spelling
+- record destructuring bind currently supports only named targets or `_`
+- record destructuring bind currently supports only explicit field mappings, not punning shorthand
 - `let-else` currently requires tuple destructuring target and `else return`
 - `let-else` tuple items are currently flat only and accept only names, `_`,
   or `quad` literals `N/F/T/S`


### PR DESCRIPTION
Closes #161

Scope:
- explicit statement-level record destructuring bind
- lowering via existing RecordGet + StoreVar path
- parser/typecheck/lowering/spec/tests only

Validation:
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --workspace