### PR TITLE
V02-05 ADT match exhaustiveness surface

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1111,12 +1111,6 @@ fn check_stmt(
                     message: "match is allowed only for quad or enum scrutinee".to_string(),
                 });
             }
-            if default.is_empty() {
-                return Err(FrontendError {
-                    pos: 0,
-                    message: "match requires default arm '_'".to_string(),
-                });
-            }
 
             for arm in arms {
                 let mut arm_env = env.clone();
@@ -1155,21 +1149,49 @@ fn check_stmt(
                 arm_env.pop_scope();
             }
 
-            let mut def_env = env.clone();
-            def_env.push_scope();
-            for s in default {
-                check_stmt(
-                    *s,
+            if default.is_empty() {
+                match missing_exhaustive_adt_variants(
+                    &st,
+                    arms.iter().map(|arm| (&arm.pat, arm.guard)),
                     arena,
-                    &mut def_env,
-                    ret_ty.clone(),
-                    table,
-                    record_table,
                     adt_table,
-                    loop_stack,
-                )?;
+                )? {
+                    Some(missing) if !missing.is_empty() => {
+                        return Err(non_exhaustive_match_error(
+                            arena,
+                            match st {
+                                Type::Adt(name) => name,
+                                _ => unreachable!(),
+                            },
+                            &missing,
+                            false,
+                        )?)
+                    }
+                    Some(_) => {}
+                    None => {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: "match requires default arm '_'".to_string(),
+                        });
+                    }
+                }
+            } else {
+                let mut def_env = env.clone();
+                def_env.push_scope();
+                for s in default {
+                    check_stmt(
+                        *s,
+                        arena,
+                        &mut def_env,
+                        ret_ty.clone(),
+                        table,
+                        record_table,
+                        adt_table,
+                        loop_stack,
+                    )?;
+                }
+                def_env.pop_scope();
             }
-            def_env.pop_scope();
             Ok(())
         }
         Stmt::Return(v) => check_return_payload(
@@ -1886,6 +1908,33 @@ mod tests {
     }
 
     #[test]
+    fn exhaustive_adt_match_expression_without_default_typechecks() {
+        let src = r#"
+            enum Maybe {
+                None,
+                Some(f64),
+            }
+
+            fn read(value: Maybe) -> f64 {
+                let total: f64 = match value {
+                    Maybe::None => { 0.0 }
+                    Maybe::Some(inner) => { inner }
+                };
+                return total;
+            }
+
+            fn main() {
+                let value: Maybe = Maybe::Some(1.0);
+                let total: f64 = read(value);
+                let same = total == total;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("exhaustive ADT match expression without default should typecheck");
+    }
+
+    #[test]
     fn match_expression_requires_quad_scrutinee() {
         let src = r#"
             fn main() {
@@ -1918,6 +1967,36 @@ mod tests {
         assert!(err
             .message
             .contains("match expression requires default arm '_'"));
+    }
+
+    #[test]
+    fn non_exhaustive_adt_match_expression_without_default_rejects() {
+        let src = r#"
+            enum Maybe {
+                None,
+                Some(f64),
+            }
+
+            fn read(value: Maybe) -> f64 {
+                let total: f64 = match value {
+                    Maybe::Some(inner) => { inner }
+                };
+                return total;
+            }
+
+            fn main() {
+                let value: Maybe = Maybe::Some(1.0);
+                let total: f64 = read(value);
+                let same = total == total;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("non-exhaustive ADT match expression without default must reject");
+        assert!(err
+            .message
+            .contains("non-exhaustive match expression for enum 'Maybe'; missing variants: None"));
     }
 
     #[test]
@@ -3680,10 +3759,6 @@ fn infer_match_expr_type(
             message: "match expression is allowed only for quad or enum scrutinee".to_string(),
         });
     }
-    let default = match_expr.default.as_ref().ok_or(FrontendError {
-        pos: 0,
-        message: "match expression requires default arm '_'".to_string(),
-    })?;
 
     let mut result_ty = None;
     for arm in &match_expr.arms {
@@ -3733,29 +3808,54 @@ fn infer_match_expr_type(
         }
     }
 
-    let default_ty = infer_value_block_type(
-        default,
-        arena,
-        env,
-        table,
-        record_table,
-        adt_table,
-        ret_ty,
-        loop_stack,
-    )?;
-    if let Some(expected) = result_ty {
-        if expected != default_ty {
-            return Err(FrontendError {
-                pos: 0,
-                message: format!(
-                    "match expression branch type mismatch: expected {:?}, got {:?}",
-                    expected, default_ty
-                ),
-            });
+    if let Some(default) = match_expr.default.as_ref() {
+        let default_ty = infer_value_block_type(
+            default,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty,
+            loop_stack,
+        )?;
+        if let Some(expected) = result_ty {
+            if expected != default_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "match expression branch type mismatch: expected {:?}, got {:?}",
+                        expected, default_ty
+                    ),
+                });
+            }
+            Ok(expected)
+        } else {
+            Ok(default_ty)
         }
-        Ok(expected)
     } else {
-        Ok(default_ty)
+        match missing_exhaustive_adt_variants(
+            &scrutinee_ty,
+            match_expr.arms.iter().map(|arm| (&arm.pat, arm.guard)),
+            arena,
+            adt_table,
+        )? {
+            Some(missing) if !missing.is_empty() => Err(non_exhaustive_match_error(
+                arena,
+                match scrutinee_ty {
+                    Type::Adt(name) => name,
+                    _ => unreachable!(),
+                },
+                &missing,
+                true,
+            )?),
+            Some(_) => Ok(result_ty
+                .expect("exhaustive enum match expression should have at least one arm")),
+            None => Err(FrontendError {
+                pos: 0,
+                message: "match expression requires default arm '_'".to_string(),
+            }),
+        }
     }
 }
 
