### PR TITLE
Docs: add M8 planning package and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/post_stable_track.md
+++ b/.github/ISSUE_TEMPLATE/post_stable_track.md
@@ -10,6 +10,8 @@ assignees: ""
 
 Status: proposed post-stable expansion track
 Track class: <fx close-out | release-maintenance | new post-stable track>
+Milestone: <M7 | M8 | M9 | M10 | maintenance-only>
+Planned wave entry: <Wave 0 | Wave 1 | ...>
 Related stable baseline: <doc path or release note>
 Published stable line impact: <none | forward-only widening on main>
 
@@ -57,6 +59,14 @@ List what current `main` may already admit, if different.
 2. <first narrow code slice>
 3. <second narrow code slice>
 4. <freeze/close-out slice>
+
+## Planned PR Wave Reading
+
+- Wave 0: <governance checkpoint>
+- Wave 1: <owner-layer / admitted surface inventory>
+- Wave 2: <surface admission>
+- Wave 3: <runtime / execution / resolution path>
+- Wave 4: <freeze>
 
 ## Acceptance Reading
 

--- a/.github/PULL_REQUEST_TEMPLATE/post_stable_slice.md
+++ b/.github/PULL_REQUEST_TEMPLATE/post_stable_slice.md
@@ -1,6 +1,8 @@
 # <TRACK-ID> <Short Slice Name>
 
 Closes part of: <issue link or track id>
+Milestone: <M7 | M8 | M9 | M10 | maintenance-only>
+Wave: <Wave 0 | Wave 1 | Wave 2 | Wave 3 | Wave 4>
 Slice type: <docs-only | code | freeze>
 One PR = one logical step.
 

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -23,6 +23,14 @@ Current remaining `v1` wave:
 
 Current post-`v1` wave:
 
