### PR TITLE
REC2-02 record let-else over explicit field patterns

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -4,7 +4,8 @@ use crate::types::{
     LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem,
     LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, RecordPatternTarget, Stmt, StmtId, SymbolId, Token, TokenKind,
+    TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -238,14 +239,16 @@ impl<'a> Parser<'a> {
                 let items = self.parse_record_pattern_items_after_lbrace()?;
                 self.expect(TokenKind::Assign, "expected '='")?;
                 let value = self.parse_expr()?;
-                if self.check(TokenKind::KwElse) {
-                    return Err(FrontendError {
-                        pos: self.pos(),
-                        message:
-                            "let-else record pattern is not part of the stable contract in this slice"
-                                .to_string(),
-                    });
+                if self.eat(TokenKind::KwElse) {
+                    let else_return = self.parse_else_return_payload("record let-else")?;
+                    return Ok(self.arena.alloc_stmt(Stmt::LetElseRecord {
+                        record_name: name,
+                        items,
+                        value,
+                        else_return,
+                    }));
                 }
+                let items = self.lower_record_pattern_items_to_bind(items)?;
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::LetRecord {
                     record_name: name,
@@ -503,12 +506,22 @@ impl<'a> Parser<'a> {
                 "expected ':' after record destructuring field name",
             )?;
             let target = if self.eat(TokenKind::Underscore) {
-                None
+                RecordPatternTarget::Discard
+            } else if self.eat(TokenKind::QuadN) {
+                RecordPatternTarget::QuadLiteral(QuadVal::N)
+            } else if self.eat(TokenKind::QuadF) {
+                RecordPatternTarget::QuadLiteral(QuadVal::F)
+            } else if self.eat(TokenKind::QuadT) {
+                RecordPatternTarget::QuadLiteral(QuadVal::T)
+            } else if self.eat(TokenKind::QuadS) {
+                RecordPatternTarget::QuadLiteral(QuadVal::S)
             } else {
-                Some(self.expect_symbol()?)
+                RecordPatternTarget::Bind(self.expect_symbol()?)
             };
-            if let Some(target_name) = target {
-                if items.iter().any(|existing| existing.target == Some(target_name)) {
+            if let RecordPatternTarget::Bind(target_name) = target {
+                if items.iter().any(|existing| {
+                    matches!(existing.target, RecordPatternTarget::Bind(existing_name) if existing_name == target_name)
+                }) {
                     return Err(FrontendError {
                         pos: self.pos(),
                         message: format!(
@@ -536,6 +549,23 @@ impl<'a> Parser<'a> {
                 pos: self.pos(),
                 message: "record destructuring pattern requires at least 1 field".to_string(),
             });
+        }
+        Ok(items)
+    }
+
+    fn lower_record_pattern_items_to_bind(
+        &self,
+        items: Vec<RecordPatternItem>,
+    ) -> Result<Vec<RecordPatternItem>, FrontendError> {
+        for item in &items {
+            if matches!(item.target, RecordPatternTarget::QuadLiteral(_)) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message:
+                        "quad literal record field patterns currently require let-else; plain record destructuring bind supports only name/_ items"
+                            .to_string(),
+                });
+            }
         }
         Ok(items)
     }
@@ -3058,14 +3088,9 @@ fn main() {
         assert_eq!(program.arena.symbol_name(*record_name), "DecisionContext");
         assert_eq!(items.len(), 2);
         assert_eq!(program.arena.symbol_name(items[0].field), "camera");
-        assert_eq!(
-            items[0]
-                .target
-                .map(|symbol| program.arena.symbol_name(symbol).to_string()),
-            Some("seen_camera".to_string())
-        );
+        assert!(matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "seen_camera"));
         assert_eq!(program.arena.symbol_name(items[1].field), "quality");
-        assert!(items[1].target.is_none());
+        assert!(matches!(items[1].target, RecordPatternTarget::Discard));
         assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
     }
 
@@ -3113,23 +3138,58 @@ fn main() {
     }
 
     #[test]
-    fn rustlike_parser_rejects_record_destructuring_let_else_surface() {
+    fn rustlike_parser_accepts_record_let_else_surface() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let DecisionContext { camera: T, quality: score } =
+        DecisionContext { camera: T, quality: 0.75 } else return;
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record let-else should parse");
+        let main = &program.functions[0];
+        let Stmt::LetElseRecord {
+            record_name,
+            items,
+            value,
+            else_return,
+        } = program.arena.stmt(main.body[0])
+        else {
+            panic!("expected record let-else statement");
+        };
+        assert_eq!(program.arena.symbol_name(*record_name), "DecisionContext");
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0].target, RecordPatternTarget::QuadLiteral(QuadVal::T)));
+        assert!(matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "score"));
+        assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
+        assert!(else_return.is_none());
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_quad_literal_record_pattern_without_let_else() {
         let src = r#"
 record DecisionContext {
     camera: quad,
 }
 
 fn main() {
-    let DecisionContext { camera: seen } = DecisionContext { camera: T } else return;
+    let DecisionContext { camera: T } = DecisionContext { camera: T };
     return;
 }
         "#;
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect_err("record let-else must reject in this slice");
+            .expect_err("plain record destructuring with quad literal must reject");
         assert!(err
             .message
-            .contains("let-else record pattern is not part of the stable contract in this slice"));
+            .contains("quad literal record field patterns currently require let-else"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use crate::types::NumericLiteral;
+use crate::types::{NumericLiteral, RecordPatternTarget};
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
 use alloc::string::ToString;
@@ -345,9 +345,102 @@ fn check_stmt(
                         ),
                     },
                 )?;
-                if let Some(target) = item.target {
-                    env.insert(target, field.ty.clone());
+                match item.target {
+                    RecordPatternTarget::Bind(target) => {
+                        env.insert(target, field.ty.clone());
+                    }
+                    RecordPatternTarget::Discard => {}
+                    RecordPatternTarget::QuadLiteral(_) => {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message:
+                                "quad literal record field patterns currently require let-else; plain record destructuring bind supports only name/_ items"
+                                    .to_string(),
+                        });
+                    }
                 }
