### PR TITLE
CI: opt workflow into Node 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+env:
+  # Opt into the upcoming GitHub Actions Node 24 runtime now so CI is
+  # validated before the platform-wide default switch.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   boundary-enforcement:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What This PR Does

- opts the CI workflow into the GitHub Actions Node 24 runtime early
- keeps the change narrow to workflow environment only
- validates Node 24 readiness before the platform-wide default switch

## What This PR Does Not Do

- does not change CI job logic
- does not widen repository semantics or release scope
- does not touch production code

## Verification

- branch CI run is green