### PR TITLE
V03-02 record schema validation checks

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -22,7 +22,8 @@ pub use types::{
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
     SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
-    UnaryOp, ValidationFieldPlan, ValidationPlan, ValidationShapePlan, ValidationVariantPlan,
+    UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
+    ValidationVariantPlan,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -156,6 +156,10 @@ pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanT
                 )?,
             ),
         };
+        let checks = match &shape {
+            ValidationShapePlan::Record(fields) => derive_record_validation_checks(fields),
+            ValidationShapePlan::TaggedUnion(_) => Vec::new(),
+        };
 
         plans.insert(
             schema.name,
@@ -163,6 +167,7 @@ pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanT
                 schema_name: schema.name,
                 role: schema.role,
                 shape,
+                checks,
             },
         );
     }
@@ -3374,6 +3379,32 @@ mod tests {
         };
         assert_eq!(**base, Type::U32);
         assert_eq!(resolve_symbol_name(&program.arena, *unit).expect("unit symbol"), "ms");
+        assert_eq!(
+            plan.checks,
+            vec![
+                ValidationCheck::RequiredField {
+                    field: fields[0].name,
+                },
+                ValidationCheck::FieldType {
+                    field: fields[0].name,
+                    ty: fields[0].ty.clone(),
+                },
+                ValidationCheck::RequiredField {
+                    field: fields[1].name,
+                },
+                ValidationCheck::FieldType {
+                    field: fields[1].name,
+                    ty: fields[1].ty.clone(),
+                },
+                ValidationCheck::RequiredField {
+                    field: fields[2].name,
+                },
+                ValidationCheck::FieldType {
+                    field: fields[2].name,
+                    ty: fields[2].ty.clone(),
+                },
+            ]
+        );
     }
 
     #[test]
@@ -3413,6 +3444,7 @@ mod tests {
             variants[1].fields[1].ty,
             Type::Result(Box::new(Type::Quad), Box::new(Type::Bool))
         );
+        assert!(plan.checks.is_empty());
     }
 
     #[test]
@@ -4996,6 +5028,18 @@ fn derive_validation_variant_plans(
             })
         })
         .collect()
+}
+
+fn derive_record_validation_checks(fields: &[ValidationFieldPlan]) -> Vec<ValidationCheck> {
+    let mut checks = Vec::with_capacity(fields.len() * 2);
+    for field in fields {
+        checks.push(ValidationCheck::RequiredField { field: field.name });
+        checks.push(ValidationCheck::FieldType {
+            field: field.name,
+            ty: field.ty.clone(),
+        });
+    }
+    checks
 }
 
 fn validate_tagged_union_schema(

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -379,6 +379,12 @@ pub struct ValidationVariantPlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationCheck {
+    RequiredField { field: SymbolId },
+    FieldType { field: SymbolId, ty: Type },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationShapePlan {
     Record(Vec<ValidationFieldPlan>),
     TaggedUnion(Vec<ValidationVariantPlan>),
@@ -389,6 +395,7 @@ pub struct ValidationPlan {
     pub schema_name: SymbolId,
     pub role: Option<SchemaRole>,
     pub shape: ValidationShapePlan,
+    pub checks: Vec<ValidationCheck>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -95,6 +95,12 @@ Current v0 schema declaration semantics:
   the frontend/typecheck path
 - canonical schema declarations may now also derive deterministic compile-time
   validation plans owned by the same frontend/typecheck path
+- record-shaped schemas currently derive first-wave validation checks in
+  declaration order:
+  - required-field checks
+  - field-type compatibility checks
+- tagged-union schemas currently derive canonical validation-plan ownership but
+  do not yet derive first-wave branch checks
 - schema role markers currently contribute compile-time declaration metadata
   only; they do not imply loading, generation, transport, or runtime behavior
 - schema declarations do not currently introduce executable types, runtime

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -44,6 +44,8 @@ Current compile-time-only declaration families:
   `wire schema`
 - deterministic compile-time validation plans derived from canonical schema
   declarations and referenced declared types
+- first-wave record-schema validation checks for required fields and field-type
+  compatibility, kept in declaration order for inspectability
 
 ## Unit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,9 @@ pub mod frontend {
         FrontendError, FrontendErrorKind, Function, LogosEntity, LogosEntityField,
         LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, MatchArm, OptLevel,
         Program, QuadVal, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
-        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationFieldPlan,
-        ValidationPlan, ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
+        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationCheck,
+        ValidationFieldPlan, ValidationPlan, ValidationPlanTable, ValidationShapePlan,
+        ValidationVariantPlan,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,
@@ -167,8 +168,9 @@ pub mod frontend {
             type_check_program, derive_validation_plan_table, AstArena, BinaryOp, Expr, ExprId,
             FnSig, FnTable, FrontendError, Function, LogosEntity, LogosLaw, LogosProgram,
             LogosSystem, LogosWhen, MatchArm, Program, QuadVal, ScopeEnv, SourceMark, Stmt,
-            StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationFieldPlan,
-            ValidationPlan, ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
+            StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationCheck,
+            ValidationFieldPlan, ValidationPlan, ValidationPlanTable, ValidationShapePlan,
+            ValidationVariantPlan,
         };
     }
 


### PR DESCRIPTION
## Summary\n- extend canonical validation plans with deterministic record-schema validation checks\n- derive first-wave required-field and field-type checks in declaration order for record-shaped schemas\n- keep tagged-union validation checks, inspectable CLI output, migrations, and host / prom-* widening out of scope\n\n## Validation\n- cargo test -p sm-front\n- cargo test --test public_api_contracts\n- cargo test --workspace\n\nPart of #122.