### PR TITLE
V03-01 schema record declarations and canonical schema table ownership

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -302,6 +302,7 @@ fn tokenize_line(
                     "ensures" => TokenKind::KwEnsures,
                     "invariant" => TokenKind::KwInvariant,
                     "record" => TokenKind::KwRecord,
+                    "schema" => TokenKind::KwSchema,
                     "enum" => TokenKind::KwEnum,
                     "const" => TokenKind::KwConst,
                     "let" => TokenKind::KwLet,

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -20,8 +20,8 @@ pub use types::{
     FrontendError, FrontendErrorKind, Function, IfExpr, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
-    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, Stmt, StmtId, SymbolId, Token,
-    TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, Stmt, StmtId,
+    SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};
@@ -52,6 +52,9 @@ pub type RecordTable = BTreeMap<SymbolId, RecordDecl>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type AdtTable = BTreeMap<SymbolId, AdtDecl>;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -201,6 +204,24 @@ pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
             });
         }
         out.insert(adt.name, adt.clone());
+    }
+    Ok(out)
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
+    let mut out = BTreeMap::new();
+    for schema in &program.schemas {
+        if out.contains_key(&schema.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "duplicate schema '{}'",
+                    resolve_symbol_name(&program.arena, schema.name)?
+                ),
+            });
+        }
+        out.insert(schema.name, schema.clone());
     }
     Ok(out)
 }