+            }
+            Ok(())
+        }
+        Stmt::LetElseRecord {
+            record_name,
+            items,
+            value,
+            else_return,
+        } => {
+            let record = record_table.get(record_name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown record type '{}' in record let-else",
+                    resolve_symbol_name(arena, *record_name)?
+                ),
+            })?;
+            let value_ty = infer_expr_type(
+                *value,
+                arena,
+                env,
+                table,
+                record_table,
+                ret_ty.clone(),
+                loop_stack,
+            )?;
+            if value_ty != Type::Record(*record_name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "record let-else requires value of type '{}', got {:?}",
+                        resolve_symbol_name(arena, *record_name)?,
+                        value_ty
+                    ),
+                });
+            }
+            check_return_payload(
+                *else_return,
+                arena,
+                env,
+                table,
+                record_table,
+                ret_ty,
+                loop_stack,
+            )?;
+            let mut saw_refutable_item = false;
+            for item in items {
+                let field = record.fields.iter().find(|field| field.name == item.field).ok_or(
+                    FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "record type '{}' has no field named '{}' in let-else",
+                            resolve_symbol_name(arena, *record_name)?,
+                            resolve_symbol_name(arena, item.field)?
+                        ),
+                    },
+                )?;
+                match item.target {
+                    RecordPatternTarget::Bind(target) => {
+                        env.insert(target, field.ty.clone());
+                    }
+                    RecordPatternTarget::Discard => {}
+                    RecordPatternTarget::QuadLiteral(_) => {
+                        saw_refutable_item = true;
+                        if field.ty != Type::Quad {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: format!(
+                                    "record let-else literal pattern requires quad field, got {:?}",
+                                    field.ty
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            if !saw_refutable_item {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "record let-else requires at least one refutable quad literal field pattern"
+                            .to_string(),
+                });
             }
             Ok(())
         }
@@ -2540,6 +2633,67 @@ mod tests {
     }
 
     #[test]
+    fn record_let_else_typechecks_with_explicit_quad_field_pattern() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: T, quality: score } =
+                    DecisionContext { camera: T, quality: 0.75 } else return;
+                let _: f64 = score;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("record let-else should typecheck");
+    }
+
+    #[test]
+    fn record_let_else_rejects_when_no_refutable_field_is_present() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: score } =
+                    DecisionContext { camera: T, quality: 0.75 } else return;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("record let-else without refutable field must reject");
+        assert!(err
+            .message
+            .contains("record let-else requires at least one refutable quad literal field pattern"));
+    }
+
+    #[test]
+    fn record_let_else_rejects_non_quad_literal_field_position() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: seen_camera, quality: T } =
+                    DecisionContext { camera: T, quality: 0.75 } else return;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("record let-else quad literal on non-quad field must reject");
+        assert!(err
+            .message
+            .contains("record let-else literal pattern requires quad field"));
+    }
+
+    #[test]
     fn ufcs_method_call_typechecks_via_ordinary_call_contract() {
         let src = r#"
             fn scale(value: f64, factor: f64) -> f64 = value * factor;
@@ -2810,7 +2964,7 @@ fn check_loop_expr_stmt(
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<(), FrontendError> {
     match arena.stmt(stmt_id) {
-        Stmt::LetElseTuple { .. } => Err(FrontendError {
+        Stmt::LetElseTuple { .. } | Stmt::LetElseRecord { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow let-else".to_string(),
         }),

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -82,7 +82,14 @@ pub struct RecordFieldExpr {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordPatternItem {
     pub field: SymbolId,
-    pub target: Option<SymbolId>,
+    pub target: RecordPatternTarget,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordPatternTarget {
+    Bind(SymbolId),
+    Discard,
+    QuadLiteral(QuadVal),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -125,6 +132,12 @@ pub enum Stmt {
         record_name: SymbolId,
         items: Vec<RecordPatternItem>,
         value: ExprId,
+    },
+    LetElseRecord {
+        record_name: SymbolId,
+        items: Vec<RecordPatternItem>,
+        value: ExprId,
+        else_return: Option<ExprId>,
     },
     LetElseTuple {
         items: Vec<TuplePatternItem>,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3,7 +3,7 @@ use crate::semcode_format::{
     write_f64_le, write_i32_le, write_u16_le, write_u32_le, Opcode, MAGIC0, MAGIC1, MAGIC2,
 };
 use sm_front::{LoopExpr, TuplePatternItem};
-use sm_front::types::{NumericLiteral, RecordPatternItem};
+use sm_front::types::{NumericLiteral, RecordPatternItem, RecordPatternTarget};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IrInstr {
@@ -1848,9 +1848,6 @@ fn bind_record_items(
         ),
     })?;
     for item in items {
-        let Some(target) = item.target else {
-            continue;
-        };
         let (index, field) = record
             .fields
             .iter()
@@ -1875,9 +1872,149 @@ fn bind_record_items(
             record_name: resolve_symbol_name(arena, record_name)?.to_string(),
             index,
         });
-        env.insert(target, field.ty.clone());
+        match item.target {
+            RecordPatternTarget::Bind(target) => {
+                env.insert(target, field.ty.clone());
+                out.push(IrInstr::StoreVar {
+                    name: resolve_symbol_name(arena, target)?.to_string(),
+                    src: reg,
+                });
+            }
+            RecordPatternTarget::Discard => {}
+            RecordPatternTarget::QuadLiteral(_) => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "quad literal record field patterns currently require let-else; plain record destructuring bind supports only name/_ items"
+                            .to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn bind_let_else_record_items(
+    record_name: SymbolId,
+    items: &[RecordPatternItem],
+    record_reg: u16,
+    record_ty: &Type,
+    else_return: Option<ExprId>,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &mut ScopeEnv,
+    loop_stack: &mut Vec<LoopLoweringFrame>,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    if *record_ty != Type::Record(record_name) {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "record let-else requires value of type '{}', got {:?}",
+                resolve_symbol_name(arena, record_name)?,
+                record_ty
+            ),
+        });
+    }
+    let record = record_table.get(&record_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown record type '{}' in record let-else",
+            resolve_symbol_name(arena, record_name)?
+        ),
+    })?;
+    let pattern_id = alloc_loop_expr_id(next);
+    let mut deferred_binds = Vec::new();
+    let mut saw_refutable_item = false;
+    for item in items {
+        let (index, field) = record
+            .fields
+            .iter()
+            .enumerate()
+            .find(|(_, field)| field.name == item.field)
+            .ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "record type '{}' has no field named '{}' in let-else",
+                    resolve_symbol_name(arena, record_name)?,
+                    resolve_symbol_name(arena, item.field)?
+                ),
+            })?;
+        let reg = alloc(next);
+        let index = u16::try_from(index).map_err(|_| FrontendError {
+            pos: 0,
+            message: "record let-else index exceeds v0 limit".to_string(),
+        })?;
+        out.push(IrInstr::RecordGet {
+            dst: reg,
+            src: record_reg,
+            record_name: resolve_symbol_name(arena, record_name)?.to_string(),
+            index,
+        });
+        match item.target {
+            RecordPatternTarget::Bind(target) => {
+                deferred_binds.push((target, reg, field.ty.clone()));
+            }
+            RecordPatternTarget::Discard => {}
+            RecordPatternTarget::QuadLiteral(pat) => {
+                saw_refutable_item = true;
+                if field.ty != Type::Quad {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "record let-else literal pattern requires quad field, got {:?}",
+                            field.ty
+                        ),
+                    });
+                }
+                let lit_reg = alloc(next);
+                out.push(IrInstr::LoadQ {
+                    dst: lit_reg,
+                    val: pat,
+                });
+                let cmp_reg = alloc(next);
+                out.push(IrInstr::CmpEq {
+                    dst: cmp_reg,
+                    lhs: reg,
+                    rhs: lit_reg,
+                });
+                let continue_label = format!("let_else_record_{}_field_{}_ok", pattern_id, index);
+                out.push(IrInstr::JmpIf {
+                    cond: cmp_reg,
+                    label: continue_label.clone(),
+                });
+                lower_return_payload(
+                    else_return,
+                    arena,
+                    next,
+                    out,
+                    env,
+                    loop_stack,
+                    fn_table,
+                    record_table,
+                    ret_ty.clone(),
+                )?;
+                out.push(IrInstr::Label {
+                    name: continue_label,
+                });
+            }
+        }
+    }
+    if !saw_refutable_item {
+        return Err(FrontendError {
+            pos: 0,
+            message:
+                "record let-else requires at least one refutable quad literal field pattern"
+                    .to_string(),
+        });
+    }
+    for (name, reg, item_ty) in deferred_binds {
+        env.insert(name, item_ty);
         out.push(IrInstr::StoreVar {
-            name: resolve_symbol_name(arena, target)?.to_string(),
+            name: resolve_symbol_name(arena, name)?.to_string(),
             src: reg,
         });
     }
