### PR TITLE
V02-06 Option and Result standard-form core surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -219,6 +219,26 @@ pub fn canonicalize_declared_type(
                 .map(|item| canonicalize_declared_type(item, record_table, adt_table, arena))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
+        Type::Option(item) => Ok(Type::Option(Box::new(canonicalize_declared_type(
+            item,
+            record_table,
+            adt_table,
+            arena,
+        )?))),
+        Type::Result(ok_ty, err_ty) => Ok(Type::Result(
+            Box::new(canonicalize_declared_type(
+                ok_ty,
+                record_table,
+                adt_table,
+                arena,
+            )?),
+            Box::new(canonicalize_declared_type(
+                err_ty,
+                record_table,
+                adt_table,
+                arena,
+            )?),
+        )),
         Type::Record(name) => {
             let is_record = record_table.contains_key(name);
             let is_adt = adt_table.contains_key(name);

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1651,6 +1651,38 @@ impl<'a> Parser<'a> {
                 }
                 return Ok(Type::QVec(32));
             }
+            if t == "Option" {
+                let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
+                if self
+                    .tokens
+                    .get(lookahead)
+                    .map(|tok| tok.kind == TokenKind::LParen)
+                    .unwrap_or(false)
+                {
+                    let _ = self.advance();
+                    self.expect(TokenKind::LParen, "expected '(' after Option type name")?;
+                    let item = self.parse_type()?;
+                    self.expect(TokenKind::RParen, "expected ')' after Option type argument")?;
+                    return Ok(Type::Option(Box::new(item)));
+                }
+            }
+            if t == "Result" {
+                let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
+                if self
+                    .tokens
+                    .get(lookahead)
+                    .map(|tok| tok.kind == TokenKind::LParen)
+                    .unwrap_or(false)
+                {
+                    let _ = self.advance();
+                    self.expect(TokenKind::LParen, "expected '(' after Result type name")?;
+                    let ok_ty = self.parse_type()?;
+                    self.expect(TokenKind::Comma, "expected ',' between Result type arguments")?;
+                    let err_ty = self.parse_type()?;
+                    self.expect(TokenKind::RParen, "expected ')' after Result type arguments")?;
+                    return Ok(Type::Result(Box::new(ok_ty), Box::new(err_ty)));
+                }
+            }
             let record_name = self.expect_symbol()?;
             return Ok(Type::Record(record_name));
         }
@@ -3401,6 +3433,58 @@ fn main() {
                 other => panic!("expected adt constructor expression, got {:?}", other),
             },
             other => panic!("expected let binding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_option_and_result_standard_form_types() {
+        let src = r#"
+fn wrap(flag: bool) -> Option(bool) {
+    let some: Option(bool) = Option::Some(flag);
+    let none: Option(bool) = Option::None;
+    let ok: Result(bool, quad) = Result::Ok(flag);
+    let err: Result(bool, quad) = Result::Err(N);
+    let _ = some;
+    let _ = none;
+    let _ = ok;
+    let _ = err;
+    return Option::Some(flag);
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("Option/Result standard-form surface should parse");
+        let wrap = &program.functions[0];
+        assert_eq!(wrap.ret, Type::Option(Box::new(Type::Bool)));
+        assert_eq!(wrap.params[0].1, Type::Bool);
+        match program.arena.stmt(wrap.body[0]) {
+            Stmt::Let { ty: Some(ty), value, .. } => {
+                assert_eq!(*ty, Type::Option(Box::new(Type::Bool)));
+                let Expr::AdtCtor(ctor) = program.arena.expr(*value) else {
+                    panic!("expected Option constructor expression");
+                };
+                assert_eq!(program.arena.symbol_name(ctor.adt_name), "Option");
+                assert_eq!(program.arena.symbol_name(ctor.variant_name), "Some");
+            }
+            other => panic!("expected typed let binding, got {:?}", other),
+        }
+        match program.arena.stmt(wrap.body[2]) {
+            Stmt::Let { ty: Some(ty), value, .. } => {
+                assert_eq!(
+                    *ty,
+                    Type::Result(Box::new(Type::Bool), Box::new(Type::Quad))
+                );
+                let Expr::AdtCtor(ctor) = program.arena.expr(*value) else {
+                    panic!("expected Result constructor expression");
+                };
+                assert_eq!(program.arena.symbol_name(ctor.adt_name), "Result");
+                assert_eq!(program.arena.symbol_name(ctor.variant_name), "Ok");
+            }
+            other => panic!("expected typed let binding, got {:?}", other),
         }
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -439,20 +439,21 @@ fn check_stmt(
                     format!("const '{}'", resolve_symbol_name(arena, *name)?),
                 )?;
             }
-            let vt = infer_expr_type(
-                *value,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )?;
             ensure_const_initializer_safe(*value, arena, env)?;
             let final_ty = if let Some(ann) = ty {
                 let expected_ty =
                     canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let vt = infer_expr_type_with_expected(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    Some(expected_ty.clone()),
+                    ret_ty,
+                    loop_stack,
+                )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
                     vt,
@@ -462,6 +463,16 @@ fn check_stmt(
                 )?;
                 expected_ty
             } else {
+                let vt = infer_expr_type(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    ret_ty,
+                    loop_stack,
+                )?;
                 vt
             };
             env.insert_const(*name, final_ty);
@@ -482,19 +493,20 @@ fn check_stmt(
                     format!("let '{}'", resolve_symbol_name(arena, *name)?),
                 )?;
             }