@@ -4882,6 +4982,66 @@ fn bind_match_pattern(
             message: "match is allowed only for quad or enum scrutinee".to_string(),
         }),
     }
+}
+
+fn missing_exhaustive_adt_variants<'a>(
+    scrutinee_ty: &Type,
+    patterns: impl IntoIterator<Item = (&'a MatchPattern, Option<ExprId>)>,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<Option<Vec<SymbolId>>, FrontendError> {
+    let Type::Adt(adt_name) = scrutinee_ty else {
+        return Ok(None);
+    };
+    let adt = adt_table.get(adt_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown enum type '{}' in match exhaustiveness check",
+            resolve_symbol_name(arena, *adt_name)?,
+        ),
+    })?;
+
+    let mut covered = BTreeSet::new();
+    for (pat, guard) in patterns {
+        if guard.is_some() {
+            continue;
+        }
+        if let MatchPattern::Adt(adt_pat) = pat {
+            if adt_pat.adt_name == *adt_name {
+                covered.insert(adt_pat.variant_name);
+            }
+        }
+    }
+
+    Ok(Some(
+        adt.variants
+            .iter()
+            .filter(|variant| !covered.contains(&variant.name))
+            .map(|variant| variant.name)
+            .collect(),
+    ))
+}
+
+fn non_exhaustive_match_error(
+    arena: &AstArena,
+    adt_name: SymbolId,
+    missing: &[SymbolId],
+    expression: bool,
+) -> Result<FrontendError, FrontendError> {
+    let missing_names = missing
+        .iter()
+        .map(|name| resolve_symbol_name(arena, *name))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(FrontendError {
+        pos: 0,
+        message: format!(
+            "non-exhaustive match{} for enum '{}'; missing variants: {}",
+            if expression { " expression" } else { "" },
+            resolve_symbol_name(arena, adt_name)?,
+            missing_names,
+        ),
+    })
 }
 
 fn check_match_guard(

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -7,6 +7,7 @@ use sm_front::types::{
     AdtCtorExpr, AdtPatternItem, MatchPattern, NumericLiteral, RecordPatternItem,
     RecordPatternTarget,
 };
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IrInstr {
@@ -3206,12 +3207,35 @@ fn lower_stmt(
                     message: "match scrutinee must be quad or enum".to_string(),
                 });
             }
