### PR TITLE
Document V03-05 schema versioning scope

### DIFF
--- a/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
+++ b/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
@@ -1,0 +1,62 @@
+# Schema Versioning And Migration Scope
+
+Status: proposed
+
+## Goal
+
+Add one canonical, diffable versioning and migration-metadata layer on top of
+the existing schema surface, without introducing runtime migration execution or
+a second editable schema truth source.
+
+## Why
+
+`V03-01` established canonical schema declarations and role markers.
+`V03-04` established deterministic generated API contract artifacts from
+canonical `api schema` and `wire schema` declarations. `V03-05` should now make
+schema evolution explicit enough for review: version identity, compatibility
+reading, and migration metadata should be visible, deterministic, and testable
+without widening runtime or host boundaries.
+
+## First-Wave Scope
+
+- explicit schema version metadata owned by the canonical schema table
+- deterministic compatibility reading between adjacent schema versions
+- migration metadata as inspectable compile-time contract data
+- stable additive-versus-breaking documentation for first-wave review
+- ownership kept inside frontend/schema tooling layers rather than runtime
+
+## Intended First-Wave Shape
+
+- one canonical version marker per schema declaration family
+- explicit compatibility categories for:
+  - additive field or variant growth
+  - incompatible removals or type changes
+- deterministic migration metadata representation owned by tooling
+- diff/review output derived only from canonical schema declarations
+
+## Intended Slice Order
+
+1. schema versioning scope checkpoint
+2. canonical schema-version metadata ownership
+3. deterministic compatibility classification for record-shaped schemas
+4. deterministic compatibility classification for tagged-union schemas
+5. migration metadata formatting and docs freeze
+
+## Non-Goals
+
+- runtime migration execution
+- config loading
+- client/server transport integration
+- schema patch application engines
+- widening `prom-*`, host capability, or VM/runtime boundaries
+- introducing a second hand-maintained migration truth layer
+
+## Acceptance Reading
+
+This issue is done only when:
+
+- schema versions are explicit and inspectable
+- compatibility reading is deterministic and diffable
+- migration metadata is documented as compile-time/tooling contract data
+- additive versus breaking evolution is documented clearly enough for stable
+  first-wave review

--- a/docs/roadmap/language_maturity/source_language_contract.md
+++ b/docs/roadmap/language_maturity/source_language_contract.md
@@ -41,5 +41,6 @@ Related staged design-target notes:
 - `docs/roadmap/language_maturity/record_scenarios.md`
 - `docs/roadmap/language_maturity/range_execution_story.md`
 - `docs/roadmap/language_maturity/schema_first_declarations_scope.md`
+- `docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md`
 - `docs/roadmap/language_maturity/units_of_measure_scope.md`
 - `docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md`


### PR DESCRIPTION
## Summary\n- define the first-wave scope for schema versioning and migration metadata\n- lock V03-05 to canonical version metadata, compatibility reading, and tooling-owned migration metadata\n- link the new checkpoint from the source-language contract freeze note\n\n## Scope\n- docs-only governance step\n- no runtime migration execution\n- no transport/runtime/prom-* widening\n\n## Validation\n- not run (docs-only slice)\n\nCloses part of #125