### PR TITLE
V03-04 tagged-union API contract generation

### DIFF
--- a/crates/smc-cli/src/api_contract.rs
+++ b/crates/smc-cli/src/api_contract.rs
@@ -115,14 +115,40 @@ pub fn build_generated_api_contract(
                     })
                     .collect::<Result<Vec<_>, GeneratedApiContractBuildError>>()?,
             ),
-            SchemaShape::TaggedUnion(_) => {
-                return Err(GeneratedApiContractBuildError {
-                    message: format!(
-                        "generated API contract derivation for tagged-union schema '{}' is not yet available in this slice",
-                        schema_name
-                    ),
-                });
-            }
+            SchemaShape::TaggedUnion(variants) => GeneratedApiSchemaShape::TaggedUnion(
+                variants
+                    .iter()
+                    .map(|variant| {
+                        Ok(GeneratedApiVariant {
+                            name: resolve_symbol_name(&program.arena, variant.name)
+                                .map_err(generated_api_contract_build_error)?
+                                .to_string(),
+                            fields: variant
+                                .fields
+                                .iter()
+                                .map(|field| {
+                                    Ok(GeneratedApiField {
+                                        name: resolve_symbol_name(&program.arena, field.name)
+                                            .map_err(generated_api_contract_build_error)?
+                                            .to_string(),
+                                        ty: display_generated_api_type(
+                                            &canonicalize_declared_type(
+                                                &field.ty,
+                                                &record_table,
+                                                &adt_table,
+                                                &program.arena,
+                                            )
+                                            .map_err(generated_api_contract_build_error)?,
+                                            &program.arena,
+                                        )
+                                        .map_err(generated_api_contract_build_error)?,
+                                    })
+                                })
+                                .collect::<Result<Vec<_>, GeneratedApiContractBuildError>>()?,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, GeneratedApiContractBuildError>>()?,
+            ),
         };
         schemas.push(GeneratedApiSchema {
             name: schema_name,
@@ -362,21 +388,34 @@ wire schema Envelope {
     }
 
     #[test]
-    fn build_generated_api_contract_rejects_tagged_union_schema_until_next_slice() {
-        let err = build_generated_api_contract(
+    fn build_generated_api_contract_derives_tagged_union_api_schema_variants() {
+        let artifact = build_generated_api_contract(
             r#"
 wire schema Envelope {
     Empty {},
     Data {
         sample_count: i32,
+        status: quad,
     },
 }
 "#,
         )
-        .expect_err("tagged-union generation should stay out of this slice");
+        .expect("tagged-union generation should now be available");
 
-        assert!(err
-            .message
-            .contains("tagged-union schema 'Envelope' is not yet available"));
+        assert_eq!(artifact.schemas.len(), 1);
+        assert_eq!(artifact.schemas[0].name, "Envelope");
+        assert_eq!(artifact.schemas[0].role, GeneratedApiSchemaRole::Wire);
+        let GeneratedApiSchemaShape::TaggedUnion(variants) = &artifact.schemas[0].shape else {
+            panic!("expected tagged-union generated schema");
+        };
+        assert_eq!(variants.len(), 2);
+        assert_eq!(variants[0].name, "Empty");
+        assert!(variants[0].fields.is_empty());
+        assert_eq!(variants[1].name, "Data");
+        assert_eq!(variants[1].fields.len(), 2);
+        assert_eq!(variants[1].fields[0].name, "sample_count");
+        assert_eq!(variants[1].fields[0].ty, "i32");
+        assert_eq!(variants[1].fields[1].name, "status");
+        assert_eq!(variants[1].fields[1].ty, "quad");
     }
 }

--- a/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
+++ b/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
@@ -60,6 +60,15 @@ record-shaped `api schema` and `wire schema` declarations.
 - `config schema` and unmarked schemas stay outside the generated API artifact
 - tagged-union generation remains deferred to the next slice
 
+## Slice-4 Contract Reading
+
+The third code slice extends generated API contract derivation to tagged-union
+`api schema` and `wire schema` declarations.
+
+- variant branches stay in declaration order
+- per-variant payload fields stay in declaration order
+- no client/server stub generation or runtime transport behavior is introduced
+
 ## Non-Goals
 
 - emitting client SDKs or server stubs


### PR DESCRIPTION
## Summary
- extend generated API contract derivation to tagged-union pi schema and wire schema
- preserve variant and payload-field declaration order in the generated artifact
- keep the work inside smc-cli without adding codegen or transport behavior

## Scope
This is the third code slice inside #124.

Included:
- tagged-union schema derivation in uild_generated_api_contract(...)
- deterministic variant ordering and payload-field ordering
- tests and docs sync for the new derivation shape

Not included:
- client/server stub emission
- runtime transport integration
- migrations
- host / prom-* widening
- final diagnostics/docs freeze for generated API artifacts

## Validation
- cargo test -p smc-cli
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #124.