-            let vt = infer_expr_type(
-                *value,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )?;
             let final_ty = if let Some(ann) = ty {
                 let expected_ty =
                     canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let vt = infer_expr_type_with_expected(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    Some(expected_ty.clone()),
+                    ret_ty,
+                    loop_stack,
+                )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
                     vt,
@@ -504,6 +516,16 @@ fn check_stmt(
                 )?;
                 expected_ty
             } else {
+                let vt = infer_expr_type(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    ret_ty,
+                    loop_stack,
+                )?;
                 vt
             };
             env.insert(*name, final_ty);
@@ -524,19 +546,20 @@ fn check_stmt(
                     "tuple destructuring bind".to_string(),
                 )?;
             }
-            let vt = infer_expr_type(
-                *value,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )?;
             let final_ty = if let Some(ann) = ty {
                 let expected_ty =
                     canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let vt = infer_expr_type_with_expected(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    Some(expected_ty.clone()),
+                    ret_ty,
+                    loop_stack,
+                )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
                     vt,
@@ -546,6 +569,16 @@ fn check_stmt(
                 )?;
                 expected_ty
             } else {
+                let vt = infer_expr_type(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    ret_ty,
+                    loop_stack,
+                )?;
                 vt
             };
             let Type::Tuple(item_tys) = final_ty else {
@@ -819,19 +852,22 @@ fn check_stmt(
                     "discard binding".to_string(),
                 )?;
             }
-            let vt = infer_expr_type(
-                *value,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )?;
             if let Some(ann) = ty {
+                let expected_ty =
+                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let vt = infer_expr_type_with_expected(
+                    *value,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    Some(expected_ty.clone()),
+                    ret_ty,
+                    loop_stack,
+                )?;
                 ensure_binding_value_type(
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?,
+                    expected_ty,
                     vt,
                     *value,
                     arena,
@@ -857,13 +893,14 @@ fn check_stmt(
                     ),
                 });
             }