@@ -2338,6 +2475,40 @@ fn lower_stmt(
                 &mut ctx.instrs,
                 env,
                 record_table,
+            )
+        }
+        Stmt::LetElseRecord {
+            record_name,
+            items,
+            value,
+            else_return,
+        } => {
+            let (record_reg, record_ty) = lower_expr_with_expected(
+                *value,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                Some(Type::Record(*record_name)),
+                ret_ty.clone(),
+            )?;
+            bind_let_else_record_items(
+                *record_name,
+                items,
+                record_reg,
+                &record_ty,
+                *else_return,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                ret_ty,
             )
         }
         Stmt::LetElseTuple {
@@ -2896,6 +3067,14 @@ fn lower_value_block_expr(
                     record_table,
                 )?;
             }
+            Stmt::LetElseRecord { .. } => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "block expression body currently does not allow record let-else"
+                            .to_string(),
+                });
+            }
             Stmt::Discard { ty, value } => {
                 let _ = lower_expr_with_expected(
                     *value,
@@ -3107,7 +3286,7 @@ fn lower_loop_expr_stmt(
     ret_ty: Type,
 ) -> Result<(), FrontendError> {
     match arena.stmt(stmt_id) {
-        Stmt::LetElseTuple { .. } => Err(FrontendError {
+        Stmt::LetElseTuple { .. } | Stmt::LetElseRecord { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow let-else".to_string(),
         }),
@@ -4491,6 +4670,43 @@ mod opt_tests {
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,
             IrInstr::StoreVar { name, .. } if name == "seen_camera"
+        )));
+    }
+
+    #[test]
+    fn lower_record_let_else_to_record_get_and_early_return_ir() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: T, quality: score } =
+                    DecisionContext { quality: 0.75, camera: T } else return;
+                assert(score == 0.75);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("record let-else should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::RecordGet { record_name, index, .. }
+                if record_name == "DecisionContext" && (*index == 0 || *index == 1)
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::LoadQ { val: QuadVal::T, .. }
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::JmpIf { label, .. } if label.starts_with("let_else_record_")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name == "score"
         )));
     }
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -941,6 +941,26 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_let_else_semcode() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: T, quality: score } =
+                    DecisionContext { quality: 0.75, camera: T } else return;
+                assert(score == 0.75);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1758,6 +1758,27 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_record_let_else_path() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera: T, quality: score } =
+                    DecisionContext { quality: 0.75, camera: T } else return;
+                assert(score == 0.75);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disassemble");
+        assert!(disasm.contains("RECORD_GET"));
+        run_semcode(&bytes).expect("record let-else path should run");
+    }
+
+    #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -126,6 +126,11 @@ Current message families include:
 - unknown record type in record destructuring bind
 - unknown field in record destructuring bind
 - record destructuring bind on non-matching record value
