### PR TITLE
D20P-D01 record punning and field shorthand

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -501,22 +501,22 @@ impl<'a> Parser<'a> {
                     ),
                 });
             }
-            self.expect(
-                TokenKind::Colon,
-                "expected ':' after record destructuring field name",
-            )?;
-            let target = if self.eat(TokenKind::Underscore) {
-                RecordPatternTarget::Discard
-            } else if self.eat(TokenKind::QuadN) {
-                RecordPatternTarget::QuadLiteral(QuadVal::N)
-            } else if self.eat(TokenKind::QuadF) {
-                RecordPatternTarget::QuadLiteral(QuadVal::F)
-            } else if self.eat(TokenKind::QuadT) {
-                RecordPatternTarget::QuadLiteral(QuadVal::T)
-            } else if self.eat(TokenKind::QuadS) {
-                RecordPatternTarget::QuadLiteral(QuadVal::S)
+            let target = if self.eat(TokenKind::Colon) {
+                if self.eat(TokenKind::Underscore) {
+                    RecordPatternTarget::Discard
+                } else if self.eat(TokenKind::QuadN) {
+                    RecordPatternTarget::QuadLiteral(QuadVal::N)
+                } else if self.eat(TokenKind::QuadF) {
+                    RecordPatternTarget::QuadLiteral(QuadVal::F)
+                } else if self.eat(TokenKind::QuadT) {
+                    RecordPatternTarget::QuadLiteral(QuadVal::T)
+                } else if self.eat(TokenKind::QuadS) {
+                    RecordPatternTarget::QuadLiteral(QuadVal::S)
+                } else {
+                    RecordPatternTarget::Bind(self.expect_symbol()?)
+                }
             } else {
-                RecordPatternTarget::Bind(self.expect_symbol()?)
+                RecordPatternTarget::Bind(field)
             };
             if let RecordPatternTarget::Bind(target_name) = target {
                 if items.iter().any(|existing| {
@@ -938,8 +938,11 @@ impl<'a> Parser<'a> {
         let mut fields = Vec::new();
         while !self.check(TokenKind::RBrace) {
             let field_name = self.expect_symbol()?;
-            self.expect(TokenKind::Colon, "expected ':' after record field name")?;
-            let value = self.parse_expr()?;
+            let value = if self.eat(TokenKind::Colon) {
+                self.parse_expr()?
+            } else {
+                self.arena.alloc_expr(Expr::Var(field_name))
+            };
             fields.push(RecordInitField {
                 name: field_name,
                 value,
@@ -962,11 +965,21 @@ impl<'a> Parser<'a> {
             return false;
         }
         let field_idx = self.next_non_layout_idx_from(lbrace_idx + 1);
-        if field_idx >= self.tokens.len() || self.tokens[field_idx].kind != TokenKind::Ident {
+        if field_idx >= self.tokens.len() {
             return false;
         }
-        let colon_idx = self.next_non_layout_idx_from(field_idx + 1);
-        colon_idx < self.tokens.len() && self.tokens[colon_idx].kind == TokenKind::Colon
+        if self.tokens[field_idx].kind == TokenKind::RBrace {
+            return true;
+        }
+        if self.tokens[field_idx].kind != TokenKind::Ident {
+            return false;
+        }
+        let next_idx = self.next_non_layout_idx_from(field_idx + 1);
+        next_idx < self.tokens.len()
+            && matches!(
+                self.tokens[next_idx].kind,
+                TokenKind::Colon | TokenKind::Comma | TokenKind::RBrace
+            )
     }
 
     fn starts_short_lambda_head(&self) -> bool {
@@ -3154,6 +3167,78 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_record_field_shorthand_in_literal_and_copy_with() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let camera: quad = T;
+    let quality: f64 = 0.75;
+    let ctx: DecisionContext = DecisionContext { camera, quality };
+    let patched: DecisionContext = ctx with { quality };
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record field shorthand should parse");
+        let main = &program.functions[0];
+        let Stmt::Let { value, .. } = program.arena.stmt(main.body[2]) else {
+            panic!("expected record literal let");
+        };
+        let Expr::RecordLiteral(record) = program.arena.expr(*value) else {
+            panic!("expected record literal expression");
+        };
+        assert!(matches!(program.arena.expr(record.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "camera"));
+        assert!(matches!(program.arena.expr(record.fields[1].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality"));
+
+        let Stmt::Let { value, .. } = program.arena.stmt(main.body[3]) else {
+            panic!("expected record copy-with let");
+        };
+        let Expr::RecordUpdate(update) = program.arena.expr(*value) else {
+            panic!("expected record copy-with expression");
+        };
+        assert_eq!(update.fields.len(), 1);
+        assert!(matches!(program.arena.expr(update.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality"));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_record_pattern_punning_in_bind_and_let_else() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let DecisionContext { camera, quality: _ } =
+        DecisionContext { camera: T, quality: 0.75 };
+    let DecisionContext { camera: T, quality } =
+        DecisionContext { camera: T, quality: 1.0 } else return;
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record pattern punning should parse");
+        let main = &program.functions[0];
+        let Stmt::LetRecord { items, .. } = program.arena.stmt(main.body[0]) else {
+            panic!("expected record destructuring bind");
+        };
+        assert!(matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "camera"));
+        assert!(matches!(items[1].target, RecordPatternTarget::Discard));
+
+        let Stmt::LetElseRecord { items, .. } = program.arena.stmt(main.body[1]) else {
+            panic!("expected record let-else");
+        };
+        assert!(matches!(items[0].target, RecordPatternTarget::QuadLiteral(QuadVal::T)));
+        assert!(matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "quality"));
+    }
+
+    #[test]
     fn rustlike_parser_rejects_duplicate_field_in_record_destructuring_bind() {
         let src = r#"
 record DecisionContext {
@@ -3194,6 +3279,28 @@ fn main() {
         assert!(err
             .message
             .contains("record destructuring pattern cannot repeat binding 'seen'"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_duplicate_binding_in_record_destructuring_bind_with_punning() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    badge: quad,
+}
+
+fn main() {
+    let DecisionContext { camera, badge: camera } =
+        DecisionContext { camera: T, badge: F };
+    return;
+}
+        "#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("duplicate binding via punning should reject");
+        assert!(err
+            .message
+            .contains("record destructuring pattern cannot repeat binding 'camera'"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -2599,6 +2599,28 @@ mod tests {
     }
 
     #[test]
+    fn record_field_shorthand_typechecks_for_literal_and_copy_with() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let camera: quad = T;
+                let quality: f64 = 0.75;
+                let ctx: DecisionContext = DecisionContext { camera, quality };
+                let patched: DecisionContext = ctx with { quality };
+                assert(patched.camera == T);
+                assert(patched.quality == 0.75);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("record field shorthand should typecheck");
+    }
+
+    #[test]
     fn record_copy_with_rejects_unknown_field() {
         let src = r#"
             record DecisionContext {
@@ -2692,6 +2714,28 @@ mod tests {
         "#;
 
         typecheck_source(src).expect("record destructuring bind should typecheck");
+    }
+
+    #[test]
+    fn record_pattern_punning_typechecks_for_bind_and_let_else() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let DecisionContext { camera, quality: _ } =
+                    DecisionContext { camera: T, quality: 0.75 };
+                let DecisionContext { camera: T, quality } =
+                    DecisionContext { camera: T, quality: 1.0 } else return;
+                assert(camera == T);
+                let _: f64 = quality;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("record pattern punning should typecheck");
     }
 
     #[test]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -4777,6 +4777,39 @@ mod opt_tests {
     }
 
     #[test]
+    fn lower_record_punning_shorthand_via_existing_record_paths() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let camera: quad = T;
+                let quality: f64 = 0.75;
+                let ctx: DecisionContext = DecisionContext { camera, quality };
+                let DecisionContext { camera: seen_camera, quality } = ctx;
+                let patched: DecisionContext = ctx with { quality };
+                assert(seen_camera == patched.camera);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("record punning shorthand should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeRecord { name, items, .. }
+                if name == "DecisionContext" && items.len() == 2
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::RecordGet { record_name, .. }
+                if record_name == "DecisionContext"
+        )));
+    }
+
+    #[test]
     fn lower_record_destructuring_bind_to_record_get_ir() {
         let src = r#"
             record DecisionContext {

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -48,6 +48,7 @@ Current v0 record declaration semantics:
 - stage-1 field access lowers through deterministic declaration-slot reads
 - stage-2 immutable record update uses `record_value with { field: expr, ... }`
 - copy-with preserves the nominal record identity of its base value
+- record field shorthand is sugar only: `RecordName { field }` means `RecordName { field: field }`, `value with { field }` means `value with { field: field }`, and `let RecordName { field } = value;` means `let RecordName { field: field } = value;`
 - explicit record destructuring bind uses `let RecordName { field: target, ... } = value;`
 - explicit record destructuring bind currently projects only the named subset of declaration fields
 - `_` targets in explicit record destructuring bind discard the projected field value without creating a source binding
@@ -417,15 +418,16 @@ Current v0 limit:
 - record field access is read-only and resolves by canonical declaration-slot order
 - record copy-with is immutable and rebuilds a value of the same nominal record type
 - unchanged record fields in copy-with are read from the base value through canonical declaration-slot access
-- record destructuring bind currently supports only statement-level explicit
-  `RecordName { field: target }` patterns
+- record destructuring bind currently supports only statement-level nominal
+  `RecordName { ... }` patterns
 - record `let-else` currently supports only statement-level explicit field
   mappings with `else return`
 - record `let-else` currently allows refutable matching only through explicit
   `quad` literal field targets
-- record copy-with currently requires explicit field mappings and does not open
-  punning or mutation semantics
-- record destructuring bind does not yet open nested patterns or punning
+- record punning remains sugar over the canonical nominal record forms and does
+  not introduce a separate runtime path
+- anonymous brace-only record forms and nested record patterns remain out of
+  scope
 - record equality remains gated to the stable field-equality subset
 - record values are not part of the PROMETHEUS host ABI surface
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -98,9 +98,10 @@ Current v0 record limits:
 - lowering preserves declaration-slot order rather than source-field order
 - record types may now appear in executable local bindings, parameters, and returns
 - record destructuring and record copy-with now participate in the stable source contract
+- record punning now participates in the stable source contract only as field shorthand inside canonical nominal record forms
 - record equality is allowed only when every field type already supports stable equality
 - record values are not part of the PROMETHEUS host ABI surface
-- record destructuring, record punning, mutation, methods, and inheritance are not part of this slice
+- anonymous brace-only record literals/patterns, mutation, methods, and inheritance are not part of this slice
 
 ## Statements
 
@@ -146,11 +147,10 @@ Current statement rules:
 - `let _ = expr;` is the current discard-bind surface
 - tuple destructuring bind is currently flat only and accepts only names or `_`
 - record destructuring bind is currently statement-level only
-- record destructuring bind currently requires explicit `RecordName { field: target }` spelling
+- record destructuring bind uses `RecordName { field: target }` and now also allows field shorthand `RecordName { field }`
 - record destructuring bind currently supports only named targets or `_`
-- record destructuring bind currently supports only explicit field mappings, not punning shorthand
 - record `let-else` is currently statement-level only
-- record `let-else` currently requires explicit `RecordName { field: target } = expr else return ...;` spelling
+- record `let-else` uses `RecordName { field: target } = expr else return ...;` and also allows shorthand bind items `RecordName { field }`
 - record `let-else` currently allows refutable items only through explicit `quad` literals `N/F/T/S`
 - plain record destructuring bind does not currently accept quad-literal field targets
 - tuple `let-else` currently requires tuple destructuring target and `else return`
@@ -217,6 +217,11 @@ Current expression forms:
 - record copy-with:
   - `ctx with { quality: 1.0 }`
   - `ctx with { camera: F, quality: 0.25 }`
+  - `ctx with { quality }`
+- record punning shorthand:
+  - `DecisionContext { camera, quality }`
+  - `let DecisionContext { camera, quality: _ } = ctx;`
+  - `let DecisionContext { camera: T, quality } = ctx else return;`
 - tuple types:
   - `(i32, bool)`
   - `(f64, quad, bool)`


### PR DESCRIPTION
## Summary
- add record field shorthand sugar inside canonical nominal record forms
- support punning in record literals, copy-with, destructuring bind, and record let-else
- keep the feature as parser-level sugar only with no separate runtime path

## Validation
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test --workspace