### PR TITLE
Docs: define M8.1 text scope checkpoint

### DIFF
--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -61,6 +61,10 @@ Default narrow PR pattern:
 - Wave 3: IR/lowering/VM path
 - Wave 4: docs/tests/compatibility freeze
 
+Current proposed checkpoint:
+
+- `docs/roadmap/language_maturity/text_type_full_scope.md`
+
 ### M8.2 Package Ecosystem Baseline
 
 - Wave 0: package scope checkpoint

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -92,6 +92,10 @@ Immediate next language-facing priorities in this proposal:
 - collections
 - first-class closures
 
+Current first proposed subtrack checkpoint:
+
+- `docs/roadmap/language_maturity/text_type_full_scope.md`
+
 ## Explicit Non-Goals
 
 This roadmap package does not by itself:

--- a/docs/roadmap/language_maturity/text_type_full_scope.md
+++ b/docs/roadmap/language_maturity/text_type_full_scope.md
@@ -1,0 +1,104 @@
+# Text Type Full Scope
+
+Status: proposed future M8.1 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce a first-class text type and the minimum text semantics needed for
+real-world language use without silently widening the published `v1.1.1` line.
+
+This is a future language-maturity subtrack. It is not a claim that text has
+already landed on the published stable line.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- the source-visible type family does not currently expose a first-class text
+  or string type
+- current literals cover `quad`, `bool`, integer families, `f64`, and `fx`, but
+  not a text literal family
+- current runtime, IR, verifier, and VM contracts do not yet admit a canonical
+  text value carrier
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of a first-class text type
+- explicit text literal spelling
+- equality semantics for text values
+- parser -> sema -> IR -> verifier -> VM path for admitted text values
+- a narrow concatenation policy only if explicitly admitted in the same track
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- full formatting engine
+- interpolation syntax
+- regex library story
+- i18n/localization framework
+- rich text / styled text APIs
+- host/runtime widening beyond the text carrier itself
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- text type ownership
+- literal family ownership
+- diagnostics inventory
+
+### Wave 2 — Source Admission
+
+- parser support
+- source typing
+- equality semantics
+
+### Wave 3 — Runtime Path
+
+- IR/lowering path
+- verifier admission
+- VM execution
+- concatenation only if explicitly admitted
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/goldens/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: text owner-layer types and literal ownership
+3. PR 3: parser/sema/type admission for text and equality
+4. PR 4: IR/verifier/VM path
+5. PR 5: freeze and close-out
+
+## Acceptance Reading
+
+This subtrack is done only when:
+
+- text is an explicit source-visible type family with a deterministic runtime
+  carrier
+- literal, equality, and any admitted concatenation semantics are explicit and
+  inspectable
+- parser, sema, IR, verifier, and VM agree on the same admitted text surface
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- formatting/interpolation as part of the first-wave text contract
+- regex support
+- rich text APIs
+- localization framework ownership


### PR DESCRIPTION
## What This PR Does
- adds the `text_type_full_scope.md` checkpoint for M8.1 Text / String Surface
- links the new text checkpoint from the M8 roadmap and phased implementation plan
- keeps the work docs-only and scoped to governance

## What This PR Does Not Do
- no text type implementation
- no parser/sema/runtime changes
- no silent widening of published `v1.1.1`

## Stable Boundary Statement
Published `v1.1.1` remains unchanged and text-free.
Current `main` is not widened by this PR; this only defines the proposed future M8.1 checkpoint on top of the M8 planning package.

## Verification
- docs-only change set
- no tests run

## Follow-Up
Next honest step after this PR:
- Wave 1 PR for text type ownership and text literal family ownership