### PR TITLE
REC2-03 immutable record update and copy-with

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -306,6 +306,7 @@ fn tokenize_line(
                     "loop" => TokenKind::KwLoop,
                     "break" => TokenKind::KwBreak,
                     "where" => TokenKind::KwWhere,
+                    "with" => TokenKind::KwWith,
                     "return" => TokenKind::KwReturn,
                     "match" => TokenKind::KwMatch,
                     "true" => TokenKind::KwTrue,

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -19,8 +19,8 @@ pub use types::{
     AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId, FrontendError, FrontendErrorKind,
     Function, IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
     LogosSystem, LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, Program, QuadVal,
-    RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr, Stmt, StmtId,
-    SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordUpdateExpr,
+    Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -4,8 +4,8 @@ use crate::types::{
     LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem,
     LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, RecordPatternTarget, Stmt, StmtId, SymbolId, Token, TokenKind,
-    TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, Stmt, StmtId, SymbolId, Token,
+    TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -808,21 +808,34 @@ impl<'a> Parser<'a> {
 
     fn parse_primary(&mut self) -> Result<ExprId, FrontendError> {
         let mut expr = self.parse_primary_atom()?;
-        while self.eat(TokenKind::Dot) {
-            let field = self.expect_symbol()?;
-            if !self.eat(TokenKind::LParen) {
-                expr = self
-                    .arena
-                    .alloc_expr(Expr::RecordField(RecordFieldExpr { base: expr, field }));
+        loop {
+            if self.eat(TokenKind::Dot) {
+                let field = self.expect_symbol()?;
+                if !self.eat(TokenKind::LParen) {
+                    expr = self
+                        .arena
+                        .alloc_expr(Expr::RecordField(RecordFieldExpr { base: expr, field }));
+                    continue;
+                }
+                let mut args = vec![CallArg {
+                    name: None,
+                    value: expr,
+                }];
+                args.extend(self.parse_call_args()?);
+                self.expect(TokenKind::RParen, "expected ')' after UFCS method call")?;
+                expr = self.arena.alloc_expr(Expr::Call(field, args));
                 continue;
             }
-            let mut args = vec![CallArg {
-                name: None,
-                value: expr,
-            }];
-            args.extend(self.parse_call_args()?);
-            self.expect(TokenKind::RParen, "expected ')' after UFCS method call")?;
-            expr = self.arena.alloc_expr(Expr::Call(field, args));
+            if self.eat(TokenKind::KwWith) {
+                self.expect(TokenKind::LBrace, "expected '{' after 'with' in record copy-with")?;
+                let fields = self.parse_record_init_fields_after_lbrace()?;
+                expr = self.arena.alloc_expr(Expr::RecordUpdate(RecordUpdateExpr {
+                    base: expr,
+                    fields,
+                }));
+                continue;
+            }
+            break;
         }
         Ok(expr)
     }
@@ -912,6 +925,16 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_record_literal_after_name(&mut self, name: SymbolId) -> Result<ExprId, FrontendError> {
+        let fields = self.parse_record_init_fields_after_lbrace()?;
+        Ok(self.arena.alloc_expr(Expr::RecordLiteral(RecordLiteralExpr {
+            name,
+            fields,
+        })))
+    }
+
+    fn parse_record_init_fields_after_lbrace(
+        &mut self,
+    ) -> Result<Vec<RecordInitField>, FrontendError> {
         let mut fields = Vec::new();
         while !self.check(TokenKind::RBrace) {
             let field_name = self.expect_symbol()?;
@@ -929,11 +952,8 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        self.expect(TokenKind::RBrace, "expected '}' after record literal")?;
-        Ok(self.arena.alloc_expr(Expr::RecordLiteral(RecordLiteralExpr {
-            name,
-            fields,
-        })))
+        self.expect(TokenKind::RBrace, "expected '}' after record field list")?;
+        Ok(fields)
     }
 
     fn starts_record_literal_head(&self) -> bool {
@@ -1119,6 +1139,13 @@ impl<'a> Parser<'a> {
             }
             Expr::RecordField(field_expr) => {
                 self.ensure_short_lambda_expr_capture_free(field_expr.base, scopes)
+            }
+            Expr::RecordUpdate(update_expr) => {
+                self.ensure_short_lambda_expr_capture_free(update_expr.base, scopes)?;
+                for field in &update_expr.fields {
+                    self.ensure_short_lambda_expr_capture_free(field.value, scopes)?;
+                }
+                Ok(())
             }
             Expr::Var(name) => {
                 if scopes.iter().rev().any(|scope| scope.contains(name)) {
@@ -3057,6 +3084,38 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*base), "ctx");
         assert_eq!(program.arena.symbol_name(field_expr.field), "camera");
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_record_copy_with_surface() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let ctx = DecisionContext { camera: T, quality: 0.75 };
+    let patched = ctx with { quality: 1.0 };
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record copy-with should parse");
+        let main = &program.functions[0];
+        let Stmt::Let { value, .. } = program.arena.stmt(main.body[1]) else {
+            panic!("expected second let");
+        };
+        let Expr::RecordUpdate(update_expr) = program.arena.expr(*value) else {
+            panic!("expected record update expr");
+        };
+        let Expr::Var(base) = program.arena.expr(update_expr.base) else {
+            panic!("expected record update base variable");
+        };
+        assert_eq!(program.arena.symbol_name(*base), "ctx");
+        assert_eq!(update_expr.fields.len(), 1);
+        assert_eq!(program.arena.symbol_name(update_expr.fields[0].name), "quality");
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -964,6 +964,15 @@ fn infer_expr_type(
             ret_ty,
             loop_stack,
         ),
+        Expr::RecordUpdate(update_expr) => infer_record_update_type(
+            update_expr,
+            arena,
+            env,
+            table,
+            record_table,
+            ret_ty,
+            loop_stack,
+        ),
         Expr::Var(v) => env.get(*v).ok_or(FrontendError {
             pos: 0,
             message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
@@ -2570,6 +2579,103 @@ mod tests {
     }
 
     #[test]
+    fn record_copy_with_typechecks_for_explicit_override_subset() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let patched: DecisionContext = ctx with { quality: 1.0 };
+                assert(patched.camera == T);
+                assert(patched.quality == 1.0);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("record copy-with should typecheck");
+    }
+
+    #[test]
+    fn record_copy_with_rejects_unknown_field() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T };
+                let patched = ctx with { badge: T };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("unknown copy-with field must reject");
+        assert!(err
+            .message
+            .contains("record copy-with 'DecisionContext' has no field named 'badge'"));
+    }
+
+    #[test]
+    fn record_copy_with_rejects_duplicate_field_override() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let patched = ctx with { quality: 1.0, quality: 2.0 };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("duplicate copy-with field must reject");
+        assert!(err
+            .message
+            .contains("record copy-with 'DecisionContext' cannot repeat field 'quality'"));
+    }
+
+    #[test]
+    fn record_copy_with_rejects_non_record_base() {
+        let src = r#"
+            fn main() {
+                let value: f64 = 1.0;
+                let patched = value with { quality: 0.75 };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-record copy-with base must reject");
+        assert!(err
+            .message
+            .contains("record copy-with requires record base before 'with', got F64"));
+    }
+
+    #[test]
+    fn record_copy_with_rejects_empty_override_set() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T };
+                let patched = ctx with { };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("empty copy-with must reject");
+        assert!(err
+            .message
+            .contains("record copy-with requires at least one explicit override field"));
+    }
+
+    #[test]
     fn record_destructuring_bind_typechecks_for_explicit_field_subset() {
         let src = r#"
             record DecisionContext {
@@ -3470,6 +3576,95 @@ fn infer_record_field_access_type(
             ),
         })?;
     Ok(field.ty.clone())
+}
+
+fn infer_record_update_type(
+    update_expr: &RecordUpdateExpr,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+) -> Result<Type, FrontendError> {
+    let base_ty = infer_expr_type(
+        update_expr.base,
+        arena,
+        env,
+        table,
+        record_table,
+        ret_ty.clone(),
+        loop_stack,
+    )?;
+    let Type::Record(record_name) = base_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "record copy-with requires record base before 'with', got {:?}",
+                base_ty
+            ),
+        });
+    };
+    let record = record_table.get(&record_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown record type '{}' in record copy-with",
+            resolve_symbol_name(arena, record_name)?
+        ),
+    })?;
+    let record_name_text = resolve_symbol_name(arena, record_name)?;
+    if update_expr.fields.is_empty() {
+        return Err(FrontendError {
+            pos: 0,
+            message: "record copy-with requires at least one explicit override field".to_string(),
+        });
+    }
+    let mut field_types = BTreeMap::new();
+    for field in &record.fields {
+        field_types.insert(field.name, field.ty.clone());
+    }
+    let mut seen = BTreeSet::new();
+    for field in &update_expr.fields {
+        if !seen.insert(field.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "record copy-with '{}' cannot repeat field '{}'",
+                    record_name_text,
+                    resolve_symbol_name(arena, field.name)?
+                ),
+            });
+        }
+        let expected_ty = field_types.get(&field.name).ok_or(FrontendError {
+            pos: 0,
+            message: format!(
+                "record copy-with '{}' has no field named '{}'",
+                record_name_text,
+                resolve_symbol_name(arena, field.name)?
+            ),
+        })?;
+        let actual_ty = infer_expr_type(
+            field.value,
+            arena,
+            env,
+            table,
+            record_table,
+            ret_ty.clone(),
+            loop_stack,
+        )?;
+        ensure_binding_value_type(
+            expected_ty.clone(),
+            actual_ty,
+            field.value,
+            arena,
+            format!(
+                "record copy-with '{}.{}'",
+                record_name_text,
+                resolve_symbol_name(arena, field.name)?
+            ),
+        )?;
+    }
+    Ok(Type::Record(record_name))
 }
 
 fn check_match_guard(

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -80,6 +80,12 @@ pub struct RecordFieldExpr {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct RecordUpdateExpr {
+    pub base: ExprId,
+    pub fields: Vec<RecordInitField>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct RecordPatternItem {
     pub field: SymbolId,
     pub target: RecordPatternTarget,
@@ -101,6 +107,7 @@ pub enum Expr {
     Tuple(Vec<ExprId>),
     RecordLiteral(RecordLiteralExpr),
     RecordField(RecordFieldExpr),
+    RecordUpdate(RecordUpdateExpr),
     Var(SymbolId),
     Call(SymbolId, Vec<CallArg>),
     Unary(UnaryOp, ExprId),
@@ -329,6 +336,7 @@ pub enum TokenKind {
     KwLoop,
     KwBreak,
     KwWhere,
+    KwWith,
     KwReturn,
     KwMatch,
     KwTrue,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1283,6 +1283,104 @@ fn lower_expr_with_expected(
             });
             Ok((dst, field.ty.clone()))
         }
+        Expr::RecordUpdate(update_expr) => {
+            let (base_reg, base_ty) = lower_expr(
+                update_expr.base,
+                arena,
+                next,
+                out,
+                env,
+                loop_stack,
+                fn_table,
+                record_table,
+                ret_ty.clone(),
+            )?;
+            let Type::Record(record_name) = base_ty else {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "record copy-with lowering requires record base before 'with', got {:?}",
+                        base_ty
+                    ),
+                });
+            };
+            let record = record_table.get(&record_name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown record type '{}' in record copy-with lowering",
+                    resolve_symbol_name(arena, record_name)?
+                ),
+            })?;
+            if update_expr.fields.is_empty() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "record copy-with requires at least one explicit override field".to_string(),
+                });
+            }
+            let mut lowered_overrides = HashMap::new();
+            for field in &update_expr.fields {
+                let expected_field_ty = record
+                    .fields
+                    .iter()
+                    .find(|decl_field| decl_field.name == field.name)
+                    .map(|decl_field| decl_field.ty.clone())
+                    .ok_or(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "record copy-with '{}' has no field named '{}' during lowering",
+                            resolve_symbol_name(arena, record_name)?,
+                            resolve_symbol_name(arena, field.name)?
+                        ),
+                    })?;
+                let (reg, _) = lower_expr_with_expected(
+                    field.value,
+                    arena,
+                    next,
+                    out,
+                    env,
+                    loop_stack,
+                    fn_table,
+                    record_table,
+                    Some(expected_field_ty),
+                    ret_ty.clone(),
+                )?;
+                if lowered_overrides.insert(field.name, reg).is_some() {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "record copy-with '{}' cannot repeat field '{}' during lowering",
+                            resolve_symbol_name(arena, record_name)?,
+                            resolve_symbol_name(arena, field.name)?
+                        ),
+                    });
+                }
+            }
+            let mut ordered_regs = Vec::with_capacity(record.fields.len());
+            for (index, decl_field) in record.fields.iter().enumerate() {
+                if let Some(override_reg) = lowered_overrides.get(&decl_field.name).copied() {
+                    ordered_regs.push(override_reg);
+                    continue;
+                }
+                let reg = alloc(next);
+                out.push(IrInstr::RecordGet {
+                    dst: reg,
+                    src: base_reg,
+                    record_name: resolve_symbol_name(arena, record_name)?.to_string(),
+                    index: u16::try_from(index).map_err(|_| FrontendError {
+                        pos: 0,
+                        message: "record copy-with slot index exceeds v0 limit".to_string(),
+                    })?,
+                });
+                ordered_regs.push(reg);
+            }
+            let dst = alloc(next);
+            out.push(IrInstr::MakeRecord {
+                dst,
+                name: resolve_symbol_name(arena, record_name)?.to_string(),
+                items: ordered_regs,
+            });
+            Ok((dst, Type::Record(record_name)))
+        }
         Expr::NumericLiteral(NumericLiteral::I32(n)) => {
             let r = alloc(next);
             if expected == Some(Type::Fx) {
@@ -4641,6 +4739,40 @@ mod opt_tests {
             instr,
             IrInstr::RecordGet { record_name, index, .. }
                 if record_name == "DecisionContext" && *index == 0
+        )));
+    }
+
+    #[test]
+    fn lower_record_copy_with_to_record_get_and_make_record_ir() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { quality: 0.75, camera: T };
+                let patched: DecisionContext = ctx with { quality: 1.0 };
+                assert(patched.camera == T);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("record copy-with should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::RecordGet { record_name, index, .. }
+                if record_name == "DecisionContext" && *index == 0
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeRecord { name, items, .. }
+                if name == "DecisionContext" && items.len() == 2
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::StoreVar { name, .. } if name == "patched"
         )));
     }
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -961,6 +961,26 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_copy_with_semcode() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let patched: DecisionContext = ctx with { quality: 1.0 };
+                assert(patched.camera == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1779,6 +1779,29 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_record_copy_with_path() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let patched: DecisionContext = ctx with { quality: 1.0 };
+                assert(patched.camera == T);
+                assert(patched.quality == 1.0);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disassemble");
+        assert!(disasm.contains("RECORD_GET"));
+        assert!(disasm.contains("MAKE_RECORD"));
+        run_semcode(&bytes).expect("record copy-with path should run");
+    }
+
+    #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
             fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -131,6 +131,11 @@ Current message families include:
 - record let-else on non-matching record value
 - record let-else without refutable quad literal field pattern
 - record let-else literal pattern on non-quad field
