### PR TITLE
POST-M8.1 Wave 1: add text owner-layer surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -21,8 +21,8 @@ pub use types::{
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, Token, TokenKind,
-    TuplePatternItem, Type,
+    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, TextLiteral,
+    TextLiteralFamily, Token, TokenKind, TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
 };

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1460,7 +1460,10 @@ impl<'a> Parser<'a> {
         scopes: &mut Vec<Vec<SymbolId>>,
     ) -> Result<(), FrontendError> {
         match self.arena.expr(expr_id) {
-            Expr::QuadLiteral(_) | Expr::BoolLiteral(_) | Expr::NumericLiteral(_) => Ok(()),
+            Expr::QuadLiteral(_)
+            | Expr::BoolLiteral(_)
+            | Expr::TextLiteral(_)
+            | Expr::NumericLiteral(_) => Ok(()),
             Expr::Range(range_expr) => {
                 self.ensure_short_lambda_expr_capture_free(range_expr.start, scopes)?;
                 self.ensure_short_lambda_expr_capture_free(range_expr.end, scopes)

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1359,6 +1359,7 @@ fn infer_expr_type(
     match expr {
         Expr::QuadLiteral(_) => Ok(Type::Quad),
         Expr::BoolLiteral(_) => Ok(Type::Bool),
+        Expr::TextLiteral(_) => Ok(Type::Text),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
             NumericLiteral::U32(_) => Ok(Type::U32),
@@ -5537,6 +5538,7 @@ fn supports_stable_equality_type_inner(
     match ty {
         Type::Quad
         | Type::Bool
+        | Type::Text
         | Type::I32
         | Type::U32
         | Type::Fx

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -9,6 +9,7 @@ pub enum Type {
     Quad,
     QVec(usize),
     Bool,
+    Text,
     I32,
     U32,
     Fx,
@@ -85,6 +86,17 @@ pub enum NumericLiteral {
     Fx(f64),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TextLiteralFamily {
+    DoubleQuotedUtf8,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TextLiteral {
+    pub family: TextLiteralFamily,
+    pub spelling: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CallArg {
     pub name: Option<SymbolId>,
@@ -152,6 +164,7 @@ pub enum RecordPatternTarget {
 pub enum Expr {
     QuadLiteral(QuadVal),
     BoolLiteral(bool),
+    TextLiteral(TextLiteral),
     NumericLiteral(NumericLiteral),
     Range(RangeExpr),
     Tuple(Vec<ExprId>),
@@ -688,5 +701,21 @@ mod tests {
         let _s2 = arena.alloc_stmt(Stmt::Return(None));
         assert_eq!(arena.expr(e0), &Expr::QuadLiteral(QuadVal::T));
         assert_eq!(arena.stmt(s0), &Stmt::Expr(e0));
+    }
+
+    #[test]
+    fn text_type_is_non_numeric_and_survives_unit_erasure() {
+        assert_eq!(Type::Text.erase_units(), Type::Text);
+        assert!(!Type::Text.is_core_numeric_scalar());
+    }
+
+    #[test]
+    fn text_literal_owner_layer_is_stable_data() {
+        let literal = TextLiteral {
+            family: TextLiteralFamily::DoubleQuotedUtf8,
+            spelling: "\"semantic\"".to_string(),
+        };
+        assert_eq!(literal.family, TextLiteralFamily::DoubleQuotedUtf8);
+        assert_eq!(literal.spelling, "\"semantic\"");
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1404,6 +1404,12 @@ fn lower_expr_with_expected(
             out.push(IrInstr::LoadBool { dst: r, val: *v });
             Ok((r, Type::Bool))
         }
+        Expr::TextLiteral(_) => Err(FrontendError {
+            pos: 0,
+            message:
+                "text literal owner-layer is present on current main, but executable lowering remains a later M8.1 wave"
+                    .to_string(),
+        }),
         Expr::Range(range_expr) => {
             let (start_reg, start_ty) = lower_expr_with_expected(
                 range_expr.start,

--- a/crates/sm-sema/src/std_adapters.rs
+++ b/crates/sm-sema/src/std_adapters.rs
@@ -43,6 +43,7 @@ impl From<Type> for SemanticType {
             Type::Quad => SemanticType::QVec(1),
             Type::QVec(n) => SemanticType::QVec(n),
             Type::Bool => SemanticType::Bool,
+            Type::Text => SemanticType::Unknown,
             Type::U32 => SemanticType::Int,
             Type::Unit => SemanticType::Unit,
             Type::Measured(base, _) => SemanticType::from((*base).clone()),

--- a/crates/smc-cli/src/api_contract.rs
+++ b/crates/smc-cli/src/api_contract.rs
@@ -235,6 +235,7 @@ fn display_generated_api_type(
         Type::Quad => "quad".to_string(),
         Type::QVec(width) => format!("qvec({})", width),
         Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
         Type::I32 => "i32".to_string(),
         Type::U32 => "u32".to_string(),
         Type::Fx => "fx".to_string(),

--- a/crates/smc-cli/src/config.rs
+++ b/crates/smc-cli/src/config.rs
@@ -347,6 +347,11 @@ fn validate_value_against_type(
                 diagnostics.push(type_mismatch(path, "expected bool value"));
             }
         }
+        Type::Text => {
+            if !matches!(value, ConfigValue::String(_)) {
+                diagnostics.push(type_mismatch(path, "expected text value"));
+            }
+        }
         Type::Quad => {
             if !matches!(value, ConfigValue::Quad(_)) {
                 diagnostics.push(type_mismatch(path, "expected quad value"));
@@ -481,6 +486,7 @@ fn display_config_type(ty: &Type, contract: &ConfigContract) -> String {
         Type::Quad => "quad".to_string(),
         Type::QVec(width) => format!("qvec({})", width),
         Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
         Type::I32 => "i32".to_string(),
         Type::U32 => "u32".to_string(),
         Type::Fx => "fx".to_string(),

--- a/crates/smc-cli/src/schema_versioning.rs
+++ b/crates/smc-cli/src/schema_versioning.rs
@@ -718,6 +718,7 @@ fn display_schema_compatibility_type(
         Type::Quad => "quad".to_string(),
         Type::QVec(width) => format!("qvec({})", width),
         Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
         Type::I32 => "i32".to_string(),
         Type::U32 => "u32".to_string(),
         Type::Fx => "fx".to_string(),

--- a/crates/smc-cli/src/wire_contract.rs
+++ b/crates/smc-cli/src/wire_contract.rs
@@ -207,6 +207,7 @@ fn display_generated_wire_type(ty: &Type, arena: &AstArena) -> Result<String, Fr
         Type::Quad => "quad".to_string(),
         Type::QVec(width) => format!("qvec({})", width),
         Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
         Type::I32 => "i32".to_string(),
         Type::U32 => "u32".to_string(),
         Type::Fx => "fx".to_string(),

--- a/docs/roadmap/language_maturity/text_type_full_scope.md
+++ b/docs/roadmap/language_maturity/text_type_full_scope.md
@@ -1,6 +1,6 @@
 # Text Type Full Scope
 
-Status: proposed future M8.1 post-stable subtrack
+Status: active M8.1 post-stable subtrack
 Related roadmap package:
 `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
 
@@ -82,6 +82,20 @@ its widened contract on `main`.
 3. PR 3: parser/sema/type admission for text and equality
 4. PR 4: IR/verifier/VM path
 5. PR 5: freeze and close-out
+
+## Current Wave Reading
+
+Current branch scope for Wave 1:
+
+- explicit `text` owner-layer type in `sm-front`
+- explicit double-quoted UTF-8 text literal family ownership in `sm-front`
+- public API and docs/snapshot sync for that owner layer
+
+Still intentionally not included in Wave 1:
+
+- parser admission for executable text literals
+- source typing/equality admission for executable text expressions
+- IR, verifier, or VM carrier/runtime work
 
 ## Acceptance Reading
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -64,6 +64,9 @@ Current honest limit:
 
 - the repository does not yet claim that every parser diagnostic code or exact
   wording is frozen as a long-term compatibility promise
+- current `main` reserves a frontend text-literal owner family, but executable
+  text parser admission diagnostics remain a later `M8.1` wave rather than part
+  of the current executable syntax contract
 
 ## Policy Diagnostics
 
@@ -225,6 +228,9 @@ Current honest limit:
 
 - exact wording of type-check messages is not yet a fully frozen compatibility
   contract
+- current `main` reserves frontend owner-layer `text`/text-literal families,
+  but executable type-check admission and equality diagnostics for text values
+  remain later `M8.1` waves
 - generated validation failures are currently documented as deterministic plan
   categories, not yet as a separate runtime or CLI diagnostic family
 - generated API contract failures are currently documented as deterministic

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -68,6 +68,20 @@ Current compile-time-only declaration families:
 - generated wire-contract artifacts preserve declaration order and expose
   explicit format-version and generator metadata for reproducible review
 
+## Text
+
+Current honest baseline:
+
+- the published stable `v1.1.1` line does not expose `text` as an executable
+  source-visible type family
+- current `main` now reserves `text` as an explicit frontend owner-layer type
+  in `sm-front`
+- current `main` also reserves a double-quoted UTF-8 text literal family in the
+  frontend owner layer
+- parser admission, source typing, equality execution, lowering, verifier
+  admission, and VM execution for executable text values remain later `M8.1`
+  waves
+
 ## Unit
 
 `unit` is the implicit type of functions without an explicit return type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,9 @@ pub mod frontend {
         FnSig, FnTable, FrontendError, FrontendErrorKind, Function, LogosEntity, LogosEntityField,
         LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, MatchArm, OptLevel,
         Program, QuadVal, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
-        SchemaVersion, ScopeEnv, Stmt, StmtId, SymbolId, Token, TokenKind, Type, UnaryOp,
-        ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationPlanTable,
-        ValidationShapePlan, ValidationVariantPlan,
+        SchemaVersion, ScopeEnv, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,
+        TokenKind, Type, UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan,
+        ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
     };
     pub use sm_ir::{
         compile_program_to_immutable_ir, compile_program_to_ir, compile_program_to_ir_optimized,
@@ -180,8 +180,9 @@ pub mod frontend {
             type_check_function_with_table, type_check_program, AstArena, BinaryOp, Expr, ExprId,
             FnSig, FnTable, FrontendError, Function, LogosEntity, LogosLaw, LogosProgram,
             LogosSystem, LogosWhen, MatchArm, Program, QuadVal, ScopeEnv, SourceMark, Stmt, StmtId,
-            SymbolId, Token, TokenKind, Type, UnaryOp, ValidationCheck, ValidationFieldPlan,
-            ValidationPlan, ValidationPlanTable, ValidationShapePlan, ValidationVariantPlan,
+            SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, Type, UnaryOp,
+            ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationPlanTable,
+            ValidationShapePlan, ValidationVariantPlan,
         };
     }
 

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -1,0 +1,94 @@
+source: crates/sm-front/src/lib.rs
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub mod types;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub use types::{
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub use sm_profile::{CompatibilityMode, ParserProfile};
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub mod lexer;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub mod parser;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub use typecheck::{
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FnSig {
+pub params: Vec<Type>,
+pub param_names: Option<Vec<SymbolId>>,
+pub param_defaults: Option<Vec<Option<ExprId>>>,
+pub ret: Type,
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type FnTable = BTreeMap<SymbolId, FnSig>;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type RecordTable = BTreeMap<SymbolId, RecordDecl>;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type AdtTable = BTreeMap<SymbolId, AdtDecl>;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub type ValidationPlanTable = BTreeMap<SymbolId, ValidationPlan>;
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeBinding {
+pub ty: Type,
+pub is_const: bool,
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeEnv {
+pub fn new() -> Self {
+pub fn with_params(params: &[(SymbolId, Type)]) -> Self {
+pub fn push_scope(&mut self) {
+pub fn pop_scope(&mut self) {
+pub fn insert(&mut self, name: SymbolId, ty: Type) {
+pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
+pub fn get(&self, name: SymbolId) -> Option<Type> {
+pub fn is_const(&self, name: SymbolId) -> bool {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_record_table(program: &Program) -> Result<RecordTable, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn canonicalize_declared_type(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn builtin_sig(name: &str) -> Option<FnSig> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn reorder_call_args(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn resolve_symbol_name<'a>(arena: &'a AstArena, id: SymbolId) -> Result<&'a str, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum AstBundle {
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy)]
+pub struct CompilePolicyView<'a> {
+pub profile: &'a ParserProfile,
+pub const fn new(profile: &'a ParserProfile) -> Self {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_rustlike(input: &str) -> Result<AstBundle, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_rustlike_with_profile(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_logos(input: &str) -> Result<AstBundle, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_logos_with_profile(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_program(input: &str) -> Result<Program, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_program_with_profile(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_logos_program(input: &str) -> Result<LogosProgram, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn parse_logos_program_with_profile(
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn lex(input: &str) -> Result<Vec<Token>, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompileProfile {
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OptLevel {

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -2,6 +2,10 @@ use std::fs;
 
 const TARGETS: &[(&str, &str)] = &[
     (
+        "crates/sm-front/src/lib.rs",
+        "tests/golden_snapshots/public_api/sm_front_lib.txt",
+    ),
+    (
         "crates/sm-ir/src/lib.rs",
         "tests/golden_snapshots/public_api/sm_ir_lib.txt",
     ),


### PR DESCRIPTION
Closes part of: #217
Slice type: code
Milestone: M8
Wave: Wave 1
One PR = one logical step.

## What This PR Does
- adds `Type::Text` to the `sm-front` owner layer
- adds `TextLiteralFamily` and `TextLiteral`, plus `Expr::TextLiteral(...)`
- syncs root/frontend re-exports, docs/spec wording, and public API snapshots

## What This PR Does Not Do
- no parser admission for executable text literals
- no source typing/equality admission for executable text expressions
- no IR/verifier/VM text runtime carrier

## Stable Boundary Statement
Published `v1.1.1`:
- does not expose executable text values

Current `main` after this PR:
- reserves text type and text literal owner-layer families in `sm-front`
- still does not admit executable text parsing/runtime yet

This PR is:
- [ ] release-maintenance only
- [x] forward-only widening on `main`
- [x] not a retroactive widening of published stable

## Files / Ownership
Owner crates or docs touched:
- `crates/sm-front`
- `crates/sm-ir`
- `crates/sm-sema`
- `crates/smc-cli`
- `docs/spec/types.md`
- `docs/spec/diagnostics.md`
- `docs/roadmap/language_maturity/text_type_full_scope.md`

## Verification
- [x] `cargo test --workspace`
- [x] `cargo test --test public_api_contracts`
- [x] extra focused tests: `cargo test -p sm-front`
- [x] docs/spec updated because contract reading changed

Exact commands run:
```powershell
cargo test -p sm-front
cargo test --test public_api_contracts
cargo test --workspace
```

## Follow-Up
Next honest step after this PR:
- Wave 2 parser/sema/type admission for text literals and text equality
