### PR TITLE
V03-05 schema version metadata ownership

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -21,7 +21,8 @@ pub use types::{
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind, TuplePatternItem, Type,
+    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, Token, TokenKind,
+    TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
 };
@@ -614,5 +615,29 @@ Law "L" [priority 1]:
     fn lex_via_frontend_crate() {
         let toks = lexer::lex_tokens("fn main() { return; }").expect("lex");
         assert!(!toks.is_empty());
+    }
+
+    #[test]
+    fn build_schema_table_retains_schema_version_metadata() {
+        let program = parse_program(
+            r#"
+api schema Telemetry version(3) {
+    enabled: bool,
+}
+
+fn main() {
+    return;
+}
+"#,
+        )
+        .expect("schema with version should parse");
+
+        let table = build_schema_table(&program).expect("schema table should build");
+        let schema = table
+            .values()
+            .next()
+            .expect("canonical schema table must contain schema");
+        assert_eq!(schema.role, Some(SchemaRole::Api));
+        assert_eq!(schema.version, Some(SchemaVersion { value: 3 }));
     }
 }

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -6,8 +6,8 @@ use crate::types::{
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
     RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField,
-    SchemaRole, SchemaShape, SchemaVariant, Stmt, StmtId, SymbolId, Token, TokenKind,
-    TuplePatternItem, Type, UnaryOp,
+    SchemaRole, SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, Token,
+    TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -218,6 +218,7 @@ impl<'a> Parser<'a> {
         let role = self.parse_optional_schema_role()?;
         self.expect(TokenKind::KwSchema, "expected 'schema'")?;
         let name = self.expect_symbol()?;
+        let version = self.parse_optional_schema_version()?;
         self.expect(TokenKind::LBrace, "expected '{' after schema name")?;
         let shape = if self.check(TokenKind::RBrace) {
             SchemaShape::Record(Vec::new())
@@ -239,7 +240,12 @@ impl<'a> Parser<'a> {
             }
         };
         self.expect(TokenKind::RBrace, "expected '}' after schema declaration")?;
-        Ok(SchemaDecl { name, role, shape })
+        Ok(SchemaDecl {
+            name,
+            role,
+            version,
+            shape,
+        })
     }
 
     fn starts_role_marked_schema_decl(&self) -> bool {
@@ -278,6 +284,44 @@ impl<'a> Parser<'a> {
 
     fn is_schema_role_marker_text(text: &str) -> bool {
         matches!(text, "config" | "api" | "wire")
+    }
+
+    fn starts_schema_version_marker(&self) -> bool {
+        let i = self.next_non_layout_idx();
+        let Some(first) = self.tokens.get(i) else {
+            return false;
+        };
+        if first.kind != TokenKind::Ident || first.text != "version" {
+            return false;
+        }
+        let next = self.next_non_layout_idx_from(i + 1);
+        self.tokens
+            .get(next)
+            .map(|tok| tok.kind == TokenKind::LParen)
+            .unwrap_or(false)
+    }
+
+    fn parse_optional_schema_version(&mut self) -> Result<Option<SchemaVersion>, FrontendError> {
+        if !self.starts_schema_version_marker() {
+            return Ok(None);
+        }
+        let marker = self.advance();
+        debug_assert_eq!(marker.text, "version");
+        self.expect(TokenKind::LParen, "expected '(' after schema version marker")?;
+        if !self.check(TokenKind::Num) {
+            return Err(FrontendError {
+                pos: self.pos(),
+                message: "schema version marker currently requires unsuffixed decimal integer"
+                    .to_string(),
+            });
+        }
+        let number = self.advance();
+        let value = parse_schema_version_literal(&number.text).map_err(|message| FrontendError {
+            pos: number.pos,
+            message,
+        })?;
+        self.expect(TokenKind::RParen, "expected ')' after schema version marker")?;
+        Ok(Some(SchemaVersion { value }))
     }
 
     fn parse_schema_record_fields_after_first(
@@ -2519,6 +2563,21 @@ fn parse_decimal_f64_literal(text: &str, kind: &str) -> Result<f64, FrontendErro
     })
 }
 
+fn parse_schema_version_literal(text: &str) -> Result<u32, String> {
+    let (core, suffix) = split_numeric_suffix(text);
+    if suffix.is_some() || core.contains('.') || core.starts_with("0x") || core.starts_with("0X") {
+        return Err("schema version marker currently requires unsuffixed decimal integer".to_string());
+    }
+    let digits = strip_digit_separators(core);
+    let value = digits
+        .parse::<u32>()
+        .map_err(|_| "invalid schema version marker".to_string())?;
+    if value == 0 {
+        return Err("schema version marker must be positive".to_string());
+    }
+    Ok(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3669,6 +3728,63 @@ fn main() {
         assert_eq!(program.schemas.len(), 2);
         assert_eq!(program.schemas[0].role, Some(SchemaRole::Config));
         assert_eq!(program.schemas[1].role, Some(SchemaRole::Wire));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_schema_version_marker() {
+        let src = r#"
+api schema Envelope version(2) {
+    Data {
+        sample_count: i32,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("schema version marker should parse");
+        assert_eq!(program.schemas.len(), 1);
+        assert_eq!(program.schemas[0].role, Some(SchemaRole::Api));
+        assert_eq!(program.schemas[0].version, Some(SchemaVersion { value: 2 }));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_zero_schema_version_marker() {
+        let src = r#"
+schema Envelope version(0) {
+    value: i32,
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("zero schema version must reject");
+        assert!(err.message.contains("schema version marker must be positive"));
+    }
+
+    #[test]
+    fn rustlike_parser_rejects_suffixed_schema_version_marker() {
+        let src = r#"
+schema Envelope version(1u32) {
+    value: i32,
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("suffixed schema version must reject");
+        assert!(err
+            .message
+            .contains("schema version marker currently requires unsuffixed decimal integer"));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -3347,6 +3347,28 @@ mod tests {
     }
 
     #[test]
+    fn version_marked_schema_declarations_typecheck_as_compile_time_items() {
+        let src = r#"
+            api schema SensorRequest version(2) {
+                payload: Result(quad, bool),
+            }
+
+            wire schema Envelope version(3) {
+                Ping {},
+                Data {
+                    value: f64,
+                },
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("version-marked schema declarations should typecheck");
+    }
+
+    #[test]
     fn derive_validation_plan_table_returns_canonical_record_schema_plan() {
         let src = r#"
             record Point {

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -353,6 +353,11 @@ pub enum SchemaRole {
     Wire,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaVersion {
+    pub value: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchemaShape {
     Record(Vec<SchemaField>),
@@ -363,6 +368,7 @@ pub enum SchemaShape {
 pub struct SchemaDecl {
     pub name: SymbolId,
     pub role: Option<SchemaRole>,
+    pub version: Option<SchemaVersion>,
     pub shape: SchemaShape,
 }
 

--- a/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
+++ b/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
@@ -42,6 +42,14 @@ without widening runtime or host boundaries.
 4. deterministic compatibility classification for tagged-union schemas
 5. migration metadata formatting and docs freeze
 
+## Slice-2 Contract Reading
+
+The first code slice owns only canonical schema-version metadata.
+
+- `schema` declarations may now attach optional `version(<u32>)` metadata
+- version metadata is retained in the canonical schema table
+- this slice does not yet derive compatibility classes or migration plans
+
 ## Non-Goals
 
 - runtime migration execution

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -49,6 +49,8 @@ Current examples include:
   `schema`, or `enum`
 - malformed role-marked schema declarations such as `config`/`api`/`wire`
   appearing without a following `schema`
+- malformed schema version markers such as missing parentheses, non-decimal
+  forms, suffixed literals, or non-positive values
 - extended numeric-literal parse failures such as invalid typed suffix/body
   combinations or decimal-only `f64`/`fx` requirements
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -85,6 +85,8 @@ Current v0 schema declaration semantics:
   - `config schema`
   - `api schema`
   - `wire schema`
+- schema declarations may now also carry optional `version(<u32>)` metadata
+  immediately after the schema name
 - record-shaped schema declarations must be non-empty and may not repeat field
   names
 - tagged-union schema declarations must declare at least one variant, may not
@@ -93,6 +95,8 @@ Current v0 schema declaration semantics:
   and resolve against the ordinary nominal/executable type tables
 - schema declarations currently live only in the canonical schema table owned by
   the frontend/typecheck path
+- schema version metadata currently lives only in that canonical schema table as
+  compile-time/tooling ownership data
 - canonical schema declarations may now also derive deterministic compile-time
   validation plans owned by the same frontend/typecheck path
 - record-shaped schemas currently derive first-wave validation checks in

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -54,6 +54,13 @@ schema Name {
 ```
 
 ```sm
+schema Name version(2) {
+    field: type,
+    ...
+}
+```
+
+```sm
 config schema Name {
     field: type,
     ...
@@ -171,6 +178,8 @@ Current v0 schema limits:
   value carriers
 - schema role markers are currently explicit only as top-level prefixes:
   `config schema`, `api schema`, and `wire schema`
+- schema declarations may now also attach optional version metadata directly
+  after the schema name: `schema Name version(2) { ... }`
 - schema names are not yet valid in executable local, parameter, return, or
   match type positions
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -42,6 +42,7 @@ Current compile-time-only declaration families:
   declaration family
 - explicit schema-role metadata via `config schema`, `api schema`, and
   `wire schema`
+- optional schema-version metadata via `version(<u32>)`
 - deterministic compile-time validation plans derived from canonical schema
   declarations and referenced declared types
 - first-wave record-schema validation checks for required fields and field-type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod frontend {
         FrontendError, FrontendErrorKind, Function, LogosEntity, LogosEntityField,
         LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, MatchArm, OptLevel,
         Program, QuadVal, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
-        ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationCheck,
+        SchemaVersion, ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp, ValidationCheck,
         ValidationFieldPlan, ValidationPlan, ValidationPlanTable, ValidationShapePlan,
         ValidationVariantPlan,
     };


### PR DESCRIPTION
## Summary\n- add optional ersion(<u32>) metadata to schema declarations\n- retain schema version metadata in the canonical schema table and frontend public surface\n- sync spec/docs for the first versioning ownership slice\n\n## Scope\n- parser, schema-table ownership, and compile-time metadata only\n- no compatibility classification yet\n- no migration execution, runtime integration, or prom-* widening\n\n## Validation\n- cargo test --workspace\n\nCloses part of #125