+- unknown record type in record copy-with
+- record copy-with on non-record base
+- empty record copy-with override set
+- duplicate field in record copy-with
+- unknown field in record copy-with
 - record equality requested outside the stable field-equality subset
 - invalid tuple arity
 - tuple type mismatch

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -46,6 +46,8 @@ Current v0 record declaration semantics:
 - stage-1 record values may flow through executable locals, parameters, and returns
 - stage-1 field access uses `record_value.field_name` and resolves against the canonical record declaration
 - stage-1 field access lowers through deterministic declaration-slot reads
+- stage-2 immutable record update uses `record_value with { field: expr, ... }`
+- copy-with preserves the nominal record identity of its base value
 - explicit record destructuring bind uses `let RecordName { field: target, ... } = value;`
 - explicit record destructuring bind currently projects only the named subset of declaration fields
 - `_` targets in explicit record destructuring bind discard the projected field value without creating a source binding
@@ -216,6 +218,8 @@ Current statement meaning:
   tuple items into named bindings
 - record destructuring bind evaluates the right-hand side once before projecting
   the requested record fields into named bindings
+- record copy-with evaluates the base value once, evaluates override expressions
+  left-to-right, then rebuilds the canonical slot carrier in declaration order
 - record `let-else` evaluates the right-hand side once, checks refutable
   `quad` field literals before introducing named bindings, and follows the
   explicit `else return` path on failure
