### PR TITLE
V02-06 Option and Result match ergonomics surface

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1540,7 +1540,7 @@ impl<'a> Parser<'a> {
         } else {
             Err(FrontendError {
                 pos: self.pos(),
-                message: "expected match pattern N|F|T|S|Enum::Variant|_".to_string(),
+                message: "expected match pattern N|F|T|S|Type::Variant|_".to_string(),
             })
         }
     }
@@ -3485,6 +3485,54 @@ fn main() {
                 assert_eq!(program.arena.symbol_name(ctor.variant_name), "Ok");
             }
             other => panic!("expected typed let binding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_option_and_result_match_patterns() {
+        let src = r#"
+fn unwrap(opt: Option(bool), res: Result(bool, quad)) {
+    match opt {
+        Option::Some(value) => { let _ = value; }
+        _ => { return; }
+    }
+    match res {
+        Result::Ok(value) => { let _ = value; }
+        Result::Err(code) => { let _ = code; }
+    }
+    return;
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("Option/Result match patterns should parse");
+        let unwrap = &program.functions[0];
+        match program.arena.stmt(unwrap.body[0]) {
+            Stmt::Match { arms, .. } => {
+                let MatchPattern::Adt(pat) = &arms[0].pat else {
+                    panic!("expected Option match pattern");
+                };
+                assert_eq!(program.arena.symbol_name(pat.adt_name), "Option");
+                assert_eq!(program.arena.symbol_name(pat.variant_name), "Some");
+                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind(_)]));
+            }
+            other => panic!("expected match stmt, got {:?}", other),
+        }
+        match program.arena.stmt(unwrap.body[1]) {
+            Stmt::Match { arms, default, .. } => {
+                assert!(default.is_empty(), "exhaustive Result match should omit default");
+                let MatchPattern::Adt(pat) = &arms[1].pat else {
+                    panic!("expected Result match pattern");
+                };
+                assert_eq!(program.arena.symbol_name(pat.adt_name), "Result");
+                assert_eq!(program.arena.symbol_name(pat.variant_name), "Err");
+                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind(_)]));
+            }
+            other => panic!("expected match stmt, got {:?}", other),
         }
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -2,7 +2,7 @@ use crate::*;
 use crate::types::{AdtCtorExpr, AdtPatternItem, MatchPattern, NumericLiteral, RecordPatternTarget};
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 
 fn fx_coercion_gap_message() -> &'static str {
     "fx coercion from non-literal numeric expressions is not implemented in the canonical Rust-like path yet"
@@ -1142,10 +1142,12 @@ fn check_stmt(
                 ret_ty.clone(),
                 loop_stack,
             )?;
-            if !matches!(st, Type::Quad | Type::Adt(_)) {
+            if !matches!(st, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "match is allowed only for quad or enum scrutinee".to_string(),
+                    message:
+                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                            .to_string(),
                 });
             }
 
