### PR TITLE
V03-02 tagged-union schema validation checks

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -158,7 +158,9 @@ pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanT
         };
         let checks = match &shape {
             ValidationShapePlan::Record(fields) => derive_record_validation_checks(fields),
-            ValidationShapePlan::TaggedUnion(_) => Vec::new(),
+            ValidationShapePlan::TaggedUnion(variants) => {
+                derive_tagged_union_validation_checks(variants)
+            }
         };
 
         plans.insert(
@@ -3444,7 +3446,35 @@ mod tests {
             variants[1].fields[1].ty,
             Type::Result(Box::new(Type::Quad), Box::new(Type::Bool))
         );
-        assert!(plan.checks.is_empty());
+        assert_eq!(
+            plan.checks,
+            vec![
+                ValidationCheck::TaggedUnionBranch {
+                    variant: variants[0].name,
+                },
+                ValidationCheck::TaggedUnionBranch {
+                    variant: variants[1].name,
+                },
+                ValidationCheck::TaggedUnionBranchRequiredField {
+                    variant: variants[1].name,
+                    field: variants[1].fields[0].name,
+                },
+                ValidationCheck::TaggedUnionBranchFieldType {
+                    variant: variants[1].name,
+                    field: variants[1].fields[0].name,
+                    ty: variants[1].fields[0].ty.clone(),
+                },
+                ValidationCheck::TaggedUnionBranchRequiredField {
+                    variant: variants[1].name,
+                    field: variants[1].fields[1].name,
+                },
+                ValidationCheck::TaggedUnionBranchFieldType {
+                    variant: variants[1].name,
+                    field: variants[1].fields[1].name,
+                    ty: variants[1].fields[1].ty.clone(),
+                },
+            ]
+        );
     }
 
     #[test]
@@ -5038,6 +5068,29 @@ fn derive_record_validation_checks(fields: &[ValidationFieldPlan]) -> Vec<Valida
             field: field.name,
             ty: field.ty.clone(),
         });
+    }
+    checks
+}
+
+fn derive_tagged_union_validation_checks(
+    variants: &[ValidationVariantPlan],
+) -> Vec<ValidationCheck> {
+    let mut checks = Vec::new();
+    for variant in variants {
+        checks.push(ValidationCheck::TaggedUnionBranch {
+            variant: variant.name,
+        });
+        for field in &variant.fields {
+            checks.push(ValidationCheck::TaggedUnionBranchRequiredField {
+                variant: variant.name,
+                field: field.name,
+            });
+            checks.push(ValidationCheck::TaggedUnionBranchFieldType {
+                variant: variant.name,
+                field: field.name,
+                ty: field.ty.clone(),
+            });
+        }
     }
     checks
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -382,6 +382,9 @@ pub struct ValidationVariantPlan {
 pub enum ValidationCheck {
     RequiredField { field: SymbolId },
     FieldType { field: SymbolId, ty: Type },
+    TaggedUnionBranch { variant: SymbolId },
+    TaggedUnionBranchRequiredField { variant: SymbolId, field: SymbolId },
+    TaggedUnionBranchFieldType { variant: SymbolId, field: SymbolId, ty: Type },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -99,8 +99,11 @@ Current v0 schema declaration semantics:
   declaration order:
   - required-field checks
   - field-type compatibility checks
-- tagged-union schemas currently derive canonical validation-plan ownership but
-  do not yet derive first-wave branch checks
+- tagged-union schemas now also derive first-wave branch checks in variant
+  declaration order:
+  - allowed-branch checks
+  - per-branch required-field checks
+  - per-branch field-type compatibility checks
 - schema role markers currently contribute compile-time declaration metadata
   only; they do not imply loading, generation, transport, or runtime behavior
 - schema declarations do not currently introduce executable types, runtime

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -46,6 +46,9 @@ Current compile-time-only declaration families:
   declarations and referenced declared types
 - first-wave record-schema validation checks for required fields and field-type
   compatibility, kept in declaration order for inspectability
+- first-wave tagged-union schema branch checks for allowed variants, required
+  per-branch fields, and per-branch field-type compatibility, kept in variant
+  declaration order for inspectability
 
 ## Unit
 


### PR DESCRIPTION
## Scope
- add first-wave tagged-union branch validation checks to the canonical validation-plan layer
- keep derivation deterministic and inspectable in variant declaration order
- sync spec text for the new branch-check coverage

## Included
- `ValidationCheck` variants for tagged-union branches and per-branch field checks
- derivation for tagged-union validation checks in `sm-front`
- tests for deterministic tagged-union validation-plan output
- spec updates in `docs/spec/source_semantics.md` and `docs/spec/types.md`

## Not Included
- config loading
- generated artifacts
- migrations
- runtime validation hooks
- host / `prom-*` widening

## Validation
- `cargo test -p sm-front`
- `cargo test --test public_api_contracts`
- `cargo test --workspace`

Part of #122.