### PR TITLE
V03-01 schema tagged-union declaration surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -20,8 +20,8 @@ pub use types::{
     FrontendError, FrontendErrorKind, Function, IfExpr, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
-    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, Stmt, StmtId,
-    SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaShape,
+    SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -5,8 +5,9 @@ use crate::types::{
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField, Stmt,
-    StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField,
+    SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
+    UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -212,9 +213,36 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::KwSchema, "expected 'schema'")?;
         let name = self.expect_symbol()?;
         self.expect(TokenKind::LBrace, "expected '{' after schema name")?;
+        let shape = if self.check(TokenKind::RBrace) {
+            SchemaShape::Record(Vec::new())
+        } else {
+            let first_name = self.expect_symbol()?;
+            if self.check(TokenKind::Colon) {
+                SchemaShape::Record(self.parse_schema_record_fields_after_first(first_name)?)
+            } else if self.check(TokenKind::LBrace) {
+                SchemaShape::TaggedUnion(
+                    self.parse_schema_tagged_union_variants_after_first(first_name)?,
+                )
+            } else {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message:
+                        "schema declaration body must use either 'field: type' entries or 'Variant { ... }' entries"
+                            .to_string(),
+                });
+            }
+        };
+        self.expect(TokenKind::RBrace, "expected '}' after schema declaration")?;
+        Ok(SchemaDecl { name, shape })
+    }
+
+    fn parse_schema_record_fields_after_first(
+        &mut self,
+        first_name: SymbolId,
+    ) -> Result<Vec<SchemaField>, FrontendError> {
         let mut fields = Vec::new();
-        while !self.check(TokenKind::RBrace) {
-            let field_name = self.expect_symbol()?;
+        let mut field_name = first_name;
+        loop {
             self.expect(TokenKind::Colon, "expected ':' after schema field name")?;
             let field_ty = self.parse_type()?;
             fields.push(SchemaField {
@@ -225,12 +253,73 @@ impl<'a> Parser<'a> {
                 if self.check(TokenKind::RBrace) {
                     break;
                 }
+                field_name = self.expect_symbol()?;
+                if !self.check(TokenKind::Colon) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "record-shaped schema declarations cannot mix field entries with tagged-union variants"
+                                .to_string(),
+                    });
+                }
                 continue;
             }
             break;
         }
-        self.expect(TokenKind::RBrace, "expected '}' after schema declaration")?;
-        Ok(SchemaDecl { name, fields })
+        Ok(fields)
+    }
+
+    fn parse_schema_tagged_union_variants_after_first(
+        &mut self,
+        first_name: SymbolId,
+    ) -> Result<Vec<SchemaVariant>, FrontendError> {
+        let mut variants = Vec::new();
+        let mut variant_name = first_name;
+        loop {
+            self.expect(
+                TokenKind::LBrace,
+                "expected '{' after schema variant name in tagged-union schema",
+            )?;
+            let mut fields = Vec::new();
+            while !self.check(TokenKind::RBrace) {
+                let field_name = self.expect_symbol()?;
+                self.expect(TokenKind::Colon, "expected ':' after schema field name")?;
+                let field_ty = self.parse_type()?;
+                fields.push(SchemaField {
+                    name: field_name,
+                    ty: field_ty,
+                });
+                if self.eat(TokenKind::Comma) {
+                    if self.check(TokenKind::RBrace) {
+                        break;
+                    }
+                    continue;
+                }
+                break;
+            }
+            self.expect(TokenKind::RBrace, "expected '}' after schema variant payload")?;
+            variants.push(SchemaVariant {
+                name: variant_name,
+                fields,
+            });
+            if self.eat(TokenKind::Comma) {
+                if self.check(TokenKind::RBrace) {
+                    break;
+                }
+                variant_name = self.expect_symbol()?;
+                if !self.check(TokenKind::LBrace) {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "tagged-union schema declarations cannot mix variant entries with record-shaped fields"
+                                .to_string(),
+                    });
+                }
+                continue;
+            }
+            break;
+        }
+        Ok(variants)
     }
 
     fn parse_adt_decl(&mut self) -> Result<AdtDecl, FrontendError> {
@@ -3474,8 +3563,42 @@ fn main() {
         assert_eq!(program.schemas.len(), 1);
         let schema = &program.schemas[0];
         assert_eq!(program.arena.symbol_name(schema.name), "SensorConfig");
-        assert_eq!(schema.fields.len(), 2);
-        assert_eq!(program.arena.symbol_name(schema.fields[0].name), "interval_ms");
+        let SchemaShape::Record(fields) = &schema.shape else {
+            panic!("expected record-shaped schema");
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(program.arena.symbol_name(fields[0].name), "interval_ms");
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_tagged_union_schema_declaration() {
+        let src = r#"
+schema Message {
+    Ping {},
+    Data {
+        value: f64,
+        status: Result(quad, bool),
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("tagged-union schema declaration should parse");
+        assert_eq!(program.schemas.len(), 1);
+        let schema = &program.schemas[0];
+        assert_eq!(program.arena.symbol_name(schema.name), "Message");
+        let SchemaShape::TaggedUnion(variants) = &schema.shape else {
+            panic!("expected tagged-union schema");
+        };
+        assert_eq!(variants.len(), 2);
+        assert_eq!(program.arena.symbol_name(variants[0].name), "Ping");
+        assert!(variants[0].fields.is_empty());
+        assert_eq!(program.arena.symbol_name(variants[1].name), "Data");
+        assert_eq!(variants[1].fields.len(), 2);
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3237,6 +3237,30 @@ mod tests {
     }
 
     #[test]
+    fn tagged_union_schema_declarations_typecheck_as_compile_time_top_level_items() {
+        let src = r#"
+            record Point {
+                x: i32,
+                y: i32,
+            }
+
+            schema Payload {
+                Empty {},
+                PointRef {
+                    point: Point,
+                    label: Option(quad),
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("tagged-union schema declarations should typecheck");
+    }
+
+    #[test]
     fn schema_declaration_rejects_duplicate_field_name() {
         let src = r#"
             schema PointPayload {
@@ -3270,6 +3294,49 @@ mod tests {
         assert!(err
             .message
             .contains("schema 'PointPayload' must declare at least 1 field"));
+    }
+
+    #[test]
+    fn tagged_union_schema_rejects_duplicate_variant_name() {
+        let src = r#"
+            schema Payload {
+                Ready {},
+                Ready {
+                    detail: quad,
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("duplicate schema variant must reject");
+        assert!(err
+            .message
+            .contains("schema 'Payload' cannot repeat variant 'Ready'"));
+    }
+
+    #[test]
+    fn tagged_union_schema_rejects_duplicate_variant_field_name() {
+        let src = r#"
+            schema Payload {
+                Data {
+                    value: i32,
+                    value: i32,
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("duplicate tagged-union schema field must reject");
+        assert!(err
+            .message
+            .contains("schema 'Payload::Data' cannot repeat field 'value'"));
     }
 
     #[test]
@@ -4674,24 +4741,107 @@ fn validate_schema_declarations(
                 resolve_symbol_name(&program.arena, schema.name)?
             ),
         })?;
-        if schema.fields.is_empty() {
+        match &schema.shape {
+            SchemaShape::Record(fields) => validate_record_shaped_schema(
+                schema.name,
+                fields,
+                record_table,
+                adt_table,
+                &program.arena,
+            )?,
+            SchemaShape::TaggedUnion(variants) => validate_tagged_union_schema(
+                schema.name,
+                variants,
+                record_table,
+                adt_table,
+                &program.arena,
+            )?,
+        }
+    }
+    Ok(())
+}
+
+fn validate_record_shaped_schema(
+    schema_name: SymbolId,
+    fields: &[SchemaField],
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if fields.is_empty() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "schema '{}' must declare at least 1 field",
+                resolve_symbol_name(arena, schema_name)?
+            ),
+        });
+    }
+    let mut seen = BTreeSet::new();
+    for field in fields {
+        if !seen.insert(field.name) {
             return Err(FrontendError {
                 pos: 0,
                 message: format!(
-                    "schema '{}' must declare at least 1 field",
-                    resolve_symbol_name(&program.arena, schema.name)?
+                    "schema '{}' cannot repeat field '{}'",
+                    resolve_symbol_name(arena, schema_name)?,
+                    resolve_symbol_name(arena, field.name)?
                 ),
             });
         }
-        let mut seen = BTreeSet::new();
-        for field in &schema.fields {
-            if !seen.insert(field.name) {
+        ensure_type_resolved(
+            &field.ty,
+            record_table,
+            adt_table,
+            arena,
+            format!(
+                "schema field '{}.{}'",
+                resolve_symbol_name(arena, schema_name)?,
+                resolve_symbol_name(arena, field.name)?
+            ),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_tagged_union_schema(
+    schema_name: SymbolId,
+    variants: &[SchemaVariant],
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if variants.is_empty() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "schema '{}' must declare at least 1 variant",
+                resolve_symbol_name(arena, schema_name)?
+            ),
+        });
+    }
+    let mut seen_variants = BTreeSet::new();
+    for variant in variants {
+        if !seen_variants.insert(variant.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "schema '{}' cannot repeat variant '{}'",
+                    resolve_symbol_name(arena, schema_name)?,
+                    resolve_symbol_name(arena, variant.name)?
+                ),
+            });
+        }
+        let mut seen_fields = BTreeSet::new();
+        for field in &variant.fields {
+            if !seen_fields.insert(field.name) {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
-                        "schema '{}' cannot repeat field '{}'",
-                        resolve_symbol_name(&program.arena, schema.name)?,
-                        resolve_symbol_name(&program.arena, field.name)?
+                        "schema '{}::{}' cannot repeat field '{}'",
+                        resolve_symbol_name(arena, schema_name)?,
+                        resolve_symbol_name(arena, variant.name)?,
+                        resolve_symbol_name(arena, field.name)?
                     ),
                 });
             }
@@ -4699,11 +4849,12 @@ fn validate_schema_declarations(
                 &field.ty,
                 record_table,
                 adt_table,
-                &program.arena,
+                arena,
                 format!(
-                    "schema field '{}.{}'",
-                    resolve_symbol_name(&program.arena, schema.name)?,
-                    resolve_symbol_name(&program.arena, field.name)?
+                    "schema field '{}::{}.{}'",
+                    resolve_symbol_name(arena, schema_name)?,
+                    resolve_symbol_name(arena, variant.name)?,
+                    resolve_symbol_name(arena, field.name)?
                 ),
             )?;
         }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -341,9 +341,21 @@ pub struct SchemaField {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SchemaDecl {
+pub struct SchemaVariant {
     pub name: SymbolId,
     pub fields: Vec<SchemaField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaShape {
+    Record(Vec<SchemaField>),
+    TaggedUnion(Vec<SchemaVariant>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDecl {
+    pub name: SymbolId,
+    pub shape: SchemaShape,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -139,6 +139,8 @@ Current message families include:
 - empty schema declaration
 - duplicate record field name
 - duplicate schema field name
+- duplicate tagged-union schema variant name
+- duplicate tagged-union schema field name
 - unknown record field type
 - unknown schema field type
 - recursive record field graph

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -78,9 +78,15 @@ Current v0 schema declaration semantics:
 
 - `schema Name { ... }` introduces one compile-time-only schema declaration
 - schema identity is nominal by schema name
-- schema declarations must be non-empty and may not repeat field names
-- schema field types reuse the current declared-type grammar and resolve
-  against the ordinary nominal/executable type tables
+- schema declarations currently support:
+  - record-shaped forms `schema Name { field: type, ... }`
+  - tagged-union forms `schema Name { Variant { field: type, ... }, ... }`
+- record-shaped schema declarations must be non-empty and may not repeat field
+  names
+- tagged-union schema declarations must declare at least one variant, may not
+  repeat variant names, and may not repeat field names inside one variant
+- schema field and variant-payload types reuse the current declared-type grammar
+  and resolve against the ordinary nominal/executable type tables
 - schema declarations currently live only in the canonical schema table owned by
   the frontend/typecheck path
 - schema declarations do not currently introduce executable types, runtime

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -54,6 +54,16 @@ schema Name {
 ```
 
 ```sm
+schema Name {
+    Variant {
+        field: type,
+        ...
+    },
+    ...
+}
+```
+
+```sm
 record DecisionContext {
     camera: quad,
     quality: f64,
@@ -109,9 +119,11 @@ Current rules:
 - record declarations must be non-empty
 - schema declarations must be non-empty
 - record field names must be unique within one declaration
-- schema field names must be unique within one declaration
+- record-shaped schema field names must be unique within one declaration
+- tagged-union schema variant names must be unique within one declaration
+- tagged-union schema field names must be unique within one variant payload
 - record field types currently use the ordinary source type grammar
-- schema field types currently use the ordinary source type grammar
+- schema field and variant-payload types currently use the ordinary source type grammar
 - `fn` introduces a function
 - parameters are named and typed explicitly
 - trailing parameters may attach a default initializer with `= expr`
@@ -142,14 +154,16 @@ Current v0 record limits:
 
 Current v0 schema limits:
 
-- only record-shaped `schema Name { field: type, ... }` declarations are part
-  of the current surface
+- record-shaped `schema Name { field: type, ... }` declarations are part of
+  the current surface
+- tagged-union `schema Name { Variant { ... }, Other { ... } }` declarations
+  are part of the current surface
 - schema declarations are compile-time-only and do not introduce executable
   value carriers
 - schema names are not yet valid in executable local, parameter, return, or
   match type positions
-- tagged-union schemas and role markers such as `config`, `api`, and `wire`
-  remain later `v0.3` slices
+- schema role markers such as `config`, `api`, and `wire` remain later `v0.3`
+  slices
 
 ## Statements
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -38,6 +38,8 @@ Current source-visible types:
 Current compile-time-only declaration families:
 
 - nominal `schema Name { ... }` declarations for boundary/model contracts
+- record-shaped and tagged-union schema forms within that compile-time-only
+  declaration family
 
 ## Unit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,8 @@ pub mod frontend {
         CompileProfile, Expr, ExprId, FnSig, FnTable, FrontendError, FrontendErrorKind,
         Function, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
         LogosSystem, LogosWhen, MatchArm, OptLevel, Program, QuadVal, SchemaDecl, SchemaField,
-        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
+        SchemaShape, SchemaVariant, ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type,
+        UnaryOp,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,


### PR DESCRIPTION
## Summary
- add tagged-union schema declarations as the second narrow slice inside #121
- keep schemas compile-time-only by extending the frontend-owned schema table only
- add parser, sema, docs, and tests for record-shaped vs tagged-union schema distinction

## Scope
- schema Name { Variant { ... }, Other { ... } }
- duplicate variant-name and per-variant field-name diagnostics
- compile-time-only schema ownership in sm-front

## Out of scope
- schema role markers (config / pi / wire)
- validation derivation
- generated artifacts
- migrations
- host or prom-* widening

## Validation
- cargo test -p sm-front
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #121.