### PR TITLE
Document V03-04 generated API contract scope

### DIFF
--- a/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
+++ b/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
@@ -1,0 +1,62 @@
+# Generated API Contract Surface Scope
+
+Status: proposed
+
+## Goal
+
+Turn canonical `api schema` and `wire schema` declarations into one deterministic,
+reproducible generated API contract artifact owned by `smc-cli`, without
+introducing hand-maintained duplicates beside the schema table.
+
+## Why
+
+`V03-01` established canonical schema declarations and role markers.
+`V03-02` established deterministic validation plans derived from those schemas.
+`V03-04` should now generate one inspectable API-contract artifact from that
+same canonical source of truth, so users can version and review boundary
+contracts without maintaining a second parallel API description layer.
+
+## First-Wave Scope
+
+- derive generated API contract artifacts only from canonical `api schema` and
+  `wire schema` declarations
+- keep artifact generation deterministic and declaration-order preserving
+- make generated outputs inspectable, versioned, and stable enough for checked-in
+  review
+- keep ownership in `smc-cli`
+- avoid any new hand-authored API description format
+
+## Intended First-Wave Artifact Shape
+
+- one canonical text artifact format owned by `smc-cli`
+- record-shaped schemas emit object fields in declaration order
+- tagged-union schemas emit variant branches in declaration order
+- role metadata stays explicit in the generated artifact
+- output includes explicit generator/version metadata for reproducibility
+
+## Intended Slice Order
+
+1. generated API contract scope checkpoint
+2. canonical API contract artifact model and formatter ownership
+3. deterministic generation for record-shaped schemas
+4. deterministic generation for tagged-union schemas
+5. diagnostics/docs freeze for generated API contract artifacts
+
+## Non-Goals
+
+- emitting client SDKs or server stubs
+- runtime transport integration
+- schema migrations
+- config loading
+- widening `prom-*`, host capability, or VM/runtime boundaries
+- introducing a second editable API truth layer
+
+## Acceptance Reading
+
+This issue is done only when:
+
+- canonical schemas generate one stable API contract artifact family
+- generated outputs are deterministic and versioned
+- there is no hand-maintained duplicate API description layer
+- user-facing artifact expectations are documented clearly enough for first-wave
+  review and version control

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -35,6 +35,7 @@ Related staged design-target notes:
 
 - `docs/roadmap/language_maturity/function_contract_invariant_scope.md`
 - `docs/roadmap/language_maturity/config_schema_contract_scope.md`
+- `docs/roadmap/language_maturity/generated_api_contract_surface_scope.md`
 - `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
 - `docs/roadmap/language_maturity/record_data_model.md`
 - `docs/roadmap/language_maturity/record_scenarios.md`


### PR DESCRIPTION
## Summary
- add a docs-only checkpoint for V03-04 generated API contract scope
- define first-wave artifact ownership, determinism, and reproducibility boundaries
- link the new scope note from the source-language contract freeze page

## Scope
- canonical generated API artifact family owned by smc-cli
- api schema and wire schema as the only first-wave generation inputs
- deterministic, declaration-order preserving artifact expectations
- explicit non-goals around SDK generation, runtime transport, migrations, and prom-* widening

No code changes; this is governance-only groundwork for #124.