### PR TITLE
V02-08 function ensures contract surface

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -296,6 +296,7 @@ fn tokenize_line(
                 let kind = match text {
                     "fn" => TokenKind::KwFn,
                     "requires" => TokenKind::KwRequires,
+                    "ensures" => TokenKind::KwEnsures,
                     "record" => TokenKind::KwRecord,
                     "const" => TokenKind::KwConst,
                     "let" => TokenKind::KwLet,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -124,7 +124,7 @@ impl<'a> Parser<'a> {
         } else {
             Type::Unit
         };
-        let requires = self.parse_requires_clauses()?;
+        let (requires, ensures) = self.parse_contract_clauses()?;
         let body = if self.eat(TokenKind::Assign) {
             let expr = self.parse_expr()?;
             self.expect(
@@ -140,12 +140,13 @@ impl<'a> Parser<'a> {
             params,
             param_defaults,
             requires,
+            ensures,
             ret,
             body,
         })
     }
 
-    fn parse_requires_clauses(&mut self) -> Result<Vec<ExprId>, FrontendError> {
+    fn parse_contract_clauses(&mut self) -> Result<(Vec<ExprId>, Vec<ExprId>), FrontendError> {
         let mut requires = Vec::new();
         while self.eat(TokenKind::KwRequires) {
             self.expect(TokenKind::LParen, "expected '(' after 'requires'")?;
@@ -153,7 +154,14 @@ impl<'a> Parser<'a> {
             self.expect(TokenKind::RParen, "expected ')' after requires condition")?;
             requires.push(condition);
         }
-        Ok(requires)
+        let mut ensures = Vec::new();
+        while self.eat(TokenKind::KwEnsures) {
+            self.expect(TokenKind::LParen, "expected '(' after 'ensures'")?;
+            let condition = self.parse_expr()?;
+            self.expect(TokenKind::RParen, "expected ')' after ensures condition")?;
+            ensures.push(condition);
+        }
+        Ok((requires, ensures))
     }
 
     fn parse_record_decl(&mut self) -> Result<RecordDecl, FrontendError> {
@@ -2180,6 +2188,49 @@ fn main() { return; }
         assert_eq!(idq.requires.len(), 1);
         assert!(matches!(
             program.arena.expr(idq.requires[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_function_ensures_clause() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn decide(ctx: DecisionContext) -> quad ensures(result == ctx.camera) {
+    return ctx.camera;
+}
+
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let decide = &program.functions[0];
+        assert_eq!(program.arena.symbol_name(decide.name), "decide");
+        assert_eq!(decide.ensures.len(), 1);
+        assert!(matches!(
+            program.arena.expr(decide.ensures[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_expression_bodied_function_with_ensures_clause() {
+        let src = r#"
+fn idq(q: quad) -> quad ensures(result == q) = q;
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let idq = &program.functions[0];
+        assert_eq!(idq.ensures.len(), 1);
+        assert!(matches!(
+            program.arena.expr(idq.ensures[0]),
             Expr::Binary(_, BinaryOp::Eq, _)
         ));
     }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -161,6 +161,7 @@ fn type_check_function_with_record_table(
         }
     }
     check_requires_clauses(func, arena, table, record_table)?;
+    check_ensures_clauses(func, arena, table, record_table)?;
     let mut env = ScopeEnv::with_params(&func.params);
     let mut loop_stack = Vec::new();
     for stmt in &func.body {
@@ -201,6 +202,55 @@ fn check_requires_clauses(
                 pos: 0,
                 message: format!(
                     "requires clause condition must be bool, got {:?}",
+                    condition_ty
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_ensures_clauses(
+    func: &Function,
+    arena: &AstArena,
+    table: &FnTable,
+    record_table: &RecordTable,
+) -> Result<(), FrontendError> {
+    if func.ensures.is_empty() {
+        return Ok(());
+    }
+    for (name, _) in &func.params {
+        if resolve_symbol_name(arena, *name)? == "result" {
+            return Err(FrontendError {
+                pos: 0,
+                message: "parameter name 'result' is reserved while ensures clauses are present"
+                    .to_string(),
+            });
+        }
+    }
+    let mut env = ScopeEnv::with_params(&func.params);
+    if func.ret != Type::Unit {
+        if let Some(result_symbol) = arena.symbol_to_id.get("result").copied() {
+            env.insert_const(result_symbol, func.ret.clone());
+        }
+    }
+    let mut loop_stack = Vec::new();
+    for condition in &func.ensures {
+        ensure_ensures_expr_supported(*condition, arena)?;
+        let condition_ty = infer_expr_type(
+            *condition,
+            arena,
+            &env,
+            table,
+            record_table,
+            func.ret.clone(),
+            &mut loop_stack,
+        )?;
+        if condition_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "ensures clause condition must be bool, got {:?}",
                     condition_ty
                 ),
             });
@@ -2107,6 +2157,82 @@ mod tests {
     }
 
     #[test]
+    fn function_ensures_clause_typechecks_with_result_and_record_field_reads() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext) -> quad
+                ensures(result == ctx.camera)
+                ensures(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx);
+                assert(seen == T);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("ensures clauses should typecheck");
+    }
+
+    #[test]
+    fn function_ensures_clause_requires_bool_condition() {
+        let src = r#"
+            fn id(count: i32) -> i32 ensures(result) {
+                return count;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("ensures clause must require bool");
+        assert!(err
+            .message
+            .contains("ensures clause condition must be bool"));
+    }
+
+    #[test]
+    fn function_ensures_clause_rejects_call_surface() {
+        let src = r#"
+            fn check(flag: bool) -> bool = flag;
+
+            fn choose(flag: bool) -> bool ensures(check(result)) {
+                return flag;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("ensures clause should reject call surface");
+        assert!(err
+            .message
+            .contains("ensures clause currently allows only parameter references, optional result binding"));
+    }
+
+    #[test]
+    fn function_ensures_clause_reserves_result_parameter_name() {
+        let src = r#"
+            fn echo(result: bool) -> bool ensures(result == true) {
+                return result;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("ensures clause must reserve synthetic result name");
+        assert!(err
+            .message
+            .contains("parameter name 'result' is reserved while ensures clauses are present"));
+    }
+
+    #[test]
     fn tuple_literals_and_tuple_types_typecheck_through_call_and_return_paths() {
         let src = r#"
             fn pair(flag: bool) -> (i32, bool) {
@@ -3545,6 +3671,29 @@ fn supports_stable_equality_type(
 }
 
 fn ensure_requires_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
+    ensure_contract_expr_supported(
+        expr_id,
+        arena,
+        "requires",
+        "parameter references",
+    )
+}
+
+fn ensure_ensures_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
+    ensure_contract_expr_supported(
+        expr_id,
+        arena,
+        "ensures",
+        "parameter references, optional result binding",
+    )
+}
+
+fn ensure_contract_expr_supported(
+    expr_id: ExprId,
+    arena: &AstArena,
+    clause_name: &str,
+    binding_desc: &str,
+) -> Result<(), FrontendError> {
     match arena.expr(expr_id) {
         Expr::QuadLiteral(_)
         | Expr::BoolLiteral(_)
@@ -3552,19 +3701,25 @@ fn ensure_requires_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(
         | Expr::Var(_) => Ok(()),
         Expr::Tuple(items) => {
             for item in items {
-                ensure_requires_expr_supported(*item, arena)?;
+                ensure_contract_expr_supported(*item, arena, clause_name, binding_desc)?;
             }
             Ok(())
         }
-        Expr::RecordField(field_expr) => ensure_requires_expr_supported(field_expr.base, arena),
-        Expr::Unary(_, inner) => ensure_requires_expr_supported(*inner, arena),
+        Expr::RecordField(field_expr) => {
+            ensure_contract_expr_supported(field_expr.base, arena, clause_name, binding_desc)
+        }
+        Expr::Unary(_, inner) => {
+            ensure_contract_expr_supported(*inner, arena, clause_name, binding_desc)
+        }
         Expr::Binary(lhs, _, rhs) => {
-            ensure_requires_expr_supported(*lhs, arena)?;
-            ensure_requires_expr_supported(*rhs, arena)
+            ensure_contract_expr_supported(*lhs, arena, clause_name, binding_desc)?;
+            ensure_contract_expr_supported(*rhs, arena, clause_name, binding_desc)
         }
         _ => Err(FrontendError {
             pos: 0,
-            message: "requires clause currently allows only parameter references, tuple literals, record field reads, and pure unary/binary operator expressions".to_string(),
+            message: format!(
+                "{clause_name} clause currently allows only {binding_desc}, tuple literals, record field reads, and pure unary/binary operator expressions"
+            ),
         }),
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -247,6 +247,7 @@ pub struct Function {
     pub params: Vec<(SymbolId, Type)>,
     pub param_defaults: Vec<Option<ExprId>>,
     pub requires: Vec<ExprId>,
+    pub ensures: Vec<ExprId>,
     pub ret: Type,
     pub body: Vec<StmtId>,
 }
@@ -327,6 +328,7 @@ pub struct Token {
 pub enum TokenKind {
     KwFn,
     KwRequires,
+    KwEnsures,
     KwRecord,
     KwConst,
     KwLet,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -324,7 +324,8 @@ fn lower_function_to_ir_with_record_table(
     fn_table: &FnTable,
     record_table: &RecordTable,
 ) -> Result<IrFunction, FrontendError> {
-    let mut ctx = LoweringCtx::new();
+    let ensures_result_symbol = find_contract_result_symbol(&func.ensures, arena)?;
+    let mut ctx = LoweringCtx::new(func.ensures.clone(), ensures_result_symbol);
     let mut env = ScopeEnv::with_params(&func.params);
     ctx.next_reg = u16::try_from(func.params.len()).map_err(|_| FrontendError {
         pos: 0,
@@ -373,6 +374,19 @@ fn lower_function_to_ir_with_record_table(
 
     if !ctx.ends_with_ret() {
         if func.ret == Type::Unit {
+            lower_ensures_clauses(
+                &ctx.ensures,
+                ctx.ensures_result_symbol,
+                None,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                &env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                func.ret.clone(),
+            )?;
             ctx.instrs.push(IrInstr::Ret { src: None });
         } else {
             return Err(FrontendError {
@@ -2021,6 +2035,8 @@ fn bind_let_else_record_items(
     record_reg: u16,
     record_ty: &Type,
     else_return: Option<ExprId>,
+    contract_ensures: &[ExprId],
+    contract_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -2109,6 +2125,8 @@ fn bind_let_else_record_items(
                 });
                 lower_return_payload(
                     else_return,
+                    contract_ensures,
+                    contract_result_symbol,
                     arena,
                     next,
                     out,
@@ -2395,6 +2413,8 @@ fn bind_let_else_tuple_items(
     tuple_reg: u16,
     tuple_ty: &Type,
     else_return: Option<ExprId>,
+    contract_ensures: &[ExprId],
+    contract_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -2466,6 +2486,8 @@ fn bind_let_else_tuple_items(
                 });
                 lower_return_payload(
                     else_return,
+                    contract_ensures,
+                    contract_result_symbol,
                     arena,
                     next,
                     out,
@@ -2622,6 +2644,8 @@ fn lower_stmt(
                 record_reg,
                 &record_ty,
                 *else_return,
+                &ctx.ensures,
+                ctx.ensures_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2656,6 +2680,8 @@ fn lower_stmt(
                 tuple_reg,
                 &final_ty,
                 *else_return,
+                &ctx.ensures,
+                ctx.ensures_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2831,6 +2857,8 @@ fn lower_stmt(
             });
             lower_return_payload(
                 *else_return,
+                &ctx.ensures,
+                ctx.ensures_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2859,6 +2887,8 @@ fn lower_stmt(
         }
         Stmt::Return(v) => lower_return_payload(
             *v,
+            &ctx.ensures,
+            ctx.ensures_result_symbol,
             arena,
             &mut ctx.next_reg,
             &mut ctx.instrs,
@@ -3272,8 +3302,67 @@ fn lower_match_guard(
     Ok(Some(guard_reg))
 }
 
+fn lower_ensures_clauses(
+    contract_ensures: &[ExprId],
+    contract_result_symbol: Option<SymbolId>,
+    result_value: Option<(u16, Type)>,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    loop_stack: &mut Vec<LoopLoweringFrame>,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    if contract_ensures.is_empty() {
+        return Ok(());
+    }
+
+    let mut contract_env = env.clone();
+    if let Some(result_symbol) = contract_result_symbol {
+        let (result_reg, result_ty) = result_value.ok_or(FrontendError {
+            pos: 0,
+            message: "ensures clause referencing result requires explicit return value".to_string(),
+        })?;
+        contract_env.insert_const(result_symbol, result_ty);
+        out.push(IrInstr::StoreVar {
+            name: "result".to_string(),
+            src: result_reg,
+        });
+    }
+
+    for condition in contract_ensures {
+        let (cond_reg, cond_ty) = lower_expr(
+            *condition,
+            arena,
+            next,
+            out,
+            &contract_env,
+            loop_stack,
+            fn_table,
+            record_table,
+            ret_ty.clone(),
+        )?;
+        if cond_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "ensures clause condition must be bool in lowering, got {:?}",
+                    cond_ty
+                ),
+            });
+        }
+        out.push(IrInstr::Assert { cond: cond_reg });
+    }
+
+    Ok(())
+}
+
 fn lower_return_payload(
     value: Option<ExprId>,
+    contract_ensures: &[ExprId],
+    contract_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -3306,6 +3395,19 @@ fn lower_return_payload(
                     ),
                 });
             }
+            lower_ensures_clauses(
+                contract_ensures,
+                contract_result_symbol,
+                Some((reg, ty.clone())),
+                arena,
+                next,
+                out,
+                env,
+                loop_stack,
+                fn_table,
+                record_table,
+                ret_ty.clone(),
+            )?;
             out.push(IrInstr::Ret { src: Some(reg) });
             Ok(())
         }
@@ -3316,6 +3418,19 @@ fn lower_return_payload(
                     message: format!("return without value in non-unit function ({:?})", ret_ty),
                 });
             }
+            lower_ensures_clauses(
+                contract_ensures,
+                contract_result_symbol,
+                None,
+                arena,
+                next,
+                out,
+                env,
+                loop_stack,
+                fn_table,
+                record_table,
+                ret_ty.clone(),
+            )?;
             out.push(IrInstr::Ret { src: None });
             Ok(())
         }
@@ -3625,6 +3740,8 @@ fn lower_loop_expr_stmt(
                 next_reg: *next,
                 next_label_id: out.len() as u32,
                 loop_stack: loop_stack.clone(),
+                ensures: Vec::new(),
+                ensures_result_symbol: None,
                 instrs: core::mem::take(out),
             };
             let result = lower_stmt(stmt_id, arena, &mut ctx, env, ret_ty, fn_table, record_table);
@@ -3958,6 +4075,8 @@ struct LoweringCtx {
     next_reg: u16,
     next_label_id: u32,
     loop_stack: Vec<LoopLoweringFrame>,
+    ensures: Vec<ExprId>,
+    ensures_result_symbol: Option<SymbolId>,
     instrs: Vec<IrInstr>,
 }
 
@@ -3970,11 +4089,13 @@ struct LoopLoweringFrame {
 }
 
 impl LoweringCtx {
-    fn new() -> Self {
+    fn new(ensures: Vec<ExprId>, ensures_result_symbol: Option<SymbolId>) -> Self {
         Self {
             next_reg: 0,
             next_label_id: 0,
             loop_stack: Vec::new(),
+            ensures,
+            ensures_result_symbol,
             instrs: Vec::new(),
         }
     }
@@ -3987,6 +4108,51 @@ impl LoweringCtx {
 
     fn ends_with_ret(&self) -> bool {
         matches!(self.instrs.last(), Some(IrInstr::Ret { .. }))
+    }
+}
+
+fn find_contract_result_symbol(
+    contract_ensures: &[ExprId],
+    arena: &AstArena,
+) -> Result<Option<SymbolId>, FrontendError> {
+    for condition in contract_ensures {
+        if let Some(symbol) = find_named_var_symbol(*condition, arena, "result")? {
+            return Ok(Some(symbol));
+        }
+    }
+    Ok(None)
+}
+
+fn find_named_var_symbol(
+    expr_id: ExprId,
+    arena: &AstArena,
+    name: &str,
+) -> Result<Option<SymbolId>, FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::Var(symbol_id) => {
+            if resolve_symbol_name(arena, *symbol_id)? == name {
+                Ok(Some(*symbol_id))
+            } else {
+                Ok(None)
+            }
+        }
+        Expr::Tuple(items) => {
+            for item in items {
+                if let Some(symbol) = find_named_var_symbol(*item, arena, name)? {
+                    return Ok(Some(symbol));
+                }
+            }
+            Ok(None)
+        }
+        Expr::RecordField(field_expr) => find_named_var_symbol(field_expr.base, arena, name),
+        Expr::Unary(_, inner) => find_named_var_symbol(*inner, arena, name),
+        Expr::Binary(lhs, _, rhs) => {
+            if let Some(symbol) = find_named_var_symbol(*lhs, arena, name)? {
+                return Ok(Some(symbol));
+            }
+            find_named_var_symbol(*rhs, arena, name)
+        }
+        _ => Ok(None),
     }
 }
 
@@ -4476,6 +4642,55 @@ mod opt_tests {
             .filter(|instr| matches!(instr, IrInstr::Assert { .. }))
             .count();
         assert_eq!(assert_count, 2);
+    }
+
+    #[test]
+    fn lower_function_ensures_clause_to_exit_asserts() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext) -> quad
+                ensures(result == ctx.camera)
+                ensures(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx);
+                assert(seen == T);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("ensures clause should lower");
+        let decide = ir
+            .iter()
+            .find(|func| func.name == "decide")
+            .expect("decide fn");
+        let ret_index = decide
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::Ret { src: Some(_) }))
+            .expect("return should exist");
+        let result_store = decide
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "result"))
+            .expect("ensures should store return value into synthetic result binding");
+        let assert_positions: Vec<_> = decide
+            .instrs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, instr)| matches!(instr, IrInstr::Assert { .. }).then_some(idx))
+            .collect();
+        assert_eq!(assert_positions.len(), 2);
+        assert!(result_store < assert_positions[0]);
+        assert!(assert_positions[0] < ret_index);
+        assert!(assert_positions[1] < ret_index);
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1556,6 +1556,48 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_function_ensures_clause_when_condition_holds() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext) -> quad
+                ensures(result == ctx.camera)
+                ensures(ctx.quality == 0.75) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx);
+                assert(seen == T);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        run_semcode(&bytes).expect("ensures clause should pass");
+    }
+
+    #[test]
+    fn vm_traps_on_failed_function_ensures_clause() {
+        let src = r#"
+            fn must_return_true(flag: bool) -> bool ensures(result == true) {
+                return flag;
+            }
+
+            fn main() {
+                let seen: bool = must_return_true(false);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let err = run_semcode(&bytes).expect_err("ensures clause should trap");
+        assert!(matches!(err, RuntimeError::Trap(RuntimeTrap::AssertionFailed)));
+    }
+
+    #[test]
     fn vm_runs_bool_ops() {
         let src = r#"
 			fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -93,6 +93,11 @@ Current message families include:
 - invalid `assert` argument count
 - invalid `assert` condition type
 - statement-only `assert` used in value position
+- non-bool `requires` condition
+- unsupported expression form inside `requires`
+- non-bool `ensures` condition
+- unsupported expression form inside `ensures`
+- reserved `result` parameter name while `ensures` clauses are present
 - positional arguments after named arguments
 - named arguments on builtin calls
 - unknown named parameter

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -34,6 +34,10 @@ Current rules:
 - function-level `requires(condition)` clauses execute at callee entry after
   parameter binding and before ordinary body statements
 - multiple `requires(condition)` clauses evaluate in source order
+- function-level `ensures(condition)` clauses execute immediately before each
+  function return path completes
+- multiple `ensures(condition)` clauses evaluate in source order on the exit
+  path that produced the return value
 
 Current v0 record declaration semantics:
 
@@ -58,6 +62,18 @@ Current v0 record declaration semantics:
 - explicit record `let-else` uses `let RecordName { field: target, ... } = value else return ...;`
 - record `let-else` currently treats only explicit `quad` literal field targets as refutable checks
 - record equality is allowed only when every field type already supports stable equality
+
+Current first-wave function-contract semantics:
+
+- only declaration-level `requires` and `ensures` are part of the current
+  stable contract surface
+- `requires` checks the narrow contract subset in a parameter-only environment
+- `ensures` checks the same narrow subset on the return path
+- non-unit functions may additionally use the synthetic `result` binding inside
+  `ensures`
+- `ensures` currently lowers to explicit core assertions before `ret`
+- `ensures` is not yet a general proof/effect system and does not imply
+  `invariant` semantics
 
 ## Deterministic Evaluation Order
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -77,6 +77,12 @@ fn name(arg: type, ...) -> ret_type requires(condition) {
 }
 ```
 
+```sm
+fn name(arg: type, ...) -> ret_type ensures(condition) {
+    ...
+}
+```
+
 Expression-bodied sugar is also part of the current v0 surface:
 
 ```sm
@@ -94,6 +100,8 @@ Current rules:
 - trailing parameters may attach a default initializer with `= expr`
 - zero or more `requires(condition)` clauses may appear after the signature and
   before the function body
+- zero or more `ensures(condition)` clauses may appear after any `requires`
+  clauses and before the function body
 - the return type is optional; omitted return type means `unit`
 - function bodies are block-delimited with `{ ... }`
 - `fn ... = expr;` is accepted as shorthand for a single returned expression
@@ -172,6 +180,7 @@ Current statement rules:
 - `guard` currently supports only the `else return` form
 - `assert(condition);` is a statement-level builtin contract form
 - `requires(condition)` is currently a function-level contract clause only
+- `ensures(condition)` is currently a function-level contract clause only
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`
 - `match` requires an explicit default arm `_ => { ... }`
@@ -341,6 +350,21 @@ Current first-wave `requires` rules:
 - each `condition` must be `bool`
 - the current stable subset allows only parameter references, tuple literals,
   record field reads, and pure unary/binary operator expressions
+- call expressions, block/control-flow expressions, range literals, record
+  construction, and record copy-with are not part of this slice
+
+Current first-wave `ensures` rules:
+
+- `ensures(condition)` currently attaches only to ordinary user-defined
+  function declarations
+- `ensures(condition)` may appear on block-bodied and expression-bodied
+  functions
+- each `condition` must be `bool`
+- the current stable subset allows parameter references, optional synthetic
+  `result` binding, tuple literals, record field reads, and pure unary/binary
+  operator expressions
+- the synthetic `result` binding is reserved while `ensures` clauses are
+  present and is available only for non-unit returns
 - call expressions, block/control-flow expressions, range literals, record
   construction, and record copy-with are not part of this slice
 


### PR DESCRIPTION
## Summary
- add the second `V02-08` slice as declaration-level `ensures(condition)` clauses
- typecheck a narrow postcondition subset with optional synthetic `result` binding
- lower `ensures` clauses to explicit exit-path `Assert` instructions and sync docs/tests

## Scope
This PR intentionally implements only the `ensures-only` slice for `#119`.

Included:
- ordinary user-defined functions
- block-bodied and expression-bodied functions
- parser, sema, lowering, VM, docs, and tests

Not included:
- `invariant`
- calls in contract expressions
- default-parameter semantics rework
- host or `prom-*` widening

## Validation
- `cargo test -p sm-front`
- `cargo test -p sm-ir`
- `cargo test -p sm-vm`
- `cargo test --workspace`

Closes part of #119.