### PR TITLE
Document post-v0.3 release freeze checkpoint

### DIFF
--- a/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
+++ b/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
@@ -1,0 +1,59 @@
+# Release Freeze Post-V03 Checkpoint
+
+Status: proposed
+
+## Goal
+
+Capture the first honest post-implementation freeze position after the `v0.1`,
+`v0.2`, and `v0.3` roadmap lines have all landed in `main`, so release
+housekeeping can proceed from one explicit checkpoint instead of from stale
+milestone state.
+
+## What Is Already Landed
+
+- `Semantic v0.1 - Density Surface` is covered by `main`
+- `Semantic v0.2 - Contract and Data Core` is covered by `main`
+- `Semantic v0.3 - Schema and Boundary Core` is covered by `main`
+- the record-layer waves used to unblock those lines are also covered by
+  `main`
+- GitHub milestone hygiene should treat these waves as implemented rather than
+  as active execution streams
+
+## What This Checkpoint Does Not Claim
+
+- it does not cut a new crate version
+- it does not create a new release tag
+- it does not declare a new runtime or host boundary
+- it does not start another feature wave before release housekeeping is done
+
+## First Honest Post-V03 State
+
+- the repository has one stable `main` line that already contains the landed
+  density, contract, schema, config, generated-API, versioning, and wire-review
+  surfaces
+- the immediate project risk is no longer missing implementation slices
+- the immediate project risk is release/accounting drift: changelog, release
+  note, milestone hygiene, and next-release scope must now be stated
+  explicitly
+
+## Intended Housekeeping Order
+
+1. normalize GitHub milestone and issue state so it matches `main`
+2. freeze one repository-local checkpoint for post-`v0.3` release status
+3. prepare release notes / compatibility summary from what is already landed
+4. decide the next public release cut without mixing in a new feature stream
+
+## Non-Goals
+
+- starting `v0.4` or another feature milestone before release housekeeping
+- widening `prom-*`, host capability, or runtime boundaries
+- mixing release-note work with another schema/language implementation wave
+
+## Acceptance Reading
+
+This checkpoint is useful only if:
+
+- closed roadmap waves are no longer presented as active work
+- the repository has one explicit post-`v0.3` freeze note
+- the next honest move becomes release-note / version-cut housekeeping rather
+  than another language feature stream

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -1,5 +1,9 @@
 # Roadmap Next (Post-Base Stabilization)
 
+Release-freeze checkpoint after `v0.1`/`v0.2`/`v0.3` close-out:
+
+- `docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md`
+
 This document tracks the next four closure tracks to move Semantic from "working" to "production-disciplined".
 
 ## NEXT-1: Import / Re-export v0.2 to FULL


### PR DESCRIPTION
## Summary
- add a repository-local post-v0.3 release-freeze checkpoint
- link the checkpoint from roadmap_next.md
- keep this step docs-only and separate from any new feature wave

## Testing
- not run (docs-only checkpoint)