+- unknown record type in record let-else
+- unknown field in record let-else
+- record let-else on non-matching record value
+- record let-else without refutable quad literal field pattern
+- record let-else literal pattern on non-quad field
 - record equality requested outside the stable field-equality subset
 - invalid tuple arity
 - tuple type mismatch

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -49,6 +49,8 @@ Current v0 record declaration semantics:
 - explicit record destructuring bind uses `let RecordName { field: target, ... } = value;`
 - explicit record destructuring bind currently projects only the named subset of declaration fields
 - `_` targets in explicit record destructuring bind discard the projected field value without creating a source binding
+- explicit record `let-else` uses `let RecordName { field: target, ... } = value else return ...;`
+- record `let-else` currently treats only explicit `quad` literal field targets as refutable checks
 - record equality is allowed only when every field type already supports stable equality
 
 ## Deterministic Evaluation Order
@@ -214,6 +216,9 @@ Current statement meaning:
   tuple items into named bindings
 - record destructuring bind evaluates the right-hand side once before projecting
   the requested record fields into named bindings
+- record `let-else` evaluates the right-hand side once, checks refutable
+  `quad` field literals before introducing named bindings, and follows the
+  explicit `else return` path on failure
 - tuple destructuring assignment evaluates the right-hand side once before
   projecting tuple items into existing assignment targets
 - tuple `let-else` introduces named bindings only on the success path; failure
