### PR TITLE
V03-04 generated API artifact model and formatter ownership

### DIFF
--- a/crates/smc-cli/src/api_contract.rs
+++ b/crates/smc-cli/src/api_contract.rs
@@ -1,0 +1,182 @@
+use std::fmt::Write;
+
+pub const GENERATED_API_CONTRACT_FORMAT_VERSION: u32 = 1;
+pub const GENERATED_API_CONTRACT_GENERATOR: &str = env!("CARGO_PKG_NAME");
+pub const GENERATED_API_CONTRACT_GENERATOR_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeneratedApiSchemaRole {
+    Api,
+    Wire,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedApiField {
+    pub name: String,
+    pub ty: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedApiVariant {
+    pub name: String,
+    pub fields: Vec<GeneratedApiField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GeneratedApiSchemaShape {
+    Record(Vec<GeneratedApiField>),
+    TaggedUnion(Vec<GeneratedApiVariant>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedApiSchema {
+    pub name: String,
+    pub role: GeneratedApiSchemaRole,
+    pub shape: GeneratedApiSchemaShape,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedApiContractArtifact {
+    pub format_version: u32,
+    pub generator_name: String,
+    pub generator_version: String,
+    pub schemas: Vec<GeneratedApiSchema>,
+}
+
+impl GeneratedApiContractArtifact {
+    pub fn new(schemas: Vec<GeneratedApiSchema>) -> Self {
+        Self {
+            format_version: GENERATED_API_CONTRACT_FORMAT_VERSION,
+            generator_name: GENERATED_API_CONTRACT_GENERATOR.to_string(),
+            generator_version: GENERATED_API_CONTRACT_GENERATOR_VERSION.to_string(),
+            schemas,
+        }
+    }
+}
+
+pub fn format_generated_api_contract(artifact: &GeneratedApiContractArtifact) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "semantic_api_contract v{}",
+        artifact.format_version
+    );
+    let _ = writeln!(
+        out,
+        "generator {} {}",
+        artifact.generator_name, artifact.generator_version
+    );
+
+    for schema in &artifact.schemas {
+        out.push('\n');
+        let _ = write!(
+            out,
+            "{} schema {} ",
+            display_generated_api_role(schema.role),
+            schema.name
+        );
+        match &schema.shape {
+            GeneratedApiSchemaShape::Record(fields) => {
+                out.push_str("{\n");
+                for field in fields {
+                    let _ = writeln!(out, "    {}: {}", field.name, field.ty);
+                }
+                out.push_str("}\n");
+            }
+            GeneratedApiSchemaShape::TaggedUnion(variants) => {
+                out.push_str("{\n");
+                for variant in variants {
+                    let _ = writeln!(out, "    {} {{", variant.name);
+                    for field in &variant.fields {
+                        let _ = writeln!(out, "        {}: {}", field.name, field.ty);
+                    }
+                    out.push_str("    }\n");
+                }
+                out.push_str("}\n");
+            }
+        }
+    }
+
+    out
+}
+
+fn display_generated_api_role(role: GeneratedApiSchemaRole) -> &'static str {
+    match role {
+        GeneratedApiSchemaRole::Api => "api",
+        GeneratedApiSchemaRole::Wire => "wire",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_api_contract_artifact_uses_canonical_metadata() {
+        let artifact = GeneratedApiContractArtifact::new(Vec::new());
+
+        assert_eq!(artifact.format_version, GENERATED_API_CONTRACT_FORMAT_VERSION);
+        assert_eq!(artifact.generator_name, GENERATED_API_CONTRACT_GENERATOR);
+        assert_eq!(
+            artifact.generator_version,
+            GENERATED_API_CONTRACT_GENERATOR_VERSION
+        );
+    }
+
+    #[test]
+    fn format_generated_api_contract_preserves_schema_and_field_order() {
+        let artifact = GeneratedApiContractArtifact::new(vec![
+            GeneratedApiSchema {
+                name: "Telemetry".to_string(),
+                role: GeneratedApiSchemaRole::Api,
+                shape: GeneratedApiSchemaShape::Record(vec![
+                    GeneratedApiField {
+                        name: "enabled".to_string(),
+                        ty: "bool".to_string(),
+                    },
+                    GeneratedApiField {
+                        name: "interval_ms".to_string(),
+                        ty: "u32[ms]".to_string(),
+                    },
+                ]),
+            },
+            GeneratedApiSchema {
+                name: "Envelope".to_string(),
+                role: GeneratedApiSchemaRole::Wire,
+                shape: GeneratedApiSchemaShape::TaggedUnion(vec![
+                    GeneratedApiVariant {
+                        name: "Empty".to_string(),
+                        fields: Vec::new(),
+                    },
+                    GeneratedApiVariant {
+                        name: "Data".to_string(),
+                        fields: vec![GeneratedApiField {
+                            name: "sample_count".to_string(),
+                            ty: "i32".to_string(),
+                        }],
+                    },
+                ]),
+            },
+        ]);
+
+        let formatted = format_generated_api_contract(&artifact);
+        let expected = "\
+semantic_api_contract v1
+generator smc-cli 0.1.0
+
+api schema Telemetry {
+    enabled: bool
+    interval_ms: u32[ms]
+}
+
+wire schema Envelope {
+    Empty {
+    }
+    Data {
+        sample_count: i32
+    }
+}
+";
+        assert_eq!(formatted, expected);
+    }
+}

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "std")]
 mod app;
 #[cfg(feature = "std")]
+mod api_contract;
+#[cfg(feature = "std")]
 mod config;
 #[cfg(feature = "std")]
 mod formatter;
@@ -25,6 +27,8 @@ pub struct CliPipeline;
 
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
+#[cfg(feature = "std")]
+pub use api_contract::{format_generated_api_contract, GeneratedApiContractArtifact, GeneratedApiField, GeneratedApiSchema, GeneratedApiSchemaRole, GeneratedApiSchemaShape, GeneratedApiVariant, GENERATED_API_CONTRACT_FORMAT_VERSION, GENERATED_API_CONTRACT_GENERATOR, GENERATED_API_CONTRACT_GENERATOR_VERSION};
 #[cfg(feature = "std")]
 pub use config::{build_config_contract, parse_config_document, validate_config_document, ConfigContract, ConfigContractBuildError, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValidationDiagnostic, ConfigValidationError, ConfigValue};
 #[cfg(feature = "std")]

--- a/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
+++ b/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
@@ -42,6 +42,15 @@ contracts without maintaining a second parallel API description layer.
 4. deterministic generation for tagged-union schemas
 5. diagnostics/docs freeze for generated API contract artifacts
 
+## Slice-2 Contract Reading
+
+The first code slice for `V03-04` owns only the canonical generated artifact
+shape and formatter in `smc-cli`.
+
+- it introduces one explicit artifact family and one formatter surface
+- it preserves declaration order supplied by later derivation slices
+- it does not yet derive artifacts from canonical schemas
+
 ## Non-Goals
 
 - emitting client SDKs or server stubs

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -4,6 +4,8 @@ pub struct CliPipeline;
 #[cfg(feature = "std")]
 pub use app::{main_entry, run};
 #[cfg(feature = "std")]
+pub use api_contract::{format_generated_api_contract, GeneratedApiContractArtifact, GeneratedApiField, GeneratedApiSchema, GeneratedApiSchemaRole, GeneratedApiSchemaShape, GeneratedApiVariant, GENERATED_API_CONTRACT_FORMAT_VERSION, GENERATED_API_CONTRACT_GENERATOR, GENERATED_API_CONTRACT_GENERATOR_VERSION};
+#[cfg(feature = "std")]
 pub use config::{build_config_contract, parse_config_document, validate_config_document, ConfigContract, ConfigContractBuildError, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValidationDiagnostic, ConfigValidationError, ConfigValue};
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};


### PR DESCRIPTION
## Summary
- add canonical generated API contract artifact types in smc-cli
- add stable formatter ownership for one inspectable text artifact family
- sync scope docs and public API snapshot for the new artifact surface

## Scope
This is the first code slice inside #124.

Included:
- artifact model ownership in smc-cli
- canonical formatter surface
- generator/version metadata and deterministic schema/field ordering through owned Vec order
- tests, docs, public API snapshot

Not included:
- derivation from canonical pi schema
- derivation from canonical wire schema
- generated client/server code
- runtime transport integration
- migrations
- host / prom-* widening

## Validation
- cargo test -p smc-cli
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #124.