-            let value_ty = infer_expr_type(
+            let value_ty = infer_expr_type_with_expected(
                 *value,
                 arena,
                 env,
                 table,
                 record_table,
                 adt_table,
+                Some(target_ty.clone()),
                 ret_ty.clone(),
                 loop_stack,
             )?;
@@ -1346,6 +1383,7 @@ fn infer_expr_type(
             table,
             record_table,
             adt_table,
+            None,
             ret_ty,
             loop_stack,
         ),
@@ -1462,17 +1500,18 @@ fn infer_expr_type(
             };
             let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
             for (i, arg) in ordered_args.iter().enumerate() {
-                let at = infer_expr_type(
+                let expected_ty = sig.params[i].clone();
+                let at = infer_expr_type_with_expected(
                     *arg,
                     arena,
                     env,
                     table,
                     record_table,
                     adt_table,
+                    Some(expected_ty.clone()),
                     ret_ty.clone(),
                     loop_stack,
                 )?;
-                let expected_ty = sig.params[i].clone();
                 if at != expected_ty {
                     if expected_ty == Type::Fx && is_numeric_for_fx_gap(&at) {
                         if !is_fx_literal_expr(*arg, arena) {
@@ -3629,6 +3668,53 @@ mod tests {
 
         typecheck_source(src).expect("adt constructor surface should typecheck");
     }
+
+    #[test]
+    fn option_and_result_standard_forms_typecheck_in_typed_positions() {
+        let src = r#"
+            fn keep(flag: bool) -> Option(bool) {
+                let seen: Option(bool) = Option::None;
+                let _ = seen;
+                return Option::Some(flag);
+            }
+
+            fn settle(flag: bool) -> Result(bool, quad) {
+                if flag {
+                    let value: Result(bool, quad) = Result::Ok(true);
+                    return value;
+                }
+                let value: Result(bool, quad) = Result::Err(N);
+                return value;
+            }
+
+            fn main() {
+                let left: Option(bool) = keep(true);
+                let right: Result(bool, quad) = settle(false);
+                let _ = left;
+                let _ = right;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("Option/Result standard forms should typecheck");
+    }
+
+    #[test]
+    fn result_constructor_requires_contextual_result_type() {
+        let src = r#"
+            fn main() {
+                let value = Result::Ok(true);
+                let _ = value;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("contextless Result constructor must currently reject");
+        assert!(err
+            .message
+            .contains("Result::Ok currently requires contextual Result(T, E) type in v0"));
+    }
 }
 
 fn is_builtin_assert_name(
@@ -4363,6 +4449,13 @@ fn ensure_type_resolved(
                 })
             }
         }
+        Type::Option(item) => {
+            ensure_type_resolved(item, record_table, adt_table, arena, context)
+        }
+        Type::Result(ok_ty, err_ty) => {
+            ensure_type_resolved(ok_ty, record_table, adt_table, arena, context.clone())?;
+            ensure_type_resolved(err_ty, record_table, adt_table, arena, context)
+        }
         _ => Ok(()),
     }
 }
@@ -4378,6 +4471,11 @@ fn ensure_executable_type_supported(
                 ensure_executable_type_supported(item, arena, context.clone())?;
             }
             Ok(())
+        }
+        Type::Option(item) => ensure_executable_type_supported(item, arena, context),
+        Type::Result(ok_ty, err_ty) => {
+            ensure_executable_type_supported(ok_ty, arena, context.clone())?;
+            ensure_executable_type_supported(err_ty, arena, context)
         }
         Type::Record(name) => {
             let _ = resolve_symbol_name(arena, *name)?;
@@ -4404,6 +4502,11 @@ fn ensure_storage_type_supported(
                 ensure_storage_type_supported(item, arena, context.clone())?;
             }
             Ok(())
+        }
+        Type::Option(item) => ensure_storage_type_supported(item, arena, context),
+        Type::Result(ok_ty, err_ty) => {
+            ensure_storage_type_supported(ok_ty, arena, context.clone())?;
+            ensure_storage_type_supported(err_ty, arena, context)
         }
         Type::Record(name) => {
             let _ = resolve_symbol_name(arena, *name)?;
@@ -4556,6 +4659,15 @@ fn supports_stable_equality_type_inner(
             }
             Ok(true)
         }
+        Type::Option(item) => {
+            supports_stable_equality_type_inner(item, record_table, adt_table, active)
+        }
+        Type::Result(ok_ty, err_ty) => {
+            if !supports_stable_equality_type_inner(ok_ty, record_table, adt_table, active)? {
+                return Ok(false);
+            }
+            supports_stable_equality_type_inner(err_ty, record_table, adt_table, active)
+        }
         Type::Record(name) => {
             if !active.insert(*name) {
                 return Ok(false);
@@ -4622,13 +4734,14 @@ fn infer_record_literal_type(
                 resolve_symbol_name(arena, field.name)?
             ),
         })?;
-        let actual_ty = infer_expr_type(
+        let actual_ty = infer_expr_type_with_expected(
             field.value,
             arena,
             env,
             table,
             record_table,
             adt_table,
+            Some(expected_ty.clone()),
             ret_ty.clone(),
             loop_stack,
         )?;
@@ -4781,13 +4894,14 @@ fn infer_record_update_type(
                 resolve_symbol_name(arena, field.name)?
             ),
         })?;
-        let actual_ty = infer_expr_type(
+        let actual_ty = infer_expr_type_with_expected(
             field.value,
             arena,
             env,
             table,
             record_table,
             adt_table,
+            Some(expected_ty.clone()),
             ret_ty.clone(),
             loop_stack,
         )?;
@@ -4813,9 +4927,23 @@ fn infer_adt_ctor_type(
     table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    expected: Option<&Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<Type, FrontendError> {
+    if let Some(ty) = infer_std_form_ctor_type(
+        ctor_expr,
+        arena,
+        env,
+        table,
+        record_table,
+        adt_table,
+        expected,
+        ret_ty.clone(),
+        loop_stack,
+    )? {
+        return Ok(ty);
+    }
     let adt = adt_table.get(&ctor_expr.adt_name).ok_or(FrontendError {
         pos: 0,
         message: format!(
@@ -4855,13 +4983,14 @@ fn infer_adt_ctor_type(
     {
         let canonical_expected =
             canonicalize_declared_type(expected_ty, record_table, adt_table, arena)?;
-        let actual_ty = infer_expr_type(
+        let actual_ty = infer_expr_type_with_expected(
             *payload_expr,
             arena,
             env,
             table,
             record_table,
             adt_table,
+            Some(canonical_expected.clone()),
             ret_ty.clone(),
             loop_stack,
         )?;
@@ -4879,6 +5008,185 @@ fn infer_adt_ctor_type(
         )?;
     }
     Ok(Type::Adt(ctor_expr.adt_name))
+}
+
+fn infer_expr_type_with_expected(
+    expr_id: ExprId,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    expected: Option<Type>,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+) -> Result<Type, FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
+            ctor_expr,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            expected.as_ref(),
+            ret_ty,
+            loop_stack,
+        ),
+        _ => infer_expr_type(
+            expr_id,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty,
+            loop_stack,
+        ),
+    }
+}
+
+fn infer_std_form_ctor_type(
+    ctor_expr: &AdtCtorExpr,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    expected: Option<&Type>,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+) -> Result<Option<Type>, FrontendError> {
+    let type_name = resolve_symbol_name(arena, ctor_expr.adt_name)?;
+    let variant_name = resolve_symbol_name(arena, ctor_expr.variant_name)?;
+
+    if type_name == "Option" {
+        return match variant_name {
+            "Some" => {
+                if ctor_expr.payload.len() != 1 {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: "Option::Some expects exactly one payload item".to_string(),
+                    });
+                }
+                let item_ty = if let Some(Type::Option(item_ty)) = expected {
+                    let expected_item = (**item_ty).clone();
+                    let actual_ty = infer_expr_type_with_expected(
+                        ctor_expr.payload[0],
+                        arena,
+                        env,
+                        table,
+                        record_table,
+                        adt_table,
+                        Some(expected_item.clone()),
+                        ret_ty,
+                        loop_stack,
+                    )?;
+                    ensure_binding_value_type(
+                        expected_item.clone(),
+                        actual_ty,
+                        ctor_expr.payload[0],
+                        arena,
+                        "Option::Some payload".to_string(),
+                    )?;
+                    expected_item
+                } else {
+                    infer_expr_type(
+                        ctor_expr.payload[0],
+                        arena,
+                        env,
+                        table,
+                        record_table,
+                        adt_table,
+                        ret_ty,
+                        loop_stack,
+                    )?
+                };
+                Ok(Some(Type::Option(Box::new(item_ty))))
+            }
+            "None" => {
+                if !ctor_expr.payload.is_empty() {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: "Option::None does not accept payload items".to_string(),
+                    });
+                }
+                match expected {
+                    Some(Type::Option(item_ty)) => {
+                        Ok(Some(Type::Option(Box::new((**item_ty).clone()))))
+                    }
+                    _ => Err(FrontendError {
+                        pos: 0,
+                        message:
+                            "Option::None currently requires contextual Option(T) type in v0"
+                                .to_string(),
+                    }),
+                }
+            }
+            _ => Err(FrontendError {
+                pos: 0,
+                message: format!("Option has no variant named '{}'", variant_name),
+            }),
+        };
+    }
+
+    if type_name == "Result" {
+        return match variant_name {
+            "Ok" | "Err" => {
+                if ctor_expr.payload.len() != 1 {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "Result::{} expects exactly one payload item",
+                            variant_name
+                        ),
+                    });
+                }
+                let Some(Type::Result(ok_ty, err_ty)) = expected else {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "Result::{} currently requires contextual Result(T, E) type in v0",
+                            variant_name
+                        ),
+                    });
+                };
+                let expected_payload = if variant_name == "Ok" {
+                    (**ok_ty).clone()
+                } else {
+                    (**err_ty).clone()
+                };
+                let actual_ty = infer_expr_type_with_expected(
+                    ctor_expr.payload[0],
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    Some(expected_payload.clone()),
+                    ret_ty,
+                    loop_stack,
+                )?;
+                ensure_binding_value_type(
+                    expected_payload,
+                    actual_ty,
+                    ctor_expr.payload[0],
+                    arena,
+                    format!("Result::{} payload", variant_name),
+                )?;
+                Ok(Some(Type::Result(
+                    Box::new((**ok_ty).clone()),
+                    Box::new((**err_ty).clone()),
+                )))
+            }
+            _ => Err(FrontendError {
+                pos: 0,
+                message: format!("Result has no variant named '{}'", variant_name),
+            }),
+        };
+    }
+
+    Ok(None)
 }
 
 fn bind_match_pattern(
@@ -5088,13 +5396,14 @@ fn check_return_payload(
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<(), FrontendError> {
     let got = if let Some(expr_id) = value {
-        infer_expr_type(
+        infer_expr_type_with_expected(
             expr_id,
             arena,
             env,
             table,
             record_table,
             adt_table,
+            Some(ret_ty.clone()),
             ret_ty.clone(),
             loop_stack,
         )?

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -15,6 +15,8 @@ pub enum Type {
     F64,
     RangeI32,
     Tuple(Vec<Type>),
+    Option(Box<Type>),
+    Result(Box<Type>, Box<Type>),
     Record(SymbolId),
     Adt(SymbolId),
     Unit,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1569,6 +1569,7 @@ fn lower_expr_with_expected(
             fn_table,
             record_table,
             adt_table,
+            expected,
             ret_ty,
         ),
         Expr::NumericLiteral(NumericLiteral::I32(n)) => {
@@ -3689,8 +3690,24 @@ fn lower_adt_ctor_expr(
     fn_table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    expected: Option<Type>,
     ret_ty: Type,
 ) -> Result<(u16, Type), FrontendError> {
+    if let Some(lowered) = lower_std_form_ctor_expr(
+        ctor_expr,
+        arena,
+        next,
+        out,
+        env,
+        loop_stack,
+        fn_table,
+        record_table,
+        adt_table,
+        expected.clone(),
+        ret_ty.clone(),
+    )? {
+        return Ok(lowered);
+    }
     let adt = adt_table.get(&ctor_expr.adt_name).ok_or(FrontendError {
         pos: 0,
         message: format!(
@@ -3768,6 +3785,171 @@ fn lower_adt_ctor_expr(
         items: regs,
     });
     Ok((dst, Type::Adt(ctor_expr.adt_name)))
+}
+
+fn lower_std_form_ctor_expr(
+    ctor_expr: &AdtCtorExpr,
+    arena: &AstArena,
+    next: &mut u16,
+    out: &mut Vec<IrInstr>,
+    env: &ScopeEnv,
+    loop_stack: &mut Vec<LoopLoweringFrame>,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    expected: Option<Type>,
+    ret_ty: Type,
+) -> Result<Option<(u16, Type)>, FrontendError> {
+    let type_name = resolve_symbol_name(arena, ctor_expr.adt_name)?;
+    let variant_name = resolve_symbol_name(arena, ctor_expr.variant_name)?;
+
+    if type_name == "Option" {
+        match variant_name {
+            "Some" => {
+                if ctor_expr.payload.len() != 1 {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message:
+                            "Option::Some expects exactly one payload item in lowering"
+                                .to_string(),
+                    });
+                }
+                let item_expected = match expected.as_ref() {
+                    Some(Type::Option(item_ty)) => Some((**item_ty).clone()),
+                    _ => None,
+                };
+                let (item_reg, item_ty) = lower_expr_with_expected(
+                    ctor_expr.payload[0],
+                    arena,
+                    next,
+                    out,
+                    env,
+                    loop_stack,
+                    fn_table,
+                    record_table,
+                    adt_table,
+                    item_expected.clone(),
+                    ret_ty,
+                )?;
+                if let Some(expected_item) = item_expected {
+                    if item_ty != expected_item {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "Option::Some payload type mismatch in lowering: expected {:?}, got {:?}",
+                                expected_item, item_ty
+                            ),
+                        });
+                    }
+                }
+                let dst = alloc(next);
+                out.push(IrInstr::MakeAdt {
+                    dst,
+                    adt_name: "Option".to_string(),
+                    variant_name: "Some".to_string(),
+                    tag: 1,
+                    items: vec![item_reg],
+                });
+                return Ok(Some((dst, Type::Option(Box::new(item_ty)))));
+            }
+            "None" => {
+                if !ctor_expr.payload.is_empty() {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: "Option::None does not accept payload items in lowering"
+                            .to_string(),
+                    });
+                }
+                let Some(Type::Option(item_ty)) = expected else {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message:
+                            "Option::None currently requires contextual Option(T) type in v0 lowering"
+                                .to_string(),
+                    });
+                };
+                let dst = alloc(next);
+                out.push(IrInstr::MakeAdt {
+                    dst,
+                    adt_name: "Option".to_string(),
+                    variant_name: "None".to_string(),
+                    tag: 0,
+                    items: Vec::new(),
+                });
+                return Ok(Some((dst, Type::Option(item_ty))));
+            }
+            _ => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!("Option has no variant named '{}' in lowering", variant_name),
+                })
+            }
+        }
+    }
+
+    if type_name == "Result" {
+        if ctor_expr.payload.len() != 1 {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "Result::{} expects exactly one payload item in lowering",
+                    variant_name
+                ),
+            });
+        }
+        let Some(Type::Result(ok_ty, err_ty)) = expected else {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "Result::{} currently requires contextual Result(T, E) type in v0 lowering",
+                    variant_name
+                ),
+            });
+        };
+        let (payload_expected, tag) = match variant_name {
+            "Ok" => ((*ok_ty).clone(), 0),
+            "Err" => ((*err_ty).clone(), 1),
+            _ => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!("Result has no variant named '{}' in lowering", variant_name),
+                })
+            }
+        };
+        let (payload_reg, payload_ty) = lower_expr_with_expected(
+            ctor_expr.payload[0],
+            arena,
+            next,
+            out,
+            env,
+            loop_stack,
+            fn_table,
+            record_table,
+            adt_table,
+            Some(payload_expected.clone()),
+            ret_ty,
+        )?;
+        if payload_ty != payload_expected {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "Result::{} payload type mismatch in lowering: expected {:?}, got {:?}",
+                    variant_name, payload_expected, payload_ty
+                ),
+            });
+        }
+        let dst = alloc(next);
+        out.push(IrInstr::MakeAdt {
+            dst,
+            adt_name: "Result".to_string(),
+            variant_name: variant_name.to_string(),
+            tag,
+            items: vec![payload_reg],
+        });
+        return Ok(Some((dst, Type::Result(ok_ty, err_ty))));
+    }
+
+    Ok(None)
 }
 
 #[derive(Debug, Clone)]