-            if default.is_empty() {
-                return Err(FrontendError {
-                    pos: 0,
-                    message: "match requires default arm '_'".to_string(),
-                });
-            }
+            let exhaustive_without_default = if default.is_empty() {
+                match missing_exhaustive_adt_variants(
+                    &scr_ty,
+                    arms.iter().map(|arm| (&arm.pat, arm.guard)),
+                    arena,
+                    adt_table,
+                )? {
+                    Some(missing) if !missing.is_empty() => {
+                        return Err(non_exhaustive_match_error(
+                            arena,
+                            match scr_ty {
+                                Type::Adt(name) => name,
+                                _ => unreachable!(),
+                            },
+                            &missing,
+                            false,
+                        )?)
+                    }
+                    Some(_) => true,
+                    None => {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: "match requires default arm '_'".to_string(),
+                        });
+                    }
+                }
+            } else {
+                false
+            };
 
             let mid = ctx.next_if_id();
             let end_label = format!("match_{}_end", mid);
@@ -3452,21 +3476,30 @@ fn lower_stmt(
             ctx.instrs.push(IrInstr::Label {
                 name: default_label,
             });
-            let mut def_env = env.clone();
-            def_env.push_scope();
-            for s in default {
-                lower_stmt(
-                    *s,
-                    arena,
-                    ctx,
-                    &mut def_env,
-                    ret_ty.clone(),
-                    fn_table,
-                    record_table,
-                    adt_table,
-                )?;
+            if exhaustive_without_default {
+                let cond = alloc(&mut ctx.next_reg);
+                ctx.instrs.push(IrInstr::LoadBool {
+                    dst: cond,
+                    val: false,
+                });
+                ctx.instrs.push(IrInstr::Assert { cond });
+            } else {
+                let mut def_env = env.clone();
+                def_env.push_scope();
+                for s in default {
+                    lower_stmt(
+                        *s,
+                        arena,
+                        ctx,
+                        &mut def_env,
+                        ret_ty.clone(),
+                        fn_table,
+                        record_table,
+                        adt_table,
+                    )?;
+                }
+                def_env.pop_scope();
             }
-            def_env.pop_scope();
             ctx.instrs.push(IrInstr::Jmp {
                 label: end_label.clone(),
             });
@@ -3870,6 +3903,80 @@ fn lower_adt_match_bindings(
         env.insert(binding.name, binding.ty.clone());
     }
     Ok(())
+}
+
+fn missing_exhaustive_adt_variants<'a>(
+    scrutinee_ty: &Type,
+    patterns: impl IntoIterator<Item = (&'a MatchPattern, Option<ExprId>)>,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<Option<Vec<SymbolId>>, FrontendError> {
+    let Type::Adt(adt_name) = scrutinee_ty else {
+        return Ok(None);
+    };
+    let adt = adt_table.get(adt_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown enum type '{}' in match lowering exhaustiveness check",
+            resolve_symbol_name(arena, *adt_name)?,
+        ),
+    })?;
+
+    let mut covered = BTreeSet::new();
+    for (pat, guard) in patterns {
+        if guard.is_some() {
+            continue;
+        }
+        if let MatchPattern::Adt(adt_pat) = pat {
+            if adt_pat.adt_name == *adt_name {
+                covered.insert(adt_pat.variant_name);
+            }
+        }
+    }
+
+    Ok(Some(
+        adt.variants
+            .iter()
+            .filter(|variant| !covered.contains(&variant.name))
+            .map(|variant| variant.name)
+            .collect(),
+    ))
+}
+
+fn non_exhaustive_match_error(
+    arena: &AstArena,
+    adt_name: SymbolId,
+    missing: &[SymbolId],
+    expression: bool,
+) -> Result<FrontendError, FrontendError> {
+    let missing_names = missing
+        .iter()
+        .map(|name| resolve_symbol_name(arena, *name))
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(FrontendError {
+        pos: 0,
+        message: format!(
+            "non-exhaustive match{} for enum '{}'; missing variants: {}",
+            if expression { " expression" } else { "" },
+            resolve_symbol_name(arena, adt_name)?,
+            missing_names,
+        ),
+    })
+}
+
+fn lower_impossible_match_trap(
+    label: String,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+) {
+    out.push(IrInstr::Label { name: label });
+    let cond = alloc(next);
+    out.push(IrInstr::LoadBool {
+        dst: cond,
+        val: false,
+    });
+    out.push(IrInstr::Assert { cond });
 }
 
 fn lower_match_guard(
@@ -4364,12 +4471,35 @@ fn lower_loop_expr_stmt(
                     message: "match scrutinee must be quad or enum".to_string(),
                 });
             }