@@ -411,14 +415,17 @@ Current stage-1 record semantics:
 Current v0 limit:
 
 - record field access is read-only and resolves by canonical declaration-slot order
+- record copy-with is immutable and rebuilds a value of the same nominal record type
+- unchanged record fields in copy-with are read from the base value through canonical declaration-slot access
 - record destructuring bind currently supports only statement-level explicit
   `RecordName { field: target }` patterns
 - record `let-else` currently supports only statement-level explicit field
   mappings with `else return`
 - record `let-else` currently allows refutable matching only through explicit
   `quad` literal field targets
-- record destructuring bind does not yet open nested patterns, update, or
-  punning
+- record copy-with currently requires explicit field mappings and does not open
+  punning or mutation semantics
+- record destructuring bind does not yet open nested patterns or punning
 - record equality remains gated to the stable field-equality subset
 - record values are not part of the PROMETHEUS host ABI surface
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -93,10 +93,11 @@ Current v0 record limits:
 
 - `RecordName { field: expr, ... }` is the current stage-1 record construction form
 - `record_value.field_name` is the current stage-1 read-only field access form
+- `record_value with { field: expr, ... }` is the current stage-2 immutable record update form
 - record literal fields must appear exactly once by name
 - lowering preserves declaration-slot order rather than source-field order
 - record types may now appear in executable local bindings, parameters, and returns
