### PR TITLE
V03-06 wire contract review surface freeze

### DIFF
--- a/docs/roadmap/language_maturity/tagged_wire_unions_and_patch_types_scope.md
+++ b/docs/roadmap/language_maturity/tagged_wire_unions_and_patch_types_scope.md
@@ -1,6 +1,6 @@
 # Tagged Wire Unions And Patch Types Scope
 
-Status: proposed
+Status: first-wave implemented
 
 ## Goal
 
@@ -76,6 +76,19 @@ record-shaped `wire schema` declarations.
   behavior
 - tagged wire-union derivation remains unchanged and stable
 
+## Slice-5 Contract Reading
+
+The final freeze slice does not widen derivation. It freezes the user-facing
+review contract around the already-landed wire-contract artifact family.
+
+- generated wire-contract build failures remain deterministic wrappers over the
+  current canonical frontend/source diagnostic messages
+- the stable review surface is the canonical text artifact owned by `smc-cli`
+- tagged-union variant order, payload-field order, patch-field order, format
+  version, and generator metadata are part of the first-wave review contract
+- this slice adds no runtime patch application, transport behavior, or host
+  widening
+
 ## Non-Goals
 
 - migration execution
@@ -96,4 +109,7 @@ This issue is done only when:
 - update semantics remain explicit in docs and tests
 - wire review artifacts stay stable and inspectable enough for checked-in
   review
+- generated wire-contract build failures are documented as deterministic build
+  error families even though they do not yet form a separate numeric-code
+  taxonomy
 - there is no implicit runtime patch engine or widened host/runtime boundary

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -156,6 +156,10 @@ Current message families include:
   source/schema declarations
 - generated API contract build failure while canonicalizing declared field or
   payload types into artifact-surface type text
+- generated wire-contract build failure while parsing or validating canonical
+  source/schema declarations
+- generated wire-contract build failure while canonicalizing tagged-union
+  payload or patch-field types into artifact-surface type text
 - recursive record field graph
 - record type declared but not yet available in executable parameter/return annotation positions
 - duplicate field in record literal
@@ -221,6 +225,9 @@ Current honest limit:
   categories, not yet as a separate runtime or CLI diagnostic family
 - generated API contract failures are currently documented as deterministic
   build-error families prefixed as `generated API contract build error: ...`,
+  not yet as a separate numeric-code taxonomy
+- generated wire-contract failures are currently documented as deterministic
+  build-error families prefixed as `generated wire contract build error: ...`,
   not yet as a separate numeric-code taxonomy
 - users should treat the failure class as stable before treating the full text
   as stable

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -125,6 +125,17 @@ Current v0 schema declaration semantics:
   declaration order for reviewability
 - generated API contract artifacts currently carry explicit format-version and
   generator metadata for reproducibility
+- `wire schema` declarations may now also derive one deterministic generated
+  wire-contract artifact family owned by `smc-cli`
+- generated wire-contract artifacts currently contain:
+  - tagged wire unions derived from canonical tagged-union `wire schema`
+    declarations
+  - wire patch types derived from canonical record-shaped `wire schema`
+    declarations
+- generated wire-contract artifacts preserve variant, payload-field, and
+  patch-field declaration order for reviewability
+- generated wire-contract artifacts currently carry explicit format-version and
+  generator metadata for reproducibility
 - `config schema` declarations do not participate in generated API artifact
   derivation in the first-wave contract
 - schema role markers currently contribute compile-time declaration metadata
@@ -390,6 +401,12 @@ Current non-goal:
   coroutine-style statement behavior
 - `guard` does not yet support arbitrary `else { ... }` recovery blocks
 - plain reassignment `name = expr;` is not yet part of the public surface
+
+Current generated wire-contract limit:
+
+- generated wire-contract artifacts are review/build outputs only
+- record patch types do not imply a runtime patch application engine
+- tagged wire unions do not imply transport/runtime integration
 
 Current v0 const limit:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -60,6 +60,13 @@ Current compile-time-only declaration families:
   `api schema` and `wire schema` declarations
 - generated API artifacts preserve declaration order and expose explicit
   format-version and generator metadata for reproducible review
+- deterministic generated wire-contract artifacts derived only from canonical
+  `wire schema` declarations
+- generated wire-contract artifacts currently expose:
+  - tagged wire unions from tagged-union `wire schema`
+  - wire patch types from record-shaped `wire schema`
+- generated wire-contract artifacts preserve declaration order and expose
+  explicit format-version and generator metadata for reproducible review
 
 ## Unit
 


### PR DESCRIPTION
## Summary
- freeze the first-wave V03-06 review contract in roadmap/spec docs
- document deterministic build-failure wording for generated wire contracts
- mark the tagged wire unions and patch types scope note as implemented

## Testing
- not run (docs-only freeze)

Closes part of #126