### PR TITLE
V03-03 record-shaped config schema validation surface

### DIFF
--- a/crates/smc-cli/src/config.rs
+++ b/crates/smc-cli/src/config.rs
@@ -1,5 +1,10 @@
-use sm_front::QuadVal;
-use std::collections::BTreeSet;
+use sm_front::{
+    build_record_table, build_schema_table, derive_validation_plan_table, parse_program,
+    resolve_symbol_name, FrontendError, Program, QuadVal, RecordDecl, RecordTable, SchemaDecl,
+    SchemaRole, SchemaTable, Type, ValidationFieldPlan, ValidationPlanTable,
+    ValidationShapePlan,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
@@ -61,6 +66,405 @@ pub fn parse_config_document(src: &str) -> Result<ConfigDocument, ConfigParseErr
         return Err(parser.error("unexpected trailing input after config document"));
     }
     Ok(ConfigDocument { fields })
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigContract {
+    program: Program,
+    record_table: RecordTable,
+    schema_table: SchemaTable,
+    validation_plans: ValidationPlanTable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigContractBuildError {
+    pub message: String,
+}
+
+impl fmt::Display for ConfigContractBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "config contract build error: {}", self.message)
+    }
+}
+
+impl Error for ConfigContractBuildError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigValidationDiagnostic {
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigValidationError {
+    pub schema_name: String,
+    pub diagnostics: Vec<ConfigValidationDiagnostic>,
+}
+
+impl fmt::Display for ConfigValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "config validation failed for schema '{}': {} diagnostic(s)",
+            self.schema_name,
+            self.diagnostics.len()
+        )
+    }
+}
+
+impl Error for ConfigValidationError {}
+
+pub fn build_config_contract(src: &str) -> Result<ConfigContract, ConfigContractBuildError> {
+    let program = parse_program(src).map_err(config_contract_build_error)?;
+    let record_table = build_record_table(&program).map_err(config_contract_build_error)?;
+    let schema_table = build_schema_table(&program).map_err(config_contract_build_error)?;
+    let validation_plans =
+        derive_validation_plan_table(&program).map_err(config_contract_build_error)?;
+    Ok(ConfigContract {
+        program,
+        record_table,
+        schema_table,
+        validation_plans,
+    })
+}
+
+pub fn validate_config_document(
+    contract: &ConfigContract,
+    schema_name: &str,
+    document: &ConfigDocument,
+) -> Result<(), ConfigValidationError> {
+    let Some((schema_symbol, schema_decl)) = contract.find_schema_decl(schema_name) else {
+        return Err(ConfigValidationError {
+            schema_name: schema_name.to_string(),
+            diagnostics: vec![ConfigValidationDiagnostic {
+                path: "<root>".to_string(),
+                message: format!("unknown config schema '{}'", schema_name),
+            }],
+        });
+    };
+
+    if schema_decl.role != Some(SchemaRole::Config) {
+        return Err(ConfigValidationError {
+            schema_name: schema_name.to_string(),
+            diagnostics: vec![ConfigValidationDiagnostic {
+                path: "<root>".to_string(),
+                message: format!("schema '{}' is not declared as config schema", schema_name),
+            }],
+        });
+    }
+
+    let Some(plan) = contract.validation_plans.get(&schema_symbol) else {
+        return Err(ConfigValidationError {
+            schema_name: schema_name.to_string(),
+            diagnostics: vec![ConfigValidationDiagnostic {
+                path: "<root>".to_string(),
+                message: format!(
+                    "missing canonical validation plan for config schema '{}'",
+                    schema_name
+                ),
+            }],
+        });
+    };
+
+    let mut diagnostics = Vec::new();
+    match &plan.shape {
+        ValidationShapePlan::Record(fields) => {
+            validate_object_entries_against_plan_fields(
+                &document.fields,
+                fields,
+                contract,
+                "",
+                &mut diagnostics,
+            );
+        }
+        ValidationShapePlan::TaggedUnion(_) => diagnostics.push(ConfigValidationDiagnostic {
+            path: "<root>".to_string(),
+            message:
+                "tagged-union config validation is not part of the current V03-03 record slice"
+                    .to_string(),
+        }),
+    }
+
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(ConfigValidationError {
+            schema_name: schema_name.to_string(),
+            diagnostics,
+        })
+    }
+}
+
+impl ConfigContract {
+    fn find_schema_decl(&self, schema_name: &str) -> Option<(sm_front::SymbolId, &SchemaDecl)> {
+        self.schema_table.iter().find_map(|(name, decl)| {
+            let resolved = resolve_symbol_name(&self.program.arena, *name).ok()?;
+            if resolved == schema_name {
+                Some((*name, decl))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+fn config_contract_build_error(error: FrontendError) -> ConfigContractBuildError {
+    ConfigContractBuildError {
+        message: error.message,
+    }
+}
+
+fn validate_object_entries_against_plan_fields(
+    entries: &[ConfigEntry],
+    fields: &[ValidationFieldPlan],
+    contract: &ConfigContract,
+    parent_path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+) {
+    let entry_map = entries
+        .iter()
+        .map(|entry| (entry.key.as_str(), &entry.value))
+        .collect::<BTreeMap<_, _>>();
+    let mut expected = BTreeSet::new();
+
+    for field in fields {
+        let field_name = contract.program.arena.symbol_name(field.name).to_string();
+        let field_path = extend_config_path(parent_path, &field_name);
+        expected.insert(field_name.clone());
+        match entry_map.get(field_name.as_str()) {
+            Some(value) => {
+                validate_value_against_type(value, &field.ty, contract, &field_path, diagnostics);
+            }
+            None => diagnostics.push(ConfigValidationDiagnostic {
+                path: field_path,
+                message: "missing required field".to_string(),
+            }),
+        }
+    }
+
+    for entry in entries {
+        if !expected.contains(entry.key.as_str()) {
+            diagnostics.push(ConfigValidationDiagnostic {
+                path: extend_config_path(parent_path, &entry.key),
+                message: "unexpected config field".to_string(),
+            });
+        }
+    }
+}
+
+fn validate_object_entries_against_record_decl(
+    entries: &[ConfigEntry],
+    record_decl: &RecordDecl,
+    contract: &ConfigContract,
+    parent_path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+) {
+    let entry_map = entries
+        .iter()
+        .map(|entry| (entry.key.as_str(), &entry.value))
+        .collect::<BTreeMap<_, _>>();
+    let mut expected = BTreeSet::new();
+
+    for field in &record_decl.fields {
+        let field_name = contract.program.arena.symbol_name(field.name).to_string();
+        let field_path = extend_config_path(parent_path, &field_name);
+        expected.insert(field_name.clone());
+        match entry_map.get(field_name.as_str()) {
+            Some(value) => {
+                validate_value_against_type(value, &field.ty, contract, &field_path, diagnostics);
+            }
+            None => diagnostics.push(ConfigValidationDiagnostic {
+                path: field_path,
+                message: "missing required field".to_string(),
+            }),
+        }
+    }
+
+    for entry in entries {
+        if !expected.contains(entry.key.as_str()) {
+            diagnostics.push(ConfigValidationDiagnostic {
+                path: extend_config_path(parent_path, &entry.key),
+                message: "unexpected config field".to_string(),
+            });
+        }
+    }
+}
+
+fn validate_value_against_type(
+    value: &ConfigValue,
+    ty: &Type,
+    contract: &ConfigContract,
+    path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+) {
+    match ty {
+        Type::Bool => {
+            if !matches!(value, ConfigValue::Bool(_)) {
+                diagnostics.push(type_mismatch(path, "expected bool value"));
+            }
+        }
+        Type::Quad => {
+            if !matches!(value, ConfigValue::Quad(_)) {
+                diagnostics.push(type_mismatch(path, "expected quad value"));
+            }
+        }
+        Type::I32 => validate_integer_number(value, path, diagnostics, "i32", |raw| {
+            raw.parse::<i32>().is_ok()
+        }),
+        Type::U32 => validate_integer_number(value, path, diagnostics, "u32", |raw| {
+            raw.parse::<u32>().is_ok()
+        }),
+        Type::F64 => validate_decimal_number(value, path, diagnostics, "f64"),
+        Type::Fx => validate_decimal_number(value, path, diagnostics, "fx"),
+        Type::Measured(base, unit) => {
+            let unit_name = contract.program.arena.symbol_name(*unit);
+            let label = format!("{}[{}]", display_config_type(base, contract), unit_name);
+            validate_measured_number(value, path, diagnostics, &label, base.as_ref(), contract);
+        }
+        Type::Record(record_name) => {
+            let Some(record_decl) = contract.record_table.get(record_name) else {
+                diagnostics.push(type_mismatch(
+                    path,
+                    &format!(
+                        "missing canonical record declaration '{}'",
+                        contract.program.arena.symbol_name(*record_name)
+                    ),
+                ));
+                return;
+            };
+            let ConfigValue::Object(entries) = value else {
+                diagnostics.push(type_mismatch(
+                    path,
+                    &format!(
+                        "expected object value for record '{}'",
+                        contract.program.arena.symbol_name(*record_name)
+                    ),
+                ));
+                return;
+            };
+            validate_object_entries_against_record_decl(entries, record_decl, contract, path, diagnostics);
+        }
+        Type::Option(_)
+        | Type::Result(_, _)
+        | Type::Tuple(_)
+        | Type::Adt(_)
+        | Type::RangeI32
+        | Type::Unit
+        | Type::QVec(_) => diagnostics.push(type_mismatch(
+            path,
+            &format!(
+                "config validation does not yet support field type '{}'",
+                display_config_type(ty, contract)
+            ),
+        )),
+    }
+}
+
+fn validate_integer_number(
+    value: &ConfigValue,
+    path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+    label: &str,
+    fits: impl Fn(&str) -> bool,
+) {
+    match value {
+        ConfigValue::Number(number) if number.kind == ConfigNumberKind::Integer && fits(&number.raw) => {}
+        _ => diagnostics.push(type_mismatch(
+            path,
+            &format!("expected {} integer value", label),
+        )),
+    }
+}
+
+fn validate_decimal_number(
+    value: &ConfigValue,
+    path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+    label: &str,
+) {
+    match value {
+        ConfigValue::Number(number) if number.raw.parse::<f64>().is_ok() => {}
+        _ => diagnostics.push(type_mismatch(
+            path,
+            &format!("expected {} numeric value", label),
+        )),
+    }
+}
+
+fn validate_measured_number(
+    value: &ConfigValue,
+    path: &str,
+    diagnostics: &mut Vec<ConfigValidationDiagnostic>,
+    label: &str,
+    base: &Type,
+    contract: &ConfigContract,
+) {
+    match base {
+        Type::I32 => validate_integer_number(value, path, diagnostics, label, |raw| {
+            raw.parse::<i32>().is_ok()
+        }),
+        Type::U32 => validate_integer_number(value, path, diagnostics, label, |raw| {
+            raw.parse::<u32>().is_ok()
+        }),
+        Type::F64 | Type::Fx => validate_decimal_number(value, path, diagnostics, label),
+        _ => diagnostics.push(type_mismatch(
+            path,
+            &format!(
+                "unsupported measured base type '{}'",
+                display_config_type(base, contract)
+            ),
+        )),
+    }
+}
+
+fn type_mismatch(path: &str, message: &str) -> ConfigValidationDiagnostic {
+    ConfigValidationDiagnostic {
+        path: path.to_string(),
+        message: message.to_string(),
+    }
+}
+
+fn extend_config_path(parent: &str, field: &str) -> String {
+    if parent.is_empty() {
+        field.to_string()
+    } else {
+        format!("{}.{}", parent, field)
+    }
+}
+
+fn display_config_type(ty: &Type, contract: &ConfigContract) -> String {
+    match ty {
+        Type::Quad => "quad".to_string(),
+        Type::QVec(width) => format!("qvec({})", width),
+        Type::Bool => "bool".to_string(),
+        Type::I32 => "i32".to_string(),
+        Type::U32 => "u32".to_string(),
+        Type::Fx => "fx".to_string(),
+        Type::F64 => "f64".to_string(),
+        Type::Measured(base, unit) => format!(
+            "{}[{}]",
+            display_config_type(base, contract),
+            contract.program.arena.symbol_name(*unit)
+        ),
+        Type::RangeI32 => "range<i32>".to_string(),
+        Type::Tuple(items) => format!(
+            "({})",
+            items
+                .iter()
+                .map(|item| display_config_type(item, contract))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Type::Option(item) => format!("Option({})", display_config_type(item, contract)),
+        Type::Result(ok_ty, err_ty) => format!(
+            "Result({}, {})",
+            display_config_type(ok_ty, contract),
+            display_config_type(err_ty, contract)
+        ),
+        Type::Record(name) => contract.program.arena.symbol_name(*name).to_string(),
+        Type::Adt(name) => contract.program.arena.symbol_name(*name).to_string(),
+        Type::Unit => "()".to_string(),
+    }
 }
 
 struct ConfigParser<'a> {
@@ -304,6 +708,23 @@ fn is_ident_continue(ch: u8) -> bool {
 mod tests {
     use super::*;
 
+    fn sample_config_contract_source() -> &'static str {
+        r#"
+record Point {
+    x: i32,
+    y: i32,
+}
+
+config schema AppConfig {
+    enabled: bool,
+    mode: quad,
+    point: Point,
+    interval_ms: u32[ms],
+    gain: f64,
+}
+"#
+    }
+
     #[test]
     fn parse_config_document_accepts_nested_object_surface() {
         let doc = parse_config_document(
@@ -362,5 +783,118 @@ mod tests {
     fn parse_config_document_rejects_non_object_root() {
         let err = parse_config_document("true").expect_err("root must be object");
         assert!(err.message.contains("config document must start with '{'"));
+    }
+
+    #[test]
+    fn validate_config_document_accepts_record_shaped_config_schema() {
+        let contract = build_config_contract(sample_config_contract_source())
+            .expect("config contract should build");
+        let doc = parse_config_document(
+            r#"{
+                enabled: true,
+                mode: T,
+                point: {
+                    x: 10,
+                    y: 20,
+                },
+                interval_ms: 250,
+                gain: 0.5,
+            }"#,
+        )
+        .expect("config document should parse");
+
+        validate_config_document(&contract, "AppConfig", &doc)
+            .expect("config document should validate");
+    }
+
+    #[test]
+    fn validate_config_document_reports_missing_and_unexpected_fields() {
+        let contract = build_config_contract(sample_config_contract_source())
+            .expect("config contract should build");
+        let doc = parse_config_document(
+            r#"{
+                mode: F,
+                point: {
+                    x: 10,
+                    y: 20,
+                    extra: 99,
+                },
+                interval_ms: 250,
+                gain: 0.5,
+                extra: true,
+            }"#,
+        )
+        .expect("config document should parse");
+
+        let err = validate_config_document(&contract, "AppConfig", &doc)
+            .expect_err("validation should fail");
+
+        assert!(err
+            .diagnostics
+            .iter()
+            .any(|diag| diag.path == "enabled" && diag.message == "missing required field"));
+        assert!(err
+            .diagnostics
+            .iter()
+            .any(|diag| diag.path == "extra" && diag.message == "unexpected config field"));
+        assert!(err
+            .diagnostics
+            .iter()
+            .any(|diag| diag.path == "point.extra" && diag.message == "unexpected config field"));
+    }
+
+    #[test]
+    fn validate_config_document_rejects_unsupported_option_field_family() {
+        let contract = build_config_contract(
+            r#"
+config schema AppConfig {
+    label: Option(quad),
+}
+"#,
+        )
+        .expect("config contract should build");
+        let doc = parse_config_document(
+            r#"{
+                label: T,
+            }"#,
+        )
+        .expect("config document should parse");
+
+        let err = validate_config_document(&contract, "AppConfig", &doc)
+            .expect_err("validation should fail");
+
+        assert!(err.diagnostics.iter().any(|diag| {
+            diag.path == "label"
+                && diag
+                    .message
+                    .contains("config validation does not yet support field type 'Option(quad)'")
+        }));
+    }
+
+    #[test]
+    fn validate_config_document_rejects_non_config_schema_role() {
+        let contract = build_config_contract(
+            r#"
+api schema ApiPayload {
+    enabled: bool,
+}
+"#,
+        )
+        .expect("config contract should build");
+        let doc = parse_config_document(
+            r#"{
+                enabled: true,
+            }"#,
+        )
+        .expect("config document should parse");
+
+        let err = validate_config_document(&contract, "ApiPayload", &doc)
+            .expect_err("non-config schema role must reject");
+
+        assert_eq!(err.diagnostics.len(), 1);
+        assert_eq!(err.diagnostics[0].path, "<root>");
+        assert!(err.diagnostics[0]
+            .message
+            .contains("schema 'ApiPayload' is not declared as config schema"));
     }
 }

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -26,7 +26,7 @@ pub struct CliPipeline;
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
 #[cfg(feature = "std")]
-pub use config::{parse_config_document, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValue};
+pub use config::{build_config_contract, parse_config_document, validate_config_document, ConfigContract, ConfigContractBuildError, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValidationDiagnostic, ConfigValidationError, ConfigValue};
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 

--- a/docs/roadmap/language_maturity/config_schema_contract_scope.md
+++ b/docs/roadmap/language_maturity/config_schema_contract_scope.md
@@ -33,6 +33,13 @@ Current chosen canonical config document surface:
 - scalar values limited to string, bool, quad, and decimal/integer numbers
 - no arrays, comments, or alternate wire/config syntaxes in the first slice
 
+Current second-slice validation boundary:
+
+- validate only record-shaped `config schema` roots
+- allow nested record fields via canonical record declarations
+- allow measured numeric fields through unit-erased numeric compatibility checks
+- keep tagged-union config validation for a later slice
+
 ## Intended Slice Order
 
 1. config contract scope checkpoint

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -4,7 +4,7 @@ pub struct CliPipeline;
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
 #[cfg(feature = "std")]
-pub use config::{parse_config_document, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValue};
+pub use config::{build_config_contract, parse_config_document, validate_config_document, ConfigContract, ConfigContractBuildError, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValidationDiagnostic, ConfigValidationError, ConfigValue};
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 pub fn compile_source(


### PR DESCRIPTION
## Summary
- add canonical config contract build and validate APIs in smc-cli
- validate record-shaped config schemas against canonical config documents and validation plans
- support nested record fields and measured numeric compatibility without widening runtime or prom-* boundaries

## Scope
- record-shaped \\config schema\\ roots only
- canonical config document model reuse
- nested record fields via canonical record declarations
- stable user-facing diagnostics for missing, unexpected, and type-mismatched fields

## Out of Scope
- tagged-union config validation
- CLI command wiring or runtime loading
- generated artifacts or migrations
- host / prom-* widening

## Validation
- cargo test -p smc-cli
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #123.