### PR TITLE
V02-08 function requires contract surface

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -295,6 +295,7 @@ fn tokenize_line(
                 let text = &line_text[start..i];
                 let kind = match text {
                     "fn" => TokenKind::KwFn,
+                    "requires" => TokenKind::KwRequires,
                     "record" => TokenKind::KwRecord,
                     "const" => TokenKind::KwConst,
                     "let" => TokenKind::KwLet,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -124,6 +124,7 @@ impl<'a> Parser<'a> {
         } else {
             Type::Unit
         };
+        let requires = self.parse_requires_clauses()?;
         let body = if self.eat(TokenKind::Assign) {
             let expr = self.parse_expr()?;
             self.expect(
@@ -138,9 +139,21 @@ impl<'a> Parser<'a> {
             name,
             params,
             param_defaults,
+            requires,
             ret,
             body,
         })
+    }
+
+    fn parse_requires_clauses(&mut self) -> Result<Vec<ExprId>, FrontendError> {
+        let mut requires = Vec::new();
+        while self.eat(TokenKind::KwRequires) {
+            self.expect(TokenKind::LParen, "expected '(' after 'requires'")?;
+            let condition = self.parse_expr()?;
+            self.expect(TokenKind::RParen, "expected ')' after requires condition")?;
+            requires.push(condition);
+        }
+        Ok(requires)
     }
 
     fn parse_record_decl(&mut self) -> Result<RecordDecl, FrontendError> {
@@ -2117,7 +2130,7 @@ fn main() { let x: quad = idq(T); return; }
         let src = r#"
 fn idq(q: quad) -> quad = q;
 fn main() { return; }
-"#;
+        "#;
 
         let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect("expression-bodied function should parse");
@@ -2126,6 +2139,49 @@ fn main() { return; }
             panic!("expected desugared return statement");
         };
         assert!(matches!(program.arena.expr(*value), Expr::Var(_)));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_function_requires_clause() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn decide(ctx: DecisionContext) -> quad requires(ctx.camera == T) {
+    return ctx.camera;
+}
+
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let decide = &program.functions[0];
+        assert_eq!(program.arena.symbol_name(decide.name), "decide");
+        assert_eq!(decide.requires.len(), 1);
+        assert!(matches!(
+            program.arena.expr(decide.requires[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_expression_bodied_function_with_requires_clause() {
+        let src = r#"
+fn idq(q: quad) -> quad requires(q == T) = q;
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let idq = &program.functions[0];
+        assert_eq!(idq.requires.len(), 1);
+        assert!(matches!(
+            program.arena.expr(idq.requires[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -160,6 +160,7 @@ fn type_check_function_with_record_table(
             )?;
         }
     }
+    check_requires_clauses(func, arena, table, record_table)?;
     let mut env = ScopeEnv::with_params(&func.params);
     let mut loop_stack = Vec::new();
     for stmt in &func.body {
@@ -172,6 +173,38 @@ fn type_check_function_with_record_table(
             record_table,
             &mut loop_stack,
         )?;
+    }
+    Ok(())
+}
+
+fn check_requires_clauses(
+    func: &Function,
+    arena: &AstArena,
+    table: &FnTable,
+    record_table: &RecordTable,
+) -> Result<(), FrontendError> {
+    let env = ScopeEnv::with_params(&func.params);
+    let mut loop_stack = Vec::new();
+    for condition in &func.requires {
+        ensure_requires_expr_supported(*condition, arena)?;
+        let condition_ty = infer_expr_type(
+            *condition,
+            arena,
+            &env,
+            table,
+            record_table,
+            func.ret.clone(),
+            &mut loop_stack,
+        )?;
+        if condition_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "requires clause condition must be bool, got {:?}",
+                    condition_ty
+                ),
+            });
+        }
     }
     Ok(())
 }
@@ -2015,6 +2048,65 @@ mod tests {
     }
 
     #[test]
+    fn function_requires_clause_typechecks_with_param_and_record_field_reads() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext, expected: quad) -> quad
+                requires(ctx.camera == expected)
+                requires(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx, T);
+                assert(seen == T);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("requires clauses should typecheck");
+    }
+
+    #[test]
+    fn function_requires_clause_requires_bool_condition() {
+        let src = r#"
+            fn choose(count: i32) -> i32 requires(count) {
+                return count;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("requires clause must require bool");
+        assert!(err
+            .message
+            .contains("requires clause condition must be bool"));
+    }
+
+    #[test]
+    fn function_requires_clause_rejects_call_surface() {
+        let src = r#"
+            fn check(flag: bool) -> bool = flag;
+
+            fn choose(flag: bool) -> bool requires(check(flag)) {
+                return flag;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("requires clause should reject call surface");
+        assert!(err
+            .message
+            .contains("requires clause currently allows only parameter references"));
+    }
+
+    #[test]
     fn tuple_literals_and_tuple_types_typecheck_through_call_and_return_paths() {
         let src = r#"
             fn pair(flag: bool) -> (i32, bool) {
@@ -3450,6 +3542,31 @@ fn supports_stable_equality_type(
 ) -> Result<bool, FrontendError> {
     let mut active = BTreeSet::new();
     supports_stable_equality_type_inner(ty, record_table, &mut active)
+}
+
+fn ensure_requires_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::QuadLiteral(_)
+        | Expr::BoolLiteral(_)
+        | Expr::NumericLiteral(_)
+        | Expr::Var(_) => Ok(()),
+        Expr::Tuple(items) => {
+            for item in items {
+                ensure_requires_expr_supported(*item, arena)?;
+            }
+            Ok(())
+        }
+        Expr::RecordField(field_expr) => ensure_requires_expr_supported(field_expr.base, arena),
+        Expr::Unary(_, inner) => ensure_requires_expr_supported(*inner, arena),
+        Expr::Binary(lhs, _, rhs) => {
+            ensure_requires_expr_supported(*lhs, arena)?;
+            ensure_requires_expr_supported(*rhs, arena)
+        }
+        _ => Err(FrontendError {
+            pos: 0,
+            message: "requires clause currently allows only parameter references, tuple literals, record field reads, and pure unary/binary operator expressions".to_string(),
+        }),
+    }
 }
 
 fn supports_stable_equality_type_inner(

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -246,6 +246,7 @@ pub struct Function {
     pub name: SymbolId,
     pub params: Vec<(SymbolId, Type)>,
     pub param_defaults: Vec<Option<ExprId>>,
+    pub requires: Vec<ExprId>,
     pub ret: Type,
     pub body: Vec<StmtId>,
 }
@@ -325,6 +326,7 @@ pub struct Token {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     KwFn,
+    KwRequires,
     KwRecord,
     KwConst,
     KwLet,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -336,6 +336,29 @@ fn lower_function_to_ir_with_record_table(
             src: idx as u16,
         });
     }
+    for condition in &func.requires {
+        let (cond_reg, cond_ty) = lower_expr(
+            *condition,
+            arena,
+            &mut ctx.next_reg,
+            &mut ctx.instrs,
+            &env,
+            &mut ctx.loop_stack,
+            fn_table,
+            record_table,
+            func.ret.clone(),
+        )?;
+        if cond_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "requires clause condition must be bool in lowering, got {:?}",
+                    cond_ty
+                ),
+            });
+        }
+        ctx.instrs.push(IrInstr::Assert { cond: cond_reg });
+    }
     for stmt in &func.body {
         lower_stmt(
             *stmt,
@@ -4407,6 +4430,52 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::Assert { .. })));
+    }
+
+    #[test]
+    fn lower_function_requires_clause_to_entry_asserts() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext, expected: quad) -> quad
+                requires(ctx.camera == expected)
+                requires(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx, T);
+                assert(seen == T);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("requires clause should lower");
+        let decide = ir
+            .iter()
+            .find(|func| func.name == "decide")
+            .expect("decide fn");
+        let first_assert = decide
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::Assert { .. }))
+            .expect("requires clause should lower to assert");
+        let param_store = decide
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "ctx"))
+            .expect("parameter store should exist");
+        assert!(param_store < first_assert);
+        let assert_count = decide
+            .instrs
+            .iter()
+            .filter(|instr| matches!(instr, IrInstr::Assert { .. }))
+            .count();
+        assert_eq!(assert_count, 2);
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1514,6 +1514,48 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_function_requires_clause_when_condition_holds() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext, expected: quad) -> quad
+                requires(ctx.camera == expected)
+                requires(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx, T);
+                assert(seen == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        run_semcode(&bytes).expect("requires clause should pass");
+    }
+
+    #[test]
+    fn vm_traps_on_failed_function_requires_clause() {
+        let src = r#"
+            fn must_be_true(flag: bool) -> bool requires(flag == true) {
+                return flag;
+            }
+
+            fn main() {
+                let seen: bool = must_be_true(false);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let err = run_semcode(&bytes).expect_err("requires clause should trap");
+        assert!(matches!(err, RuntimeError::Trap(RuntimeTrap::AssertionFailed)));
+    }
+
+    #[test]
     fn vm_runs_bool_ops() {
         let src = r#"
 			fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -101,6 +101,8 @@ Current message families include:
 - required parameter after default parameter
 - non-const-safe default parameter initializer
 - default parameter type mismatch
+- non-bool `requires` condition
+- unsupported expression form inside `requires`
 - let-binding type mismatch
 - discard-binding type mismatch
 - non-const-safe initializer in const declaration

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -31,6 +31,9 @@ Current rules:
 - there is no dynamic entrypoint discovery or module-level executable code
 - `fn name(...) -> ret = expr;` is semantically equivalent to a body containing
   only `return expr;`
+- function-level `requires(condition)` clauses execute at callee entry after
+  parameter binding and before ordinary body statements
+- multiple `requires(condition)` clauses evaluate in source order
 
 Current v0 record declaration semantics:
 
@@ -122,6 +125,20 @@ Current default-parameter semantics:
   lowering
 - default initializers must remain within the current const-safe expression
   subset and may not depend on function parameters or local runtime bindings
+
+Current first-wave function-contract semantics:
+
+- `requires(condition)` is currently the only declaration-level contract clause
+  in the stable source surface
+- each `requires` condition is type-checked in a parameter-only environment
+- the current stable subset allows only parameter references, tuple literals,
+  record field reads, and pure unary/binary operator expressions
+- function calls, record construction, record copy-with, range literals,
+  blocks, and control-flow expressions are not yet part of the stable
+  `requires` subset
+- lowering translates each `requires` clause to an explicit core assertion at
+  function entry
+- this slice does not yet claim `ensures(...)` or `invariant(...)`
 
 Current v0 limits:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -69,6 +69,14 @@ fn name(arg: type, optional_arg: type = expr) -> ret_type {
 }
 ```
 
+First-wave declaration contracts are also part of the current surface:
+
+```sm
+fn name(arg: type, ...) -> ret_type requires(condition) {
+    ...
+}
+```
+
 Expression-bodied sugar is also part of the current v0 surface:
 
 ```sm
@@ -84,6 +92,8 @@ Current rules:
 - `fn` introduces a function
 - parameters are named and typed explicitly
 - trailing parameters may attach a default initializer with `= expr`
+- zero or more `requires(condition)` clauses may appear after the signature and
+  before the function body
 - the return type is optional; omitted return type means `unit`
 - function bodies are block-delimited with `{ ... }`
 - `fn ... = expr;` is accepted as shorthand for a single returned expression
@@ -161,6 +171,7 @@ Current statement rules:
 - `for ... in range` currently accepts only `i32` range expressions
 - `guard` currently supports only the `else return` form
 - `assert(condition);` is a statement-level builtin contract form
+- `requires(condition)` is currently a function-level contract clause only
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`
 - `match` requires an explicit default arm `_ => { ... }`
@@ -320,6 +331,18 @@ Current named-argument rules:
 - named arguments reorder to the declared parameter order before ordinary
   type-checking and lowering
 - named arguments are not yet part of the builtin-call surface
+
+Current first-wave `requires` rules:
+
+- `requires(condition)` currently attaches only to ordinary user-defined
+  function declarations
+- `requires(condition)` may appear on block-bodied and expression-bodied
+  functions
+- each `condition` must be `bool`
+- the current stable subset allows only parameter references, tuple literals,
+  record field reads, and pure unary/binary operator expressions
+- call expressions, block/control-flow expressions, range literals, record
+  construction, and record copy-with are not part of this slice
 
 Current UFCS / method-call rules:
 


### PR DESCRIPTION
## Summary
- add the first `V02-08` function-contract slice as declaration-level `requires(condition)` clauses
- validate a narrow supported expression subset in sema and require `bool` conditions
- lower `requires` clauses to explicit entry-path `Assert` instructions and sync docs/tests

## Scope
This PR intentionally implements only the first `requires-only` slice for `#119`.

Included:
- ordinary user-defined functions
- block-bodied and expression-bodied functions
- parser, sema, lowering, VM, docs, and tests

Not included:
- `ensures`
- `invariant`
- calls in contract expressions
- default-parameter semantics rework
- host or `prom-*` widening

## Validation
- `cargo test -p sm-front`
- `cargo test -p sm-ir`
- `cargo test -p sm-vm`
- `cargo test --workspace`

Closes part of #119.