### PR TITLE
V02-07 units of measure core surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -219,6 +219,19 @@ pub fn canonicalize_declared_type(
                 .map(|item| canonicalize_declared_type(item, record_table, adt_table, arena))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
+        Type::Measured(base, unit) => {
+            let canonical_base = canonicalize_declared_type(base, record_table, adt_table, arena)?;
+            if !canonical_base.is_core_numeric_scalar() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "unit annotation '{}' is allowed only on i32, u32, f64, or fx in v0",
+                        resolve_symbol_name(arena, *unit)?
+                    ),
+                });
+            }
+            Ok(Type::Measured(Box::new(canonical_base), *unit))
+        }
         Type::Option(item) => Ok(Type::Option(Box::new(canonicalize_declared_type(
             item,
             record_table,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1633,10 +1633,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_type(&mut self) -> Result<Type, FrontendError> {
-        if self.eat(TokenKind::LParen) {
-            return self.parse_paren_type_or_tuple();
-        }
-        if self.check(TokenKind::Ident) {
+        let base = if self.eat(TokenKind::LParen) {
+            self.parse_paren_type_or_tuple()?
+        } else if self.check(TokenKind::Ident) {
             let t = self.tokens[self.next_non_layout_idx()].text.clone();
             if t == "qvec" {
                 let _ = self.advance();
@@ -1647,11 +1646,11 @@ impl<'a> Parser<'a> {
                         32
                     };
                     let _ = self.eat(TokenKind::RBracket) || self.eat(TokenKind::RParen);
-                    return Ok(Type::QVec(n));
+                    Type::QVec(n)
+                } else {
+                    Type::QVec(32)
                 }
-                return Ok(Type::QVec(32));
-            }
-            if t == "Option" {
+            } else if t == "Option" {
                 let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
                 if self
                     .tokens
@@ -1663,10 +1662,12 @@ impl<'a> Parser<'a> {
                     self.expect(TokenKind::LParen, "expected '(' after Option type name")?;
                     let item = self.parse_type()?;
                     self.expect(TokenKind::RParen, "expected ')' after Option type argument")?;
-                    return Ok(Type::Option(Box::new(item)));
+                    Type::Option(Box::new(item))
+                } else {
+                    let record_name = self.expect_symbol()?;
+                    Type::Record(record_name)
                 }
-            }
-            if t == "Result" {
+            } else if t == "Result" {
                 let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
                 if self
                     .tokens
@@ -1680,35 +1681,51 @@ impl<'a> Parser<'a> {
                     self.expect(TokenKind::Comma, "expected ',' between Result type arguments")?;
                     let err_ty = self.parse_type()?;
                     self.expect(TokenKind::RParen, "expected ')' after Result type arguments")?;
-                    return Ok(Type::Result(Box::new(ok_ty), Box::new(err_ty)));
+                    Type::Result(Box::new(ok_ty), Box::new(err_ty))
+                } else {
+                    let record_name = self.expect_symbol()?;
+                    Type::Record(record_name)
                 }
+            } else {
+                let record_name = self.expect_symbol()?;
+                Type::Record(record_name)
             }
-            let record_name = self.expect_symbol()?;
-            return Ok(Type::Record(record_name));
-        }
-        if self.eat(TokenKind::TyQuad) {
-            return Ok(Type::Quad);
-        }
-        if self.eat(TokenKind::TyBool) {
-            return Ok(Type::Bool);
-        }
-        if self.eat(TokenKind::TyI32) {
-            return Ok(Type::I32);
-        }
-        if self.eat(TokenKind::TyU32) {
-            return Ok(Type::U32);
-        }
-        if self.eat(TokenKind::TyFx) {
-            return Ok(Type::Fx);
-        }
-        if self.eat(TokenKind::TyF64) {
+        } else if self.eat(TokenKind::TyQuad) {
+            Type::Quad
+        } else if self.eat(TokenKind::TyBool) {
+            Type::Bool
+        } else if self.eat(TokenKind::TyI32) {
+            Type::I32
+        } else if self.eat(TokenKind::TyU32) {
+            Type::U32
+        } else if self.eat(TokenKind::TyFx) {
+            Type::Fx
+        } else if self.eat(TokenKind::TyF64) {
             self.require_f64_feature("type 'f64' is disabled by profile policy")?;
-            return Ok(Type::F64);
+            Type::F64
+        } else {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: "expected type".to_string(),
+            });
+        };
+        self.parse_optional_measure_annotation(base)
+    }
+
+    fn parse_optional_measure_annotation(&mut self, base: Type) -> Result<Type, FrontendError> {
+        if !self.eat(TokenKind::LBracket) {
+            return Ok(base);
         }
-        Err(FrontendError {
-            pos: self.pos(),
-            message: "expected type".to_string(),
-        })
+        if !base.is_core_numeric_scalar() {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "unit annotation is allowed only on i32, u32, f64, or fx in v0".to_string(),
+            });
+        }
+        let unit = self.expect_symbol()?;
+        self.expect(TokenKind::RBracket, "expected ']' after unit annotation")?;
+        Ok(Type::Measured(Box::new(base), unit))
     }
 
     fn parse_paren_type_or_tuple(&mut self) -> Result<Type, FrontendError> {
@@ -1974,33 +1991,50 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_type_raw(&mut self) -> Result<Type, FrontendError> {
-        if self.check_raw(TokenKind::Ident) {
+        let base = if self.check_raw(TokenKind::Ident) {
             let t = self.tokens[self.idx].text.clone();
             if t == "qvec" {
                 self.idx += 1;
-                return Ok(Type::QVec(32));
+                Type::QVec(32)
+            } else {
+                return Err(self.error_at_current("expected type", "E0234"));
             }
-        }
-        if self.eat_raw(TokenKind::TyQuad) {
-            return Ok(Type::Quad);
-        }
-        if self.eat_raw(TokenKind::TyBool) {
-            return Ok(Type::Bool);
-        }
-        if self.eat_raw(TokenKind::TyI32) {
-            return Ok(Type::I32);
-        }
-        if self.eat_raw(TokenKind::TyU32) {
-            return Ok(Type::U32);
-        }
-        if self.eat_raw(TokenKind::TyFx) {
-            return Ok(Type::Fx);
-        }
-        if self.eat_raw(TokenKind::TyF64) {
+        } else if self.eat_raw(TokenKind::TyQuad) {
+            Type::Quad
+        } else if self.eat_raw(TokenKind::TyBool) {
+            Type::Bool
+        } else if self.eat_raw(TokenKind::TyI32) {
+            Type::I32
+        } else if self.eat_raw(TokenKind::TyU32) {
+            Type::U32
+        } else if self.eat_raw(TokenKind::TyFx) {
+            Type::Fx
+        } else if self.eat_raw(TokenKind::TyF64) {
             self.require_f64_feature("type 'f64' is disabled by profile policy")?;
-            return Ok(Type::F64);
+            Type::F64
+        } else {
+            return Err(self.error_at_current("expected type", "E0234"));
+        };
+        self.parse_optional_measure_annotation_raw(base)
+    }
+
+    fn parse_optional_measure_annotation_raw(&mut self, base: Type) -> Result<Type, FrontendError> {
+        if !self.eat_raw(TokenKind::LBracket) {
+            return Ok(base);
         }
-        Err(self.error_at_current("expected type", "E0234"))
+        if !base.is_core_numeric_scalar() {
+            return Err(self.error_at_current(
+                "unit annotation is allowed only on i32, u32, f64, or fx in v0",
+                "E0234",
+            ));
+        }
+        if !self.check_raw(TokenKind::Ident) {
+            return Err(self.error_at_current("expected unit symbol", "E0234"));
+        }
+        let unit = self.arena.intern_symbol(&self.tokens[self.idx].text.clone());
+        self.idx += 1;
+        self.expect_raw(TokenKind::RBracket, "expected ']'", "E0234")?;
+        Ok(Type::Measured(Box::new(base), unit))
     }
 
     fn collect_until_raw(&mut self, stop: TokenKind) -> Result<Vec<Token>, FrontendError> {
@@ -3534,6 +3568,103 @@ fn main() {
             }
             other => panic!("expected match stmt, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_units_of_measure_annotations_in_declared_types() {
+        let src = r#"
+record Measurement {
+    distance: f64[m],
+    ticks: u32[ms],
+    maybe: Option(f64[m]),
+}
+
+fn keep(
+    distance: f64[m],
+    pair: (f64[m], u32[ms]),
+    maybe: Option(f64[m]),
+    result: Result(f64[m], quad)
+) -> f64[m] {
+    let reading: f64[m] = 1.0;
+    let _ = pair;
+    let _ = maybe;
+    let _ = result;
+    return reading;
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("units-of-measure annotations should parse");
+        let record = &program.records[0];
+        assert!(matches!(
+            &record.fields[0].ty,
+            Type::Measured(base, unit)
+                if base.as_ref() == &Type::F64 && program.arena.symbol_name(*unit) == "m"
+        ));
+        assert!(matches!(
+            &record.fields[1].ty,
+            Type::Measured(base, unit)
+                if base.as_ref() == &Type::U32 && program.arena.symbol_name(*unit) == "ms"
+        ));
+        assert!(matches!(
+            &record.fields[2].ty,
+            Type::Option(inner)
+                if matches!(
+                    inner.as_ref(),
+                    Type::Measured(base, unit)
+                        if base.as_ref() == &Type::F64
+                            && program.arena.symbol_name(*unit) == "m"
+                )
+        ));
+
+        let func = &program.functions[0];
+        assert!(matches!(
+            &func.params[0].1,
+            Type::Measured(base, unit)
+                if base.as_ref() == &Type::F64 && program.arena.symbol_name(*unit) == "m"
+        ));
+        assert!(matches!(
+            &func.params[1].1,
+            Type::Tuple(items)
+                if items.len() == 2
+                    && matches!(
+                        &items[0],
+                        Type::Measured(base, unit)
+                            if base.as_ref() == &Type::F64
+                                && program.arena.symbol_name(*unit) == "m"
+                    )
+                    && matches!(
+                        &items[1],
+                        Type::Measured(base, unit)
+                            if base.as_ref() == &Type::U32
+                                && program.arena.symbol_name(*unit) == "ms"
+                    )
+        ));
+        assert!(matches!(
+            &func.ret,
+            Type::Measured(base, unit)
+                if base.as_ref() == &Type::F64 && program.arena.symbol_name(*unit) == "m"
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_unit_annotation_on_non_numeric_type() {
+        let src = r#"
+fn main() {
+    let bad: bool[m] = true;
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("non-numeric unit annotations must reject");
+        assert!(err
+            .message
+            .contains("unit annotation is allowed only on i32, u32, f64, or fx in v0"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -16,15 +16,44 @@ fn fx_unary_gap_message() -> &'static str {
     "fx unary +/- is not implemented in the canonical Rust-like path yet"
 }
 
+fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
+    match arena.expr(expr_id) {
+        Expr::NumericLiteral(_) => true,
+        Expr::Unary(UnaryOp::Pos | UnaryOp::Neg, inner) => is_numeric_literal_like_expr(*inner, arena),
+        _ => false,
+    }
+}
+
 fn is_numeric_for_fx_gap(ty: &Type) -> bool {
-    matches!(ty, Type::I32 | Type::U32 | Type::F64)
+    matches!(ty.erase_units(), Type::I32 | Type::U32 | Type::F64)
 }
 
 fn is_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> bool {
-    match arena.expr(expr_id) {
-        Expr::NumericLiteral(_) => true,
-        Expr::Unary(UnaryOp::Pos | UnaryOp::Neg, inner) => is_fx_literal_expr(*inner, arena),
+    is_numeric_literal_like_expr(expr_id, arena)
+}
+
+fn match_unit_lift(expected: &Type, actual: &Type, expr_id: ExprId, arena: &AstArena) -> bool {
+    match expected.measured_parts() {
+        Some((base, _)) if base == actual => is_numeric_literal_like_expr(expr_id, arena),
         _ => false,
+    }
+}
+
+fn measured_numeric_parts(ty: &Type) -> Option<(&Type, SymbolId)> {
+    ty.measured_parts()
+}
+
+fn lift_literal_to_expected_type(
+    expected: Option<&Type>,
+    actual: &Type,
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Option<Type> {
+    match expected {
+        Some(expected_ty) if match_unit_lift(expected_ty, actual, expr_id, arena) => {
+            Some(expected_ty.clone())
+        }
+        _ => None,
     }
 }
 
@@ -1545,6 +1574,7 @@ fn infer_expr_type(
                 ret_ty.clone(),
                 loop_stack,
             )?;
+            let measured = measured_numeric_parts(&t);
             match op {
                 UnaryOp::Not => match t {
                     Type::Quad | Type::Bool => Ok(t),
@@ -1563,6 +1593,20 @@ fn infer_expr_type(
                             pos: 0,
                             message: fx_unary_gap_message().to_string(),
                         })
+                    } else if let Some((base, _)) = measured {
+                        if *base == Type::F64 {
+                            Ok(t)
+                        } else if *base == Type::Fx {
+                            Err(FrontendError {
+                                pos: 0,
+                                message: fx_unary_gap_message().to_string(),
+                            })
+                        } else {
+                            Err(FrontendError {
+                                pos: 0,
+                                message: format!("operator +/- unsupported for {:?}", t),
+                            })
+                        }
                     } else {
                         Err(FrontendError {
                             pos: 0,
@@ -1649,6 +1693,35 @@ fn infer_expr_type(
                     }
                 }
                 BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
+                    if measured_numeric_parts(&lt).is_some() || measured_numeric_parts(&rt).is_some() {
+                        if lt != rt {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: format!("operator type mismatch: {:?} vs {:?}", lt, rt),
+                            });
+                        }
+                        let (base, _) = measured_numeric_parts(&lt).ok_or(FrontendError {
+                            pos: 0,
+                            message: format!("operator unsupported for {:?}", lt),
+                        })?;
+                        return match op {
+                            BinaryOp::Add | BinaryOp::Sub if *base == Type::F64 => Ok(lt),
+                            BinaryOp::Add | BinaryOp::Sub if *base == Type::Fx => Err(FrontendError {
+                                pos: 0,
+                                message: fx_arithmetic_gap_message().to_string(),
+                            }),
+                            BinaryOp::Mul | BinaryOp::Div => Err(FrontendError {
+                                pos: 0,
+                                message:
+                                    "*, / on unit-carrying values are rejected in the first-wave units surface"
+                                        .to_string(),
+                            }),
+                            _ => Err(FrontendError {
+                                pos: 0,
+                                message: format!("operator unsupported for {:?}", lt),
+                            }),
+                        };
+                    }
                     if lt == Type::Fx && rt == Type::Fx {
                         return Err(FrontendError {
                             pos: 0,
@@ -3784,6 +3857,85 @@ mod tests {
             .message
             .contains("match arm pattern type 'Option' does not match scrutinee Result(T, E)"));
     }
+
+    #[test]
+    fn units_of_measure_typecheck_through_transport_and_supported_operators() {
+        let src = r#"
+            record Measurement {
+                distance: f64[m],
+            }
+
+            fn echo(
+                distance: f64[m],
+                pair: (f64[m], f64[m]),
+                maybe: Option(f64[m]),
+                result: Result(f64[m], quad),
+                sample: Measurement
+            ) -> f64[m] {
+                let left: f64[m] = 1.0;
+                let right: f64[m] = 2.0;
+                let pair_copy: (f64[m], f64[m]) = pair;
+                let maybe_copy: Option(f64[m]) = maybe;
+                let result_copy: Result(f64[m], quad) = result;
+                let total: f64[m] = left + right;
+                let same: bool = total == sample.distance;
+                let _ = pair_copy;
+                let _ = maybe_copy;
+                let _ = result_copy;
+                assert(same == true);
+                return total;
+            }
+
+            fn main() {
+                let sample: Measurement = Measurement { distance: 3.0 };
+                let total: f64[m] = echo(
+                    1.0,
+                    (1.0, 2.0),
+                    Option::Some(1.0),
+                    Result::Ok(2.0),
+                    sample
+                );
+                let expected: f64[m] = 3.0;
+                assert(total == expected);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("first-wave units transport and operators should typecheck");
+    }
+
+    #[test]
+    fn units_of_measure_reject_mismatched_symbols_in_binding() {
+        let src = r#"
+            fn main() {
+                let distance: f64[m] = 1.0;
+                let time: f64[s] = distance;
+                let _ = time;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("different unit symbols must reject");
+        assert!(err.message.contains("type mismatch in let 'time'"));
+    }
+
+    #[test]
+    fn units_of_measure_reject_mul_and_div_in_first_wave() {
+        let src = r#"
+            fn main() {
+                let distance: f64[m] = 1.0;
+                let area: f64[m] = distance * distance;
+                let _ = area;
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("mul/div on unit-carrying values must reject in first wave");
+        assert!(err
+            .message
+            .contains("*, / on unit-carrying values are rejected in the first-wave units surface"));
+    }
 }
 
 fn is_builtin_assert_name(
@@ -4490,6 +4642,20 @@ fn ensure_type_resolved(
             }
             Ok(())
         }
+        Type::Measured(base, _) => {
+            ensure_type_resolved(base, record_table, adt_table, arena, context.clone())?;
+            if base.is_core_numeric_scalar() {
+                Ok(())
+            } else {
+                Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "unit annotation is allowed only on i32, u32, f64, or fx in {}",
+                        context
+                    ),
+                })
+            }
+        }
         Type::Record(name) => {
             if record_table.contains_key(name) || adt_table.contains_key(name) {
                 Ok(())
@@ -4541,6 +4707,7 @@ fn ensure_executable_type_supported(
             }
             Ok(())
         }
+        Type::Measured(base, _) => ensure_executable_type_supported(base, arena, context),
         Type::Option(item) => ensure_executable_type_supported(item, arena, context),
         Type::Result(ok_ty, err_ty) => {
             ensure_executable_type_supported(ok_ty, arena, context.clone())?;
@@ -4572,6 +4739,7 @@ fn ensure_storage_type_supported(
             }
             Ok(())
         }
+        Type::Measured(base, _) => ensure_storage_type_supported(base, arena, context),
         Type::Option(item) => ensure_storage_type_supported(item, arena, context),
         Type::Result(ok_ty, err_ty) => {
             ensure_storage_type_supported(ok_ty, arena, context.clone())?;
@@ -4718,6 +4886,9 @@ fn supports_stable_equality_type_inner(
         | Type::Fx
         | Type::F64
         | Type::Unit => Ok(true),
+        Type::Measured(base, _) => {
+            supports_stable_equality_type_inner(base, record_table, adt_table, active)
+        }
         Type::QVec(_) => Ok(false),
         Type::RangeI32 => Ok(false),
         Type::Tuple(items) => {
@@ -5091,6 +5262,49 @@ fn infer_expr_type_with_expected(
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<Type, FrontendError> {
     match arena.expr(expr_id) {
+        Expr::Tuple(items) => {
+            let expected_items = match expected.as_ref() {
+                Some(Type::Tuple(types)) => Some(types),
+                _ => None,
+            };
+            if let Some(types) = expected_items {
+                if types.len() != items.len() {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "tuple arity mismatch in typed position: expected {}, got {}",
+                            types.len(),
+                            items.len()
+                        ),
+                    });
+                }
+            }
+            let mut item_tys = Vec::with_capacity(items.len());
+            for (index, item) in items.iter().enumerate() {
+                let item_expected = expected_items.and_then(|types| types.get(index)).cloned();
+                let item_ty = infer_expr_type_with_expected(
+                    *item,
+                    arena,
+                    env,
+                    table,
+                    record_table,
+                    adt_table,
+                    item_expected,
+                    ret_ty.clone(),
+                    loop_stack,
+                )?;
+                if item_ty == Type::RangeI32 {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message:
+                            "range literal is not yet part of the stable tuple/user-data surface"
+                                .to_string(),
+                    });
+                }
+                item_tys.push(item_ty);
+            }
+            Ok(Type::Tuple(item_tys))
+        }
         Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
             ctor_expr,
             arena,
@@ -5102,16 +5316,20 @@ fn infer_expr_type_with_expected(
             ret_ty,
             loop_stack,
         ),
-        _ => infer_expr_type(
-            expr_id,
-            arena,
-            env,
-            table,
-            record_table,
-            adt_table,
-            ret_ty,
-            loop_stack,
-        ),
+        _ => {
+            let actual = infer_expr_type(
+                expr_id,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty,
+                loop_stack,
+            )?;
+            Ok(lift_literal_to_expected_type(expected.as_ref(), &actual, expr_id, arena)
+                .unwrap_or(actual))
+        }
     }
 }
 
@@ -5573,6 +5791,9 @@ fn ensure_binding_value_type(
     context: String,
 ) -> Result<(), FrontendError> {
     if expected == actual {
+        return Ok(());
+    }
+    if match_unit_lift(&expected, &actual, value_expr, arena) {
         return Ok(());
     }
     if expected == Type::Fx && is_numeric_for_fx_gap(&actual) {

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -13,6 +13,7 @@ pub enum Type {
     U32,
     Fx,
     F64,
+    Measured(Box<Type>, SymbolId),
     RangeI32,
     Tuple(Vec<Type>),
     Option(Box<Type>),
@@ -20,6 +21,32 @@ pub enum Type {
     Record(SymbolId),
     Adt(SymbolId),
     Unit,
+}
+
+impl Type {
+    pub fn erase_units(&self) -> Type {
+        match self {
+            Type::Measured(base, _) => base.erase_units(),
+            Type::Tuple(items) => Type::Tuple(items.iter().map(Type::erase_units).collect()),
+            Type::Option(item) => Type::Option(Box::new(item.erase_units())),
+            Type::Result(ok_ty, err_ty) => Type::Result(
+                Box::new(ok_ty.erase_units()),
+                Box::new(err_ty.erase_units()),
+            ),
+            _ => self.clone(),
+        }
+    }
+
+    pub fn measured_parts(&self) -> Option<(&Type, SymbolId)> {
+        match self {
+            Type::Measured(base, unit) => Some((base.as_ref(), *unit)),
+            _ => None,
+        }
+    }
+
+    pub fn is_core_numeric_scalar(&self) -> bool {
+        matches!(self, Type::I32 | Type::U32 | Type::Fx | Type::F64)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1143,6 +1143,30 @@ fn has_v2_fx_instr(funcs: &[IrFunction]) -> bool {
         .any(|f| f.instrs.iter().any(|i| matches!(i, IrInstr::LoadFx { .. })))
 }
 
+fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
+    match arena.expr(expr_id) {
+        Expr::NumericLiteral(_) => true,
+        Expr::Unary(UnaryOp::Pos | UnaryOp::Neg, inner) => is_numeric_literal_like_expr(*inner, arena),
+        _ => false,
+    }
+}
+
+fn erased_expected(expected: Option<&Type>) -> Option<Type> {
+    expected.map(Type::erase_units)
+}
+
+fn lift_lowered_type(expected: Option<&Type>, actual: &Type, expr_id: ExprId, arena: &AstArena) -> Type {
+    match expected {
+        Some(expected_ty)
+            if matches!(expected_ty.measured_parts(), Some((base, _)) if base == actual)
+                && is_numeric_literal_like_expr(expr_id, arena) =>
+        {
+            expected_ty.clone()
+        }
+        _ => actual.clone(),
+    }
+}
+
 #[derive(Debug, Default)]
 struct StringInterner {
     ids: HashMap<String, u16>,
@@ -1574,47 +1598,50 @@ fn lower_expr_with_expected(
         ),
         Expr::NumericLiteral(NumericLiteral::I32(n)) => {
             let r = alloc(next);
-            if expected == Some(Type::Fx) {
+            let expected_erased = erased_expected(expected.as_ref());
+            if expected_erased == Some(Type::Fx) {
                 let val = try_encode_fx_literal_expr(expr_id, arena)?.ok_or(FrontendError {
                     pos: 0,
                     message: "expected fx literal".to_string(),
                 })?;
                 out.push(IrInstr::LoadFx { dst: r, val });
-                Ok((r, Type::Fx))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::Fx, expr_id, arena)))
             } else {
                 let val = i32::try_from(*n).map_err(|_| FrontendError {
                     pos: 0,
                     message: format!("numeric literal {} does not fit in i32", n),
                 })?;
                 out.push(IrInstr::LoadI32 { dst: r, val });
-                Ok((r, Type::I32))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::I32, expr_id, arena)))
             }
         }
         Expr::NumericLiteral(NumericLiteral::U32(n)) => {
             let r = alloc(next);
-            if expected == Some(Type::Fx) {
+            let expected_erased = erased_expected(expected.as_ref());
+            if expected_erased == Some(Type::Fx) {
                 let val = try_encode_fx_literal_expr(expr_id, arena)?.ok_or(FrontendError {
                     pos: 0,
                     message: "expected fx literal".to_string(),
                 })?;
                 out.push(IrInstr::LoadFx { dst: r, val });
-                Ok((r, Type::Fx))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::Fx, expr_id, arena)))
             } else {
                 out.push(IrInstr::LoadU32 { dst: r, val: *n });
-                Ok((r, Type::U32))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::U32, expr_id, arena)))
             }
         }
         Expr::NumericLiteral(NumericLiteral::F64(n)) => {
             let r = alloc(next);
-            if expected == Some(Type::Fx) {
+            let expected_erased = erased_expected(expected.as_ref());
+            if expected_erased == Some(Type::Fx) {
                 out.push(IrInstr::LoadFx {
                     dst: r,
                     val: encode_fx_literal(*n)?,
                 });
-                Ok((r, Type::Fx))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::Fx, expr_id, arena)))
             } else {
                 out.push(IrInstr::LoadF64 { dst: r, val: *n });
-                Ok((r, Type::F64))
+                Ok((r, lift_lowered_type(expected.as_ref(), &Type::F64, expr_id, arena)))
             }
         }
         Expr::NumericLiteral(NumericLiteral::Fx(n)) => {
@@ -1623,7 +1650,7 @@ fn lower_expr_with_expected(
                 dst: r,
                 val: encode_fx_literal(*n)?,
             });
-            Ok((r, Type::Fx))
+            Ok((r, lift_lowered_type(expected.as_ref(), &Type::Fx, expr_id, arena)))
         }
         Expr::Var(name) => {
             let ty = env.get(*name).ok_or(FrontendError {
@@ -1795,6 +1822,7 @@ fn lower_expr_with_expected(
             let ordered_args = reorder_call_args(*name, args, &sig, arena)?;
             let mut regs = Vec::new();
             for (i, arg) in ordered_args.iter().enumerate() {
+                let expected_arg_ty = sig.params[i].clone();
                 let (r, t) = lower_expr_with_expected(
                     *arg,
                     arena,
@@ -1805,10 +1833,10 @@ fn lower_expr_with_expected(
                     fn_table,
                     record_table,
                     adt_table,
-                    Some(sig.params[i].clone()),
+                    Some(expected_arg_ty.clone()),
                     ret_ty.clone(),
                 )?;
-                if t != sig.params[i] {
+                if t != expected_arg_ty {
                     return Err(FrontendError {
                         pos: 0,
                         message: format!(
@@ -1816,7 +1844,7 @@ fn lower_expr_with_expected(
                             i,
                             resolve_symbol_name(arena, *name)?,
                             t,
-                            sig.params[i]
+                            expected_arg_ty
                         ),
                     });
                 }
@@ -1840,11 +1868,12 @@ fn lower_expr_with_expected(
             Ok((r, sig.ret.clone()))
         }
         Expr::Unary(op, inner) => {
-            if expected == Some(Type::Fx) {
+            let expected_erased = erased_expected(expected.as_ref());
+            if expected_erased == Some(Type::Fx) {
                 if let Some(value) = try_encode_fx_literal_expr(expr_id, arena)? {
                     let dst = alloc(next);
                     out.push(IrInstr::LoadFx { dst, val: value });
-                    return Ok((dst, Type::Fx));
+                    return Ok((dst, lift_lowered_type(expected.as_ref(), &Type::Fx, expr_id, arena)));
                 }
             }
             let (src, ty) = lower_expr_with_expected(
@@ -1878,6 +1907,8 @@ fn lower_expr_with_expected(
                 UnaryOp::Pos => {
                     if ty == Type::F64 {
                         Ok((src, Type::F64))
+                    } else if matches!(ty.measured_parts(), Some((base, _)) if *base == Type::F64) {
+                        Ok((src, ty))
                     } else {
                         Err(FrontendError {
                             pos: 0,
@@ -1886,12 +1917,16 @@ fn lower_expr_with_expected(
                     }
                 }
                 UnaryOp::Neg => {
-                    if ty != Type::F64 {
+                    let result_ty = if ty == Type::F64 {
+                        Type::F64
+                    } else if matches!(ty.measured_parts(), Some((base, _)) if *base == Type::F64) {
+                        ty.clone()
+                    } else {
                         return Err(FrontendError {
                             pos: 0,
                             message: format!("operator - unsupported for {:?}", ty),
                         });
-                    }
+                    };
                     let zero = alloc(next);
                     out.push(IrInstr::LoadF64 {
                         dst: zero,
@@ -1903,7 +1938,7 @@ fn lower_expr_with_expected(
                         lhs: zero,
                         rhs: src,
                     });
-                    Ok((dst, Type::F64))
+                    Ok((dst, result_ty))
                 }
             }
         }
@@ -1941,6 +1976,7 @@ fn lower_expr_with_expected(
                 });
             }
             let dst = alloc(next);
+            let erased_lt = lt.erase_units();
             match op {
                 BinaryOp::AndAnd => match lt {
                     Type::Quad => out.push(IrInstr::QAnd {
@@ -2009,7 +2045,13 @@ fn lower_expr_with_expected(
                     return Ok((dst, Type::Bool));
                 }
                 BinaryOp::Add => {
-                    if lt != Type::F64 {
+                    if matches!(lt.measured_parts(), Some((_, _))) && erased_lt != Type::F64 {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!("operator + unsupported for {:?}", lt),
+                        });
+                    }
+                    if erased_lt != Type::F64 {
                         return Err(FrontendError {
                             pos: 0,
                             message: format!("operator + unsupported for {:?}", lt),
@@ -2020,10 +2062,16 @@ fn lower_expr_with_expected(
                         lhs: lr,
                         rhs: rr,
                     });
-                    return Ok((dst, Type::F64));
+                    return Ok((dst, lt));
                 }
                 BinaryOp::Sub => {
-                    if lt != Type::F64 {
+                    if matches!(lt.measured_parts(), Some((_, _))) && erased_lt != Type::F64 {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!("operator - unsupported for {:?}", lt),
+                        });
+                    }
+                    if erased_lt != Type::F64 {
                         return Err(FrontendError {
                             pos: 0,
                             message: format!("operator - unsupported for {:?}", lt),
@@ -2034,9 +2082,17 @@ fn lower_expr_with_expected(
                         lhs: lr,
                         rhs: rr,
                     });
-                    return Ok((dst, Type::F64));
+                    return Ok((dst, lt));
                 }
                 BinaryOp::Mul => {
+                    if lt.measured_parts().is_some() {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message:
+                                "*, / on unit-carrying values are rejected in the first-wave units surface"
+                                    .to_string(),
+                        });
+                    }
                     if lt != Type::F64 {
                         return Err(FrontendError {
                             pos: 0,
@@ -2051,6 +2107,14 @@ fn lower_expr_with_expected(
                     return Ok((dst, Type::F64));
                 }
                 BinaryOp::Div => {
+                    if lt.measured_parts().is_some() {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message:
+                                "*, / on unit-carrying values are rejected in the first-wave units surface"
+                                    .to_string(),
+                        });
+                    }
                     if lt != Type::F64 {
                         return Err(FrontendError {
                             pos: 0,
@@ -6686,6 +6750,77 @@ mod opt_tests {
             instr,
             IrInstr::AdtGet { adt_name, index, .. } if adt_name == "Result" && *index == 0
         )));
+    }
+
+    #[test]
+    fn lower_units_of_measure_through_existing_numeric_ir_path() {
+        let src = r#"
+            record Measurement {
+                distance: f64[m],
+            }
+
+            fn echo(distance: f64[m], sample: Measurement) -> f64[m] {
+                let total: f64[m] = distance + sample.distance;
+                let same: bool = total == distance;
+                assert(same == false || same == true);
+                return total;
+            }
+
+            fn main() {
+                let sample: Measurement = Measurement { distance: 2.0 };
+                let total: f64[m] = echo(3.0, sample);
+                let expected: f64[m] = 5.0;
+                assert(total == expected);
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("units-of-measure values should lower");
+        let echo = ir.iter().find(|func| func.name == "echo").expect("echo fn");
+        assert!(echo
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::RecordGet { record_name, index, .. } if record_name == "Measurement" && *index == 0)));
+        assert!(echo
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::AddF64 { .. })));
+        assert!(echo
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::CmpEq { .. })));
+
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 2.0).abs() < f64::EPSILON)));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadF64 { val, .. } if (*val - 3.0).abs() < f64::EPSILON)));
+        assert!(!main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::MakeTuple { .. })));
+    }
+
+    #[test]
+    fn lower_measured_u32_literal_through_existing_integer_carrier() {
+        let src = r#"
+            fn main() {
+                let ticks: u32[ms] = 1_000u32;
+                let _ = ticks;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("measured u32 literal should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadU32 { val, .. } if *val == 1000)));
     }
 
     #[test]

--- a/crates/sm-sema/src/std_adapters.rs
+++ b/crates/sm-sema/src/std_adapters.rs
@@ -45,6 +45,7 @@ impl From<Type> for SemanticType {
             Type::Bool => SemanticType::Bool,
             Type::U32 => SemanticType::Int,
             Type::Unit => SemanticType::Unit,
+            Type::Measured(base, _) => SemanticType::from((*base).clone()),
             Type::RangeI32 => SemanticType::Unknown,
             Type::Tuple(_) => SemanticType::Unknown,
             Type::Option(_) => SemanticType::Unknown,

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -116,6 +116,9 @@ Current message families include:
 - unsupported expression form inside `requires`
 - let-binding type mismatch
 - discard-binding type mismatch
+- invalid unit annotation on non-numeric type family
+- measured numeric type mismatch across binding/call/return transport
+- `*` / `/` requested on unit-carrying values in the first-wave surface
 - `Option::None` without contextual `Option(T)` type
 - `Result::Ok(...)` / `Result::Err(...)` without contextual `Result(T, E)` type
 - non-const-safe initializer in const declaration

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -203,6 +203,31 @@ Current honest limit:
 - exponent notation and binary/octal literal families are not yet part of the
   stable contract
 
+## Units Of Measure
+
+Current first-wave units-of-measure semantics:
+
+- unit annotations refine the source type of `i32`, `u32`, `f64`, or `fx`
+  without changing the underlying execution carrier
+- unsuffixed numeric literals remain ordinary numeric literals and become
+  unit-carrying only through typed positions such as annotated locals,
+  parameters, returns, tuple elements, record fields, and contextual
+  `Option(T)` / `Result(T, E)` payloads
+- assignment, call, return, and pattern-binding transport require exact base
+  family and exact unit-symbol equality
+- unit annotations may travel through tuples, records, `Option(T)`, and
+  `Result(T, E)` when those positions contain supported numeric families
+- lowering erases units after semantic validation and reuses the existing
+  numeric lowering path
+
+Current v0 limits:
+
+- unit annotations are compile-time-only source contracts, not VM value tags
+- implicit conversion between unit symbols is not part of the stable contract
+- compound unit algebra, conversion tables, and inference from untyped numeric
+  literals are not part of the first-wave surface
+- `*` and `/` on unit-carrying values are rejected in the first-wave contract
+
 ## Range Literal
 
 Current range-literal semantics:
@@ -590,6 +615,16 @@ Current operator meaning:
 - `!` works on `bool` and `quad`
 - `->` is quad implication and returns `quad`
 - `+`, `-`, `*`, `/` currently have stable arithmetic meaning only on `f64`
+
+Current first-wave units operator rules:
+
+- `+` and `-` preserve a unit annotation only when both operands have the same
+  measured type
+- `==` and `!=` are valid on unit-carrying values only when both sides have the
+  same measured type
+- `*` and `/` on unit-carrying values are rejected in the first-wave surface
+- after unit validation, lowering reuses the existing numeric execution opcodes
+  rather than widening the runtime operator family
 
 Current honest limit:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -264,6 +264,11 @@ Current expression forms:
 - tuple types:
   - `(i32, bool)`
   - `(f64, quad, bool)`
+- first-wave units-of-measure annotations:
+  - `f64[m]`
+  - `u32[ms]`
+  - `Option(f64[m])`
+  - `(f64[m], u32[ms])`
 - block expressions with a trailing tail value:
   - `{ let x = 1; x }`
 - `if` expressions with explicit `else` blocks:
@@ -325,6 +330,21 @@ Current v0 tuple limits:
   tuple type
 - tuple field access and tuple pattern matching beyond flat destructuring bind
   are not yet part of the stable surface
+
+Current first-wave units-of-measure syntax rules:
+
+- declared type positions may attach `[unit_symbol]` only to `i32`, `u32`,
+  `f64`, or `fx`
+- unit annotations may appear inside tuples, record fields, `Option(T)`, and
+  `Result(T, E)` payload positions when the annotated inner type is still one
+  of those core numeric families
+- this is a narrow source-level contract only; the execution carrier remains
+  the existing numeric family after semantic validation
+- unit annotations on non-numeric type families are rejected in v0
+- compound unit syntax such as `m/s` or exponent-style unit algebra is not part
+  of the stable surface
+- unannotated numeric literal spelling remains unchanged; units are acquired
+  only through typed positions
 
 Current first-wave `Option` / `Result` standard-form rules:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -27,6 +27,7 @@ Current source-visible types:
 - `u32`
 - `f64`
 - `fx`
+- measured numeric forms such as `f64[m]` and `u32[ms]`
 - `unit`
 - `qvec(N)` as a reserved parser-level family
 
@@ -125,6 +126,39 @@ Current honest limits:
   long-term contract
 - unary `+` and unary `-` on `fx` are still intentionally limited in the
   canonical Rust-like path
+
+## Units Of Measure
+
+First-wave units of measure are source-level refinements over the existing core
+numeric families.
+
+Current supported forms:
+
+- `i32[unit]`
+- `u32[unit]`
+- `f64[unit]`
+- `fx[unit]`
+
+Current rules:
+
+- the bracket payload is a single unit symbol
+- measured numeric types may appear in locals, parameters, returns, tuple
+  elements, record fields, `Option(T)`, and `Result(T, E)` payload positions
+- assignment, call, return, and pattern-binding transport require exact base
+  type and exact unit-symbol equality
+- `+`, `-`, `==`, and `!=` are valid only when both operands have the same
+  measured type
+- lowering erases the unit annotation after semantic validation and reuses the
+  existing numeric execution carrier
+
+Current honest limits:
+
+- units are not part of the VM value representation or public host ABI shape
+- implicit conversions between unit symbols are not part of the contract
+- compound unit algebra such as `m/s`, `N*m`, or exponent notation is not part
+  of the first-wave surface
+- `*` and `/` on unit-carrying values are intentionally rejected in the
+  first-wave contract
 
 ## QVec
 


### PR DESCRIPTION
## Summary
- add first-wave units-of-measure annotations for `i32`, `u32`, `f64`, and `fx`
- enforce exact unit equality in binding/call/return/pattern transport and allow only same-unit `+`, `-`, `==`, `!=`
- keep lowering unit-erased over the existing numeric IR / verifier / VM path and sync parser/typecheck/lowering/docs/tests

## Scope
- compile-time-only source contract over existing numeric carriers
- units may flow through tuples, records, `Option(T)`, and `Result(T, E)` payloads
- no conversions, no compound units, no host or `prom-*` widening

## Validation
- `cargo test -p sm-front`
- `cargo test -p sm-ir`
- `cargo test --test public_api_contracts`
- `cargo test --workspace`

Closes #118