@@ -1187,23 +1189,14 @@ fn check_stmt(
             }
 
             if default.is_empty() {
-                match missing_exhaustive_adt_variants(
+                match missing_exhaustive_sum_variants(
                     &st,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
                     arena,
                     adt_table,
                 )? {
-                    Some(missing) if !missing.is_empty() => {
-                        return Err(non_exhaustive_match_error(
-                            arena,
-                            match st {
-                                Type::Adt(name) => name,
-                                _ => unreachable!(),
-                            },
-                            &missing,
-                            false,
-                        )?)
-                    }
+                    Some((family_label, missing)) if !missing.is_empty() =>
+                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?),
                     Some(_) => {}
                     None => {
                         return Err(FrontendError {
@@ -1988,7 +1981,7 @@ mod tests {
         let err = typecheck_source(src).expect_err("non-quad match expression must reject");
         assert!(err
             .message
-            .contains("match expression is allowed only for quad or enum scrutinee"));
+            .contains("match expression is allowed only for quad"));
     }
 
     #[test]
@@ -3715,6 +3708,82 @@ mod tests {
             .message
             .contains("Result::Ok currently requires contextual Result(T, E) type in v0"));
     }
+
+    #[test]
+    fn option_and_result_match_patterns_typecheck_without_default_when_exhaustive() {
+        let src = r#"
+            fn unwrap(opt: Option(bool)) -> bool {
+                let out: bool = match opt {
+                    Option::Some(value) => { value }
+                    Option::None => { false }
+                };
+                return out;
+            }
+
+            fn settle(res: Result(quad, quad)) -> quad {
+                let out: quad = match res {
+                    Result::Ok(value) => { value }
+                    Result::Err(code) => { code }
+                };
+                return out;
+            }
+
+            fn main() {
+                let left: bool = unwrap(Option::Some(true));
+                let right: quad = settle(Result::Err(S));
+                assert(left == true);
+                assert(right == S);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("Option/Result match ergonomics should typecheck");
+    }
+
+    #[test]
+    fn option_match_without_none_arm_rejects_as_non_exhaustive() {
+        let src = r#"
+            fn unwrap(opt: Option(bool)) -> bool {
+                let out: bool = match opt {
+                    Option::Some(value) => { value }
+                };
+                return out;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("non-exhaustive Option match expression without default must reject");
+        assert!(err
+            .message
+            .contains("non-exhaustive match expression for Option(T); missing variants: None"));
+    }
+
+    #[test]
+    fn result_pattern_family_must_match_result_scrutinee() {
+        let src = r#"
+            fn settle(res: Result(bool, quad)) -> bool {
+                let out: bool = match res {
+                    Option::Some(value) => { value }
+                    _ => { false }
+                };
+                return out;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("mismatched standard-form match family must reject");
+        assert!(err
+            .message
+            .contains("match arm pattern type 'Option' does not match scrutinee Result(T, E)"));
+    }
 }
 
 fn is_builtin_assert_name(
@@ -3839,10 +3908,15 @@ fn infer_match_expr_type(
             ret_ty.clone(),
             loop_stack,
         )?;
-    if !matches!(scrutinee_ty, Type::Quad | Type::Adt(_)) {
+    if !matches!(
+        scrutinee_ty,
+        Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+    ) {
         return Err(FrontendError {
             pos: 0,
-            message: "match expression is allowed only for quad or enum scrutinee".to_string(),
+            message:
+                "match expression is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                    .to_string(),
         });
     }
 
@@ -3920,21 +3994,14 @@ fn infer_match_expr_type(
             Ok(default_ty)
         }
     } else {
-        match missing_exhaustive_adt_variants(
+        match missing_exhaustive_sum_variants(
             &scrutinee_ty,
             match_expr.arms.iter().map(|arm| (&arm.pat, arm.guard)),
             arena,
             adt_table,
         )? {
-            Some(missing) if !missing.is_empty() => Err(non_exhaustive_match_error(
-                arena,
-                match scrutinee_ty {
-                    Type::Adt(name) => name,
-                    _ => unreachable!(),
-                },
-                &missing,
-                true,
-            )?),
+            Some((family_label, missing)) if !missing.is_empty() =>
+                Err(non_exhaustive_match_error(&family_label, &missing, true)?),
             Some(_) => Ok(result_ty
                 .expect("exhaustive enum match expression should have at least one arm")),
             None => Err(FrontendError {
@@ -4073,10 +4140,12 @@ fn check_loop_expr_stmt(
                 ret_ty.clone(),
                 loop_stack,
             )?;
-            if !matches!(st, Type::Quad | Type::Adt(_)) {
+            if !matches!(st, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "match is allowed only for quad or enum scrutinee".to_string(),
+                    message:
+                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                            .to_string(),
                 });
             }
             if default.is_empty() {
@@ -5189,6 +5258,79 @@ fn infer_std_form_ctor_type(
     Ok(None)
 }
 
+#[derive(Debug, Clone)]
+struct MatchFamilyVariantSpec {
+    name: String,
+    payload: Vec<Type>,
+}
+
+#[derive(Debug, Clone)]
+struct MatchFamilySpec {
+    family_name: String,
+    display_label: String,
+    variants: Vec<MatchFamilyVariantSpec>,
+}
+
+fn resolve_match_family_spec(
+    scrutinee_ty: &Type,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<Option<MatchFamilySpec>, FrontendError> {
+    match scrutinee_ty {
+        Type::Adt(adt_name) => {
+            let adt = adt_table.get(adt_name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown enum type '{}' in match resolution",
+                    resolve_symbol_name(arena, *adt_name)?,
+                ),
+            })?;
+            let family_name = resolve_symbol_name(arena, *adt_name)?.to_string();
+            let mut variants = Vec::new();
+            for variant in &adt.variants {
+                variants.push(MatchFamilyVariantSpec {
+                    name: resolve_symbol_name(arena, variant.name)?.to_string(),
+                    payload: variant.payload.clone(),
+                });
+            }
+            Ok(Some(MatchFamilySpec {
+                display_label: format!("enum '{}'", family_name),
+                family_name,
+                variants,
+            }))
+        }
+        Type::Option(item_ty) => Ok(Some(MatchFamilySpec {
+            family_name: "Option".to_string(),
+            display_label: "Option(T)".to_string(),
+            variants: vec![
+                MatchFamilyVariantSpec {
+                    name: "None".to_string(),
+                    payload: Vec::new(),
+                },
+                MatchFamilyVariantSpec {
+                    name: "Some".to_string(),
+                    payload: vec![(**item_ty).clone()],
+                },
+            ],
+        })),
+        Type::Result(ok_ty, err_ty) => Ok(Some(MatchFamilySpec {
+            family_name: "Result".to_string(),
+            display_label: "Result(T, E)".to_string(),
+            variants: vec![
+                MatchFamilyVariantSpec {
+                    name: "Ok".to_string(),
+                    payload: vec![(**ok_ty).clone()],
+                },
+                MatchFamilyVariantSpec {
+                    name: "Err".to_string(),
+                    payload: vec![(**err_ty).clone()],
+                },
+            ],
+        })),
+        _ => Ok(None),
+    }
+}
+
 fn bind_match_pattern(
     pat: &MatchPattern,
     scrutinee_ty: &Type,
@@ -5201,56 +5343,60 @@ fn bind_match_pattern(
         (Type::Quad, MatchPattern::Adt(adt_pat)) => Err(FrontendError {
             pos: 0,
             message: format!(
-                "enum match pattern '{}::{}' can be used only with enum scrutinee",
+                "sum match pattern '{}::{}' can be used only with sum scrutinee",
                 resolve_symbol_name(arena, adt_pat.adt_name)?,
                 resolve_symbol_name(arena, adt_pat.variant_name)?,
             ),
         }),
-        (Type::Adt(scrutinee_name), MatchPattern::Quad(pat)) => Err(FrontendError {
-            pos: 0,
-            message: format!(
-                "quad match pattern '{:?}' can be used only with quad scrutinee, not enum '{}'",
-                pat,
-                resolve_symbol_name(arena, *scrutinee_name)?,
-            ),
-        }),
-        (Type::Adt(scrutinee_name), MatchPattern::Adt(adt_pat)) => {
-            if adt_pat.adt_name != *scrutinee_name {
+        (_, MatchPattern::Quad(pat)) => {
+            let family = resolve_match_family_spec(scrutinee_ty, arena, adt_table)?
+                .expect("non-quad matchable family should resolve");
+            Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "quad match pattern '{:?}' can be used only with quad scrutinee, not {}",
+                    pat, family.display_label
+                ),
+            })
+        }
+        (_, MatchPattern::Adt(adt_pat)) => {
+            let Some(family) = resolve_match_family_spec(scrutinee_ty, arena, adt_table)? else {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                            .to_string(),
+                });
+            };
+            let pattern_family = resolve_symbol_name(arena, adt_pat.adt_name)?.to_string();
+            if pattern_family != family.family_name {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
-                        "match arm pattern enum '{}' does not match scrutinee enum '{}'",
-                        resolve_symbol_name(arena, adt_pat.adt_name)?,
-                        resolve_symbol_name(arena, *scrutinee_name)?,
+                        "match arm pattern type '{}' does not match scrutinee {}",
+                        pattern_family, family.display_label
                     ),
                 });
             }
-            let adt = adt_table.get(scrutinee_name).ok_or(FrontendError {
-                pos: 0,
-                message: format!(
-                    "unknown enum type '{}' in match pattern",
-                    resolve_symbol_name(arena, *scrutinee_name)?,
-                ),
-            })?;
-            let variant = adt
+            let pattern_variant = resolve_symbol_name(arena, adt_pat.variant_name)?.to_string();
+            let variant = family
                 .variants
                 .iter()
-                .find(|variant| variant.name == adt_pat.variant_name)
+                .find(|variant| variant.name == pattern_variant)
                 .ok_or(FrontendError {
                     pos: 0,
                     message: format!(
-                        "enum '{}' has no variant named '{}' in match pattern",
-                        resolve_symbol_name(arena, *scrutinee_name)?,
-                        resolve_symbol_name(arena, adt_pat.variant_name)?,
+                        "{} has no variant named '{}' in match pattern",
+                        family.display_label, pattern_variant,
                     ),
                 })?;
             if variant.payload.len() != adt_pat.items.len() {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
-                        "enum match pattern '{}::{}' expects {} payload items, got {}",
-                        resolve_symbol_name(arena, *scrutinee_name)?,
-                        resolve_symbol_name(arena, adt_pat.variant_name)?,
+                        "match pattern '{}::{}' expects {} payload items, got {}",
+                        family.family_name,
+                        pattern_variant,
                         variant.payload.len(),
                         adt_pat.items.len(),
                     ),
@@ -5272,9 +5418,9 @@ fn bind_match_pattern(
                         return Err(FrontendError {
                             pos: 0,
                             message: format!(
-                                "enum match pattern '{}::{}' repeats binding '{}' at payload item {}",
-                                resolve_symbol_name(arena, *scrutinee_name)?,
-                                resolve_symbol_name(arena, adt_pat.variant_name)?,
+                                "match pattern '{}::{}' repeats binding '{}' at payload item {}",
+                                family.family_name,
+                                pattern_variant,
                                 resolve_symbol_name(arena, *name)?,
                                 index,
                             ),
@@ -5285,29 +5431,18 @@ fn bind_match_pattern(
             }
             Ok(bindings)
         }
-        (_, MatchPattern::Quad(_)) | (_, MatchPattern::Adt(_)) => Err(FrontendError {
-            pos: 0,
-            message: "match is allowed only for quad or enum scrutinee".to_string(),
-        }),
     }
 }
 
-fn missing_exhaustive_adt_variants<'a>(
+fn missing_exhaustive_sum_variants<'a>(
     scrutinee_ty: &Type,
     patterns: impl IntoIterator<Item = (&'a MatchPattern, Option<ExprId>)>,
     arena: &AstArena,
     adt_table: &AdtTable,
-) -> Result<Option<Vec<SymbolId>>, FrontendError> {
-    let Type::Adt(adt_name) = scrutinee_ty else {
+) -> Result<Option<(String, Vec<String>)>, FrontendError> {
+    let Some(family) = resolve_match_family_spec(scrutinee_ty, arena, adt_table)? else {
         return Ok(None);
     };
-    let adt = adt_table.get(adt_name).ok_or(FrontendError {
-        pos: 0,
-        message: format!(
-            "unknown enum type '{}' in match exhaustiveness check",
-            resolve_symbol_name(arena, *adt_name)?,
-        ),
-    })?;
 
     let mut covered = BTreeSet::new();
     for (pat, guard) in patterns {
@@ -5315,39 +5450,36 @@ fn missing_exhaustive_adt_variants<'a>(
             continue;
         }
         if let MatchPattern::Adt(adt_pat) = pat {
-            if adt_pat.adt_name == *adt_name {
-                covered.insert(adt_pat.variant_name);
+            if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name
+            {
+                covered.insert(resolve_symbol_name(arena, adt_pat.variant_name)?.to_string());
             }
         }
     }
 
-    Ok(Some(
-        adt.variants
+    Ok(Some((
+        family.display_label,
+        family
+            .variants
             .iter()
             .filter(|variant| !covered.contains(&variant.name))
-            .map(|variant| variant.name)
+            .map(|variant| variant.name.clone())
             .collect(),
-    ))
+    )))
 }
 
 fn non_exhaustive_match_error(
-    arena: &AstArena,
-    adt_name: SymbolId,
-    missing: &[SymbolId],
+    family_label: &str,
+    missing: &[String],
     expression: bool,
 ) -> Result<FrontendError, FrontendError> {
-    let missing_names = missing
-        .iter()
-        .map(|name| resolve_symbol_name(arena, *name))
-        .collect::<Result<Vec<_>, _>>()?
-        .join(", ");
     Ok(FrontendError {
         pos: 0,
         message: format!(
-            "non-exhaustive match{} for enum '{}'; missing variants: {}",
+            "non-exhaustive match{} for {}; missing variants: {}",
             if expression { " expression" } else { "" },
-            resolve_symbol_name(arena, adt_name)?,
-            missing_names,
+            family_label,
+            missing.join(", "),
         ),
     })
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3202,30 +3202,23 @@ fn lower_stmt(
                 adt_table,
                 ret_ty.clone(),
             )?;
-            if !matches!(scr_ty, Type::Quad | Type::Adt(_)) {
+            if !matches!(scr_ty, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "match scrutinee must be quad or enum".to_string(),
+                    message:
+                        "match scrutinee must be quad, enum, Option(T), or Result(T, E)"
+                            .to_string(),
                 });
             }
             let exhaustive_without_default = if default.is_empty() {
-                match missing_exhaustive_adt_variants(
+                match missing_exhaustive_sum_variants(
                     &scr_ty,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
                     arena,
                     adt_table,
                 )? {
-                    Some(missing) if !missing.is_empty() => {
-                        return Err(non_exhaustive_match_error(
-                            arena,
-                            match scr_ty {
-                                Type::Adt(name) => name,
-                                _ => unreachable!(),
-                            },
-                            &missing,
-                            false,
-                        )?)
-                    }
+                    Some((family_label, missing)) if !missing.is_empty() =>
+                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?),
                     Some(_) => true,
                     None => {
                         return Err(FrontendError {
@@ -3368,19 +3361,21 @@ fn lower_stmt(
                         });
                     }
                 }
-                Type::Adt(scrutinee_name) => {
+                Type::Adt(_) | Type::Option(_) | Type::Result(_, _) => {
+                    let family = resolve_match_family_for_lowering(&scr_ty, arena, adt_table)?
+                        .expect("sum scrutinee family should resolve");
                     let scr_tag_reg = alloc(&mut ctx.next_reg);
                     ctx.instrs.push(IrInstr::AdtTag {
                         dst: scr_tag_reg,
                         src: scr_reg,
-                        adt_name: resolve_symbol_name(arena, scrutinee_name)?.to_string(),
+                        adt_name: family.family_name.clone(),
                     });
                     let resolved_patterns = arms
                         .iter()
                         .map(|arm| {
-                            resolve_adt_match_pattern_for_lowering(
+                            resolve_sum_match_pattern_for_lowering(
                                 &arm.pat,
-                                scrutinee_name,
+                                &scr_ty,
                                 arena,
                                 record_table,
                                 adt_table,
@@ -3966,6 +3961,20 @@ struct LoweredAdtMatchPattern {
     bindings: Vec<LoweredAdtMatchBinding>,
 }
 
+#[derive(Debug, Clone)]
+struct LoweredMatchFamilyVariant {
+    name: String,
+    tag: i32,
+    payload: Vec<Type>,
+}
+
+#[derive(Debug, Clone)]
+struct LoweredMatchFamily {
+    family_name: String,
+    display_label: String,
+    variants: Vec<LoweredMatchFamilyVariant>,
+}
+
 fn expect_quad_match_pattern(pat: &MatchPattern) -> Result<QuadVal, FrontendError> {
     match pat {
         MatchPattern::Quad(pat) => Ok(*pat),
@@ -3976,59 +3985,128 @@ fn expect_quad_match_pattern(pat: &MatchPattern) -> Result<QuadVal, FrontendErro
     }
 }
 
-fn resolve_adt_match_pattern_for_lowering(
+fn resolve_match_family_for_lowering(
+    scrutinee_ty: &Type,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<Option<LoweredMatchFamily>, FrontendError> {
+    match scrutinee_ty {
+        Type::Adt(adt_name) => {
+            let adt = adt_table.get(adt_name).ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown enum type '{}' in match lowering",
+                    resolve_symbol_name(arena, *adt_name)?,
+                ),
+            })?;
+            let family_name = resolve_symbol_name(arena, *adt_name)?.to_string();
+            let mut variants = Vec::new();
+            for (tag, variant) in adt.variants.iter().enumerate() {
+                variants.push(LoweredMatchFamilyVariant {
+                    name: resolve_symbol_name(arena, variant.name)?.to_string(),
+                    tag: i32::try_from(tag).map_err(|_| FrontendError {
+                        pos: 0,
+                        message: "enum variant tag exceeds v0 lowering limit".to_string(),
+                    })?,
+                    payload: variant.payload.clone(),
+                });
+            }
+            Ok(Some(LoweredMatchFamily {
+                display_label: format!("enum '{}'", family_name),
+                family_name,
+                variants,
+            }))
+        }
+        Type::Option(item_ty) => Ok(Some(LoweredMatchFamily {
+            family_name: "Option".to_string(),
+            display_label: "Option(T)".to_string(),
+            variants: vec![
+                LoweredMatchFamilyVariant {
+                    name: "None".to_string(),
+                    tag: 0,
+                    payload: Vec::new(),
+                },
+                LoweredMatchFamilyVariant {
+                    name: "Some".to_string(),
+                    tag: 1,
+                    payload: vec![(**item_ty).clone()],
+                },
+            ],
+        })),
+        Type::Result(ok_ty, err_ty) => Ok(Some(LoweredMatchFamily {
+            family_name: "Result".to_string(),
+            display_label: "Result(T, E)".to_string(),
+            variants: vec![
+                LoweredMatchFamilyVariant {
+                    name: "Ok".to_string(),
+                    tag: 0,
+                    payload: vec![(**ok_ty).clone()],
+                },
+                LoweredMatchFamilyVariant {
+                    name: "Err".to_string(),
+                    tag: 1,
+                    payload: vec![(**err_ty).clone()],
+                },
+            ],
+        })),
+        _ => Ok(None),
+    }
+}
+
+fn resolve_sum_match_pattern_for_lowering(
     pat: &MatchPattern,
-    scrutinee_name: SymbolId,
+    scrutinee_ty: &Type,
     arena: &AstArena,
     record_table: &RecordTable,
     adt_table: &AdtTable,
 ) -> Result<LoweredAdtMatchPattern, FrontendError> {
     let MatchPattern::Adt(adt_pat) = pat else {
+        let family = resolve_match_family_for_lowering(scrutinee_ty, arena, adt_table)?
+            .expect("non-quad match family should resolve");
         return Err(FrontendError {
             pos: 0,
             message: format!(
-                "quad match pattern requires quad scrutinee; enum '{}' needs explicit variant patterns in lowering",
-                resolve_symbol_name(arena, scrutinee_name)?,
+                "quad match pattern requires quad scrutinee; {} needs explicit variant patterns in lowering",
+                family.display_label,
             ),
         });
     };
-    if adt_pat.adt_name != scrutinee_name {
+    let Some(family) = resolve_match_family_for_lowering(scrutinee_ty, arena, adt_table)? else {
+        return Err(FrontendError {
+            pos: 0,
+            message:
+                "match scrutinee must be quad, enum, Option(T), or Result(T, E)".to_string(),
+        });
+    };
+    let pattern_family = resolve_symbol_name(arena, adt_pat.adt_name)?.to_string();
+    if pattern_family != family.family_name {
         return Err(FrontendError {
             pos: 0,
             message: format!(
-                "match arm pattern enum '{}' does not match scrutinee enum '{}' in lowering",
-                resolve_symbol_name(arena, adt_pat.adt_name)?,
-                resolve_symbol_name(arena, scrutinee_name)?,
+                "match arm pattern type '{}' does not match scrutinee {} in lowering",
+                pattern_family, family.display_label,
             ),
         });
     }
-    let adt = adt_table.get(&scrutinee_name).ok_or(FrontendError {
-        pos: 0,
-        message: format!(
-            "unknown enum type '{}' in match lowering",
-            resolve_symbol_name(arena, scrutinee_name)?,
-        ),
-    })?;
-    let (tag, variant) = adt
+    let pattern_variant = resolve_symbol_name(arena, adt_pat.variant_name)?.to_string();
+    let variant = family
         .variants
         .iter()
-        .enumerate()
-        .find(|(_, variant)| variant.name == adt_pat.variant_name)
+        .find(|variant| variant.name == pattern_variant)
         .ok_or(FrontendError {
             pos: 0,
             message: format!(
-                "enum '{}' has no variant named '{}' in match lowering",
-                resolve_symbol_name(arena, scrutinee_name)?,
-                resolve_symbol_name(arena, adt_pat.variant_name)?,
+                "{} has no variant named '{}' in match lowering",
+                family.display_label, pattern_variant,
             ),
         })?;
     if variant.payload.len() != adt_pat.items.len() {
         return Err(FrontendError {
             pos: 0,
             message: format!(
-                "enum match pattern '{}::{}' expects {} payload items in lowering, got {}",
-                resolve_symbol_name(arena, scrutinee_name)?,
-                resolve_symbol_name(arena, adt_pat.variant_name)?,
+                "match pattern '{}::{}' expects {} payload items in lowering, got {}",
+                family.family_name,
+                pattern_variant,
                 variant.payload.len(),
                 adt_pat.items.len(),
             ),
@@ -4053,11 +4131,8 @@ fn resolve_adt_match_pattern_for_lowering(
     }
 
     Ok(LoweredAdtMatchPattern {
-        adt_name: resolve_symbol_name(arena, scrutinee_name)?.to_string(),
-        tag: i32::try_from(tag).map_err(|_| FrontendError {
-            pos: 0,
-            message: "enum variant tag exceeds v0 lowering limit".to_string(),
-        })?,
+        adt_name: family.family_name,
+        tag: variant.tag,
         bindings,
     })
 }
@@ -4087,22 +4162,15 @@ fn lower_adt_match_bindings(
     Ok(())
 }
 
-fn missing_exhaustive_adt_variants<'a>(
+fn missing_exhaustive_sum_variants<'a>(
     scrutinee_ty: &Type,
     patterns: impl IntoIterator<Item = (&'a MatchPattern, Option<ExprId>)>,
     arena: &AstArena,
     adt_table: &AdtTable,
-) -> Result<Option<Vec<SymbolId>>, FrontendError> {
-    let Type::Adt(adt_name) = scrutinee_ty else {
+) -> Result<Option<(String, Vec<String>)>, FrontendError> {
+    let Some(family) = resolve_match_family_for_lowering(scrutinee_ty, arena, adt_table)? else {
         return Ok(None);
     };
-    let adt = adt_table.get(adt_name).ok_or(FrontendError {
-        pos: 0,
-        message: format!(
-            "unknown enum type '{}' in match lowering exhaustiveness check",
-            resolve_symbol_name(arena, *adt_name)?,
-        ),
-    })?;
 
     let mut covered = BTreeSet::new();
     for (pat, guard) in patterns {
@@ -4110,39 +4178,35 @@ fn missing_exhaustive_adt_variants<'a>(
             continue;
         }
         if let MatchPattern::Adt(adt_pat) = pat {
-            if adt_pat.adt_name == *adt_name {
-                covered.insert(adt_pat.variant_name);
+            if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name {
+                covered.insert(resolve_symbol_name(arena, adt_pat.variant_name)?.to_string());
             }
         }
     }
 
-    Ok(Some(
-        adt.variants
+    Ok(Some((
+        family.display_label,
+        family
+            .variants
             .iter()
             .filter(|variant| !covered.contains(&variant.name))
-            .map(|variant| variant.name)
+            .map(|variant| variant.name.clone())
             .collect(),
-    ))
+    )))
 }
 
 fn non_exhaustive_match_error(
-    arena: &AstArena,
-    adt_name: SymbolId,
-    missing: &[SymbolId],
+    family_label: &str,
+    missing: &[String],
     expression: bool,
 ) -> Result<FrontendError, FrontendError> {
-    let missing_names = missing
-        .iter()
-        .map(|name| resolve_symbol_name(arena, *name))
-        .collect::<Result<Vec<_>, _>>()?
-        .join(", ");
     Ok(FrontendError {
         pos: 0,
         message: format!(
-            "non-exhaustive match{} for enum '{}'; missing variants: {}",
+            "non-exhaustive match{} for {}; missing variants: {}",
             if expression { " expression" } else { "" },
-            resolve_symbol_name(arena, adt_name)?,
-            missing_names,
+            family_label,
+            missing.join(", "),
         ),
     })
 }
@@ -4647,30 +4711,23 @@ fn lower_loop_expr_stmt(
                 adt_table,
                 ret_ty.clone(),
             )?;
-            if !matches!(scr_ty, Type::Quad | Type::Adt(_)) {
+            if !matches!(scr_ty, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
                 return Err(FrontendError {
                     pos: 0,
-                    message: "match scrutinee must be quad or enum".to_string(),
+                    message:
+                        "match scrutinee must be quad, enum, Option(T), or Result(T, E)"
+                            .to_string(),
                 });
             }
             let exhaustive_without_default = if default.is_empty() {
-                match missing_exhaustive_adt_variants(
+                match missing_exhaustive_sum_variants(
                     &scr_ty,
                     arms.iter().map(|arm| (&arm.pat, arm.guard)),
                     arena,
                     adt_table,
                 )? {
-                    Some(missing) if !missing.is_empty() => {
-                        return Err(non_exhaustive_match_error(
-                            arena,
-                            match scr_ty {
-                                Type::Adt(name) => name,
-                                _ => unreachable!(),
-                            },
-                            &missing,
-                            false,
-                        )?)
-                    }
+                    Some((family_label, missing)) if !missing.is_empty() =>
+                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?),
                     Some(_) => true,
                     None => {
                         return Err(FrontendError {
@@ -4770,19 +4827,21 @@ fn lower_loop_expr_stmt(
                         });
                     }
                 }
-                Type::Adt(scrutinee_name) => {
+                Type::Adt(_) | Type::Option(_) | Type::Result(_, _) => {
+                    let family = resolve_match_family_for_lowering(&scr_ty, arena, adt_table)?
+                        .expect("sum scrutinee family should resolve");
                     let scr_tag_reg = alloc(next);
                     out.push(IrInstr::AdtTag {
                         dst: scr_tag_reg,
                         src: scr_reg,
-                        adt_name: resolve_symbol_name(arena, scrutinee_name)?.to_string(),
+                        adt_name: family.family_name.clone(),
                     });
                     let resolved_patterns = arms
                         .iter()
                         .map(|arm| {
-                            resolve_adt_match_pattern_for_lowering(
+                            resolve_sum_match_pattern_for_lowering(
                                 &arm.pat,
-                                scrutinee_name,
+                                &scr_ty,
                                 arena,
                                 record_table,
                                 adt_table,
@@ -4968,30 +5027,23 @@ fn lower_match_expr(
         adt_table,
         ret_ty.clone(),
     )?;
-    if !matches!(scr_ty, Type::Quad | Type::Adt(_)) {
+    if !matches!(scr_ty, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
         return Err(FrontendError {
             pos: 0,
-            message: "match expression scrutinee must be quad or enum".to_string(),
+            message:
+                "match expression scrutinee must be quad, enum, Option(T), or Result(T, E)"
+                    .to_string(),
         });
     }
     let exhaustive_without_default = if match_expr.default.is_none() {
-        match missing_exhaustive_adt_variants(
+        match missing_exhaustive_sum_variants(
             &scr_ty,
             match_expr.arms.iter().map(|arm| (&arm.pat, arm.guard)),
             arena,
             adt_table,
         )? {
-            Some(missing) if !missing.is_empty() => {
-                return Err(non_exhaustive_match_error(
-                    arena,
-                    match scr_ty {
-                        Type::Adt(name) => name,
-                        _ => unreachable!(),
-                    },
-                    &missing,
-                    true,
-                )?)
-            }
+            Some((family_label, missing)) if !missing.is_empty() =>
+                return Err(non_exhaustive_match_error(&family_label, &missing, true)?),
             Some(_) => true,
             None => {
                 return Err(FrontendError {
@@ -5111,20 +5163,22 @@ fn lower_match_expr(
                 });
             }
         }
-        Type::Adt(scrutinee_name) => {
+        Type::Adt(_) | Type::Option(_) | Type::Result(_, _) => {
+            let family = resolve_match_family_for_lowering(&scr_ty, arena, adt_table)?
+                .expect("sum scrutinee family should resolve");
             let scr_tag_reg = alloc(next);
             out.push(IrInstr::AdtTag {
                 dst: scr_tag_reg,
                 src: scr_reg,
-                adt_name: resolve_symbol_name(arena, scrutinee_name)?.to_string(),
+                adt_name: family.family_name.clone(),
             });
             let resolved_patterns = match_expr
                 .arms
                 .iter()
                 .map(|arm| {
-                    resolve_adt_match_pattern_for_lowering(
+                    resolve_sum_match_pattern_for_lowering(
                         &arm.pat,
-                        scrutinee_name,
+                        &scr_ty,
                         arena,
                         record_table,
                         adt_table,
@@ -6582,6 +6636,55 @@ mod opt_tests {
             instr,
             IrInstr::MakeAdt { adt_name, variant_name, tag, items, .. }
                 if adt_name == "Result" && variant_name == "Err" && *tag == 1 && items.len() == 1
+        )));
+    }
+
+    #[test]
+    fn lower_option_and_result_match_patterns_to_existing_adt_tag_path() {
+        let src = r#"
+            fn unwrap(opt: Option(bool)) -> bool {
+                let out: bool = match opt {
+                    Option::Some(value) => { value }
+                    Option::None => { false }
+                };
+                return out;
+            }
+
+            fn settle(res: Result(quad, quad)) -> quad {
+                let out: quad = match res {
+                    Result::Ok(value) => { value }
+                    Result::Err(code) => { code }
+                };
+                return out;
+            }
+
+            fn main() {
+                let left: bool = unwrap(Option::Some(true));
+                let right: quad = settle(Result::Err(S));
+                assert(left == true);
+                assert(right == S);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("Option/Result match ergonomics should lower");
+        let unwrap = ir.iter().find(|func| func.name == "unwrap").expect("unwrap fn");
+        assert!(unwrap.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtTag { adt_name, .. } if adt_name == "Option"
+        )));
+        assert!(unwrap.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtGet { adt_name, index, .. } if adt_name == "Option" && *index == 0
+        )));
+        let settle = ir.iter().find(|func| func.name == "settle").expect("settle fn");
+        assert!(settle.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtTag { adt_name, .. } if adt_name == "Result"
+        )));
+        assert!(settle.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtGet { adt_name, index, .. } if adt_name == "Result" && *index == 0
         )));
     }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1976,6 +1976,43 @@ mod tests {
     }
 
     #[test]
+    fn vm_runs_option_and_result_match_ergonomics_paths() {
+        let src = r#"
+            fn unwrap(opt: Option(bool)) -> bool {
+                let out: bool = match opt {
+                    Option::Some(value) => { value }
+                    Option::None => { false }
+                };
+                return out;
+            }
+
+            fn settle(res: Result(quad, quad)) -> quad {
+                let out: quad = match res {
+                    Result::Ok(value) => { value }
+                    Result::Err(code) => { code }
+                };
+                return out;
+            }
+
+            fn main() {
+                let left: bool = unwrap(Option::Some(true));
+                let right: bool = unwrap(Option::None);
+                let code: quad = settle(Result::Err(S));
+                assert(left == true);
+                assert(right == false);
+                assert(code == S);
+                return;
+            }
+        "#;
+
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disasm");
+        assert!(disasm.contains("ADT_TAG"));
+        assert!(disasm.contains("ADT_GET"));
+        run_semcode(&bytes).expect("Option/Result match ergonomics paths should run");
+    }
+
+    #[test]
     fn vm_runs_stage1_adt_match_path() {
         let src = r#"
             enum Maybe {

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -177,6 +177,9 @@ Current message families include:
 - `match`-expression branch type mismatch
 - invalid `match` scrutinee or missing `_` arm
 - enum match pattern that does not match the scrutinee enum
+- standard-form match pattern that does not match the scrutinee `Option(T)` /
+  `Result(T, E)` family
+- non-exhaustive `Option(T)` / `Result(T, E)` match without `_`
 - enum match payload arity mismatch
 - unsupported enum match payload item shape
 - unsupported statement forms inside a value-producing block

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -473,8 +473,9 @@ Current first-wave semantics:
   surrounding typed position
 - `Result::Ok(value)` and `Result::Err(error)` currently require contextual
   `Result(T, E)` type from the surrounding typed position
-- current verified execution coverage is over constructor creation and typed
-  success/none/error flows, not over dedicated `Option` / `Result` match sugar
+- current verified execution coverage now includes constructor creation plus
+  explicit `Option::Some/None` and `Result::Ok/Err` match flows over
+  success/none/error paths
 
 Current v0 limit:
 
@@ -482,8 +483,9 @@ Current v0 limit:
 - the current slice does not add user-defined parameterized declarations
 - the current slice does not inject hidden prelude enums into the nominal ADT
   table
-- the current slice does not yet add special `Option` / `Result` match patterns
-  beyond the existing canonical enum machinery
+- `Option` / `Result` match ergonomics are still limited to the existing
+  canonical variant pattern machinery; they do not add bare `Some/Ok` names,
+  nested payload patterns, or a wider generic pattern system
 
 ## Records
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -192,12 +192,17 @@ Current statement rules:
 - `ensures(condition)` is currently a function-level contract clause only
 - `invariant(condition)` is currently a function-level contract clause only
 - `if` conditions must be `bool`
-- `match` currently accepts `quad` scrutinees and nominal enum scrutinees
+- `match` currently accepts `quad` scrutinees, nominal enum scrutinees, and
+  the standard-form `Option(T)` / `Result(T, E)` families
 - `quad` `match` requires an explicit default arm `_ => { ... }`
 - enum `match` may omit `_ => { ... }` only when explicit unguarded variant
   coverage is exhaustive
+- `Option` / `Result` `match` may omit `_ => { ... }` only when explicit
+  unguarded `Some/None` or `Ok/Err` coverage is exhaustive
 - `_` in `match` remains the current wildcard/default arm spelling
 - enum match patterns currently require explicit `Enum::Variant`
+- standard-form match patterns currently require explicit `Option::Some`,
+  `Option::None`, `Result::Ok`, or `Result::Err`
 - enum match payload patterns are currently flat only and accept only names or `_`
 - unit-returning calls may be used as statements
 - extended numeric literal spelling does not itself widen arithmetic support
@@ -338,8 +343,15 @@ Current first-wave `Option` / `Result` standard-form rules:
   `Result(T, E)` type
 - canonical `Option` / `Result` constructors reuse the existing `MakeAdt`
   lowering family
-- `match` ergonomics for `Option` / `Result` remain a later slice; this wave
-  does not widen the general pattern system
+- `match` now accepts explicit standard-form patterns:
+  - `Option::Some(name_or_)`
+  - `Option::None`
+  - `Result::Ok(name_or_)`
+  - `Result::Err(name_or_)`
+- exhaustive `Option` / `Result` matches may omit `_ => { ... }` when all
+  unguarded variants are covered
+- this still reuses the existing canonical ADT-style pattern machinery rather
+  than widening the general pattern system
 
 Current precedence, from tighter to looser:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -51,7 +51,8 @@ Current rule:
 Current rules:
 
 - `quad` participates in equality and implication
-- `match` currently operates on `quad` and nominal enum scrutinees
+- `match` currently operates on `quad`, nominal enum scrutinees, and the
+  standard-form `Option(T)` / `Result(T, E)` families
 - `quad` is not accepted directly as an `if` condition
 
 ## Standard Forms
@@ -66,6 +67,8 @@ Current first-wave standard forms:
   declarations
 - they currently lower through the same canonical aggregate carrier family used
   by nominal ADTs
+- explicit `Option::Some/None` and `Result::Ok/Err` patterns participate in
+  the stable match surface over these families
 
 ## Bool
 
@@ -137,7 +140,7 @@ Current equality and control rules:
 
 - `==` and `!=` require meaningful same-family comparisons
 - `if` requires `bool`
-- `match` requires `quad`
+- `match` requires `quad`, nominal enum, `Option(T)`, or `Result(T, E)`
 
 ## Function Typing Rules
 


### PR DESCRIPTION
## Summary
- add Option/Result match ergonomics on top of the landed ADT match path
- reuse canonical ADT tag/payload lowering for `Option::Some/None` and `Result::Ok/Err`
- sync parser/typecheck/lowering/VM/spec/tests without widening generics or host boundaries

## Scope
This is the second slice inside #117.

Includes:
- explicit standard-form match patterns for `Option(T)` and `Result(T, E)`
- exhaustive omission of `_` when `Some/None` or `Ok/Err` coverage is complete
- verified success/none/error execution coverage

Out of scope:
- angle-bracket generics
- user-defined parameterized types
- bare `Some` / `Ok` pattern sugar
- host / `prom-*` widening
