### PR TITLE
Document V02-06 Option and Result scope checkpoint

### DIFF
--- a/docs/roadmap/language_maturity/option_result_standard_forms_scope.md
+++ b/docs/roadmap/language_maturity/option_result_standard_forms_scope.md
@@ -1,0 +1,133 @@
+# Option and Result Standard Forms Scope
+
+Status: proposed checkpoint
+
+## Purpose
+
+Freeze the decision boundary for `V02-06` before opening implementation work
+for first-class `Option` and `Result`.
+
+This document exists because `#117` is not just "more ADT work". The current
+language now has:
+
+- nominal ADT declarations
+- ADT constructors
+- ADT match core
+- first-wave exhaustiveness checks
+
+But it still does **not** have a general generic type system. Without an
+explicit checkpoint, it is too easy to accidentally turn `#117` into:
+
+- a hidden prelude/type injection story
+- a stealth generics feature
+- or a broad standard-library/runtime expansion
+
+## Current Landed State
+
+The current `main` already includes:
+
+- canonical ADT declarations and constructors
+- canonical `MakeAdt` lowering through verifier and VM
+- ADT `match` core with explicit `Enum::Variant(...)` patterns
+- first-wave exhaustive enum `match` enforcement
+
+The current source type grammar still remains intentionally narrow:
+
+- primitives such as `quad`, `bool`, `i32`, `u32`, `fx`, `f64`
+- nominal record or enum names
+- tuple types
+- range carrier types
+
+It does **not** include:
+
+- angle-bracket generics
+- hidden standard-form injection into the ADT table
+- a general higher-kinded or type-parameterized declaration model
+
+## Why A Separate Scope Checkpoint Is Needed
+
+`Option` and `Result` are listed as first-class standard forms in `#117`, but
+there are two materially different ways to interpret that requirement:
+
+1. narrow standard forms that reuse the current ADT execution path
+2. a wider generic/type-constructor language feature
+
+Those are not the same amount of work or risk.
+
+If the project wants to keep `V02-06` inside `v0.2`, the first wave must stay
+inside the existing language and contract surface.
+
+## Recommended First-Wave Shape
+
+If `#117` remains in `v0.2`, keep it narrow and explicit.
+
+Recommended first-wave model:
+
+- add standard-form type syntax `Option(T)` and `Result(T, E)`
+- keep type arguments inside ordinary parenthesized type grammar, not angle
+  brackets
+- keep constructor surface canonical and explicit:
+  - `Option::Some(value)`
+  - `Option::None`
+  - `Result::Ok(value)`
+  - `Result::Err(error)`
+- treat those forms as built-in standard families in sema/typechecking rather
+  than as user-declared generic enums
+- lower them through the existing canonical ADT-style carrier path
+- support `match` ergonomics only through the already-canonical explicit
+  variant patterns
+
+This keeps the first wave honest:
+
+- type syntax becomes slightly richer
+- the execution path stays canonical and inspectable
+- no separate generic runtime or host boundary is introduced
+
+## Explicit Non-Goals For First-Wave `#117`
+
+Do not include any of the following in the first implementation wave:
+
+- general generic type parameters
+- angle-bracket type application
+- user-defined parameterized enums or records
+- hidden prelude declarations that silently materialize user-visible ADTs
+- special host ABI widening for `Option` or `Result`
+- shorthand match patterns beyond canonical explicit variant form
+- call-boundary or exception semantics disguised as `Result` ergonomics
+
+If any of those become necessary, they should be treated as a later expansion
+issue, not as part of `V02-06`.
+
+## Binary Decision Rule For `#117`
+
+Close `#117` only if one of these becomes true:
+
+1. a narrow standard-forms wave lands in `main` with explicit `Option(T)` /
+   `Result(T, E)` typing, canonical constructors, and verified success/none/error
+   execution tests
+2. `#117` is explicitly reshaped so first-class `Option`/`Result` move out of
+   `v0.2` and into a later generics or stdlib expansion wave
+
+Anything in between is roadmap drift.
+
+## Acceptance Criteria For A Narrow Standard-Forms Wave
+
+- parser accepts `Option(T)` and `Result(T, E)` in declared type positions
+- sema validates those forms without introducing a general generic system
+- constructor typing works for `Some` / `None` / `Ok` / `Err`
+- `match` over those standard forms reuses the canonical ADT pattern path
+- lowering stays on one inspectable carrier family
+- docs and diagnostics describe the exact first-wave boundary
+- verified-path tests cover success, none, and error flows
+
+## Recommended Next Action
+
+Before opening a code PR for `#117`, decide intentionally whether `Option` and
+`Result` are being implemented as narrow standard forms inside the current
+language surface.
+
+If the answer is yes, the next implementation branch should be a first slice
+for type syntax and constructor semantics only.
+
+If the answer is no, reshape `#117` first and move the wider feature to a later
+wave.

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -34,6 +34,7 @@ Semantic already has a strong execution contract. What it still lacks is a fully
 Related staged design-target notes:
 
 - `docs/roadmap/language_maturity/function_contract_invariant_scope.md`
+- `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
 - `docs/roadmap/language_maturity/record_data_model.md`
 - `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`


### PR DESCRIPTION
## Summary
- add a `V02-06` scope checkpoint for first-class `Option` and `Result`
- link the checkpoint from the source-language contract freeze page
- freeze the binary next step before opening code work for `#117`

## Why
`#117` is not just another small ADT feature. The language now has ADT declarations, constructors, match core, and first-wave exhaustiveness, but it still has no general generic type system.

This docs-only PR fixes the decision boundary before implementation:
- either `Option` / `Result` land as narrow standard forms inside `v0.2`
- or `#117` is explicitly reshaped into a later generics/stdlib expansion wave

## Scope
Included:
- `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
- discoverability link from `docs/roadmap/language_maturity/source_language_contract.md`

Not included:
- no parser/typecheck/lowering/runtime changes
- no `Option` / `Result` semantics yet
- no widening into generic type parameters, hidden prelude injection, or host boundary work

Closes no issue. Follow-up for #117.