@@ -561,6 +582,7 @@ mod tests {
             AstBundle::RustLike(p) => {
                 assert!(p.adts.is_empty());
                 assert!(p.records.is_empty());
+                assert!(p.schemas.is_empty());
                 assert_eq!(p.functions.len(), 1);
             }
             AstBundle::Logos(_) => panic!("expected rustlike bundle"),

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -5,8 +5,8 @@ use crate::types::{
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, Stmt, StmtId, SymbolId, Token,
-    TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField, Stmt,
+    StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -61,6 +61,7 @@ impl<'a> Parser<'a> {
     fn parse_program(&mut self) -> Result<Program, FrontendError> {
         let mut adts = Vec::new();
         let mut records = Vec::new();
+        let mut schemas = Vec::new();
         let mut functions = Vec::new();
         loop {
             let i = self.next_non_layout_idx();
@@ -72,10 +73,12 @@ impl<'a> Parser<'a> {
                 TokenKind::KwEnum => adts.push(self.parse_adt_decl()?),
                 TokenKind::KwFn => functions.push(self.parse_function()?),
                 TokenKind::KwRecord => records.push(self.parse_record_decl()?),
+                TokenKind::KwSchema => schemas.push(self.parse_schema_decl()?),
                 _ => {
                     return Err(FrontendError {
                         pos: self.tokens[i].pos,
-                        message: "expected top-level 'enum', 'fn', or 'record'".to_string(),
+                        message: "expected top-level 'enum', 'fn', 'record', or 'schema'"
+                            .to_string(),
                     });
                 }
             }
@@ -84,6 +87,7 @@ impl<'a> Parser<'a> {
             arena: ::core::mem::take(&mut self.arena),
             adts,
             records,
+            schemas,
             functions,
         })
     }
@@ -201,6 +205,32 @@ impl<'a> Parser<'a> {
         }
         self.expect(TokenKind::RBrace, "expected '}' after record declaration")?;
         Ok(RecordDecl { name, fields })
+    }
+
+    fn parse_schema_decl(&mut self) -> Result<SchemaDecl, FrontendError> {
+        self.require_schema_surface("schema declarations are disabled by profile policy")?;
+        self.expect(TokenKind::KwSchema, "expected 'schema'")?;
+        let name = self.expect_symbol()?;
+        self.expect(TokenKind::LBrace, "expected '{' after schema name")?;
+        let mut fields = Vec::new();
+        while !self.check(TokenKind::RBrace) {
+            let field_name = self.expect_symbol()?;
+            self.expect(TokenKind::Colon, "expected ':' after schema field name")?;
+            let field_ty = self.parse_type()?;
+            fields.push(SchemaField {
+                name: field_name,
+                ty: field_ty,
+            });
+            if self.eat(TokenKind::Comma) {
+                if self.check(TokenKind::RBrace) {
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+        self.expect(TokenKind::RBrace, "expected '}' after schema declaration")?;
+        Ok(SchemaDecl { name, fields })
     }
 
     fn parse_adt_decl(&mut self) -> Result<AdtDecl, FrontendError> {
@@ -2176,6 +2206,14 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn require_schema_surface(&self, message: &str) -> Result<(), FrontendError> {
+        if self.policy.profile.features.allow_schema_surface {
+            Ok(())
+        } else {
+            Err(FrontendError::policy_violation(self.pos(), message))
+        }
+    }
+
     fn require_legacy_compatibility(&self, message: &str) -> Result<(), FrontendError> {
         if self.policy.profile.compatibility == CompatibilityMode::LegacySupport {
             Ok(())
@@ -3416,6 +3454,47 @@ fn main() {
         assert_eq!(record.fields[0].ty, Type::Quad);
         assert_eq!(record.fields[2].ty, Type::F64);
         assert_eq!(program.functions.len(), 1);
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_top_level_schema_declaration() {
+        let src = r#"
+schema SensorConfig {
+    interval_ms: u32[ms],
+    fallback: Option(quad),
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("schema declaration should parse");
+        assert_eq!(program.schemas.len(), 1);
+        let schema = &program.schemas[0];
+        assert_eq!(program.arena.symbol_name(schema.name), "SensorConfig");
+        assert_eq!(schema.fields.len(), 2);
+        assert_eq!(program.arena.symbol_name(schema.fields[0].name), "interval_ms");
+    }
+
+    #[test]
+    fn strict_profile_rejects_schema_surface() {
+        let src = r#"
+schema SensorConfig {
+    interval_ms: u32,
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::default())
+            .expect_err("strict profile must reject schema surface");
+
+        assert_eq!(err.kind(), FrontendErrorKind::PolicyViolation);
+        assert!(err.message.contains("schema"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -67,6 +67,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
     let mut table = BTreeMap::new();
     let record_table = build_record_table(program)?;
     let adt_table = build_adt_table(program)?;
+    let schema_table = build_schema_table(program)?;
     let func = &program.functions[0];
     table.insert(
         func.name,
@@ -81,9 +82,10 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
             ret: canonicalize_declared_type(&func.ret, &record_table, &adt_table, &program.arena)?,
         },
     );
-    validate_top_level_name_collisions(program, &table, &record_table, &adt_table)?;
+    validate_top_level_name_collisions(program, &table, &record_table, &adt_table, &schema_table)?;
     validate_record_declarations(program, &record_table, &adt_table)?;
     validate_adt_declarations(program, &record_table, &adt_table)?;
+    validate_schema_declarations(program, &schema_table, &record_table, &adt_table)?;
     type_check_function_with_tables(func, &program.arena, &table, &record_table, &adt_table)
 }
 
@@ -91,9 +93,11 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     let table = build_fn_table(p)?;
     let record_table = build_record_table(p)?;
     let adt_table = build_adt_table(p)?;
-    validate_top_level_name_collisions(p, &table, &record_table, &adt_table)?;
+    let schema_table = build_schema_table(p)?;
+    validate_top_level_name_collisions(p, &table, &record_table, &adt_table, &schema_table)?;
     validate_record_declarations(p, &record_table, &adt_table)?;
     validate_adt_declarations(p, &record_table, &adt_table)?;
+    validate_schema_declarations(p, &schema_table, &record_table, &adt_table)?;
     let main_id = p
         .arena
         .symbol_to_id
@@ -3212,6 +3216,85 @@ mod tests {
     }
 
     #[test]
+    fn schema_declarations_typecheck_as_compile_time_top_level_items() {
+        let src = r#"
+            record Point {
+                x: i32,
+                y: i32,
+            }
+
+            schema PointPayload {
+                point: Point,
+                label: Option(quad),
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("schema declarations should typecheck");
+    }
+
+    #[test]
+    fn schema_declaration_rejects_duplicate_field_name() {
+        let src = r#"
+            schema PointPayload {
+                point: i32,
+                point: i32,
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("duplicate schema field must reject");
+        assert!(err
+            .message
+            .contains("schema 'PointPayload' cannot repeat field 'point'"));
+    }
+
+    #[test]
+    fn schema_declaration_rejects_empty_body() {
+        let src = r#"
+            schema PointPayload {
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("empty schema must reject");
+        assert!(err
+            .message
+            .contains("schema 'PointPayload' must declare at least 1 field"));
+    }
+
+    #[test]
+    fn schema_declaration_rejects_top_level_name_collision_with_record() {
+        let src = r#"
+            record PointPayload {
+                x: i32,
+            }
+
+            schema PointPayload {
+                point: i32,
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("schema/record collision must reject");
+        assert!(err.message.contains(
+            "top-level name 'PointPayload' cannot be used for both record and schema"
+        ));
+    }
+
+    #[test]
     fn record_declaration_rejects_recursive_field_graph() {
         let src = r#"
             record A {
@@ -4370,6 +4453,7 @@ fn validate_top_level_name_collisions(
     fn_table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    schema_table: &SchemaTable,
 ) -> Result<(), FrontendError> {
     for record in &program.records {
         if fn_table.contains_key(&record.name) {
@@ -4386,6 +4470,15 @@ fn validate_top_level_name_collisions(
                 pos: 0,
                 message: format!(
                     "top-level name '{}' cannot be used for both record and enum",
+                    resolve_symbol_name(&program.arena, record.name)?
+                ),
+            });
+        }
+        if schema_table.contains_key(&record.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "top-level name '{}' cannot be used for both record and schema",
                     resolve_symbol_name(&program.arena, record.name)?
                 ),
             });
@@ -4407,6 +4500,44 @@ fn validate_top_level_name_collisions(
                 message: format!(
                     "top-level name '{}' cannot be used for both enum and record",
                     resolve_symbol_name(&program.arena, adt.name)?
+                ),
+            });
+        }
+        if schema_table.contains_key(&adt.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "top-level name '{}' cannot be used for both enum and schema",
+                    resolve_symbol_name(&program.arena, adt.name)?
+                ),
+            });
+        }
+    }
+    for schema in &program.schemas {
+        if fn_table.contains_key(&schema.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "top-level name '{}' cannot be used for both schema and function",
+                    resolve_symbol_name(&program.arena, schema.name)?
+                ),
+            });
+        }
+        if record_table.contains_key(&schema.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "top-level name '{}' cannot be used for both schema and record",
+                    resolve_symbol_name(&program.arena, schema.name)?
+                ),
+            });
+        }
+        if adt_table.contains_key(&schema.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "top-level name '{}' cannot be used for both schema and enum",
+                    resolve_symbol_name(&program.arena, schema.name)?
                 ),
             });
         }
@@ -4525,6 +4656,57 @@ fn validate_adt_declarations(
             &mut active,
             &mut visited,
         )?;
+    }
+    Ok(())
+}
+
+fn validate_schema_declarations(
+    program: &Program,
+    schema_table: &SchemaTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    for schema in &program.schemas {
+        let _ = schema_table.get(&schema.name).ok_or(FrontendError {
+            pos: 0,
+            message: format!(
+                "missing schema '{}' in canonical schema table",
+                resolve_symbol_name(&program.arena, schema.name)?
+            ),
+        })?;
+        if schema.fields.is_empty() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "schema '{}' must declare at least 1 field",
+                    resolve_symbol_name(&program.arena, schema.name)?
+                ),
+            });
+        }
+        let mut seen = BTreeSet::new();
+        for field in &schema.fields {
+            if !seen.insert(field.name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "schema '{}' cannot repeat field '{}'",
+                        resolve_symbol_name(&program.arena, schema.name)?,
+                        resolve_symbol_name(&program.arena, field.name)?
+                    ),
+                });
+            }
+            ensure_type_resolved(
+                &field.ty,
+                record_table,
+                adt_table,
+                &program.arena,
+                format!(
+                    "schema field '{}.{}'",
+                    resolve_symbol_name(&program.arena, schema.name)?,
+                    resolve_symbol_name(&program.arena, field.name)?
+                ),
+            )?;
+        }
     }
     Ok(())
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -334,11 +334,24 @@ pub struct AdtDecl {
     pub variants: Vec<AdtVariant>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaField {
+    pub name: SymbolId,
+    pub ty: Type,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDecl {
+    pub name: SymbolId,
+    pub fields: Vec<SchemaField>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
     pub arena: AstArena,
     pub adts: Vec<AdtDecl>,
     pub records: Vec<RecordDecl>,
+    pub schemas: Vec<SchemaDecl>,
     pub functions: Vec<Function>,
 }
 
@@ -402,6 +415,7 @@ pub enum TokenKind {
     KwEnsures,
     KwInvariant,
     KwRecord,
+    KwSchema,
     KwEnum,
     KwConst,
     KwLet,

--- a/crates/sm-profile/src/lib.rs
+++ b/crates/sm-profile/src/lib.rs
@@ -67,6 +67,7 @@ pub struct FeaturePolicy {
     pub allow_f64_math: bool,
     pub allow_gate_surface: bool,
     pub allow_logos_surface: bool,
+    pub allow_schema_surface: bool,
 }
 
 impl FeaturePolicy {
@@ -76,6 +77,7 @@ impl FeaturePolicy {
             allow_f64_math: false,
             allow_gate_surface: false,
             allow_logos_surface: false,
+            allow_schema_surface: false,
         }
     }
 }
@@ -148,6 +150,7 @@ impl ParserProfile {
                 allow_f64_math: true,
                 allow_gate_surface: true,
                 allow_logos_surface: true,
+                allow_schema_surface: true,
             },
             capabilities: CapabilityExpectations::permissive(),
             aliases: BTreeMap::new(),

--- a/docs/roadmap/language_maturity/schema_first_declarations_scope.md
+++ b/docs/roadmap/language_maturity/schema_first_declarations_scope.md
@@ -1,0 +1,87 @@
+# Schema-First Declarations Scope
+
+Status: proposed first-wave checkpoint
+Related issue: `#121`
+
+## Goal
+
+Define a narrow, executable first-wave contract for schema-first declarations
+without accidentally opening validation generation, config loading, API codegen,
+migrations, or PROMETHEUS boundary work inside the first `v0.3` slice.
+
+## Decision
+
+`#121` should start as a declaration-surface wave, not as a generation or
+runtime wave.
+
+The first honest target is a canonical schema declaration family that can
+describe:
+
+- product-shaped models
+- tagged union models
+- schema roles for later config/API/wire use
+
+while remaining separate from:
+
+- executable record / ADT runtime carriers
+- generated validation logic
+- host integration
+- serialization / migration machinery
+
+## Included In `#121`
+
+- top-level nominal schema declarations as language-owned source items
+- canonical schema forms for:
+  - record-shaped schemas
+  - tagged-union schemas
+  - role markers for `config`, `api`, and `wire`
+- reuse of the current declared type grammar inside schema field / payload
+  positions
+- clean profile or edition gating so schema declarations can exist without
+  widening unrelated execution surfaces
+- deterministic frontend ownership of schema tables and diagnostics
+
+## Explicit Non-Goals
+
+- deriving validation or runtime checks from schemas
+- config-file loading or parsing
+- generated client/server artifacts
+- schema versioning or migration metadata
+- patch types or wire-format unions beyond the declaration layer
+- widening `prom-*`, host capability scope, or executable VM value families
+- silently treating schemas as executable records or ADTs
+
+## Honest First-Wave Rules
+
+- schema declarations are compile-time contract items, not executable value
+  families
+- schema declarations may reference already-supported declared source types,
+  including records, tuples, nominal enums, `Option(T)`, `Result(T, E)`, and
+  measured numeric forms
+- schema declarations must stay nominal and deterministic; duplicate names or
+  ambiguous shape forms are compile-time errors
+- config/API/wire meaning is introduced only as explicit schema-role metadata,
+  not through ad hoc naming conventions
+- `#121` is not done when only one shape family exists; records, tagged unions,
+  and schema-role markers are all part of the acceptance boundary
+
+## Expected Slice Order
+
+1. schema record declarations and canonical schema table ownership
+2. schema tagged-union declarations
+3. schema role markers for `config`, `api`, and `wire`
+4. docs/spec freeze for declaration-only schema surface
+
+## Done Boundary
+
+`#121` can close when:
+
+1. canonical schema declaration syntax exists for record and tagged-union
+   shapes,
+2. schema-role markers for `config`, `api`, and `wire` are explicit and
+   deterministic,
+3. schema declarations stay compile-time-only and separate from executable
+   runtime carriers,
+4. docs and diagnostics describe the declaration surface honestly,
+5. the implementation remains inside `sm-front` / `sm-profile` / `sm-sema` /
+   `sm-ir` and does not widen PROMETHEUS or host boundaries.

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -38,4 +38,5 @@ Related staged design-target notes:
 - `docs/roadmap/language_maturity/record_data_model.md`
 - `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`
+- `docs/roadmap/language_maturity/schema_first_declarations_scope.md`
 - `docs/roadmap/language_maturity/units_of_measure_scope.md`

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -45,7 +45,8 @@ Current examples include:
 - `let-else` parse failures such as plain binding targets, discard targets, or
   non-`return` else branches in the current v0 surface
 - `match`-expression parse failures such as invalid literal arm patterns
-- top-level parse failures such as unexpected items other than `fn` or `record`
+- top-level parse failures such as unexpected items other than `fn`, `record`,
+  `schema`, or `enum`
 - extended numeric-literal parse failures such as invalid typed suffix/body
   combinations or decimal-only `f64`/`fx` requirements
 
@@ -75,6 +76,7 @@ Current examples include:
 
 - `f64` surface disabled by profile policy
 - Logos surface disabled by profile policy
+- schema surface disabled by profile policy
 - legacy compatibility paths disabled by profile policy
 
 ## Type Diagnostics
@@ -128,10 +130,17 @@ Current message families include:
 - range literal rejected in tuple/user-data position
 - for-range requires `i32` range expression
 - duplicate record declaration
+- duplicate schema declaration
 - top-level record/function name collision
+- top-level schema/function name collision
+- top-level schema/record name collision
+- top-level schema/enum name collision
 - empty record declaration
+- empty schema declaration
 - duplicate record field name
+- duplicate schema field name
 - unknown record field type
+- unknown schema field type
 - recursive record field graph
 - record type declared but not yet available in executable parameter/return annotation positions
 - duplicate field in record literal

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -24,8 +24,11 @@ The current Rust-like executable surface is a deterministic function program.
 
 Current rules:
 
-- top-level source items currently include nominal `record` declarations and executable functions
+- top-level source items currently include nominal `record`, compile-time-only
+  `schema`, and executable function declarations
 - `record` declarations contribute nominal type identity but are not themselves executable entrypoints
+- `schema` declarations contribute compile-time contract metadata only and are
+  not executable entrypoints or value families
 - execution begins at `fn main()`
 - `main` must currently have signature `fn main()`
 - there is no dynamic entrypoint discovery or module-level executable code
@@ -70,6 +73,18 @@ Current v0 record declaration semantics:
 - explicit record `let-else` uses `let RecordName { field: target, ... } = value else return ...;`
 - record `let-else` currently treats only explicit `quad` literal field targets as refutable checks
 - record equality is allowed only when every field type already supports stable equality
+
+Current v0 schema declaration semantics:
+
+- `schema Name { ... }` introduces one compile-time-only schema declaration
+- schema identity is nominal by schema name
+- schema declarations must be non-empty and may not repeat field names
+- schema field types reuse the current declared-type grammar and resolve
+  against the ordinary nominal/executable type tables
+- schema declarations currently live only in the canonical schema table owned by
+  the frontend/typecheck path
+- schema declarations do not currently introduce executable types, runtime
+  carriers, or host ABI shapes
 
 Current first-wave function-contract semantics:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -36,11 +36,18 @@ public source-surface contracts are specified separately in:
 
 ## Program Structure
 
-The current Rust-like executable program is a sequence of top-level `record`
-declarations and functions:
+The current Rust-like executable program is a sequence of top-level `record`,
+`schema`, `enum`, and function declarations:
 
 ```sm
 record Name {
+    field: type,
+    ...
+}
+```
+
+```sm
+schema Name {
     field: type,
     ...
 }
@@ -98,9 +105,13 @@ fn name(arg: type, ...) -> ret_type = expr;
 Current rules:
 
 - `record` introduces a nominal top-level record declaration
+- `schema` introduces a compile-time-only top-level schema declaration
 - record declarations must be non-empty
+- schema declarations must be non-empty
 - record field names must be unique within one declaration
+- schema field names must be unique within one declaration
 - record field types currently use the ordinary source type grammar
+- schema field types currently use the ordinary source type grammar
 - `fn` introduces a function
 - parameters are named and typed explicitly
 - trailing parameters may attach a default initializer with `= expr`
@@ -128,6 +139,17 @@ Current v0 record limits:
 - record equality is allowed only when every field type already supports stable equality
 - record values are not part of the PROMETHEUS host ABI surface
 - anonymous brace-only record literals/patterns, mutation, methods, and inheritance are not part of this slice
+
+Current v0 schema limits:
+
+- only record-shaped `schema Name { field: type, ... }` declarations are part
+  of the current surface
+- schema declarations are compile-time-only and do not introduce executable
+  value carriers
+- schema names are not yet valid in executable local, parameter, return, or
+  match type positions
+- tagged-union schemas and role markers such as `config`, `api`, and `wire`
+  remain later `v0.3` slices
 
 ## Statements
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -11,6 +11,10 @@ Semantic programs.
 It covers the executable source surface rather than the SemCode or VM
 representation layer.
 
+Compile-time-only declaration families such as `schema Name { ... }` are part
+of the source contract, but they are not yet executable source-visible types or
+VM value families.
+
 Operational source-level meaning such as call resolution, control-flow
 selection, and source diagnostics is specified separately in:
 
@@ -30,6 +34,10 @@ Current source-visible types:
 - measured numeric forms such as `f64[m]` and `u32[ms]`
 - `unit`
 - `qvec(N)` as a reserved parser-level family
+
+Current compile-time-only declaration families:
+
+- nominal `schema Name { ... }` declarations for boundary/model contracts
 
 ## Unit
 
@@ -200,8 +208,8 @@ That means:
 
 The current source type contract does not yet claim stable support for:
 
-- user-defined aggregate types
-- algebraic data types
+- schema names as executable local, parameter, or return types
+- user-defined parameterized algebraic data types
 - generics
 - trait or protocol systems
 - implicit numeric widening across unrelated families

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,8 @@ pub mod frontend {
         type_check_function_with_table, type_check_program, AstArena, BinaryOp, CompilePolicyView,
         CompileProfile, Expr, ExprId, FnSig, FnTable, FrontendError, FrontendErrorKind,
         Function, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
-        LogosSystem, LogosWhen, MatchArm, OptLevel, Program, QuadVal, ScopeEnv, Stmt, StmtId,
-        SymbolId, Token, TokenKind, Type, UnaryOp,
+        LogosSystem, LogosWhen, MatchArm, OptLevel, Program, QuadVal, SchemaDecl, SchemaField,
+        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,
@@ -153,6 +153,7 @@ pub mod frontend {
             arena: ::core::mem::take(&mut p.arena),
             adts: p.adts,
             records: p.records,
+            schemas: p.schemas,
             functions: p.functions,
         })
     }

--- a/tests/golden_snapshots/public_api/sm_profile_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_profile_lib.txt
@@ -18,6 +18,7 @@ pub allow_debug_symbols: bool,
 pub allow_f64_math: bool,
 pub allow_gate_surface: bool,
 pub allow_logos_surface: bool,
+pub allow_schema_surface: bool,
 pub const fn core() -> Self {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -56,4 +57,3 @@ pub input: &'a str,
 pub target: &'a str,
 pub fn train_profile(samples: &[TrainingSample<'_>]) -> ParserProfile {
 pub fn train_profile_in_place(profile: &mut ParserProfile, samples: &[TrainingSample<'_>]) {
-


### PR DESCRIPTION
## Summary
- add top-level schema Name { field: type, ... } declarations behind a new llow_schema_surface profile gate
- introduce canonical schema-table ownership in sm-front and validate non-empty declarations, duplicate fields, type resolution, and top-level name collisions
- sync spec/docs and update the intentional sm-profile public API snapshot

## Scope
This is the first narrow code slice under #121.

Included:
- record-shaped schema declarations only
- compile-time-only schema metadata ownership
- parser + sema + diagnostics + spec

Explicitly out of scope:
- tagged-union schemas
- config / pi / wire role markers
- validation derivation
- generated artifacts
- migrations
- host / prom-* widening
- executable runtime carriers for schemas

## Validation
- cargo test -p sm-front
- cargo test --test public_api_contracts
- cargo test --workspace

Closes part of #121.