### PR TITLE
CI: upgrade checkout action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   boundary-enforcement:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Root cleanliness and legacy perimeter guard
@@ -27,7 +27,7 @@ jobs:
   public-api-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Public API inventory guard
@@ -36,7 +36,7 @@ jobs:
   runtime-release-gates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Runtime and SemCode release-facing validation gates
@@ -50,7 +50,7 @@ jobs:
   release-bundle-process:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify release bundle process
         shell: pwsh
         run: |
@@ -59,7 +59,7 @@ jobs:
   test-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Test (std)
@@ -68,7 +68,7 @@ jobs:
   check-no-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check (no default features)


### PR DESCRIPTION
## What This PR Does

- upgrades `actions/checkout` from `v4` to `v6` in CI
- removes the remaining Node 20-targeted action from the workflow
- keeps the change limited to workflow maintenance only

## What This PR Does Not Do

- does not change CI job logic
- does not touch production code
- does not widen repository semantics or release scope

## Verification

- branch CI run is green on `actions/checkout@v6`