### PR TITLE
V02-08 function invariant contract surface

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -297,6 +297,7 @@ fn tokenize_line(
                     "fn" => TokenKind::KwFn,
                     "requires" => TokenKind::KwRequires,
                     "ensures" => TokenKind::KwEnsures,
+                    "invariant" => TokenKind::KwInvariant,
                     "record" => TokenKind::KwRecord,
                     "const" => TokenKind::KwConst,
                     "let" => TokenKind::KwLet,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -124,7 +124,7 @@ impl<'a> Parser<'a> {
         } else {
             Type::Unit
         };
-        let (requires, ensures) = self.parse_contract_clauses()?;
+        let (requires, ensures, invariants) = self.parse_contract_clauses()?;
         let body = if self.eat(TokenKind::Assign) {
             let expr = self.parse_expr()?;
             self.expect(
@@ -141,12 +141,15 @@ impl<'a> Parser<'a> {
             param_defaults,
             requires,
             ensures,
+            invariants,
             ret,
             body,
         })
     }
 
-    fn parse_contract_clauses(&mut self) -> Result<(Vec<ExprId>, Vec<ExprId>), FrontendError> {
+    fn parse_contract_clauses(
+        &mut self,
+    ) -> Result<(Vec<ExprId>, Vec<ExprId>, Vec<ExprId>), FrontendError> {
         let mut requires = Vec::new();
         while self.eat(TokenKind::KwRequires) {
             self.expect(TokenKind::LParen, "expected '(' after 'requires'")?;
@@ -161,7 +164,14 @@ impl<'a> Parser<'a> {
             self.expect(TokenKind::RParen, "expected ')' after ensures condition")?;
             ensures.push(condition);
         }
-        Ok((requires, ensures))
+        let mut invariants = Vec::new();
+        while self.eat(TokenKind::KwInvariant) {
+            self.expect(TokenKind::LParen, "expected '(' after 'invariant'")?;
+            let condition = self.parse_expr()?;
+            self.expect(TokenKind::RParen, "expected ')' after invariant condition")?;
+            invariants.push(condition);
+        }
+        Ok((requires, ensures, invariants))
     }
 
     fn parse_record_decl(&mut self) -> Result<RecordDecl, FrontendError> {
@@ -2231,6 +2241,49 @@ fn main() { return; }
         assert_eq!(idq.ensures.len(), 1);
         assert!(matches!(
             program.arena.expr(idq.ensures[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_function_invariant_clause() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn decide(ctx: DecisionContext) -> quad invariant(ctx.quality == 0.75) {
+    return ctx.camera;
+}
+
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let decide = &program.functions[0];
+        assert_eq!(program.arena.symbol_name(decide.name), "decide");
+        assert_eq!(decide.invariants.len(), 1);
+        assert!(matches!(
+            program.arena.expr(decide.invariants[0]),
+            Expr::Binary(_, BinaryOp::Eq, _)
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_expression_bodied_function_with_invariant_clause() {
+        let src = r#"
+fn idq(q: quad) -> quad invariant(result == q) = q;
+fn main() { return; }
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("parse");
+        let idq = &program.functions[0];
+        assert_eq!(idq.invariants.len(), 1);
+        assert!(matches!(
+            program.arena.expr(idq.invariants[0]),
             Expr::Binary(_, BinaryOp::Eq, _)
         ));
     }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -162,6 +162,7 @@ fn type_check_function_with_record_table(
     }
     check_requires_clauses(func, arena, table, record_table)?;
     check_ensures_clauses(func, arena, table, record_table)?;
+    check_invariant_clauses(func, arena, table, record_table)?;
     let mut env = ScopeEnv::with_params(&func.params);
     let mut loop_stack = Vec::new();
     for stmt in &func.body {
@@ -219,15 +220,7 @@ fn check_ensures_clauses(
     if func.ensures.is_empty() {
         return Ok(());
     }
-    for (name, _) in &func.params {
-        if resolve_symbol_name(arena, *name)? == "result" {
-            return Err(FrontendError {
-                pos: 0,
-                message: "parameter name 'result' is reserved while ensures clauses are present"
-                    .to_string(),
-            });
-        }
-    }
+    ensure_contract_result_name_available(func, arena)?;
     let mut env = ScopeEnv::with_params(&func.params);
     if func.ret != Type::Unit {
         if let Some(result_symbol) = arena.symbol_to_id.get("result").copied() {
@@ -253,6 +246,98 @@ fn check_ensures_clauses(
                     "ensures clause condition must be bool, got {:?}",
                     condition_ty
                 ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_invariant_clauses(
+    func: &Function,
+    arena: &AstArena,
+    table: &FnTable,
+    record_table: &RecordTable,
+) -> Result<(), FrontendError> {
+    if func.invariants.is_empty() {
+        return Ok(());
+    }
+    ensure_contract_result_name_available(func, arena)?;
+    ensure_invariant_result_usage(func, arena)?;
+    let mut env = ScopeEnv::with_params(&func.params);
+    if func.ret != Type::Unit {
+        if let Some(result_symbol) = arena.symbol_to_id.get("result").copied() {
+            env.insert_const(result_symbol, func.ret.clone());
+        }
+    }
+    let mut loop_stack = Vec::new();
+    for condition in &func.invariants {
+        ensure_invariant_expr_supported(*condition, arena)?;
+        let condition_ty = infer_expr_type(
+            *condition,
+            arena,
+            &env,
+            table,
+            record_table,
+            func.ret.clone(),
+            &mut loop_stack,
+        )?;
+        if condition_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "invariant clause condition must be bool, got {:?}",
+                    condition_ty
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_contract_result_name_available(
+    func: &Function,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if func.ensures.is_empty() && func.invariants.is_empty() {
+        return Ok(());
+    }
+    for (name, _) in &func.params {
+        if resolve_symbol_name(arena, *name)? == "result" {
+            let message = match (func.ensures.is_empty(), func.invariants.is_empty()) {
+                (false, true) => {
+                    "parameter name 'result' is reserved while ensures clauses are present"
+                }
+                (true, false) => {
+                    "parameter name 'result' is reserved while invariant clauses are present"
+                }
+                (false, false) => {
+                    "parameter name 'result' is reserved while ensures or invariant clauses are present"
+                }
+                (true, true) => unreachable!("contract result reservation requires contract clauses"),
+            };
+            return Err(FrontendError {
+                pos: 0,
+                message: message.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_invariant_result_usage(
+    func: &Function,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if func.ret != Type::Unit {
+        return Ok(());
+    }
+    for condition in &func.invariants {
+        if contract_clause_references_result(*condition, arena)? {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "invariant clause may reference 'result' only in non-unit return functions"
+                        .to_string(),
             });
         }
     }
@@ -2233,6 +2318,96 @@ mod tests {
     }
 
     #[test]
+    fn function_invariant_clause_typechecks_with_entry_and_exit_subset() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn decide(ctx: DecisionContext) -> quad
+                invariant(ctx.quality == 0.75)
+                invariant(result == ctx.camera) {
+                return ctx.camera;
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let seen: quad = decide(ctx);
+                assert(seen == T);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("invariant clauses should typecheck");
+    }
+
+    #[test]
+    fn function_invariant_clause_requires_bool_condition() {
+        let src = r#"
+            fn id(count: i32) -> i32 invariant(result) {
+                return count;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("invariant clause must require bool");
+        assert!(err
+            .message
+            .contains("invariant clause condition must be bool"));
+    }
+
+    #[test]
+    fn function_invariant_clause_rejects_call_surface() {
+        let src = r#"
+            fn check(flag: bool) -> bool = flag;
+
+            fn choose(flag: bool) -> bool invariant(check(result)) {
+                return flag;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src).expect_err("invariant clause should reject call surface");
+        assert!(err
+            .message
+            .contains("invariant clause currently allows only parameter references, optional result binding"));
+    }
+
+    #[test]
+    fn function_invariant_clause_reserves_result_parameter_name() {
+        let src = r#"
+            fn echo(result: bool) -> bool invariant(result == true) {
+                return result;
+            }
+
+            fn main() { return; }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("invariant clause must reserve synthetic result name");
+        assert!(err
+            .message
+            .contains("parameter name 'result' is reserved while invariant clauses are present"));
+    }
+
+    #[test]
+    fn function_invariant_clause_rejects_result_in_unit_return_function() {
+        let src = r#"
+            fn main() invariant(result == true) {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("unit-return invariant cannot reference result");
+        assert!(err
+            .message
+            .contains("invariant clause may reference 'result' only in non-unit return functions"));
+    }
+
+    #[test]
     fn tuple_literals_and_tuple_types_typecheck_through_call_and_return_paths() {
         let src = r#"
             fn pair(flag: bool) -> (i32, bool) {
@@ -3688,6 +3863,18 @@ fn ensure_ensures_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<()
     )
 }
 
+fn ensure_invariant_expr_supported(
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    ensure_contract_expr_supported(
+        expr_id,
+        arena,
+        "invariant",
+        "parameter references, optional result binding",
+    )
+}
+
 fn ensure_contract_expr_supported(
     expr_id: ExprId,
     arena: &AstArena,
@@ -3721,6 +3908,46 @@ fn ensure_contract_expr_supported(
                 "{clause_name} clause currently allows only {binding_desc}, tuple literals, record field reads, and pure unary/binary operator expressions"
             ),
         }),
+    }
+}
+
+fn contract_clause_references_result(
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Result<bool, FrontendError> {
+    Ok(find_named_var_symbol(expr_id, arena, "result")?.is_some())
+}
+
+fn find_named_var_symbol(
+    expr_id: ExprId,
+    arena: &AstArena,
+    name: &str,
+) -> Result<Option<SymbolId>, FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::Var(symbol_id) => {
+            if resolve_symbol_name(arena, *symbol_id)? == name {
+                Ok(Some(*symbol_id))
+            } else {
+                Ok(None)
+            }
+        }
+        Expr::Tuple(items) => {
+            for item in items {
+                if let Some(symbol) = find_named_var_symbol(*item, arena, name)? {
+                    return Ok(Some(symbol));
+                }
+            }
+            Ok(None)
+        }
+        Expr::RecordField(field_expr) => find_named_var_symbol(field_expr.base, arena, name),
+        Expr::Unary(_, inner) => find_named_var_symbol(*inner, arena, name),
+        Expr::Binary(lhs, _, rhs) => {
+            if let Some(symbol) = find_named_var_symbol(*lhs, arena, name)? {
+                return Ok(Some(symbol));
+            }
+            find_named_var_symbol(*rhs, arena, name)
+        }
+        _ => Ok(None),
     }
 }
 

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -248,6 +248,7 @@ pub struct Function {
     pub param_defaults: Vec<Option<ExprId>>,
     pub requires: Vec<ExprId>,
     pub ensures: Vec<ExprId>,
+    pub invariants: Vec<ExprId>,
     pub ret: Type,
     pub body: Vec<StmtId>,
 }
@@ -329,6 +330,7 @@ pub enum TokenKind {
     KwFn,
     KwRequires,
     KwEnsures,
+    KwInvariant,
     KwRecord,
     KwConst,
     KwLet,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -325,7 +325,13 @@ fn lower_function_to_ir_with_record_table(
     record_table: &RecordTable,
 ) -> Result<IrFunction, FrontendError> {
     let ensures_result_symbol = find_contract_result_symbol(&func.ensures, arena)?;
-    let mut ctx = LoweringCtx::new(func.ensures.clone(), ensures_result_symbol);
+    let invariants_result_symbol = find_contract_result_symbol(&func.invariants, arena)?;
+    let mut ctx = LoweringCtx::new(
+        func.ensures.clone(),
+        ensures_result_symbol,
+        func.invariants.clone(),
+        invariants_result_symbol,
+    );
     let mut env = ScopeEnv::with_params(&func.params);
     ctx.next_reg = u16::try_from(func.params.len()).map_err(|_| FrontendError {
         pos: 0,
@@ -360,6 +366,20 @@ fn lower_function_to_ir_with_record_table(
         }
         ctx.instrs.push(IrInstr::Assert { cond: cond_reg });
     }
+    lower_invariant_clauses(
+        &ctx.invariants,
+        ctx.invariants_result_symbol,
+        None,
+        ContractInvariantPhase::Entry,
+        arena,
+        &mut ctx.next_reg,
+        &mut ctx.instrs,
+        &env,
+        &mut ctx.loop_stack,
+        fn_table,
+        record_table,
+        func.ret.clone(),
+    )?;
     for stmt in &func.body {
         lower_stmt(
             *stmt,
@@ -378,6 +398,20 @@ fn lower_function_to_ir_with_record_table(
                 &ctx.ensures,
                 ctx.ensures_result_symbol,
                 None,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                &env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                func.ret.clone(),
+            )?;
+            lower_invariant_clauses(
+                &ctx.invariants,
+                ctx.invariants_result_symbol,
+                None,
+                ContractInvariantPhase::Exit,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2037,6 +2071,8 @@ fn bind_let_else_record_items(
     else_return: Option<ExprId>,
     contract_ensures: &[ExprId],
     contract_result_symbol: Option<SymbolId>,
+    contract_invariants: &[ExprId],
+    contract_invariant_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -2127,6 +2163,8 @@ fn bind_let_else_record_items(
                     else_return,
                     contract_ensures,
                     contract_result_symbol,
+                    contract_invariants,
+                    contract_invariant_result_symbol,
                     arena,
                     next,
                     out,
@@ -2415,6 +2453,8 @@ fn bind_let_else_tuple_items(
     else_return: Option<ExprId>,
     contract_ensures: &[ExprId],
     contract_result_symbol: Option<SymbolId>,
+    contract_invariants: &[ExprId],
+    contract_invariant_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -2488,6 +2528,8 @@ fn bind_let_else_tuple_items(
                     else_return,
                     contract_ensures,
                     contract_result_symbol,
+                    contract_invariants,
+                    contract_invariant_result_symbol,
                     arena,
                     next,
                     out,
@@ -2646,6 +2688,8 @@ fn lower_stmt(
                 *else_return,
                 &ctx.ensures,
                 ctx.ensures_result_symbol,
+                &ctx.invariants,
+                ctx.invariants_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2682,6 +2726,8 @@ fn lower_stmt(
                 *else_return,
                 &ctx.ensures,
                 ctx.ensures_result_symbol,
+                &ctx.invariants,
+                ctx.invariants_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2859,6 +2905,8 @@ fn lower_stmt(
                 *else_return,
                 &ctx.ensures,
                 ctx.ensures_result_symbol,
+                &ctx.invariants,
+                ctx.invariants_result_symbol,
                 arena,
                 &mut ctx.next_reg,
                 &mut ctx.instrs,
@@ -2889,6 +2937,8 @@ fn lower_stmt(
             *v,
             &ctx.ensures,
             ctx.ensures_result_symbol,
+            &ctx.invariants,
+            ctx.invariants_result_symbol,
             arena,
             &mut ctx.next_reg,
             &mut ctx.instrs,
@@ -3359,10 +3409,85 @@ fn lower_ensures_clauses(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContractInvariantPhase {
+    Entry,
+    Exit,
+}
+
+fn lower_invariant_clauses(
+    contract_invariants: &[ExprId],
+    contract_result_symbol: Option<SymbolId>,
+    result_value: Option<(u16, Type)>,
+    phase: ContractInvariantPhase,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    loop_stack: &mut Vec<LoopLoweringFrame>,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    ret_ty: Type,
+) -> Result<(), FrontendError> {
+    if contract_invariants.is_empty() {
+        return Ok(());
+    }
+
+    let mut contract_env = env.clone();
+    if let Some(result_symbol) = contract_result_symbol {
+        if let Some((result_reg, result_ty)) = result_value.clone() {
+            contract_env.insert_const(result_symbol, result_ty);
+            out.push(IrInstr::StoreVar {
+                name: "result".to_string(),
+                src: result_reg,
+            });
+        }
+    }
+
+    for condition in contract_invariants {
+        let references_result = contract_clause_references_result(*condition, arena)?;
+        if references_result && phase == ContractInvariantPhase::Entry {
+            continue;
+        }
+        if references_result && result_value.is_none() {
+            return Err(FrontendError {
+                pos: 0,
+                message: "invariant clause referencing result requires explicit return value"
+                    .to_string(),
+            });
+        }
+        let (cond_reg, cond_ty) = lower_expr(
+            *condition,
+            arena,
+            next,
+            out,
+            &contract_env,
+            loop_stack,
+            fn_table,
+            record_table,
+            ret_ty.clone(),
+        )?;
+        if cond_ty != Type::Bool {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "invariant clause condition must be bool in lowering, got {:?}",
+                    cond_ty
+                ),
+            });
+        }
+        out.push(IrInstr::Assert { cond: cond_reg });
+    }
+
+    Ok(())
+}
+
 fn lower_return_payload(
     value: Option<ExprId>,
     contract_ensures: &[ExprId],
     contract_result_symbol: Option<SymbolId>,
+    contract_invariants: &[ExprId],
+    contract_invariant_result_symbol: Option<SymbolId>,
     arena: &AstArena,
     next: &mut u16,
     out: &mut Vec<IrInstr>,
@@ -3408,6 +3533,20 @@ fn lower_return_payload(
                 record_table,
                 ret_ty.clone(),
             )?;
+            lower_invariant_clauses(
+                contract_invariants,
+                contract_invariant_result_symbol,
+                Some((reg, ty.clone())),
+                ContractInvariantPhase::Exit,
+                arena,
+                next,
+                out,
+                env,
+                loop_stack,
+                fn_table,
+                record_table,
+                ret_ty.clone(),
+            )?;
             out.push(IrInstr::Ret { src: Some(reg) });
             Ok(())
         }
@@ -3422,6 +3561,20 @@ fn lower_return_payload(
                 contract_ensures,
                 contract_result_symbol,
                 None,
+                arena,
+                next,
+                out,
+                env,
+                loop_stack,
+                fn_table,
+                record_table,
+                ret_ty.clone(),
+            )?;
+            lower_invariant_clauses(
+                contract_invariants,
+                contract_invariant_result_symbol,
+                None,
+                ContractInvariantPhase::Exit,
                 arena,
                 next,
                 out,
@@ -3742,6 +3895,8 @@ fn lower_loop_expr_stmt(
                 loop_stack: loop_stack.clone(),
                 ensures: Vec::new(),
                 ensures_result_symbol: None,
+                invariants: Vec::new(),
+                invariants_result_symbol: None,
                 instrs: core::mem::take(out),
             };
             let result = lower_stmt(stmt_id, arena, &mut ctx, env, ret_ty, fn_table, record_table);
@@ -4077,6 +4232,8 @@ struct LoweringCtx {
     loop_stack: Vec<LoopLoweringFrame>,
     ensures: Vec<ExprId>,
     ensures_result_symbol: Option<SymbolId>,
+    invariants: Vec<ExprId>,
+    invariants_result_symbol: Option<SymbolId>,
     instrs: Vec<IrInstr>,
 }
 
@@ -4089,13 +4246,20 @@ struct LoopLoweringFrame {
 }
 
 impl LoweringCtx {
-    fn new(ensures: Vec<ExprId>, ensures_result_symbol: Option<SymbolId>) -> Self {
+    fn new(
+        ensures: Vec<ExprId>,
+        ensures_result_symbol: Option<SymbolId>,
+        invariants: Vec<ExprId>,
+        invariants_result_symbol: Option<SymbolId>,
+    ) -> Self {
         Self {
             next_reg: 0,
             next_label_id: 0,
             loop_stack: Vec::new(),
             ensures,
             ensures_result_symbol,
+            invariants,
+            invariants_result_symbol,
             instrs: Vec::new(),
         }
     }
@@ -4121,6 +4285,13 @@ fn find_contract_result_symbol(
         }
     }
     Ok(None)
+}
+
+fn contract_clause_references_result(
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Result<bool, FrontendError> {
+    Ok(find_named_var_symbol(expr_id, arena, "result")?.is_some())
 }
 
 fn find_named_var_symbol(
@@ -4691,6 +4862,47 @@ mod opt_tests {
         assert!(result_store < assert_positions[0]);
         assert!(assert_positions[0] < ret_index);
         assert!(assert_positions[1] < ret_index);
+    }
+
+    #[test]
+    fn lower_function_invariant_clauses_to_entry_and_exit_asserts() {
+        let src = r#"
+            fn keep(flag: bool) -> bool
+                invariant(flag == true)
+                invariant(result == flag) {
+                return flag;
+            }
+
+            fn main() {
+                let seen: bool = keep(true);
+                assert(seen == true);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("invariant clauses should lower");
+        let keep = ir.iter().find(|func| func.name == "keep").expect("keep fn");
+        let ret_index = keep
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::Ret { src: Some(_) }))
+            .expect("return should exist");
+        let result_store = keep
+            .instrs
+            .iter()
+            .position(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "result"))
+            .expect("exit invariant path should store synthetic result binding");
+        let assert_positions: Vec<_> = keep
+            .instrs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, instr)| matches!(instr, IrInstr::Assert { .. }).then_some(idx))
+            .collect();
+        assert_eq!(assert_positions.len(), 3);
+        assert!(assert_positions[0] < result_store);
+        assert!(result_store < assert_positions[1]);
+        assert!(result_store < assert_positions[2]);
+        assert!(assert_positions[2] < ret_index);
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1598,6 +1598,42 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_function_invariant_clauses_when_conditions_hold() {
+        let src = r#"
+            fn keep(flag: bool) -> bool
+                invariant(flag == true)
+                invariant(result == flag) {
+                return flag;
+            }
+
+            fn main() {
+                let seen: bool = keep(true);
+                assert(seen == true);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        run_semcode(&bytes).expect("invariant clauses should pass");
+    }
+
+    #[test]
+    fn vm_traps_on_failed_function_invariant_clause() {
+        let src = r#"
+            fn must_stay_true(flag: bool) -> bool invariant(result == true) {
+                return flag;
+            }
+
+            fn main() {
+                let seen: bool = must_stay_true(false);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let err = run_semcode(&bytes).expect_err("invariant clause should trap");
+        assert!(matches!(err, RuntimeError::Trap(RuntimeTrap::AssertionFailed)));
+    }
+
+    #[test]
     fn vm_runs_bool_ops() {
         let src = r#"
 			fn main() {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -98,6 +98,10 @@ Current message families include:
 - non-bool `ensures` condition
 - unsupported expression form inside `ensures`
 - reserved `result` parameter name while `ensures` clauses are present
+- non-bool `invariant` condition
+- unsupported expression form inside `invariant`
+- reserved `result` parameter name while `invariant` clauses are present
+- `result` referenced from `invariant` on a unit-return function
 - positional arguments after named arguments
 - named arguments on builtin calls
 - unknown named parameter

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -38,6 +38,14 @@ Current rules:
   function return path completes
 - multiple `ensures(condition)` clauses evaluate in source order on the exit
   path that produced the return value
+- function-level `invariant(condition)` clauses are first-wave entry/exit
+  contract checks rather than a separate proof system
+- invariant clauses that do not reference `result` execute at both function
+  entry and function exit
+- invariant clauses that reference the synthetic `result` binding execute only
+  on function exit and only for non-unit returns
+- multiple `invariant(condition)` clauses evaluate in source order at each
+  applicable check point
 
 Current v0 record declaration semantics:
 
@@ -65,15 +73,19 @@ Current v0 record declaration semantics:
 
 Current first-wave function-contract semantics:
 
-- only declaration-level `requires` and `ensures` are part of the current
-  stable contract surface
+- only declaration-level `requires`, `ensures`, and narrow `invariant` are
+  part of the current stable contract surface
 - `requires` checks the narrow contract subset in a parameter-only environment
 - `ensures` checks the same narrow subset on the return path
 - non-unit functions may additionally use the synthetic `result` binding inside
-  `ensures`
+  `ensures` and `invariant`
+- `invariant` checks the same narrow subset at function entry and exit
+- `invariant` clauses that reference `result` are exit-only checks
 - `ensures` currently lowers to explicit core assertions before `ret`
-- `ensures` is not yet a general proof/effect system and does not imply
-  `invariant` semantics
+- `invariant` currently lowers to the same explicit core assertion path used by
+  the other contract clauses
+- this slice is not yet a general proof/effect system and does not imply loop,
+  block, or mutation-point invariant semantics
 
 ## Deterministic Evaluation Order
 
@@ -144,17 +156,27 @@ Current default-parameter semantics:
 
 Current first-wave function-contract semantics:
 
-- `requires(condition)` is currently the only declaration-level contract clause
-  in the stable source surface
+- `requires(condition)`, `ensures(condition)`, and narrow
+  `invariant(condition)` are the current declaration-level function contract
+  clauses in the stable source surface
 - each `requires` condition is type-checked in a parameter-only environment
+- each `ensures` condition is type-checked in a parameter-plus-optional-result
+  environment
+- each `invariant` condition is type-checked in the same narrow environment,
+  with `result` allowed only for non-unit returns
 - the current stable subset allows only parameter references, tuple literals,
-  record field reads, and pure unary/binary operator expressions
+  record field reads, optional `result`, and pure unary/binary operator
+  expressions
 - function calls, record construction, record copy-with, range literals,
   blocks, and control-flow expressions are not yet part of the stable
-  `requires` subset
+  contract-expression subset
 - lowering translates each `requires` clause to an explicit core assertion at
   function entry
-- this slice does not yet claim `ensures(...)` or `invariant(...)`
+- lowering translates each `ensures` clause to an explicit core assertion on
+  each return path
+- lowering translates each `invariant` clause to explicit core assertions at
+  function entry and/or function exit depending on whether the clause
+  references `result`
 
 Current v0 limits:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -83,6 +83,12 @@ fn name(arg: type, ...) -> ret_type ensures(condition) {
 }
 ```
 
+```sm
+fn name(arg: type, ...) -> ret_type invariant(condition) {
+    ...
+}
+```
+
 Expression-bodied sugar is also part of the current v0 surface:
 
 ```sm
@@ -102,6 +108,8 @@ Current rules:
   before the function body
 - zero or more `ensures(condition)` clauses may appear after any `requires`
   clauses and before the function body
+- zero or more `invariant(condition)` clauses may appear after any
+  `requires/ensures` clauses and before the function body
 - the return type is optional; omitted return type means `unit`
 - function bodies are block-delimited with `{ ... }`
 - `fn ... = expr;` is accepted as shorthand for a single returned expression
@@ -181,6 +189,7 @@ Current statement rules:
 - `assert(condition);` is a statement-level builtin contract form
 - `requires(condition)` is currently a function-level contract clause only
 - `ensures(condition)` is currently a function-level contract clause only
+- `invariant(condition)` is currently a function-level contract clause only
 - `if` conditions must be `bool`
 - `match` is currently restricted to `quad`
 - `match` requires an explicit default arm `_ => { ... }`


### PR DESCRIPTION
Closes #119

This is the final narrow function-contract slice for `V02-08`.

Scope:
- declaration-level `invariant(condition)` for ordinary user-defined functions
- same narrow contract-expression subset as `requires` and `ensures`
- explicit entry/exit `Assert` lowering only
- parser, sema, lowering, VM, docs, and tests

Out of scope:
- `#120` default-parameter rework
- statement-local, loop, or block invariants
- mutation-point rechecking
- call expressions inside contract clauses
- host or `prom-*` widening

Validation:
- `cargo test -p sm-front`
- `cargo test -p sm-ir`
- `cargo test -p sm-vm`
- `cargo test --workspace`