@@ -6348,6 +6530,58 @@ mod opt_tests {
             instr,
             IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
                 if adt_name == "Maybe" && variant_name == "None" && *tag == 0 && items.is_empty()
+        )));
+    }
+
+    #[test]
+    fn lower_option_and_result_standard_forms_to_canonical_make_adt_ir() {
+        let src = r#"
+            fn keep(flag: bool) -> Option(bool) {
+                let fallback: Option(bool) = Option::None;
+                let _ = fallback;
+                return Option::Some(flag);
+            }
+
+            fn settle(flag: bool) -> Result(bool, quad) {
+                if flag {
+                    let value: Result(bool, quad) = Result::Ok(true);
+                    return value;
+                }
+                let value: Result(bool, quad) = Result::Err(N);
+                return value;
+            }
+
+            fn main() {
+                let left: Option(bool) = keep(true);
+                let right: Result(bool, quad) = settle(false);
+                let _ = left;
+                let _ = right;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("Option/Result standard forms should lower");
+        let keep = ir.iter().find(|func| func.name == "keep").expect("keep fn");
+        assert!(keep.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
+                if adt_name == "Option" && variant_name == "None" && *tag == 0 && items.is_empty()
+        )));
+        assert!(keep.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
+                if adt_name == "Option" && variant_name == "Some" && *tag == 1 && items.len() == 1
+        )));
+        let settle = ir.iter().find(|func| func.name == "settle").expect("settle fn");
+        assert!(settle.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
+                if adt_name == "Result" && variant_name == "Ok" && *tag == 0 && items.len() == 1
+        )));
+        assert!(settle.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
+                if adt_name == "Result" && variant_name == "Err" && *tag == 1 && items.len() == 1
         )));
     }
 