-- record destructuring and record update are not yet part of the stable source contract
+- record destructuring and record copy-with now participate in the stable source contract
 - record equality is allowed only when every field type already supports stable equality
 - record values are not part of the PROMETHEUS host ABI surface
 - record destructuring, record punning, mutation, methods, and inheritance are not part of this slice
@@ -113,6 +114,7 @@ Current statement forms:
 - `let (a, _): (type_a, type_b) = expr;`
 - `let RecordName { field_name: local_name, other_field: _ } = expr;`
 - `let RecordName { field_name: T, other_field: local_name } = expr else return;`
+- `let next = current with { quality: 1.0 };`
 - `let (a, T) = expr else return;`
 - `let (a, T): (type_a, quad) = expr else return expr;`
 - `let _ = expr;`
@@ -212,6 +214,9 @@ Current expression forms:
 - record field access:
   - `ctx.camera`
   - `ctx.quality`
+- record copy-with:
+  - `ctx with { quality: 1.0 }`
+  - `ctx with { camera: F, quality: 0.25 }`
 - tuple types:
   - `(i32, bool)`
   - `(f64, quad, bool)`


### PR DESCRIPTION
## Summary
- add immutable ecord_value with { field: expr, ... } surface
- typecheck copy-with against nominal record declarations and rebuild the same canonical record type
- lower through existing RecordGet + MakeRecord paths with verifier/vm/spec coverage

## Validation
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --workspace