### PR TITLE
Add post-v0.3 prerelease notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Added
+- `v0.1` density-surface wave landed in `main`, including expression-valued
+  control, guarded control, composition/call density, flow primitives,
+  assertion contracts, const declarations, and expanded numeric literal forms.
+- `v0.2` contract/data-core wave landed in `main`, including:
+  - tuple literals and tuple types
+  - tuple destructuring bind/assignment and tuple `let-else`
+  - nominal ADT declarations and constructors
+  - ADT match core plus exhaustiveness enforcement
+  - `Option(T)` / `Result(T, E)` standard forms and match ergonomics
+  - first-wave function contracts: `requires`, `ensures`, and narrow
+    `invariant`
+  - first-wave units of measure for supported numeric families
+- record-layer waves landed in `main`, including canonical nominal records,
+  field access, pass/return, equality-safe comparisons, destructuring, narrow
+  record `let-else`, immutable copy-with, and shorthand/punning ergonomics.
+- `v0.3` schema/boundary-core wave landed in `main`, including:
+  - canonical schema declarations with record/tagged-union forms, role markers,
+    and version metadata
+  - deterministic validation-plan ownership and derived validation checks
+  - canonical config-contract parsing and validation paths
+  - deterministic generated API-contract artifacts
+  - deterministic schema compatibility classification and migration metadata
+  - deterministic generated wire-contract artifacts for tagged wire unions and
+    record patch types
+
+### Changed
+- GitHub roadmap hygiene was normalized so implemented `v0.1`, `v0.2`, `v0.3`,
+  density, and record-layer milestones no longer remain open after landing in
+  `main`.
+- The repository now carries an explicit post-`v0.3` release-freeze checkpoint
+  in `docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md`.
+
+### Notes
+- This section records the post-`v0.3` freeze state only; it does not yet cut a
+  new version or tag.
+- The next honest release step is asset/release-note/version-cut housekeeping
+  on top of the current `main`, not another feature wave.
+
 ## v1.0.0 - 2026-02-14
 
 ### Added

--- a/docs/roadmap/post_v03_release_notes.md
+++ b/docs/roadmap/post_v03_release_notes.md
@@ -1,0 +1,111 @@
+# Semantic Post-v0.3 Release Notes
+
+Status: prerelease checkpoint
+
+These notes summarize the current release-ready surface after `v0.1`, `v0.2`,
+and `v0.3` have all landed in `main`. They do not themselves cut a version or
+publish assets.
+
+## Exact Source Commit
+
+- `main` freeze checkpoint: `4fec82f`
+
+## Ready Surfaces
+
+### Language Surface
+
+- expression-valued control:
+  - block expressions
+  - `if` as expression
+  - `match` as expression
+- guarded control:
+  - match guards
+  - guard clause
+- composition and call density:
+  - pipeline operator
+  - expression-bodied functions
+  - capture-free short lambdas
+  - named arguments
+  - default parameters
+- flow/data density:
+  - range literals
+  - `for ... in range`
+  - tuple literals and tuple types
+  - tuple destructuring bind/assignment
+  - tuple `let-else`
+- contract visibility and compile-time density:
+  - `assert`
+  - `const`
+  - extended numeric literals
+
+### Contract And Data Core
+
+- first-wave function contracts:
+  - `requires(condition)`
+  - `ensures(condition)`
+  - narrow `invariant(condition)`
+- nominal ADT declarations and constructors
+- ADT match core and exhaustiveness enforcement
+- `Option(T)` and `Result(T, E)` standard forms
+- `Option::Some/None` and `Result::Ok/Err` match ergonomics
+- first-wave units of measure over supported numeric families
+
+### Record Layer
+
+- canonical nominal record declarations
+- record literals
+- read-only field access
+- pass/return and equality-safe comparisons
+- explicit record destructuring bind
+- narrow record `let-else`
+- immutable copy-with update
+- shorthand/punning ergonomics on canonical record forms
+
+### Schema And Boundary Core
+
+- canonical `schema` declarations:
+  - record-shaped
+  - tagged-union
+  - role-marked `config schema`, `api schema`, `wire schema`
+  - optional `version(<u32>)`
+- deterministic validation-plan ownership and generated validation checks
+- canonical config-document parsing and schema validation in `smc-cli`
+- deterministic generated API-contract artifacts
+- deterministic schema compatibility classification and migration metadata
+- deterministic generated wire-contract artifacts:
+  - tagged wire unions
+  - record patch types
+
+## Current Known Limits
+
+- no new release tag has been cut from this checkpoint yet
+- published asset validation for the next tag has not yet been recorded
+- generated API and wire contracts are review/build artifacts, not runtime
+  transport engines
+- wire patch types are review metadata only; there is no runtime patch
+  application engine
+- no widening of `prom-*`, host capability, or runtime boundaries is implied by
+  these waves
+- the `smlsp` / workbench protocol bridge remains outside this release note
+  unless promoted separately
+
+## Required Before Tag Cut
+
+- run `cargo test --workspace` on the exact release candidate commit
+- run `cargo test --test public_api_contracts`
+- run `pwsh -File scripts/verify_release_bundle.ps1`
+- validate downloaded release assets against
+  `docs/roadmap/release_asset_smoke_matrix.md`
+- decide the next forward version/tag without rewriting existing stable history
+
+## Notes
+
+- canonical language/source contract remains centered in:
+  - `docs/spec/syntax.md`
+  - `docs/spec/types.md`
+  - `docs/spec/source_semantics.md`
+  - `docs/spec/diagnostics.md`
+  - `docs/spec/modules.md`
+  - `docs/spec/logos.md`
+- post-`v0.3` freeze governance note lives in:
+  - `docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md`


### PR DESCRIPTION
## Summary
- add a post-v0.3 prerelease release-notes document
- add an Unreleased changelog section that summarizes landed v0.1/v0.2/v0.3 surfaces
- keep this step docs-only and separate from version/tag cut

## Testing
- not run (docs-only release-note housekeeping)