### PR TITLE
V03-01 schema role marker surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -20,8 +20,9 @@ pub use types::{
     FrontendError, FrontendErrorKind, Function, IfExpr, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
-    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaShape,
-    SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
+    SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
+    UnaryOp,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -6,8 +6,8 @@ use crate::types::{
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
     RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField,
-    SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
-    UnaryOp,
+    SchemaRole, SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind,
+    TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -70,6 +70,10 @@ impl<'a> Parser<'a> {
                 break;
             }
             self.idx = i;
+            if self.starts_role_marked_schema_decl() {
+                schemas.push(self.parse_schema_decl()?);
+                continue;
+            }
             match self.tokens[i].kind {
                 TokenKind::KwEnum => adts.push(self.parse_adt_decl()?),
                 TokenKind::KwFn => functions.push(self.parse_function()?),
@@ -78,8 +82,9 @@ impl<'a> Parser<'a> {
                 _ => {
                     return Err(FrontendError {
                         pos: self.tokens[i].pos,
-                        message: "expected top-level 'enum', 'fn', 'record', or 'schema'"
-                            .to_string(),
+                        message:
+                            "expected top-level 'enum', 'fn', 'record', 'schema', or role-marked schema declaration"
+                                .to_string(),
                     });
                 }
             }
@@ -210,6 +215,7 @@ impl<'a> Parser<'a> {
 
     fn parse_schema_decl(&mut self) -> Result<SchemaDecl, FrontendError> {
         self.require_schema_surface("schema declarations are disabled by profile policy")?;
+        let role = self.parse_optional_schema_role()?;
         self.expect(TokenKind::KwSchema, "expected 'schema'")?;
         let name = self.expect_symbol()?;
         self.expect(TokenKind::LBrace, "expected '{' after schema name")?;
@@ -233,7 +239,45 @@ impl<'a> Parser<'a> {
             }
         };
         self.expect(TokenKind::RBrace, "expected '}' after schema declaration")?;
-        Ok(SchemaDecl { name, shape })
+        Ok(SchemaDecl { name, role, shape })
+    }
+
+    fn starts_role_marked_schema_decl(&self) -> bool {
+        let i = self.next_non_layout_idx();
+        let Some(first) = self.tokens.get(i) else {
+            return false;
+        };
+        if first.kind != TokenKind::Ident || !Self::is_schema_role_marker_text(&first.text) {
+            return false;
+        }
+        let next = self.next_non_layout_idx_from(i + 1);
+        self.tokens
+            .get(next)
+            .map(|tok| tok.kind == TokenKind::KwSchema)
+            .unwrap_or(false)
+    }
+
+    fn parse_optional_schema_role(&mut self) -> Result<Option<SchemaRole>, FrontendError> {
+        if !self.starts_role_marked_schema_decl() {
+            return Ok(None);
+        }
+        let role_tok = self.advance();
+        let role = match role_tok.text.as_str() {
+            "config" => SchemaRole::Config,
+            "api" => SchemaRole::Api,
+            "wire" => SchemaRole::Wire,
+            _ => {
+                return Err(FrontendError {
+                    pos: role_tok.pos,
+                    message: "unknown schema role marker".to_string(),
+                })
+            }
+        };
+        Ok(Some(role))
+    }
+
+    fn is_schema_role_marker_text(text: &str) -> bool {
+        matches!(text, "config" | "api" | "wire")
     }
 
     fn parse_schema_record_fields_after_first(
@@ -3599,6 +3643,32 @@ fn main() {
         assert!(variants[0].fields.is_empty());
         assert_eq!(program.arena.symbol_name(variants[1].name), "Data");
         assert_eq!(variants[1].fields.len(), 2);
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_role_marked_schema_declarations() {
+        let src = r#"
+config schema AppConfig {
+    interval_ms: u32[ms],
+}
+
+wire schema Envelope {
+    Ping {},
+    Data {
+        value: f64,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("role-marked schema declarations should parse");
+        assert_eq!(program.schemas.len(), 2);
+        assert_eq!(program.schemas[0].role, Some(SchemaRole::Config));
+        assert_eq!(program.schemas[1].role, Some(SchemaRole::Wire));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3261,6 +3261,32 @@ mod tests {
     }
 
     #[test]
+    fn role_marked_schema_declarations_typecheck_as_compile_time_items() {
+        let src = r#"
+            config schema AppConfig {
+                interval_ms: u32[ms],
+            }
+
+            api schema SensorRequest {
+                payload: Result(quad, bool),
+            }
+
+            wire schema Envelope {
+                Ping {},
+                Data {
+                    value: f64,
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("role-marked schema declarations should typecheck");
+    }
+
+    #[test]
     fn schema_declaration_rejects_duplicate_field_name() {
         let src = r#"
             schema PointPayload {

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -346,6 +346,13 @@ pub struct SchemaVariant {
     pub fields: Vec<SchemaField>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaRole {
+    Config,
+    Api,
+    Wire,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchemaShape {
     Record(Vec<SchemaField>),
@@ -355,6 +362,7 @@ pub enum SchemaShape {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaDecl {
     pub name: SymbolId,
+    pub role: Option<SchemaRole>,
     pub shape: SchemaShape,
 }
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -47,6 +47,8 @@ Current examples include:
 - `match`-expression parse failures such as invalid literal arm patterns
 - top-level parse failures such as unexpected items other than `fn`, `record`,
   `schema`, or `enum`
+- malformed role-marked schema declarations such as `config`/`api`/`wire`
+  appearing without a following `schema`
 - extended numeric-literal parse failures such as invalid typed suffix/body
   combinations or decimal-only `f64`/`fx` requirements
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -81,6 +81,10 @@ Current v0 schema declaration semantics:
 - schema declarations currently support:
   - record-shaped forms `schema Name { field: type, ... }`
   - tagged-union forms `schema Name { Variant { field: type, ... }, ... }`
+- schema declarations may now also carry one explicit role marker:
+  - `config schema`
+  - `api schema`
+  - `wire schema`
 - record-shaped schema declarations must be non-empty and may not repeat field
   names
 - tagged-union schema declarations must declare at least one variant, may not
@@ -89,6 +93,8 @@ Current v0 schema declaration semantics:
   and resolve against the ordinary nominal/executable type tables
 - schema declarations currently live only in the canonical schema table owned by
   the frontend/typecheck path
+- schema role markers currently contribute compile-time declaration metadata
+  only; they do not imply loading, generation, transport, or runtime behavior
 - schema declarations do not currently introduce executable types, runtime
   carriers, or host ABI shapes
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -54,6 +54,13 @@ schema Name {
 ```
 
 ```sm
+config schema Name {
+    field: type,
+    ...
+}
+```
+
+```sm
 schema Name {
     Variant {
         field: type,
@@ -116,6 +123,8 @@ Current rules:
 
 - `record` introduces a nominal top-level record declaration
 - `schema` introduces a compile-time-only top-level schema declaration
+- `config schema`, `api schema`, and `wire schema` introduce the same
+  compile-time-only schema declaration family with explicit role metadata
 - record declarations must be non-empty
 - schema declarations must be non-empty
 - record field names must be unique within one declaration
@@ -160,10 +169,10 @@ Current v0 schema limits:
   are part of the current surface
 - schema declarations are compile-time-only and do not introduce executable
   value carriers
+- schema role markers are currently explicit only as top-level prefixes:
+  `config schema`, `api schema`, and `wire schema`
 - schema names are not yet valid in executable local, parameter, return, or
   match type positions
-- schema role markers such as `config`, `api`, and `wire` remain later `v0.3`
-  slices
 
 ## Statements
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -40,6 +40,8 @@ Current compile-time-only declaration families:
 - nominal `schema Name { ... }` declarations for boundary/model contracts
 - record-shaped and tagged-union schema forms within that compile-time-only
   declaration family
+- explicit schema-role metadata via `config schema`, `api schema`, and
+  `wire schema`
 
 ## Unit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ pub mod frontend {
         CompileProfile, Expr, ExprId, FnSig, FnTable, FrontendError, FrontendErrorKind,
         Function, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
         LogosSystem, LogosWhen, MatchArm, OptLevel, Program, QuadVal, SchemaDecl, SchemaField,
-        SchemaShape, SchemaVariant, ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type,
-        UnaryOp,
+        SchemaRole, SchemaShape, SchemaVariant, ScopeEnv, Stmt, StmtId, SymbolId, Token,
+        TokenKind, Type, UnaryOp,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,


### PR DESCRIPTION
## Summary\n- add explicit config schema, pi schema, and wire schema role markers as the third narrow slice inside #121\n- keep role markers compile-time-only as schema-table metadata owned by the frontend\n- extend parser, sema, docs, and tests only, without validation derivation, codegen, migrations, or host widening\n\n## Validation\n- cargo test -p sm-front\n- cargo test --test public_api_contracts\n- cargo test --workspace\n\nPart of #121.