### PR TITLE
V03-05 tagged-union schema compatibility classification

### DIFF
--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -36,7 +36,7 @@ pub use config::{build_config_contract, parse_config_document, validate_config_d
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
-pub use schema_versioning::{classify_record_schema_compatibility, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind};
+pub use schema_versioning::{classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 
 #[cfg(feature = "std")]
 struct CliFsProvider;

--- a/crates/smc-cli/src/schema_versioning.rs
+++ b/crates/smc-cli/src/schema_versioning.rs
@@ -37,6 +37,29 @@ pub struct RecordSchemaCompatibilityReport {
     pub changes: Vec<SchemaFieldChange>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaVariantChangeKind {
+    Added,
+    Removed,
+    PayloadChanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedUnionSchemaVariantChange {
+    pub variant_name: String,
+    pub kind: SchemaVariantChangeKind,
+    pub field_changes: Vec<SchemaFieldChange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedUnionSchemaCompatibilityReport {
+    pub schema_name: String,
+    pub previous_version: u32,
+    pub next_version: u32,
+    pub compatibility: SchemaCompatibilityKind,
+    pub variant_changes: Vec<TaggedUnionSchemaVariantChange>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaCompatibilityBuildError {
     pub message: String,
@@ -107,17 +130,20 @@ pub fn classify_record_schema_compatibility(
 
     let mut next_by_name = BTreeMap::new();
     for field in next_fields {
-        next_by_name.insert(field.name, field);
+        let field_name = resolve_symbol_name(&next_program.arena, field.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        next_by_name.insert(field_name, field);
     }
     let mut previous_names = BTreeSet::new();
     let mut changes = Vec::new();
     let mut compatibility = SchemaCompatibilityKind::Equivalent;
 
     for field in previous_fields {
-        previous_names.insert(field.name);
         let field_name = resolve_symbol_name(&previous_program.arena, field.name)
             .map_err(schema_compatibility_build_error)?
             .to_string();
+        previous_names.insert(field_name.clone());
         let previous_type = canonicalize_declared_type(
             &field.ty,
             &previous_record_table,
@@ -128,7 +154,7 @@ pub fn classify_record_schema_compatibility(
         let previous_type_text =
             display_schema_compatibility_type(&previous_type, &previous_program.arena)
                 .map_err(schema_compatibility_build_error)?;
-        match next_by_name.get(&field.name) {
+        match next_by_name.get(&field_name) {
             Some(next_field) => {
                 let next_type = canonicalize_declared_type(
                     &next_field.ty,
@@ -162,12 +188,12 @@ pub fn classify_record_schema_compatibility(
     }
 
     for field in next_fields {
-        if previous_names.contains(&field.name) {
-            continue;
-        }
         let field_name = resolve_symbol_name(&next_program.arena, field.name)
             .map_err(schema_compatibility_build_error)?
             .to_string();
+        if previous_names.contains(&field_name) {
+            continue;
+        }
         let next_type = canonicalize_declared_type(
             &field.ty,
             &next_record_table,
@@ -194,6 +220,144 @@ pub fn classify_record_schema_compatibility(
         next_version: next_version.value,
         compatibility,
         changes,
+    })
+}
+
+pub fn classify_tagged_union_schema_compatibility(
+    previous_src: &str,
+    next_src: &str,
+    schema_name: &str,
+) -> Result<TaggedUnionSchemaCompatibilityReport, SchemaCompatibilityBuildError> {
+    let previous_program = parse_program(previous_src).map_err(schema_compatibility_build_error)?;
+    let next_program = parse_program(next_src).map_err(schema_compatibility_build_error)?;
+
+    let previous_schema = find_named_schema(&previous_program, schema_name)?;
+    let next_schema = find_named_schema(&next_program, schema_name)?;
+
+    let previous_version = require_schema_version(previous_schema, &previous_program.arena)?;
+    let next_version = require_schema_version(next_schema, &next_program.arena)?;
+    if next_version.value <= previous_version.value {
+        return Err(SchemaCompatibilityBuildError {
+            message: format!(
+                "schema '{}' compatibility requires increasing versions; got {} -> {}",
+                schema_name, previous_version.value, next_version.value
+            ),
+        });
+    }
+    if previous_schema.role != next_schema.role {
+        return Err(SchemaCompatibilityBuildError {
+            message: format!(
+                "schema '{}' compatibility requires stable schema role across versions",
+                schema_name
+            ),
+        });
+    }
+
+    let SchemaShape::TaggedUnion(previous_variants) = &previous_schema.shape else {
+        return Err(SchemaCompatibilityBuildError {
+            message: format!(
+                "schema '{}' compatibility slice currently supports only tagged-union schemas",
+                schema_name
+            ),
+        });
+    };
+    let SchemaShape::TaggedUnion(next_variants) = &next_schema.shape else {
+        return Err(SchemaCompatibilityBuildError {
+            message: format!(
+                "schema '{}' compatibility slice currently supports only tagged-union schemas",
+                schema_name
+            ),
+        });
+    };
+
+    let previous_record_table =
+        build_record_table(&previous_program).map_err(schema_compatibility_build_error)?;
+    let previous_adt_table =
+        build_adt_table(&previous_program).map_err(schema_compatibility_build_error)?;
+    let next_record_table =
+        build_record_table(&next_program).map_err(schema_compatibility_build_error)?;
+    let next_adt_table = build_adt_table(&next_program).map_err(schema_compatibility_build_error)?;
+
+    let mut next_by_name = BTreeMap::new();
+    for variant in next_variants {
+        let variant_name = resolve_symbol_name(&next_program.arena, variant.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        next_by_name.insert(variant_name, variant);
+    }
+    let mut previous_names = BTreeSet::new();
+    let mut variant_changes = Vec::new();
+    let mut compatibility = SchemaCompatibilityKind::Equivalent;
+
+    for variant in previous_variants {
+        let variant_name = resolve_symbol_name(&previous_program.arena, variant.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        previous_names.insert(variant_name.clone());
+        match next_by_name.get(&variant_name) {
+            Some(next_variant) => {
+                let field_changes = classify_variant_field_changes(
+                    &variant.fields,
+                    &previous_program.arena,
+                    &previous_record_table,
+                    &previous_adt_table,
+                    &next_variant.fields,
+                    &next_program.arena,
+                    &next_record_table,
+                    &next_adt_table,
+                )?;
+                if !field_changes.is_empty() {
+                    if field_changes.iter().any(|change| {
+                        matches!(
+                            change.kind,
+                            SchemaFieldChangeKind::Removed | SchemaFieldChangeKind::TypeChanged
+                        )
+                    }) {
+                        compatibility = SchemaCompatibilityKind::Breaking;
+                    } else if compatibility != SchemaCompatibilityKind::Breaking {
+                        compatibility = SchemaCompatibilityKind::Additive;
+                    }
+                    variant_changes.push(TaggedUnionSchemaVariantChange {
+                        variant_name,
+                        kind: SchemaVariantChangeKind::PayloadChanged,
+                        field_changes,
+                    });
+                }
+            }
+            None => {
+                compatibility = SchemaCompatibilityKind::Breaking;
+                variant_changes.push(TaggedUnionSchemaVariantChange {
+                    variant_name,
+                    kind: SchemaVariantChangeKind::Removed,
+                    field_changes: Vec::new(),
+                });
+            }
+        }
+    }
+
+    for variant in next_variants {
+        let variant_name = resolve_symbol_name(&next_program.arena, variant.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        if previous_names.contains(&variant_name) {
+            continue;
+        }
+        if compatibility != SchemaCompatibilityKind::Breaking {
+            compatibility = SchemaCompatibilityKind::Additive;
+        }
+        variant_changes.push(TaggedUnionSchemaVariantChange {
+            variant_name,
+            kind: SchemaVariantChangeKind::Added,
+            field_changes: Vec::new(),
+        });
+    }
+
+    Ok(TaggedUnionSchemaCompatibilityReport {
+        schema_name: schema_name.to_string(),
+        previous_version: previous_version.value,
+        next_version: next_version.value,
+        compatibility,
+        variant_changes,
     })
 }
 
@@ -230,6 +394,99 @@ fn require_schema_version<'a>(
             resolve_symbol_name(arena, schema.name).unwrap_or("<invalid-schema>")
         ),
     })
+}
+
+fn classify_variant_field_changes(
+    previous_fields: &[sm_front::SchemaField],
+    previous_arena: &AstArena,
+    previous_record_table: &sm_front::RecordTable,
+    previous_adt_table: &sm_front::AdtTable,
+    next_fields: &[sm_front::SchemaField],
+    next_arena: &AstArena,
+    next_record_table: &sm_front::RecordTable,
+    next_adt_table: &sm_front::AdtTable,
+) -> Result<Vec<SchemaFieldChange>, SchemaCompatibilityBuildError> {
+    let mut next_by_name = BTreeMap::new();
+    for field in next_fields {
+        let field_name = resolve_symbol_name(next_arena, field.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        next_by_name.insert(field_name, field);
+    }
+    let mut previous_names = BTreeSet::new();
+    let mut changes = Vec::new();
+
+    for field in previous_fields {
+        let field_name = resolve_symbol_name(previous_arena, field.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        previous_names.insert(field_name.clone());
+        let previous_type = canonicalize_declared_type(
+            &field.ty,
+            previous_record_table,
+            previous_adt_table,
+            previous_arena,
+        )
+        .map_err(schema_compatibility_build_error)?;
+        let previous_type_text = display_schema_compatibility_type(&previous_type, previous_arena)
+            .map_err(schema_compatibility_build_error)?;
+
+        match next_by_name.get(&field_name) {
+            Some(next_field) => {
+                let next_type = canonicalize_declared_type(
+                    &next_field.ty,
+                    next_record_table,
+                    next_adt_table,
+                    next_arena,
+                )
+                .map_err(schema_compatibility_build_error)?;
+                let next_type_text = display_schema_compatibility_type(&next_type, next_arena)
+                    .map_err(schema_compatibility_build_error)?;
+                if previous_type != next_type {
+                    changes.push(SchemaFieldChange {
+                        field_name,
+                        kind: SchemaFieldChangeKind::TypeChanged,
+                        previous_type: Some(previous_type_text),
+                        next_type: Some(next_type_text),
+                    });
+                }
+            }
+            None => {
+                changes.push(SchemaFieldChange {
+                    field_name,
+                    kind: SchemaFieldChangeKind::Removed,
+                    previous_type: Some(previous_type_text),
+                    next_type: None,
+                });
+            }
+        }
+    }
+
+    for field in next_fields {
+        let field_name = resolve_symbol_name(next_arena, field.name)
+            .map_err(schema_compatibility_build_error)?
+            .to_string();
+        if previous_names.contains(&field_name) {
+            continue;
+        }
+        let next_type = canonicalize_declared_type(
+            &field.ty,
+            next_record_table,
+            next_adt_table,
+            next_arena,
+        )
+        .map_err(schema_compatibility_build_error)?;
+        let next_type_text = display_schema_compatibility_type(&next_type, next_arena)
+            .map_err(schema_compatibility_build_error)?;
+        changes.push(SchemaFieldChange {
+            field_name,
+            kind: SchemaFieldChangeKind::Added,
+            previous_type: None,
+            next_type: Some(next_type_text),
+        });
+    }
+
+    Ok(changes)
 }
 
 fn display_schema_compatibility_type(
@@ -404,5 +661,174 @@ fn main() {
         assert!(err
             .message
             .contains("currently supports only record-shaped schemas"));
+    }
+
+    #[test]
+    fn classify_tagged_union_schema_compatibility_reports_additive_variant_growth() {
+        let previous = r#"
+wire schema Envelope version(1) {
+    Empty {},
+}
+
+fn main() {
+    return;
+}
+"#;
+        let next = r#"
+wire schema Envelope version(2) {
+    Empty {},
+    Data {
+        count: i32,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let report = classify_tagged_union_schema_compatibility(previous, next, "Envelope")
+            .expect("tagged-union compatibility should classify additive variant growth");
+
+        assert_eq!(report.compatibility, SchemaCompatibilityKind::Additive);
+        assert_eq!(report.variant_changes.len(), 1);
+        assert_eq!(report.variant_changes[0].variant_name, "Data");
+        assert_eq!(report.variant_changes[0].kind, SchemaVariantChangeKind::Added);
+        assert!(report.variant_changes[0].field_changes.is_empty());
+    }
+
+    #[test]
+    fn classify_tagged_union_schema_compatibility_reports_additive_payload_growth() {
+        let previous = r#"
+api schema Event version(2) {
+    Data {
+        count: i32,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+        let next = r#"
+api schema Event version(3) {
+    Data {
+        count: i32,
+        interval_ms: u32[ms],
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let report = classify_tagged_union_schema_compatibility(previous, next, "Event")
+            .expect("tagged-union payload growth should classify");
+
+        assert_eq!(report.compatibility, SchemaCompatibilityKind::Additive);
+        assert_eq!(report.variant_changes.len(), 1);
+        assert_eq!(report.variant_changes[0].variant_name, "Data");
+        assert_eq!(
+            report.variant_changes[0].kind,
+            SchemaVariantChangeKind::PayloadChanged
+        );
+        assert_eq!(report.variant_changes[0].field_changes.len(), 1);
+        assert_eq!(
+            report.variant_changes[0].field_changes[0].kind,
+            SchemaFieldChangeKind::Added
+        );
+        assert_eq!(
+            report.variant_changes[0].field_changes[0].field_name,
+            "interval_ms"
+        );
+    }
+
+    #[test]
+    fn classify_tagged_union_schema_compatibility_reports_breaking_variant_and_payload_changes() {
+        let previous = r#"
+wire schema Envelope version(3) {
+    Empty {},
+    Data {
+        count: i32,
+        status: quad,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+        let next = r#"
+wire schema Envelope version(4) {
+    Data {
+        count: u32,
+    },
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let report = classify_tagged_union_schema_compatibility(previous, next, "Envelope")
+            .expect("breaking tagged-union changes should still classify");
+
+        assert_eq!(report.compatibility, SchemaCompatibilityKind::Breaking);
+        assert_eq!(report.variant_changes.len(), 2);
+        let removed = report
+            .variant_changes
+            .iter()
+            .find(|change| change.variant_name == "Empty")
+            .expect("removed variant should be present");
+        assert_eq!(removed.kind, SchemaVariantChangeKind::Removed);
+
+        let payload_changed = report
+            .variant_changes
+            .iter()
+            .find(|change| change.variant_name == "Data")
+            .expect("payload-changed variant should be present");
+        assert_eq!(
+            payload_changed.kind,
+            SchemaVariantChangeKind::PayloadChanged
+        );
+        assert_eq!(payload_changed.field_changes.len(), 2);
+        assert_eq!(
+            payload_changed.field_changes[0].kind,
+            SchemaFieldChangeKind::TypeChanged
+        );
+        assert_eq!(
+            payload_changed.field_changes[1].kind,
+            SchemaFieldChangeKind::Removed
+        );
+    }
+
+    #[test]
+    fn classify_tagged_union_schema_compatibility_rejects_record_schemas_in_union_slice() {
+        let previous = r#"
+api schema Telemetry version(1) {
+    enabled: bool,
+}
+
+fn main() {
+    return;
+}
+"#;
+        let next = r#"
+api schema Telemetry version(2) {
+    enabled: bool,
+    interval_ms: u32[ms],
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let err = classify_tagged_union_schema_compatibility(previous, next, "Telemetry")
+            .expect_err("record-shaped schemas are deferred in tagged-union slice");
+        assert!(err
+            .message
+            .contains("currently supports only tagged-union schemas"));
     }
 }

--- a/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
+++ b/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
@@ -61,6 +61,18 @@ for record-shaped schemas across two explicit schema versions.
   breaking
 - tagged-union compatibility and migration metadata remain deferred
 
+## Slice-4 Contract Reading
+
+The third code slice extends deterministic compatibility classification to
+tagged-union schemas across two explicit schema versions.
+
+- both compared schemas must carry explicit version metadata
+- this slice still classifies only `Equivalent`, `Additive`, or `Breaking`
+- variant additions and payload-field additions are additive
+- variant removals, payload-field removals, and payload type changes are
+  breaking
+- migration metadata remains deferred
+
 ## Non-Goals
 
 - runtime migration execution

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -100,6 +100,9 @@ Current v0 schema declaration semantics:
 - record-shaped schemas with explicit version metadata may now also participate
   in deterministic tooling-owned compatibility classification across two schema
   revisions
+- tagged-union schemas with explicit version metadata may now also participate
+  in deterministic tooling-owned compatibility classification across two schema
+  revisions
 - the current first-wave compatibility classes are `Equivalent`, `Additive`,
   and `Breaking`
 - canonical schema declarations may now also derive deterministic compile-time

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -45,6 +45,8 @@ Current compile-time-only declaration families:
 - optional schema-version metadata via `version(<u32>)`
 - deterministic record-schema compatibility reports across two explicit schema
   versions with first-wave classes `Equivalent`, `Additive`, and `Breaking`
+- deterministic tagged-union schema compatibility reports across two explicit
+  schema versions with the same first-wave classes
 - deterministic compile-time validation plans derived from canonical schema
   declarations and referenced declared types
 - first-wave record-schema validation checks for required fields and field-type

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -10,7 +10,7 @@ pub use config::{build_config_contract, parse_config_document, validate_config_d
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
-pub use schema_versioning::{classify_record_schema_compatibility, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind};
+pub use schema_versioning::{classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 pub fn compile_source(
 pub fn build_ir(
 pub fn semantic_check_source(src: &str) -> Result<SemanticReport, String> {


### PR DESCRIPTION
## Summary
- add tagged-union schema compatibility classification in smc-cli
- expose tagged-union compatibility report types and formatter-facing public API
- switch cross-revision schema comparison to canonical name-based matching instead of local SymbolId equality

## Scope
- tagged-union schemas only
- explicit version metadata required on both revisions
- first-wave classes remain Equivalent, Additive, and Breaking
- variant additions and payload-field additions are additive
- variant removals, payload-field removals, and payload type changes are breaking

## Out of Scope
- migration execution or migration artifact generation
- runtime or host integration
- prom-* widening

## Validation
- cargo test -p smc-cli
- cargo test --test public_api_contracts
- cargo test --workspace

Part of #125