### PR TITLE
REC2-05 stage-2 record ergonomics freeze and scenario validation

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -981,6 +981,35 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_stage2_ergonomics_scenario() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                override_state: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let camera: quad = T;
+                let override_state: quad = N;
+                let quality: f64 = 0.75;
+                let ctx: DecisionContext = DecisionContext { camera, override_state, quality };
+                let DecisionContext { camera, quality: _ } = ctx;
+                let patched: DecisionContext = ctx with { camera };
+                let DecisionContext { camera: T, override_state, quality } =
+                    patched else return;
+                assert(camera == T);
+                assert(override_state == N);
+                assert(quality == 0.75);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1802,6 +1802,37 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_record_stage2_ergonomics_scenario() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                override_state: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let camera: quad = T;
+                let override_state: quad = N;
+                let quality: f64 = 0.75;
+                let ctx: DecisionContext = DecisionContext { camera, override_state, quality };
+                let DecisionContext { camera, quality: _ } = ctx;
+                let patched: DecisionContext = ctx with { camera };
+                let DecisionContext { camera: T, override_state, quality } =
+                    patched else return;
+                assert(camera == T);
+                assert(override_state == N);
+                assert(quality == 0.75);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disassemble");
+        assert!(disasm.contains("RECORD_GET"));
+        assert!(disasm.contains("MAKE_RECORD"));
+        run_semcode(&bytes).expect("record stage-2 ergonomics scenario should run");
+    }
+
+    #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
             fn main() {

--- a/docs/roadmap/language_maturity/record_data_model.md
+++ b/docs/roadmap/language_maturity/record_data_model.md
@@ -1,13 +1,13 @@
 # Record Data Model
 
-Status: implemented stage-1 v0
+Status: implemented stage-2 v0
 
 ## Purpose
 
 This document defines the first stabilized aggregate family currently available
 in the Semantic executable language surface: nominal records.
 
-It is no longer only a design target. It records the narrow stage-1 contract
+It is no longer only a design target. It records the narrow stage-2 contract
 that now exists across parser, sema, IR, verifier, and VM.
 
 ## Why Records First
@@ -20,7 +20,7 @@ Records are the right first aggregate family because they:
 - do not require hidden dynamic dispatch
 - compose naturally with existing `quad` and numeric values
 
-## Canonical Stage-1 Surface
+## Canonical Stage-2 Surface
 
 The proposed source form is a nominal `record` declaration:
 
@@ -51,6 +51,16 @@ ctx.camera
 ctx.quality
 ```
 
+Stage-2 ergonomics are now available as sugar over the same nominal slot-based
+carrier:
+
+```sm
+let ctx = DecisionContext { camera, badge, quality, override_state };
+let next = ctx with { quality };
+let DecisionContext { camera, quality: _ } = ctx;
+let DecisionContext { camera: T, quality } = next else return;
+```
+
 ## Type Identity
 
 Current rules:
@@ -63,12 +73,13 @@ Current rules:
 
 ## Value Semantics
 
-Current stage-1 rules:
+Current stage-2 rules:
 
 - record values are immutable after construction
 - record construction requires every declared field exactly once
 - no implicit default field values
-- no field mutation syntax in the first stage
+- copy-with rebuilds a value of the same nominal record type
+- no field mutation syntax exists in the stable surface
 - passing a record to a function passes one nominal logical value through the
   verified execution path
 
@@ -85,41 +96,22 @@ Current rules:
 
 ## Pattern And Match Scope
 
-Records do not yet reopen a full pattern system.
+Records still do not reopen a full pattern system.
 
-Current stage-1 rule:
+Current stage-2 rule:
 
-- record destructuring and record-pattern matching are out of scope
-- users access fields explicitly rather than through destructuring syntax
-
-This keeps the first aggregate family coherent without forcing a broad match
-expansion in the same change wave.
-
-## Record Punning Gate
-
-`record punning` is intentionally not part of the first canonical record layer.
-
-For the `Density-20 Plus` backlog this means `D20P-D01` stays blocked until all
-of the following are true:
-
-- nominal `record` declarations are part of the executable source contract
-- record construction with explicit field names is implemented end-to-end
-- explicit field access lowers through a stable deterministic slot model
-- the repository has a separate decision reopening record destructuring syntax
-
-Until then, forms such as:
-
-```sm
-Point { x, y }
-let { x, y } = point;
-```
-
-must remain out of scope. The first record wave should keep field names explicit
-and should not reopen pattern/destructuring ergonomics by accident.
+- statement-level record destructuring is supported through nominal
+  `RecordName { field: target }`
+- record `let-else` is supported through nominal
+  `RecordName { field: target } = value else return ...;`
+- record punning is sugar only inside canonical nominal record forms
+- record-pattern matching in `match` arms remains out of scope
+- anonymous brace-only record forms such as `let { x, y } = value;` remain out
+  of scope
 
 ## Lowering Strategy
 
-The current stage-1 record implementation preserves the deterministic VM story.
+The current stage-2 record implementation preserves the deterministic VM story.
 
 Current strategy:
 
@@ -133,13 +125,13 @@ like a dynamic object.
 
 ## IR Implications
 
-The stage-1 implementation keeps the IR change set narrow.
+The stage-2 implementation keeps the IR change set narrow.
 
 Current direction:
 
 - explicit record-type metadata exists in the frontend and sema layers
-- record construction lowers through canonical `MakeRecord`
-- field access lowers through deterministic `RecordGet`
+- record construction and copy-with lower through canonical `MakeRecord`
+- field access and destructuring lower through deterministic `RecordGet`
 - generic dictionary-like runtime operations remain out of scope
 
 The contract goal remains explicit: records lower to predictable slots, not
@@ -147,7 +139,7 @@ opaque runtime blobs.
 
 ## VM And Verifier Implications
 
-Stage-1 records do not abandon the verified execution model.
+Stage-2 records do not abandon the verified execution model.
 
 Current rules:
 
@@ -187,13 +179,15 @@ This phase does not attempt to provide:
 - mutable structs
 - inheritance
 - methods or dynamic dispatch
-- record destructuring patterns
+- record pattern matching in `match`
+- anonymous brace-only record forms
+- nested record patterns
 - record-specific generics
 - heap allocation semantics as a user-visible contract
 
 ## Example Workloads
 
-The record family already supports stage-1 scenarios such as:
+The record family already supports stage-2 scenarios such as:
 
 - access-policy contexts
 - structured sensor snapshots
@@ -205,11 +199,11 @@ while staying within the current verified-path contract.
 
 ## Acceptance Criteria
 
-The Stage-1 record family should be considered properly frozen for v0 when the
+The Stage-2 record family should be considered properly frozen for v0 when the
 repository has:
 
 - a stable canonical source form
-- explicit construction and access rules
+- explicit construction, access, destructuring, copy-with, and punning-shorthand rules
 - explicit equality and non-goals
 - a documented deterministic lowering direction
 - examples showing why records are better than scalar-only decomposition

--- a/docs/roadmap/language_maturity/record_scenarios.md
+++ b/docs/roadmap/language_maturity/record_scenarios.md
@@ -1,19 +1,21 @@
 # Record Scenarios
 
-Status: validated against stage-1 v0
+Status: validated against stage-2 v0
 
 ## Purpose
 
 This document gives concrete user-data scenarios that justify records as the
 first aggregate family for Semantic and tracks which parts are already covered
-by the current stage-1 implementation.
+by the current stage-2 implementation.
 
 The goal is to show real workloads that are awkward in the current scalar-only
 surface and become clearer with nominal records.
 
-These examples are no longer only design targets. The stage-1 contract now
+These examples are no longer only design targets. The stage-2 contract now
 supports nominal record declarations, construction, field access, pass/return,
-and equality inside the stable field-equality subset.
+equality inside the stable field-equality subset, statement-level record
+destructuring, narrow record `let-else`, immutable copy-with, and punning
+shorthand inside canonical nominal record forms.
 
 ## Why Scenarios Matter
 
@@ -73,7 +75,7 @@ Why this matters:
 - field names remain explicit
 - `quad`-oriented semantics stay first-class inside the aggregate
 
-Stage-1 validation status:
+Stage-2 validation status:
 
 - compiles through the verified path
 - runs through the VM with explicit field access and ordinary control flow
@@ -112,7 +114,7 @@ Why this matters:
 - helper functions can accept one meaningful argument
 - later field additions do not explode parameter lists immediately
 
-Stage-1 validation status:
+Stage-2 validation status:
 
 - compiles through the verified path
 - field access resolves deterministically by declaration-slot order
@@ -148,7 +150,7 @@ Why this matters:
 - grouped policy inputs read like one contract
 - the code documents intent without relying on naming conventions alone
 
-Stage-1 validation status:
+Stage-2 validation status:
 
 - supported as a nominal input object
 - compatible with pass/return through the verified execution path
@@ -178,6 +180,49 @@ Current limit:
 
 - record values are still not part of the PROMETHEUS host ABI surface
 - config bundles may participate in verified-local execution, not host calls
+
+## Scenario 5: Ergonomic Patch And Unpack Flow
+
+The second honest record wave is not about a new carrier. It is about making
+the already-canonical carrier easier to work with without opening mutation or a
+general pattern language.
+
+```sm
+record DecisionContext {
+    camera: quad,
+    override_state: quad,
+    quality: f64,
+}
+
+fn main() {
+    let camera: quad = T;
+    let override_state: quad = N;
+    let quality: f64 = 0.75;
+
+    let ctx: DecisionContext = DecisionContext { camera, override_state, quality };
+    let DecisionContext { camera, quality: _ } = ctx;
+    let patched: DecisionContext = ctx with { camera };
+    let DecisionContext { camera: T, override_state, quality } = patched else return;
+
+    assert(camera == T);
+    assert(override_state == N);
+    assert(quality == 0.75);
+    return;
+}
+```
+
+Why this matters:
+
+- construction, unpacking, and update stay nominal and deterministic
+- punning reduces boilerplate without introducing a new runtime path
+- copy-with remains immutable and explicit
+- let-else keeps early-exit ergonomics local without reopening general match
+
+Stage-2 validation status:
+
+- compiles through the verified path
+- runs through the VM using the existing `RecordGet` and `MakeRecord` paths
+- keeps anonymous brace-only forms and mutation out of scope
 
 ## Comparison With Logos Entities
 
@@ -212,11 +257,12 @@ and instead pass one explicit domain value with named fields.
 
 ## Explicit Non-Goals Still In Force
 
-The current stage-1 implementation still does not include:
+The current stage-2 implementation still does not include:
 
-- record destructuring
-- record update / copy-with
-- record punning
+- anonymous brace-only record forms
+- record pattern matching in `match`
+- nested record patterns
+- mutation
 - methods, inheritance, or dynamic dispatch
 - host ABI passage for record values
 

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -36,9 +36,3 @@ Related staged design-target notes:
 - `docs/roadmap/language_maturity/record_data_model.md`
 - `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`
-
-Current gated follow-up:
-
-- `D20P-D01 record punning` remains blocked until the canonical record data
-  model is implemented and record destructuring is intentionally reopened as a
-  later contract slice.


### PR DESCRIPTION
## Summary
- update record roadmap docs from stage-1 design-target wording to implemented stage-2 ergonomics reality
- validate one explicit stage-2 record ergonomics scenario through verifier and VM
- keep mutation, methods, inheritance, anonymous brace-only forms, and host ABI widening explicit non-goals

## Validation
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test --workspace