-            if default.is_empty() {
-                return Err(FrontendError {
-                    pos: 0,
-                    message: "match requires default arm '_'".to_string(),
-                });
-            }
+            let exhaustive_without_default = if default.is_empty() {
+                match missing_exhaustive_adt_variants(
+                    &scr_ty,
+                    arms.iter().map(|arm| (&arm.pat, arm.guard)),
+                    arena,
+                    adt_table,
+                )? {
+                    Some(missing) if !missing.is_empty() => {
+                        return Err(non_exhaustive_match_error(
+                            arena,
+                            match scr_ty {
+                                Type::Adt(name) => name,
+                                _ => unreachable!(),
+                            },
+                            &missing,
+                            false,
+                        )?)
+                    }
+                    Some(_) => true,
+                    None => {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: "match requires default arm '_'".to_string(),
+                        });
+                    }
+                }
+            } else {
+                false
+            };
 
             let id = alloc_loop_expr_id(next);
             let end_label = format!("loop_match_{}_end", id);
@@ -4570,26 +4700,35 @@ fn lower_loop_expr_stmt(
             out.push(IrInstr::Label {
                 name: default_label,
             });
-            let mut def_env = env.clone();
-            def_env.push_scope();
-            for stmt in default {
-                lower_loop_expr_stmt(
-                    *stmt,
-                    arena,
-                    next,
-                    out,
-                    &mut def_env,
-                    loop_stack,
-                    fn_table,
-                    record_table,
-                    adt_table,
-                    ret_ty.clone(),
-                )?;
+            if exhaustive_without_default {
+                let cond = alloc(next);
+                out.push(IrInstr::LoadBool {
+                    dst: cond,
+                    val: false,
+                });
+                out.push(IrInstr::Assert { cond });
+            } else {
+                let mut def_env = env.clone();
+                def_env.push_scope();
+                for stmt in default {
+                    lower_loop_expr_stmt(
+                        *stmt,
+                        arena,
+                        next,
+                        out,
+                        &mut def_env,
+                        loop_stack,
+                        fn_table,
+                        record_table,
+                        adt_table,
+                        ret_ty.clone(),
+                    )?;
+                }
+                def_env.pop_scope();
+                out.push(IrInstr::Jmp {
+                    label: end_label.clone(),
+                });
             }
-            def_env.pop_scope();
-            out.push(IrInstr::Jmp {
-                label: end_label.clone(),
-            });
             out.push(IrInstr::Label { name: end_label });
             Ok(())
         }
@@ -4653,10 +4792,35 @@ fn lower_match_expr(
             message: "match expression scrutinee must be quad or enum".to_string(),
         });
     }
-    let default = match_expr.default.as_ref().ok_or(FrontendError {
-        pos: 0,
-        message: "match expression requires default arm '_'".to_string(),
-    })?;
+    let exhaustive_without_default = if match_expr.default.is_none() {
+        match missing_exhaustive_adt_variants(
+            &scr_ty,
+            match_expr.arms.iter().map(|arm| (&arm.pat, arm.guard)),
+            arena,
+            adt_table,
+        )? {
+            Some(missing) if !missing.is_empty() => {
+                return Err(non_exhaustive_match_error(
+                    arena,
+                    match scr_ty {
+                        Type::Adt(name) => name,
+                        _ => unreachable!(),
+                    },
+                    &missing,
+                    true,
+                )?)
+            }
+            Some(_) => true,
+            None => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "match expression requires default arm '_'".to_string(),
+                });
+            }
+        }
+    } else {
+        false
+    };
 
     let id = alloc_match_expr_id(next);
     let end_label = format!("match_expr_{}_end", id);
