### PR TITLE
V03-02 schema validation plan ownership

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -22,7 +22,7 @@ pub use types::{
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
     SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
-    UnaryOp,
+    UnaryOp, ValidationFieldPlan, ValidationPlan, ValidationShapePlan, ValidationVariantPlan,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};
@@ -34,7 +34,10 @@ pub mod parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
 mod typecheck;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use typecheck::{type_check_function, type_check_function_with_table, type_check_program};
+pub use typecheck::{
+    derive_validation_plan_table, type_check_function, type_check_function_with_table,
+    type_check_program,
+};
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,6 +59,9 @@ pub type AdtTable = BTreeMap<SymbolId, AdtDecl>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type ValidationPlanTable = BTreeMap<SymbolId, ValidationPlan>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -123,6 +123,53 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     Ok(())
 }
 
+pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanTable, FrontendError> {
+    let record_table = build_record_table(program)?;
+    let adt_table = build_adt_table(program)?;
+    let schema_table = build_schema_table(program)?;
+    let fn_table = build_fn_table(program)?;
+    validate_top_level_name_collisions(program, &fn_table, &record_table, &adt_table, &schema_table)?;
+    validate_record_declarations(program, &record_table, &adt_table)?;
+    validate_adt_declarations(program, &record_table, &adt_table)?;
+    validate_schema_declarations(program, &schema_table, &record_table, &adt_table)?;
+
+    let mut plans = ValidationPlanTable::new();
+    for schema in &program.schemas {
+        let _ = schema_table.get(&schema.name).ok_or(FrontendError {
+            pos: 0,
+            message: format!(
+                "missing schema '{}' in canonical schema table",
+                resolve_symbol_name(&program.arena, schema.name)?
+            ),
+        })?;
+
+        let shape = match &schema.shape {
+            SchemaShape::Record(fields) => ValidationShapePlan::Record(
+                derive_validation_field_plans(fields, &record_table, &adt_table, &program.arena)?,
+            ),
+            SchemaShape::TaggedUnion(variants) => ValidationShapePlan::TaggedUnion(
+                derive_validation_variant_plans(
+                    variants,
+                    &record_table,
+                    &adt_table,
+                    &program.arena,
+                )?,
+            ),
+        };
+
+        plans.insert(
+            schema.name,
+            ValidationPlan {
+                schema_name: schema.name,
+                role: schema.role,
+                shape,
+            },
+        );
+    }
+
+    Ok(plans)
+}
+
 pub fn type_check_function_with_table(
     func: &Function,
     arena: &AstArena,
@@ -1758,6 +1805,12 @@ mod tests {
         type_check_program(&program)
     }
 
+    fn derive_validation_plans_from_source(src: &str) -> Result<(Program, ValidationPlanTable), FrontendError> {
+        let program = parse_program(src)?;
+        let plans = derive_validation_plan_table(&program)?;
+        Ok((program, plans))
+    }
+
     #[test]
     fn fx_identity_surface_typechecks() {
         let src = r#"
@@ -3284,6 +3337,82 @@ mod tests {
         "#;
 
         typecheck_source(src).expect("role-marked schema declarations should typecheck");
+    }
+
+    #[test]
+    fn derive_validation_plan_table_returns_canonical_record_schema_plan() {
+        let src = r#"
+            record Point {
+                x: i32,
+                y: i32,
+            }
+
+            config schema PointPayload {
+                point: Point,
+                label: Option(quad),
+                interval_ms: u32[ms],
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let (program, plans) =
+            derive_validation_plans_from_source(src).expect("validation plans should derive");
+        let schema_name = program.schemas[0].name;
+        let plan = plans.get(&schema_name).expect("schema plan must exist");
+        assert_eq!(plan.role, Some(SchemaRole::Config));
+        let ValidationShapePlan::Record(fields) = &plan.shape else {
+            panic!("expected record-shaped validation plan");
+        };
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0].ty, Type::Record(program.records[0].name));
+        assert_eq!(fields[1].ty, Type::Option(Box::new(Type::Quad)));
+        let Type::Measured(base, unit) = &fields[2].ty else {
+            panic!("expected measured u32 field in validation plan");
+        };
+        assert_eq!(**base, Type::U32);
+        assert_eq!(resolve_symbol_name(&program.arena, *unit).expect("unit symbol"), "ms");
+    }
+
+    #[test]
+    fn derive_validation_plan_table_returns_tagged_union_schema_plan() {
+        let src = r#"
+            record Point {
+                x: i32,
+                y: i32,
+            }
+
+            wire schema Envelope {
+                Empty {},
+                Data {
+                    point: Point,
+                    verdict: Result(quad, bool),
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let (program, plans) =
+            derive_validation_plans_from_source(src).expect("validation plans should derive");
+        let schema_name = program.schemas[0].name;
+        let plan = plans.get(&schema_name).expect("schema plan must exist");
+        assert_eq!(plan.role, Some(SchemaRole::Wire));
+        let ValidationShapePlan::TaggedUnion(variants) = &plan.shape else {
+            panic!("expected tagged-union validation plan");
+        };
+        assert_eq!(variants.len(), 2);
+        assert_eq!(variants[0].fields.len(), 0);
+        assert_eq!(variants[1].fields.len(), 2);
+        assert_eq!(variants[1].fields[0].ty, Type::Record(program.records[0].name));
+        assert_eq!(
+            variants[1].fields[1].ty,
+            Type::Result(Box::new(Type::Quad), Box::new(Type::Bool))
+        );
     }
 
     #[test]
@@ -4828,6 +4957,45 @@ fn validate_record_shaped_schema(
         )?;
     }
     Ok(())
+}
+
+fn derive_validation_field_plans(
+    fields: &[SchemaField],
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    arena: &AstArena,
+) -> Result<Vec<ValidationFieldPlan>, FrontendError> {
+    fields
+        .iter()
+        .map(|field| {
+            Ok(ValidationFieldPlan {
+                name: field.name,
+                ty: canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?,
+            })
+        })
+        .collect()
+}
+
+fn derive_validation_variant_plans(
+    variants: &[SchemaVariant],
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    arena: &AstArena,
+) -> Result<Vec<ValidationVariantPlan>, FrontendError> {
+    variants
+        .iter()
+        .map(|variant| {
+            Ok(ValidationVariantPlan {
+                name: variant.name,
+                fields: derive_validation_field_plans(
+                    &variant.fields,
+                    record_table,
+                    adt_table,
+                    arena,
+                )?,
+            })
+        })
+        .collect()
 }
 
 fn validate_tagged_union_schema(

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -366,6 +366,31 @@ pub struct SchemaDecl {
     pub shape: SchemaShape,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationFieldPlan {
+    pub name: SymbolId,
+    pub ty: Type,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationVariantPlan {
+    pub name: SymbolId,
+    pub fields: Vec<ValidationFieldPlan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationShapePlan {
+    Record(Vec<ValidationFieldPlan>),
+    TaggedUnion(Vec<ValidationVariantPlan>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationPlan {
+    pub schema_name: SymbolId,
+    pub role: Option<SchemaRole>,
+    pub shape: ValidationShapePlan,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
     pub arena: AstArena,

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -93,6 +93,8 @@ Current v0 schema declaration semantics:
   and resolve against the ordinary nominal/executable type tables
 - schema declarations currently live only in the canonical schema table owned by
   the frontend/typecheck path
+- canonical schema declarations may now also derive deterministic compile-time
+  validation plans owned by the same frontend/typecheck path
 - schema role markers currently contribute compile-time declaration metadata
   only; they do not imply loading, generation, transport, or runtime behavior
 - schema declarations do not currently introduce executable types, runtime

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -42,6 +42,8 @@ Current compile-time-only declaration families:
   declaration family
 - explicit schema-role metadata via `config schema`, `api schema`, and
   `wire schema`
+- deterministic compile-time validation plans derived from canonical schema
+  declarations and referenced declared types
 
 ## Unit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,12 +128,13 @@ pub mod frontend {
         build_fn_table, builtin_sig, lex, parse_logos_program, parse_program, parse_rustlike,
         parse_logos_program_with_profile, parse_logos_with_profile, parse_program_with_profile,
         parse_rustlike_with_profile, resolve_symbol_name, type_check_function,
-        type_check_function_with_table, type_check_program, AstArena, BinaryOp, CompilePolicyView,
-        CompileProfile, Expr, ExprId, FnSig, FnTable, FrontendError, FrontendErrorKind,
-        Function, LogosEntity, LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram,
-        LogosSystem, LogosWhen, MatchArm, OptLevel, Program, QuadVal, SchemaDecl, SchemaField,
-        SchemaRole, SchemaShape, SchemaVariant, ScopeEnv, Stmt, StmtId, SymbolId, Token,
-        TokenKind, Type, UnaryOp,
+        type_check_function_with_table, type_check_program, derive_validation_plan_table,
+        AstArena, BinaryOp, CompilePolicyView, CompileProfile, Expr, ExprId, FnSig, FnTable,
+        FrontendError, FrontendErrorKind, Function, LogosEntity, LogosEntityField,
+        LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, MatchArm, OptLevel,
+        Program, QuadVal, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
+        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationFieldPlan,
+        ValidationPlan, ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,
@@ -163,10 +164,11 @@ pub mod frontend {
         pub use super::{
             build_fn_table, lex, parse_function, parse_logos_program, parse_program,
             resolve_symbol_name, type_check_function, type_check_function_with_table,
-            type_check_program, AstArena, BinaryOp, Expr, ExprId, FnSig, FnTable, FrontendError,
-            Function, LogosEntity, LogosLaw, LogosProgram, LogosSystem, LogosWhen, MatchArm,
-            Program, QuadVal, ScopeEnv, SourceMark, Stmt, StmtId, SymbolId, Token, TokenKind,
-            Type, UnaryOp,
+            type_check_program, derive_validation_plan_table, AstArena, BinaryOp, Expr, ExprId,
+            FnSig, FnTable, FrontendError, Function, LogosEntity, LogosLaw, LogosProgram,
+            LogosSystem, LogosWhen, MatchArm, Program, QuadVal, ScopeEnv, SourceMark, Stmt,
+            StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationFieldPlan,
+            ValidationPlan, ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
         };
     }
 


### PR DESCRIPTION
## Summary\n- add canonical validation-plan ownership for schema declarations and referenced declared types\n- derive deterministic record and tagged-union validation plans from the existing canonical schema table\n- keep this slice compile-time-only and inspectable, without config loading, generated artifacts, migrations, or host / prom-* widening\n\n## Validation\n- cargo test -p sm-front\n- cargo test --test public_api_contracts\n- cargo test --workspace\n\nPart of #122.