### PR TITLE
V03-04 generated API contract diagnostics and docs freeze

### DIFF
--- a/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
+++ b/docs/roadmap/language_maturity/generated_api_contract_surface_scope.md
@@ -1,6 +1,6 @@
 # Generated API Contract Surface Scope
 
-Status: proposed
+Status: first-wave implemented
 
 ## Goal
 
@@ -69,6 +69,18 @@ The third code slice extends generated API contract derivation to tagged-union
 - per-variant payload fields stay in declaration order
 - no client/server stub generation or runtime transport behavior is introduced
 
+## Slice-5 Contract Reading
+
+The final freeze slice does not widen derivation. It freezes the user-facing
+review contract around the already-landed generated artifact family.
+
+- generated API contract build failures stay deterministic wrappers over the
+  current canonical frontend/source diagnostic messages
+- the stable review surface is the canonical text artifact owned by `smc-cli`
+- declaration order, role filtering, format version, and generator metadata are
+  part of the first-wave artifact contract
+- this slice adds no transport, codegen, or runtime behavior
+
 ## Non-Goals
 
 - emitting client SDKs or server stubs
@@ -87,3 +99,6 @@ This issue is done only when:
 - there is no hand-maintained duplicate API description layer
 - user-facing artifact expectations are documented clearly enough for first-wave
   review and version control
+- generated API contract build failures are documented as deterministic build
+  error families even though they do not yet form a separate numeric-code
+  taxonomy

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -150,6 +150,10 @@ Current message families include:
 - generated validation-plan failure for disallowed tagged-union branch
 - generated validation-plan failure for missing required tagged-union branch field
 - generated validation-plan failure for incompatible tagged-union branch field type
+- generated API contract build failure while parsing or validating canonical
+  source/schema declarations
+- generated API contract build failure while canonicalizing declared field or
+  payload types into artifact-surface type text
 - recursive record field graph
 - record type declared but not yet available in executable parameter/return annotation positions
 - duplicate field in record literal
@@ -213,6 +217,9 @@ Current honest limit:
   contract
 - generated validation failures are currently documented as deterministic plan
   categories, not yet as a separate runtime or CLI diagnostic family
+- generated API contract failures are currently documented as deterministic
+  build-error families prefixed as `generated API contract build error: ...`,
+  not yet as a separate numeric-code taxonomy
 - users should treat the failure class as stable before treating the full text
   as stable
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -104,6 +104,14 @@ Current v0 schema declaration semantics:
   - allowed-branch checks
   - per-branch required-field checks
   - per-branch field-type compatibility checks
+- `api schema` and `wire schema` declarations may now also derive one
+  deterministic generated API contract artifact family owned by `smc-cli`
+- generated API contract artifacts preserve schema, variant, and field
+  declaration order for reviewability
+- generated API contract artifacts currently carry explicit format-version and
+  generator metadata for reproducibility
+- `config schema` declarations do not participate in generated API artifact
+  derivation in the first-wave contract
 - schema role markers currently contribute compile-time declaration metadata
   only; they do not imply loading, generation, transport, or runtime behavior
 - schema declarations do not currently introduce executable types, runtime

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -49,6 +49,10 @@ Current compile-time-only declaration families:
 - first-wave tagged-union schema branch checks for allowed variants, required
   per-branch fields, and per-branch field-type compatibility, kept in variant
   declaration order for inspectability
+- deterministic generated API contract artifacts derived only from canonical
+  `api schema` and `wire schema` declarations
+- generated API artifacts preserve declaration order and expose explicit
+  format-version and generator metadata for reproducible review
 
 ## Unit
 


### PR DESCRIPTION
## Summary\n- freeze the generated API contract review/done boundary for V03-04\n- document generated API contract build-error families in the source diagnostics spec\n- sync source semantics and type docs with the already-landed artifact behavior\n\n## Scope\n- docs/spec and roadmap freeze wording only\n- no artifact generation changes\n- no transport/runtime/codegen/prom-* widening\n\n## Validation\n- not run (docs-only slice)\n\nCloses part of #124