### PR TITLE
Document V02-07 units of measure scope

### DIFF
--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -38,3 +38,4 @@ Related staged design-target notes:
 - `docs/roadmap/language_maturity/record_data_model.md`
 - `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`
+- `docs/roadmap/language_maturity/units_of_measure_scope.md`

--- a/docs/roadmap/language_maturity/units_of_measure_scope.md
+++ b/docs/roadmap/language_maturity/units_of_measure_scope.md
@@ -1,0 +1,73 @@
+# Units Of Measure Scope
+
+Status: proposed first-wave checkpoint
+Related issue: `#118`
+
+## Goal
+
+Define a narrow, executable first-wave units-of-measure contract for `v0.2`
+without opening a general dimensional-analysis system or widening runtime and
+host boundaries.
+
+## Decision
+
+`#118` will be implemented as a compile-time-only source contract over the
+existing core numeric families.
+
+First-wave syntax:
+
+- `i32[m]`
+- `u32[ms]`
+- `f64[kg]`
+- `fx[rpm]`
+
+where the bracket payload is a single unit symbol.
+
+## Included In First Wave
+
+- unit annotations on `i32`, `u32`, `f64`, and `fx`
+- unit-carrying local bindings, parameters, returns, tuple items, record
+  fields, `Option(T)`, and `Result(T, E)` payload positions
+- exact unit equality for assignment, call arguments, returns, and pattern
+  bindings
+- `+` and `-` only when both operands have the same numeric base type and the
+  same unit annotation
+- `==` and `!=` only when both operands have the same numeric base type and the
+  same unit annotation
+- explicit docs describing which operations preserve units and which ones reject
+- lowering by erasing units after semantic validation, reusing the existing
+  numeric carrier path
+
+## Explicit Non-Goals
+
+- implicit conversions between units
+- conversion functions or conversion tables
+- compound unit algebra such as `m/s`, `N*m`, or exponent notation
+- unit inference from literals
+- unit annotations on non-numeric families
+- widening VM value carriers or public host ABI shapes
+- reopening arithmetic policy beyond the documented first-wave subset
+
+## Honest First-Wave Rules
+
+- unit annotations are part of the source type contract, not part of the VM
+  value representation
+- unsuffixed numeric literals remain ordinary numeric literals and become
+  unit-carrying only through typed positions
+- `+`, `-`, `==`, and `!=` preserve the declared unit when both sides match
+  exactly
+- `*` and `/` on unit-carrying values are rejected in the first wave
+- unannotated numeric values do not implicitly coerce to annotated numeric types
+- different unit symbols with the same numeric carrier are still mismatched
+  types
+
+## Done Boundary
+
+`#118` can close when:
+
+1. parser accepts first-wave unit annotations in declared type positions,
+2. sema reports compile-time mismatches on incompatible unit-annotated numeric
+   values,
+3. lowering remains unit-erased and reuses the existing numeric execution path,
+4. docs define supported operations and honest non-conversion rules,
+5. verified tests cover assignment/call/return/operator mismatch cases.


### PR DESCRIPTION
## Summary
- add a docs-only checkpoint for the first-wave units-of-measure boundary
- freeze units as compile-time-only annotations on core numeric families
- document supported operations, explicit non-goals, and done boundary before code

## Scope
This PR does not add units semantics to the compiler.

It only:
- adds `units_of_measure_scope.md`
- links it from the source-language contract freeze note
- fixes the decision boundary for #118 before implementation