@@ -4893,42 +5057,50 @@ fn lower_match_expr(
         _ => unreachable!("non-matchable scrutinee handled above"),
     }
 
-    out.push(IrInstr::Label {
-        name: default_label,
-    });
-    let (default_reg, default_ty) = lower_value_block_expr(
-        default,
-        arena,
-        next,
-        out,
-        env,
-        loop_stack,
-        fn_table,
-        record_table,
-        adt_table,
-        expected,
-        ret_ty,
-    )?;
-    if let Some(ref expected_ty) = result_ty {
-        if *expected_ty != default_ty {
-            return Err(FrontendError {
-                pos: 0,
-                message: format!(
-                    "match expression branch type mismatch in lowering: expected {:?}, got {:?}",
-                    expected_ty, default_ty
-                ),
-            });
-        }
+    if exhaustive_without_default {
+        lower_impossible_match_trap(default_label, next, out);
     } else {
-        result_ty = Some(default_ty);
+        let default = match_expr
+            .default
+            .as_ref()
+            .expect("non-exhaustive match expression requires explicit default in lowering");
+        out.push(IrInstr::Label {
+            name: default_label,
+        });
+        let (default_reg, default_ty) = lower_value_block_expr(
+            default,
+            arena,
+            next,
+            out,
+            env,
+            loop_stack,
+            fn_table,
+            record_table,
+            adt_table,
+            expected,
+            ret_ty,
+        )?;
+        if let Some(ref expected_ty) = result_ty {
+            if *expected_ty != default_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "match expression branch type mismatch in lowering: expected {:?}, got {:?}",
+                        expected_ty, default_ty
+                    ),
+                });
+            }
+        } else {
+            result_ty = Some(default_ty);
+        }
+        out.push(IrInstr::StoreVar {
+            name: result_name.clone(),
+            src: default_reg,
+        });
+        out.push(IrInstr::Jmp {
+            label: end_label.clone(),
+        });
     }
-    out.push(IrInstr::StoreVar {
-        name: result_name.clone(),
-        src: default_reg,
-    });
-    out.push(IrInstr::Jmp {
-        label: end_label.clone(),
-    });
 
     out.push(IrInstr::Label { name: end_label });
     let dst = alloc(next);
@@ -4936,7 +5108,10 @@ fn lower_match_expr(
         dst,
         name: result_name,
     });