@@ -262,6 +267,8 @@ Current v0 limit:
   tuple destructuring binds, `const` bindings, discard binds, and expression
   statements before the tail value
 - tuple `let-else` is not yet part of the stable value-producing block-body
+  contract
+- record `let-else` is not yet part of the stable value-producing block-body
   contract
 - discard bind is accepted in value-producing block bodies, but richer pattern
   destructuring is not yet part of the stable block-expression contract
@@ -406,8 +413,12 @@ Current v0 limit:
 - record field access is read-only and resolves by canonical declaration-slot order
 - record destructuring bind currently supports only statement-level explicit
   `RecordName { field: target }` patterns
-- record destructuring bind does not yet open `let-else`, nested patterns,
-  literal field patterns, update, or punning
+- record `let-else` currently supports only statement-level explicit field
+  mappings with `else return`
+- record `let-else` currently allows refutable matching only through explicit
+  `quad` literal field targets
+- record destructuring bind does not yet open nested patterns, update, or
+  punning
 - record equality remains gated to the stable field-equality subset
 - record values are not part of the PROMETHEUS host ABI surface
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -112,6 +112,7 @@ Current statement forms:
 - `let (a, b) = expr;`
 - `let (a, _): (type_a, type_b) = expr;`
 - `let RecordName { field_name: local_name, other_field: _ } = expr;`
+- `let RecordName { field_name: T, other_field: local_name } = expr else return;`
 - `let (a, T) = expr else return;`
 - `let (a, T): (type_a, quad) = expr else return expr;`
 - `let _ = expr;`
@@ -146,7 +147,11 @@ Current statement rules:
 - record destructuring bind currently requires explicit `RecordName { field: target }` spelling
 - record destructuring bind currently supports only named targets or `_`
 - record destructuring bind currently supports only explicit field mappings, not punning shorthand
-- `let-else` currently requires tuple destructuring target and `else return`
+- record `let-else` is currently statement-level only
+- record `let-else` currently requires explicit `RecordName { field: target } = expr else return ...;` spelling
+- record `let-else` currently allows refutable items only through explicit `quad` literals `N/F/T/S`
+- plain record destructuring bind does not currently accept quad-literal field targets
+- tuple `let-else` currently requires tuple destructuring target and `else return`
 - `let-else` tuple items are currently flat only and accept only names, `_`,
   or `quad` literals `N/F/T/S`
 - tuple destructuring assignment is currently flat only and accepts only names or `_`


### PR DESCRIPTION
## Summary
- add narrow record let-else over explicit field patterns
- keep the slice refutable only through explicit quad literal field targets
- add lowering, verifier, VM, and spec coverage for the new surface

## Validation
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --workspace