--- a/crates/sm-sema/src/std_adapters.rs
+++ b/crates/sm-sema/src/std_adapters.rs
@@ -47,6 +47,8 @@ impl From<Type> for SemanticType {
             Type::Unit => SemanticType::Unit,
             Type::RangeI32 => SemanticType::Unknown,
             Type::Tuple(_) => SemanticType::Unknown,
+            Type::Option(_) => SemanticType::Unknown,
+            Type::Result(_, _) => SemanticType::Unknown,
             Type::Record(_) => SemanticType::Unknown,
             Type::Adt(_) => SemanticType::Unknown,
         }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1943,6 +1943,39 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_option_and_result_standard_form_paths() {
+        let src = r#"
+            fn keep(flag: bool) -> Option(bool) {
+                let fallback: Option(bool) = Option::None;
+                let _ = fallback;
+                return Option::Some(flag);
+            }
+
+            fn settle(flag: bool) -> Result(bool, quad) {
+                if flag {
+                    let value: Result(bool, quad) = Result::Ok(true);
+                    return value;
+                }
+                let value: Result(bool, quad) = Result::Err(N);
+                return value;
+            }
+
+            fn main() {
+                let left: Option(bool) = keep(true);
+                let right: Result(bool, quad) = settle(false);
+                let _ = left;
+                let _ = right;
+                return;
+            }
+        "#;
+
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disasm");
+        assert!(disasm.contains("MAKE_ADT"));
+        run_semcode(&bytes).expect("Option/Result standard-form paths should run");
+    }
+
+    #[test]
     fn vm_runs_stage1_adt_match_path() {
         let src = r#"
             enum Maybe {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -116,6 +116,8 @@ Current message families include:
 - unsupported expression form inside `requires`
 - let-binding type mismatch
 - discard-binding type mismatch
+- `Option::None` without contextual `Option(T)` type
+- `Result::Ok(...)` / `Result::Err(...)` without contextual `Result(T, E)` type
 - non-const-safe initializer in const declaration
 - invalid typed numeric literal form
 - range literal requires `i32` bounds

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -458,6 +458,33 @@ Current v0 limit:
   tuple-specific operators are not yet part of the stable contract
 - tuple values are not part of the PROMETHEUS host ABI surface
 
+## Option and Result Standard Forms
+
+Current first-wave semantics:
+
+- `Option(T)` and `Result(T, E)` are built-in standard-form types in declared
+  type positions
+- they are not user-declared generic enums and do not imply a general generic
+  type system
+- constructor evaluation reuses the canonical ADT-style carrier path
+- `Option::Some(value)` produces `Option(value_type)` when no stronger context
+  is required
+- `Option::None` currently requires contextual `Option(T)` type from the
+  surrounding typed position
+- `Result::Ok(value)` and `Result::Err(error)` currently require contextual
+  `Result(T, E)` type from the surrounding typed position
+- current verified execution coverage is over constructor creation and typed
+  success/none/error flows, not over dedicated `Option` / `Result` match sugar
+
+Current v0 limit:
+
+- the current slice does not add angle-bracket generics
+- the current slice does not add user-defined parameterized declarations
+- the current slice does not inject hidden prelude enums into the nominal ADT
+  table
+- the current slice does not yet add special `Option` / `Result` match patterns
+  beyond the existing canonical enum machinery
+
 ## Records
 
 Current stage-1 record semantics:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -321,6 +321,26 @@ Current v0 tuple limits:
 - tuple field access and tuple pattern matching beyond flat destructuring bind
   are not yet part of the stable surface
 
+Current first-wave `Option` / `Result` standard-form rules:
+
+- declared type positions now accept `Option(type)` and `Result(ok_type, err_type)`
+- canonical constructors are:
+  - `Option::Some(value)`
+  - `Option::None`
+  - `Result::Ok(value)`
+  - `Result::Err(error)`
+- this is a narrow standard-forms surface, not a general generic type system
+- angle-bracket type application and user-defined parameterized declarations are
+  not part of this slice
+- `Option::Some(value)` may infer `Option(T)` from its payload type
+- `Option::None` currently requires contextual `Option(T)` type
+- `Result::Ok(...)` and `Result::Err(...)` currently require contextual
+  `Result(T, E)` type
+- canonical `Option` / `Result` constructors reuse the existing `MakeAdt`
+  lowering family
+- `match` ergonomics for `Option` / `Result` remain a later slice; this wave
+  does not widen the general pattern system
+
 Current precedence, from tighter to looser:
 
 1. primary expressions and calls

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -54,6 +54,19 @@ Current rules:
 - `match` currently operates on `quad` and nominal enum scrutinees
 - `quad` is not accepted directly as an `if` condition
 
+## Standard Forms
+
+Current first-wave standard forms:
+
+- `Option(T)` is the canonical optional-value type family in declared type
+  positions
+- `Result(T, E)` is the canonical success/error type family in declared type
+  positions
+- these forms are language-owned standard families, not user-defined generic
+  declarations
+- they currently lower through the same canonical aggregate carrier family used
+  by nominal ADTs
+
 ## Bool
 
 `bool` is the ordinary binary condition type.


### PR DESCRIPTION
## Summary
- add first-wave `Option(T)` / `Result(T, E)` declared type syntax without opening a general generic system
- type canonical constructors through the existing ADT-style carrier path
- add parser, sema, lowering, VM, spec, and verified-path coverage for narrow success/none/error flows

## Scope
Included:
- `Type::Option` and `Type::Result`
- declared type parsing for `Option(type)` and `Result(ok_type, err_type)`
- canonical constructor support:
  - `Option::Some(value)`
  - `Option::None`
  - `Result::Ok(value)`
  - `Result::Err(error)`
- explicit contextual typing rule for ambiguous constructors
- canonical `MakeAdt` lowering reuse
- parser/typecheck/lowering/VM/docs/tests

Not included:
- no angle-bracket generics
- no user-defined parameterized enums or records
- no hidden prelude injection into the nominal ADT table
- no `Option` / `Result` match ergonomics yet
- no host / `prom-*` widening

## Current boundary
This is the first implementation slice for `#117`, not the whole issue. It lands type syntax and canonical constructor semantics first, while keeping `Option` / `Result` match ergonomics for a follow-up slice.

## Validation
- `cargo test -p sm-front`
- `cargo test -p sm-ir`
- `cargo test -p sm-vm`
- `cargo test --workspace`