-    Ok((dst, result_ty.expect("default arm guarantees result type")))
+    Ok((
+        dst,
+        result_ty.expect("match expression lowering must establish a result type"),
+    ))
 }
 
 fn lower_expr_stmt(
@@ -5348,6 +5523,37 @@ mod opt_tests {
             .instrs
             .iter()
             .any(|instr| matches!(instr, IrInstr::AdtGet { index: 0, .. })));
+    }
+
+    #[test]
+    fn lower_exhaustive_adt_match_expression_without_default_to_trap_backstop() {
+        let src = r#"
+            enum Maybe {
+                None,
+                Some(f64),
+            }
+
+            fn main() {
+                let total: f64 = match Maybe::Some(1.0) {
+                    Maybe::None => { 0.0 }
+                    Maybe::Some(inner) => { inner }
+                };
+                let same = total == total;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src)
+            .expect("exhaustive ADT match expression without default should lower");
+        let main = &ir[0];
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::AdtTag { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::Assert { .. })));
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1973,6 +1973,36 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_exhaustive_adt_match_without_default_path() {
+        let src = r#"
+            enum Maybe {
+                None,
+                Some(f64),
+            }
+
+            fn unwrap(value: Maybe) -> f64 {
+                let total: f64 = match value {
+                    Maybe::None => { 0.0 }
+                    Maybe::Some(inner) => { inner }
+                };
+                return total;
+            }
+
+            fn main() {
+                let total: f64 = unwrap(Maybe::Some(2.5));
+                assert(total == 2.5);
+                return;
+            }
+        "#;
+
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disasm");
+        assert!(disasm.contains("ADT_TAG"));
+        assert!(disasm.contains("ASSERT"));
+        run_semcode(&bytes).expect("run");
+    }
+
+    #[test]
     fn vm_runs_stage1_record_field_access_path() {
         let src = r#"
             record DecisionContext {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -97,6 +97,8 @@ Current message families include:
 - unsupported expression form inside `requires`
 - non-bool `ensures` condition
 - unsupported expression form inside `ensures`
+- non-exhaustive enum `match`
+- `quad` match without explicit default arm
 - reserved `result` parameter name while `ensures` clauses are present
 - non-bool `invariant` condition
 - unsupported expression form inside `invariant`

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -505,7 +505,8 @@ Current `match` semantics:
 - enum arms currently use explicit nominal patterns `Enum::Variant` or
   `Enum::Variant(name, _)`
 - non-default arms may attach a `bool` guard with `if guard_expr`
-- `_` is required as the default arm
+- `quad` `match` still requires an explicit default arm `_`
+- enum `match` may omit `_` only when unguarded variant coverage is exhaustive
 - `_` currently means wildcard/default only in `match`, not a general rich
   pattern system
 - the first matching arm is selected deterministically
@@ -515,7 +516,9 @@ Current `match` expression semantics:
 - `match scrutinee { ... }` may appear in value position
 - each non-default arm uses a value-producing block after `=>`
 - expression arms may use the same `if guard_expr` form as statement-side arms
-- `_` is required as the default arm for value-producing `match`
+- value-producing `quad` `match` still requires `_`
+- value-producing enum `match` may omit `_` only when unguarded variant
+  coverage is exhaustive
 - all arms, including `_`, must produce the same type
 
 This is a deliberately narrow source contract rather than a full general
@@ -525,8 +528,9 @@ Current v0 limit:
 
 - the default `_` arm does not yet support guards
 - enum match payload patterns are currently flat only and accept only names or `_`
-- nested enum patterns, enum literal payload checks, and exhaustiveness are not
-  yet part of the stable source contract
+- guarded enum arms do not contribute to exhaustiveness
+- nested enum patterns and enum literal payload checks are not yet part of the
+  stable source contract
 
 ## Short Lambdas
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -193,7 +193,9 @@ Current statement rules:
 - `invariant(condition)` is currently a function-level contract clause only
 - `if` conditions must be `bool`
 - `match` currently accepts `quad` scrutinees and nominal enum scrutinees
-- `match` requires an explicit default arm `_ => { ... }`
+- `quad` `match` requires an explicit default arm `_ => { ... }`
+- enum `match` may omit `_ => { ... }` only when explicit unguarded variant
+  coverage is exhaustive
 - `_` in `match` remains the current wildcard/default arm spelling
 - enum match patterns currently require explicit `Enum::Variant`
 - enum match payload patterns are currently flat only and accept only names or `_`


### PR DESCRIPTION
## Summary
- add first exhaustiveness slice for canonical ADT matches
- allow enum `match` without `_` only when unguarded variant coverage is exhaustive
- lower exhaustive no-default enum matches with an explicit impossible-path `ASSERT` backstop

## Scope
This draft covers only the first `#116` slice:
- canonical enum / ADT exhaustiveness
- statement and expression `match`
- precise missing-variant diagnostics

Out of scope:
- `Result` / `Option` surfaces
- quad exhaustiveness changes
- nested patterns
- unreachable-arm diagnostics
- host / `prom-*` widening

## Validation
- cargo test -p sm-front
- cargo test -p sm-ir
- cargo test -p sm-vm
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #116.