+- `UI application boundary for Semantic desktop applications` is the current
+  active post-stable track and is scoped in
+  `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
+- the proposed next language-maturity package after the current post-stable UI
+  work is documented in:
+  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
+  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now
@@ -46,8 +54,6 @@ Current post-`v1` wave:
 - the first-wave `fx` arithmetic expansion track is completed and now lives as
   frozen baseline history in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
-
-No additional post-`v1` feature track is currently active.
 
 Foundational work already in place:
 

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md
@@ -1,0 +1,126 @@
+# M8 Everyday Expressiveness Blueprint
+
+Status: proposed future post-stable language-maturity blueprint
+
+Related documents:
+
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
+
+## Purpose
+
+Define the architectural reading for the next Semantic language-maturity phase
+after the stable `v1.1.1` line.
+
+## Layer Model
+
+### Layer A — Stable Semantic Core
+
+Includes:
+
+- syntax contract
+- type contract
+- records / ADT / match
+- contracts
+- schemas / validation / boundary core
+- verifier / VM path
+
+This layer remains canonical and must not be destabilized casually.
+
+### Layer B — Everyday Language Expansion
+
+Includes:
+
+- text values and operations
+- packages / manifests / dependency contract
+- collections and iteration foundations
+- first-class closure values
+
+This layer is where immediate language-maturity work belongs.
+
+### Layer C — General Abstraction Expansion
+
+Includes:
+
+- generics
+- protocols / traits / interfaces
+- broader abstraction carriers
+- richer pattern semantics
+
+This layer depends on Layer B becoming stable first.
+
+### Layer D — Platform / Runtime Expansion
+
+Includes:
+
+- UI boundary
+- broader runtime families
+- concurrency
+- extended orchestration semantics
+- platform packaging and distribution forms
+
+This layer is explicitly separate from language-maturity work.
+
+## Dependency Order
+
+Correct order:
+
+1. preserve stable semantic core
+2. strengthen everyday expressiveness
+3. open general abstractions
+4. open broader platform/runtime expansion
+
+Discouraged anti-order:
+
+- traits before generics are understood
+- generics before text/data/package baseline exists
+- UI before text/data/runtime ergonomics
+- concurrency before package/data abstractions
+
+## Design Doctrine
+
+- Carrier before abstraction
+- Narrow first-wave, then formal close-out
+- Stable line honesty
+- Optional means optional
+- One active stream
+- Platform boundary is not language syntax
+
+## M8 Reading
+
+The proposed M8 package should be read as one coherent language phase with four
+ordered tracks:
+
+1. text / strings
+2. package ecosystem baseline
+3. collections
+4. first-class closures
+
+Why package before collections:
+
+- package/dependency contract should be explicit before broader language growth
+  starts depending on file-only modularity
+
+Why closures still belong in M8:
+
+- they are part of ordinary language expressiveness, not only later
+  abstraction machinery
+
+## M9 Reading
+
+M9 stays blocked until M8 core outputs are stable.
+
+This is where it becomes reasonable to open:
+
+- generics
+- traits / protocols / interfaces
+- iterable abstraction
+- richer patterns
+
+## M10 Reading
+
+M10 remains a separate class of work.
+
+If repository governance already carries a separately opened UI milestone, that
+milestone stays the canonical platform-track entry point rather than being
+silently absorbed by this language-maturity package.

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -1,0 +1,120 @@
+# M8 Everyday Expressiveness Phased Implementation Plan
+
+Status: proposed future post-stable execution plan
+
+Related documents:
+
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
+
+## Purpose
+
+Translate the proposed M8+ package into milestone sequencing, PR-wave
+discipline, and a narrow execution model.
+
+## Milestone Table
+
+| Milestone | Name | Focus | Status | Depends on |
+|---|---|---|---|---|
+| M8 | Everyday Expressiveness Foundation | text, package baseline, collections, closures | proposed | stable `v1.1.1` baseline |
+| M9 | General Abstraction Layer | generics, traits, iterables, richer patterns | proposed | M8 core outputs |
+| M10 | Application and Platform Expansion | UI boundary, concurrency, broader runtime/platform surfaces | proposed | M8 + selected M9 outputs |
+
+## PR Wave Discipline
+
+Default wave template:
+
+- Wave 0: governance checkpoint and scope document
+- Wave 1: owner-layer types and admitted surface inventory
+- Wave 2: parser/sema/type-surface admission
+- Wave 3: IR/runtime/VM or package-resolution execution path
+- Wave 4: docs/tests/goldens/compatibility freeze
+
+Default narrow PR pattern:
+
+1. scope checkpoint or wave-opening docs update
+2. owner-layer scaffolding
+3. surface admission
+4. execution/runtime/package path
+5. freeze and close-out
+
+## Phase Table
+
+| Phase | Track | Goal | Output | Success Criteria |
+|---|---|---|---|---|
+| Phase 1 | M8.1 Text | introduce first-class text contract | text spec + implementation + tests | text is a stable admitted type across parse/sema/IR/VM |
+| Phase 2 | M8.2 Packages | establish package/dependency contract | manifest/package baseline + docs + tests | package identity/dependency rules are explicit and reproducible |
+| Phase 3 | M8.3 Collections | introduce minimum first-class collection carriers | collections spec + implementation + tests | at least one narrow collection baseline is usable and documented |
+| Phase 4 | M8.4 Closures | introduce real closure values | closure spec + capture rules + runtime path | closures are no longer only immediate/pipeline sugar |
+| Phase 5 | M9.1 Generics | open parametric abstraction | generics spec + implementation + tests | reusable typed abstractions become possible without surface ambiguity |
+| Phase 6 | M9.2 Traits | open behavior abstraction | protocol/trait baseline + docs + tests | behavior contracts are expressible without ad hoc duplication |
+| Phase 7 | M9.3/M9.4 | iterables + richer patterns | iterable/pattern docs + implementation | abstraction layer becomes practical rather than merely theoretical |
+| Phase 8 | M10.1 | UI boundary | UI/application boundary contract | application/platform story becomes possible without contaminating the language roadmap |
+
+## Track-by-Track Wave Reading
+
+### M8.1 Text
+
+- Wave 0: `text_type_full_scope.md`
+- Wave 1: text type ownership and literal forms
+- Wave 2: parser/sema/type admission
+- Wave 3: IR/lowering/VM path
+- Wave 4: docs/tests/compatibility freeze
+
+### M8.2 Package Ecosystem Baseline
+
+- Wave 0: package scope checkpoint
+- Wave 1: manifest/package identity ownership
+- Wave 2: dependency declaration and module/package relationship admission
+- Wave 3: resolution/lock baseline or explicit first-wave non-commitment
+- Wave 4: docs/tests/compatibility freeze
+
+### M8.3 Collections
+
+- Wave 0: collection scope checkpoint
+- Wave 1: admitted collection family ownership
+- Wave 2: construction/access/type-surface admission
+- Wave 3: iteration/runtime/VM path
+- Wave 4: docs/tests/compatibility freeze
+
+### M8.4 Closures
+
+- Wave 0: closure scope checkpoint
+- Wave 1: closure value and capture-policy ownership
+- Wave 2: source typing and invocation admission
+- Wave 3: lowering/runtime representation
+- Wave 4: docs/tests/compatibility freeze
+
+## Primary Recommended Order
+
+1. M8.1 Text / strings
+2. M8.2 Package ecosystem baseline
+3. M8.3 Collections
+4. M8.4 First-class closures
+5. M9.1 Generics
+6. M9.2 Traits / protocols
+7. M9.3 and M9.4 iterables / richer patterns
+8. M10.1 UI application boundary
+
+## Acceptable Alternative
+
+If immediate data-shaping needs become more urgent than ecosystem scaling:
+
+1. M8.1 Text / strings
+2. M8.3 Collections
+3. M8.2 Package ecosystem baseline
+4. M8.4 First-class closures
+5. M9.1 Generics
+6. M9.2 Traits / protocols
+
+## Operational Rule
+
+Open a new track only when:
+
+- it belongs to the current milestone order
+- it has a scope checkpoint
+- admitted contract is explicit
+- exclusions are explicit
+- it does not silently widen the published stable line
+- it does not reopen a closed first-wave surface without a new versioned
+  decision

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -1,0 +1,112 @@
+# M8 Everyday Expressiveness Roadmap
+
+Status: proposed future post-stable language-maturity package
+
+Related documents:
+
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
+
+## Goal
+
+Define the next language-facing phase after the current post-stable platform and
+runtime tracks.
+
+This roadmap does not reopen the published `v1.1.1` line. It describes a
+future forward-only language-maturity package for current `main`.
+
+## Strategic Reading
+
+Before opening larger abstraction systems, Semantic should first gain stronger
+everyday expressiveness.
+
+Primary order:
+
+1. text / strings
+2. package ecosystem
+3. collections
+4. first-class closures
+
+Only after those foundations become stable should the language open wider
+abstraction surfaces such as:
+
+- generics
+- traits / protocols
+- richer iterable abstraction
+- broader pattern systems
+
+Platform-specific expansion such as UI boundary, graphics, or broader runtime
+families remains a separate class of work and must not be mixed into this
+language-maturity stream.
+
+## Proposed Milestone Reading
+
+### M8 — Everyday Expressiveness Foundation
+
+Tracks:
+
+- M8.1 Text / String Surface
+- M8.2 Package Ecosystem Baseline
+- M8.3 Collections Surface
+- M8.4 First-Class Closures
+
+Exit reading:
+
+Semantic can express common application-facing data and modular code more
+naturally without weakening its semantic core discipline.
+
+### M9 — General Abstraction Layer
+
+Tracks:
+
+- M9.1 Generics / Parametric Polymorphism
+- M9.2 Traits / Protocols / Interfaces
+- M9.3 Iterable Abstraction
+- M9.4 Richer Pattern Surface
+
+Exit reading:
+
+Semantic can express reusable APIs and reusable abstractions without overloading
+concrete nominal forms.
+
+### M10 — Application And Platform Expansion
+
+Tracks:
+
+- M10.1 UI Application Boundary
+- M10.2 Broader Package/Distribution Layout
+- M10.3 Optional Concurrency Model
+- M10.4 Optional Extended Runtime Families
+
+Exit reading:
+
+Semantic can serve as an application/platform language without compromising
+release discipline.
+
+## Top-Priority Reading
+
+Immediate next language-facing priorities in this proposal:
+
+- text / strings
+- package ecosystem baseline
+- collections
+- first-class closures
+
+## Explicit Non-Goals
+
+This roadmap package does not by itself:
+
+- silently widen the published `v1.1.1` line
+- reopen closed first-wave tracks
+- mix language maturity with PROMETHEUS/runtime widening
+- treat UI/platform work as if it were just syntax growth
+
+## Decision Rule
+
+Each proposed track under this package should be opened only when:
+
+- the current active stream is no longer in conflict with it
+- a scope checkpoint exists
+- the admitted contract is explicit
+- exclusions are explicit
+- stable/main distinction stays honest

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -89,3 +89,29 @@
   - current stable-note checkpoints:
     - `docs/roadmap/language_maturity/release_version_cut_decision.md`
     - `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`
+- `M7 UI Application Boundary`
+  - desktop window lifecycle
+  - explicit UI capability/admission ownership
+  - deterministic event polling and frame lifecycle
+  - minimal draw-command family and one canonical demo application
+  - current status: proposed post-stable milestone
+  - scope checkpoint:
+    `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
+  - current planning rule:
+    - keep backend choice internal to the runtime owner
+    - keep published `v1.1.1` separate from widened `main`
+    - deliver through PR waves rather than one large integration PR
+- `M8 Everyday Expressiveness Foundation`
+  - text / strings
+  - package ecosystem baseline
+  - collections
+  - first-class closures
+  - current status: proposed future post-stable language-maturity package
+  - planning docs:
+    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
+    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
+  - planning rule:
+    - keep package baseline earlier than broad abstraction machinery
+    - keep one active stream at a time
+    - keep UI/platform expansion separate from language-maturity work


### PR DESCRIPTION
## What This PR Does
- adds a split M8 planning package for roadmap, blueprint, and phased execution
- aligns backlog and milestones with the proposed future M8 language-maturity package
- tightens post-stable issue/PR templates with milestone and wave fields

## What This PR Does Not Do
- no language/runtime implementation changes
- no silent widening of published v1.1.1
- no reopening of closed first-wave tracks

## Stable Boundary Statement
Published 1.1.1 remains unchanged.
Current main after this PR only gains planning/governance structure for a future M8 language-maturity phase.

## Verification
- docs-only change set
- no tests run

## Follow-Up
Next honest step after this PR:
- choose whether to keep the current active UI track first, or explicitly open M8.1 Text as the next language-facing stream