### PR TITLE
POST-M8.1 Wave 2: admit text literals and equality

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -5,9 +5,9 @@ use crate::types::{
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField,
-    SchemaRole, SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, Token,
-    TokenKind, TuplePatternItem, Type, UnaryOp,
+    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
+    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, TextLiteral,
+    TextLiteralFamily, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -307,7 +307,10 @@ impl<'a> Parser<'a> {
         }
         let marker = self.advance();
         debug_assert_eq!(marker.text, "version");
-        self.expect(TokenKind::LParen, "expected '(' after schema version marker")?;
+        self.expect(
+            TokenKind::LParen,
+            "expected '(' after schema version marker",
+        )?;
         if !self.check(TokenKind::Num) {
             return Err(FrontendError {
                 pos: self.pos(),
@@ -316,11 +319,15 @@ impl<'a> Parser<'a> {
             });
         }
         let number = self.advance();
-        let value = parse_schema_version_literal(&number.text).map_err(|message| FrontendError {
-            pos: number.pos,
-            message,
-        })?;
-        self.expect(TokenKind::RParen, "expected ')' after schema version marker")?;
+        let value =
+            parse_schema_version_literal(&number.text).map_err(|message| FrontendError {
+                pos: number.pos,
+                message,
+            })?;
+        self.expect(
+            TokenKind::RParen,
+            "expected ')' after schema version marker",
+        )?;
         Ok(Some(SchemaVersion { value }))
     }
 
@@ -385,7 +392,10 @@ impl<'a> Parser<'a> {
                 }
                 break;
             }
-            self.expect(TokenKind::RBrace, "expected '}' after schema variant payload")?;
+            self.expect(
+                TokenKind::RBrace,
+                "expected '}' after schema variant payload",
+            )?;
             variants.push(SchemaVariant {
                 name: variant_name,
                 fields,
@@ -697,7 +707,9 @@ impl<'a> Parser<'a> {
         self.tokens.get(i).map(|t| t.kind) == Some(TokenKind::Assign)
     }
 
-    fn parse_tuple_pattern_items_after_lparen(&mut self) -> Result<Vec<TuplePatternItem>, FrontendError> {
+    fn parse_tuple_pattern_items_after_lparen(
+        &mut self,
+    ) -> Result<Vec<TuplePatternItem>, FrontendError> {
         let mut items = Vec::new();
         loop {
             if self.check(TokenKind::LParen) {
@@ -743,7 +755,10 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        self.expect(TokenKind::RParen, "expected ')' after tuple destructuring pattern")?;
+        self.expect(
+            TokenKind::RParen,
+            "expected ')' after tuple destructuring pattern",
+        )?;
         if items.len() < 2 {
             return Err(FrontendError {
                 pos: self.pos(),
@@ -928,7 +943,9 @@ impl<'a> Parser<'a> {
             return Ok(tail);
         }
         let statements = self.parse_where_bindings()?;
-        Ok(self.arena.alloc_expr(Expr::Block(BlockExpr { statements, tail })))
+        Ok(self
+            .arena
+            .alloc_expr(Expr::Block(BlockExpr { statements, tail })))
     }
 
     fn parse_pipe(&mut self) -> Result<ExprId, FrontendError> {
@@ -1119,12 +1136,14 @@ impl<'a> Parser<'a> {
                 continue;
             }
             if self.eat(TokenKind::KwWith) {
-                self.expect(TokenKind::LBrace, "expected '{' after 'with' in record copy-with")?;
+                self.expect(
+                    TokenKind::LBrace,
+                    "expected '{' after 'with' in record copy-with",
+                )?;
                 let fields = self.parse_record_init_fields_after_lbrace()?;
-                expr = self.arena.alloc_expr(Expr::RecordUpdate(RecordUpdateExpr {
-                    base: expr,
-                    fields,
-                }));
+                expr = self
+                    .arena
+                    .alloc_expr(Expr::RecordUpdate(RecordUpdateExpr { base: expr, fields }));
                 continue;
             }
             break;
@@ -1169,6 +1188,13 @@ impl<'a> Parser<'a> {
         if self.eat(TokenKind::KwFalse) {
             return Ok(self.arena.alloc_expr(Expr::BoolLiteral(false)));
         }
+        if self.check(TokenKind::String) {
+            let spelling = self.advance().text;
+            return Ok(self.arena.alloc_expr(Expr::TextLiteral(TextLiteral {
+                family: TextLiteralFamily::DoubleQuotedUtf8,
+                spelling,
+            })));
+        }
         if self.check(TokenKind::Num) {
             let text = self.advance().text;
             return self.parse_numeric_literal_expr(&text);
@@ -1194,7 +1220,10 @@ impl<'a> Parser<'a> {
                 return Ok(self.arena.alloc_expr(Expr::Call(name, args)));
             }
             if self.starts_record_literal_head() {
-                self.expect(TokenKind::LBrace, "expected '{' after record literal type name")?;
+                self.expect(
+                    TokenKind::LBrace,
+                    "expected '{' after record literal type name",
+                )?;
                 return self.parse_record_literal_after_name(name);
             }
             return Ok(self.arena.alloc_expr(Expr::Var(name)));
@@ -1223,7 +1252,10 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        self.expect(TokenKind::RParen, "expected ')' after enum constructor payload")?;
+        self.expect(
+            TokenKind::RParen,
+            "expected ')' after enum constructor payload",
+        )?;
         Ok(payload)
     }
 
@@ -1253,10 +1285,9 @@ impl<'a> Parser<'a> {
 
     fn parse_record_literal_after_name(&mut self, name: SymbolId) -> Result<ExprId, FrontendError> {
         let fields = self.parse_record_init_fields_after_lbrace()?;
-        Ok(self.arena.alloc_expr(Expr::RecordLiteral(RecordLiteralExpr {
-            name,
-            fields,
-        })))
+        Ok(self
+            .arena
+            .alloc_expr(Expr::RecordLiteral(RecordLiteralExpr { name, fields })))
     }
 
     fn parse_record_init_fields_after_lbrace(
@@ -1389,7 +1420,10 @@ impl<'a> Parser<'a> {
         }
 
         let param = self.expect_symbol()?;
-        self.expect(TokenKind::FatArrow, "expected '=>' after short lambda parameter")?;
+        self.expect(
+            TokenKind::FatArrow,
+            "expected '=>' after short lambda parameter",
+        )?;
         let body = self.parse_expr()?;
         self.expect(TokenKind::RParen, "expected ')' after short lambda body")?;
         self.ensure_short_lambda_capture_free(body, param)?;
@@ -1424,7 +1458,10 @@ impl<'a> Parser<'a> {
                 message: "short lambda v0 currently supports exactly one argument".to_string(),
             });
         }
-        self.expect(TokenKind::RParen, "expected ')' after short lambda argument")?;
+        self.expect(
+            TokenKind::RParen,
+            "expected ')' after short lambda argument",
+        )?;
         Ok(arg)
     }
 
@@ -1520,9 +1557,7 @@ impl<'a> Parser<'a> {
                 self.ensure_short_lambda_expr_capture_free(*lhs, scopes)?;
                 self.ensure_short_lambda_expr_capture_free(*rhs, scopes)
             }
-            Expr::Block(block) => {
-                self.ensure_short_lambda_block_capture_free(block, scopes)
-            }
+            Expr::Block(block) => self.ensure_short_lambda_block_capture_free(block, scopes),
             Expr::If(if_expr) => {
                 self.ensure_short_lambda_expr_capture_free(if_expr.condition, scopes)?;
                 self.ensure_short_lambda_block_capture_free(&if_expr.then_block, scopes)?;
@@ -1607,12 +1642,15 @@ impl<'a> Parser<'a> {
                 }
                 Ok(())
             }
-            Stmt::Discard { value, .. } => self.ensure_short_lambda_expr_capture_free(*value, scopes),
+            Stmt::Discard { value, .. } => {
+                self.ensure_short_lambda_expr_capture_free(*value, scopes)
+            }
             Stmt::Expr(expr_id) => self.ensure_short_lambda_expr_capture_free(*expr_id, scopes),
             _ => Err(FrontendError {
                 pos: self.pos(),
-                message: "short lambda body currently supports only expression-compatible block forms"
-                    .to_string(),
+                message:
+                    "short lambda body currently supports only expression-compatible block forms"
+                        .to_string(),
             }),
         }
     }
@@ -1771,7 +1809,8 @@ impl<'a> Parser<'a> {
             } else {
                 return Err(FrontendError {
                     pos: self.pos(),
-                    message: "enum match payload patterns currently support only flat name/_ items".to_string(),
+                    message: "enum match payload patterns currently support only flat name/_ items"
+                        .to_string(),
                 });
             }
             if self.eat(TokenKind::Comma) {
@@ -1782,7 +1821,10 @@ impl<'a> Parser<'a> {
             }
             break;
         }
-        self.expect(TokenKind::RParen, "expected ')' after enum match pattern payload")?;
+        self.expect(
+            TokenKind::RParen,
+            "expected ')' after enum match pattern payload",
+        )?;
         Ok(items)
     }
 
@@ -1888,14 +1930,23 @@ impl<'a> Parser<'a> {
                     let _ = self.advance();
                     self.expect(TokenKind::LParen, "expected '(' after Result type name")?;
                     let ok_ty = self.parse_type()?;
-                    self.expect(TokenKind::Comma, "expected ',' between Result type arguments")?;
+                    self.expect(
+                        TokenKind::Comma,
+                        "expected ',' between Result type arguments",
+                    )?;
                     let err_ty = self.parse_type()?;
-                    self.expect(TokenKind::RParen, "expected ')' after Result type arguments")?;
+                    self.expect(
+                        TokenKind::RParen,
+                        "expected ')' after Result type arguments",
+                    )?;
                     Type::Result(Box::new(ok_ty), Box::new(err_ty))
                 } else {
                     let record_name = self.expect_symbol()?;
                     Type::Record(record_name)
                 }
+            } else if t == "text" {
+                let _ = self.advance();
+                Type::Text
             } else {
                 let record_name = self.expect_symbol()?;
                 Type::Record(record_name)
@@ -1929,8 +1980,8 @@ impl<'a> Parser<'a> {
         if !base.is_core_numeric_scalar() {
             return Err(FrontendError {
                 pos: self.pos(),
-                message:
-                    "unit annotation is allowed only on i32, u32, f64, or fx in v0".to_string(),
+                message: "unit annotation is allowed only on i32, u32, f64, or fx in v0"
+                    .to_string(),
             });
         }
         let unit = self.expect_symbol()?;
@@ -2241,7 +2292,9 @@ impl<'a> Parser<'a> {
         if !self.check_raw(TokenKind::Ident) {
             return Err(self.error_at_current("expected unit symbol", "E0234"));
         }
-        let unit = self.arena.intern_symbol(&self.tokens[self.idx].text.clone());
+        let unit = self
+            .arena
+            .intern_symbol(&self.tokens[self.idx].text.clone());
         self.idx += 1;
         self.expect_raw(TokenKind::RBracket, "expected ']'", "E0234")?;
         Ok(Type::Measured(Box::new(base), unit))
@@ -2569,7 +2622,9 @@ fn parse_decimal_f64_literal(text: &str, kind: &str) -> Result<f64, FrontendErro
 fn parse_schema_version_literal(text: &str) -> Result<u32, String> {
     let (core, suffix) = split_numeric_suffix(text);
     if suffix.is_some() || core.contains('.') || core.starts_with("0x") || core.starts_with("0X") {
-        return Err("schema version marker currently requires unsuffixed decimal integer".to_string());
+        return Err(
+            "schema version marker currently requires unsuffixed decimal integer".to_string(),
+        );
     }
     let digits = strip_digit_separators(core);
     let value = digits
@@ -2629,8 +2684,8 @@ fn decide(ctx: DecisionContext) -> quad requires(ctx.camera == T) {
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let decide = &program.functions[0];
         assert_eq!(program.arena.symbol_name(decide.name), "decide");
         assert_eq!(decide.requires.len(), 1);
@@ -2647,8 +2702,8 @@ fn idq(q: quad) -> quad requires(q == T) = q;
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let idq = &program.functions[0];
         assert_eq!(idq.requires.len(), 1);
         assert!(matches!(
@@ -2672,8 +2727,8 @@ fn decide(ctx: DecisionContext) -> quad ensures(result == ctx.camera) {
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let decide = &program.functions[0];
         assert_eq!(program.arena.symbol_name(decide.name), "decide");
         assert_eq!(decide.ensures.len(), 1);
@@ -2690,8 +2745,8 @@ fn idq(q: quad) -> quad ensures(result == q) = q;
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let idq = &program.functions[0];
         assert_eq!(idq.ensures.len(), 1);
         assert!(matches!(
@@ -2715,8 +2770,8 @@ fn decide(ctx: DecisionContext) -> quad invariant(ctx.quality == 0.75) {
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let decide = &program.functions[0];
         assert_eq!(program.arena.symbol_name(decide.name), "decide");
         assert_eq!(decide.invariants.len(), 1);
@@ -2733,8 +2788,8 @@ fn idq(q: quad) -> quad invariant(result == q) = q;
 fn main() { return; }
         "#;
 
-        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect("parse");
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
         let idq = &program.functions[0];
         assert_eq!(idq.invariants.len(), 1);
         assert!(matches!(
@@ -2801,7 +2856,10 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*name), "total");
         assert_eq!(*ty, Some(Type::F64));
-        assert!(matches!(program.arena.expr(*value), Expr::Binary(_, BinaryOp::Add, _)));
+        assert!(matches!(
+            program.arena.expr(*value),
+            Expr::Binary(_, BinaryOp::Add, _)
+        ));
     }
 
     #[test]
@@ -2854,6 +2912,38 @@ fn main() {
     }
 
     #[test]
+    fn rustlike_parser_accepts_text_literal_and_text_type_surface() {
+        let src = r#"
+fn main() {
+    let message: text = "hello";
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("text literal and text type should parse");
+        let func = &program.functions[0];
+
+        let Stmt::Let {
+            name,
+            ty: Some(Type::Text),
+            value,
+        } = program.arena.stmt(func.body[0])
+        else {
+            panic!("expected text-typed let binding");
+        };
+
+        assert_eq!(program.arena.symbol_name(*name), "message");
+        assert!(matches!(
+            program.arena.expr(*value),
+            Expr::TextLiteral(TextLiteral {
+                family: TextLiteralFamily::DoubleQuotedUtf8,
+                spelling,
+            }) if spelling == "\"hello\""
+        ));
+    }
+
+    #[test]
     fn strict_profile_accepts_explicit_fx_literals_without_f64_surface() {
         let src = r#"
 fn main() {
@@ -2879,7 +2969,9 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("hex f64 literal must reject");
-        assert!(err.message.contains("f64 literal currently requires decimal form"));
+        assert!(err
+            .message
+            .contains("f64 literal currently requires decimal form"));
     }
 
     #[test]
@@ -3027,7 +3119,10 @@ fn main() {
             program.arena.expr(*value),
             Expr::NumericLiteral(NumericLiteral::F64(_))
         ));
-        assert!(matches!(program.arena.expr(block.tail), Expr::Binary(_, BinaryOp::Add, _)));
+        assert!(matches!(
+            program.arena.expr(block.tail),
+            Expr::Binary(_, BinaryOp::Add, _)
+        ));
     }
 
     #[test]
@@ -3517,7 +3612,10 @@ fn main() {
             panic!("expected tuple destructuring statement");
         };
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].map(|name| program.arena.symbol_name(name)), Some("count"));
+        assert_eq!(
+            items[0].map(|name| program.arena.symbol_name(name)),
+            Some("count")
+        );
         assert!(items[1].is_none());
         assert_eq!(*ty, Some(Type::Tuple(vec![Type::I32, Type::Bool])));
         let Expr::Call(name, args) = program.arena.expr(*value) else {
@@ -3552,7 +3650,10 @@ fn main() {
         };
         assert_eq!(items.len(), 2);
         assert!(matches!(items[0], TuplePatternItem::Bind(_)));
-        assert!(matches!(items[1], TuplePatternItem::QuadLiteral(QuadVal::T)));
+        assert!(matches!(
+            items[1],
+            TuplePatternItem::QuadLiteral(QuadVal::T)
+        ));
         assert_eq!(*ty, Some(Type::Tuple(vec![Type::I32, Type::Quad])));
         assert!(else_return.is_none());
         let Expr::Call(name, args) = program.arena.expr(*value) else {
@@ -3616,8 +3717,14 @@ fn main() {
             panic!("expected tuple destructuring assignment");
         };
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].map(|name| program.arena.symbol_name(name)), Some("count"));
-        assert_eq!(items[1].map(|name| program.arena.symbol_name(name)), Some("ready"));
+        assert_eq!(
+            items[0].map(|name| program.arena.symbol_name(name)),
+            Some("count")
+        );
+        assert_eq!(
+            items[1].map(|name| program.arena.symbol_name(name)),
+            Some("ready")
+        );
         let Expr::Call(name, args) = program.arena.expr(*value) else {
             panic!("expected call expression");
         };
@@ -3768,7 +3875,9 @@ fn main() {
 
         let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
             .expect_err("zero schema version must reject");
-        assert!(err.message.contains("schema version marker must be positive"));
+        assert!(err
+            .message
+            .contains("schema version marker must be positive"));
     }
 
     #[test]
@@ -3887,7 +3996,11 @@ fn main() {
         assert_eq!(wrap.ret, Type::Option(Box::new(Type::Bool)));
         assert_eq!(wrap.params[0].1, Type::Bool);
         match program.arena.stmt(wrap.body[0]) {
-            Stmt::Let { ty: Some(ty), value, .. } => {
+            Stmt::Let {
+                ty: Some(ty),
+                value,
+                ..
+            } => {
                 assert_eq!(*ty, Type::Option(Box::new(Type::Bool)));
                 let Expr::AdtCtor(ctor) = program.arena.expr(*value) else {
                     panic!("expected Option constructor expression");
@@ -3898,7 +4011,11 @@ fn main() {
             other => panic!("expected typed let binding, got {:?}", other),
         }
         match program.arena.stmt(wrap.body[2]) {
-            Stmt::Let { ty: Some(ty), value, .. } => {
+            Stmt::Let {
+                ty: Some(ty),
+                value,
+                ..
+            } => {
                 assert_eq!(
                     *ty,
                     Type::Result(Box::new(Type::Bool), Box::new(Type::Quad))
@@ -3949,7 +4066,10 @@ fn main() {
         }
         match program.arena.stmt(unwrap.body[1]) {
             Stmt::Match { arms, default, .. } => {
-                assert!(default.is_empty(), "exhaustive Result match should omit default");
+                assert!(
+                    default.is_empty(),
+                    "exhaustive Result match should omit default"
+                );
                 let MatchPattern::Adt(pat) = &arms[1].pat else {
                     panic!("expected Result match pattern");
                 };
@@ -4078,8 +4198,12 @@ fn main() {
             .expect("record type name in signature should parse");
         let func = &program.functions[0];
         assert_eq!(program.arena.symbol_name(func.name), "describe");
-        assert!(matches!(func.params[0].1, Type::Record(name) if program.arena.symbol_name(name) == "DecisionContext"));
-        assert!(matches!(func.ret, Type::Record(name) if program.arena.symbol_name(name) == "DecisionContext"));
+        assert!(
+            matches!(func.params[0].1, Type::Record(name) if program.arena.symbol_name(name) == "DecisionContext")
+        );
+        assert!(
+            matches!(func.ret, Type::Record(name) if program.arena.symbol_name(name) == "DecisionContext")
+        );
     }
 
     #[test]
@@ -4186,7 +4310,10 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*base), "ctx");
         assert_eq!(update_expr.fields.len(), 1);
-        assert_eq!(program.arena.symbol_name(update_expr.fields[0].name), "quality");
+        assert_eq!(
+            program.arena.symbol_name(update_expr.fields[0].name),
+            "quality"
+        );
     }
 
     #[test]
@@ -4218,7 +4345,9 @@ fn main() {
         assert_eq!(program.arena.symbol_name(*record_name), "DecisionContext");
         assert_eq!(items.len(), 2);
         assert_eq!(program.arena.symbol_name(items[0].field), "camera");
-        assert!(matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "seen_camera"));
+        assert!(
+            matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "seen_camera")
+        );
         assert_eq!(program.arena.symbol_name(items[1].field), "quality");
         assert!(matches!(items[1].target, RecordPatternTarget::Discard));
         assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
@@ -4250,8 +4379,12 @@ fn main() {
         let Expr::RecordLiteral(record) = program.arena.expr(*value) else {
             panic!("expected record literal expression");
         };
-        assert!(matches!(program.arena.expr(record.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "camera"));
-        assert!(matches!(program.arena.expr(record.fields[1].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality"));
+        assert!(
+            matches!(program.arena.expr(record.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "camera")
+        );
+        assert!(
+            matches!(program.arena.expr(record.fields[1].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality")
+        );
 
         let Stmt::Let { value, .. } = program.arena.stmt(main.body[3]) else {
             panic!("expected record copy-with let");
@@ -4260,7 +4393,9 @@ fn main() {
             panic!("expected record copy-with expression");
         };
         assert_eq!(update.fields.len(), 1);
-        assert!(matches!(program.arena.expr(update.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality"));
+        assert!(
+            matches!(program.arena.expr(update.fields[0].value), Expr::Var(name) if program.arena.symbol_name(*name) == "quality")
+        );
     }
 
     #[test]
@@ -4286,14 +4421,21 @@ fn main() {
         let Stmt::LetRecord { items, .. } = program.arena.stmt(main.body[0]) else {
             panic!("expected record destructuring bind");
         };
-        assert!(matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "camera"));
+        assert!(
+            matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "camera")
+        );
         assert!(matches!(items[1].target, RecordPatternTarget::Discard));
 
         let Stmt::LetElseRecord { items, .. } = program.arena.stmt(main.body[1]) else {
             panic!("expected record let-else");
         };
-        assert!(matches!(items[0].target, RecordPatternTarget::QuadLiteral(QuadVal::T)));
-        assert!(matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "quality"));
+        assert!(matches!(
+            items[0].target,
+            RecordPatternTarget::QuadLiteral(QuadVal::T)
+        ));
+        assert!(
+            matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "quality")
+        );
     }
 
     #[test]
@@ -4390,8 +4532,13 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(*record_name), "DecisionContext");
         assert_eq!(items.len(), 2);
-        assert!(matches!(items[0].target, RecordPatternTarget::QuadLiteral(QuadVal::T)));
-        assert!(matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "score"));
+        assert!(matches!(
+            items[0].target,
+            RecordPatternTarget::QuadLiteral(QuadVal::T)
+        ));
+        assert!(
+            matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "score")
+        );
         assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
         assert!(else_return.is_none());
     }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1,5 +1,7 @@
+use crate::types::{
+    AdtCtorExpr, AdtPatternItem, MatchPattern, NumericLiteral, RecordPatternTarget,
+};
 use crate::*;
-use crate::types::{AdtCtorExpr, AdtPatternItem, MatchPattern, NumericLiteral, RecordPatternTarget};
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
 use alloc::string::{String, ToString};
@@ -15,7 +17,9 @@ fn fx_measured_arithmetic_gap_message() -> &'static str {
 fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
     match arena.expr(expr_id) {
         Expr::NumericLiteral(_) => true,
-        Expr::Unary(UnaryOp::Pos | UnaryOp::Neg, inner) => is_numeric_literal_like_expr(*inner, arena),
+        Expr::Unary(UnaryOp::Pos | UnaryOp::Neg, inner) => {
+            is_numeric_literal_like_expr(*inner, arena)
+        }
         _ => false,
     }
 }
@@ -71,7 +75,9 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
             params: func
                 .params
                 .iter()
-                .map(|(_, t)| canonicalize_declared_type(t, &record_table, &adt_table, &program.arena))
+                .map(|(_, t)| {
+                    canonicalize_declared_type(t, &record_table, &adt_table, &program.arena)
+                })
                 .collect::<Result<Vec<_>, _>>()?,
             param_names: Some(func.params.iter().map(|(name, _)| *name).collect()),
             param_defaults: Some(func.param_defaults.clone()),
@@ -119,12 +125,20 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     Ok(())
 }
 
-pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanTable, FrontendError> {
+pub fn derive_validation_plan_table(
+    program: &Program,
+) -> Result<ValidationPlanTable, FrontendError> {
     let record_table = build_record_table(program)?;
     let adt_table = build_adt_table(program)?;
     let schema_table = build_schema_table(program)?;
     let fn_table = build_fn_table(program)?;
-    validate_top_level_name_collisions(program, &fn_table, &record_table, &adt_table, &schema_table)?;
+    validate_top_level_name_collisions(
+        program,
+        &fn_table,
+        &record_table,
+        &adt_table,
+        &schema_table,
+    )?;
     validate_record_declarations(program, &record_table, &adt_table)?;
     validate_adt_declarations(program, &record_table, &adt_table)?;
     validate_schema_declarations(program, &schema_table, &record_table, &adt_table)?;
@@ -143,14 +157,14 @@ pub fn derive_validation_plan_table(program: &Program) -> Result<ValidationPlanT
             SchemaShape::Record(fields) => ValidationShapePlan::Record(
                 derive_validation_field_plans(fields, &record_table, &adt_table, &program.arena)?,
             ),
-            SchemaShape::TaggedUnion(variants) => ValidationShapePlan::TaggedUnion(
-                derive_validation_variant_plans(
+            SchemaShape::TaggedUnion(variants) => {
+                ValidationShapePlan::TaggedUnion(derive_validation_variant_plans(
                     variants,
                     &record_table,
                     &adt_table,
                     &program.arena,
-                )?,
-            ),
+                )?)
+            }
         };
         let checks = match &shape {
             ValidationShapePlan::Record(fields) => derive_record_validation_checks(fields),
@@ -226,28 +240,33 @@ fn type_check_function_with_tables(
         record_table,
         adt_table,
         arena,
-        format!("return type of '{}'", resolve_symbol_name(arena, func.name)?),
+        format!(
+            "return type of '{}'",
+            resolve_symbol_name(arena, func.name)?
+        ),
     )?;
     ensure_executable_type_supported(
         &canonical_ret,
         arena,
-        format!("return type of '{}'", resolve_symbol_name(arena, func.name)?),
+        format!(
+            "return type of '{}'",
+            resolve_symbol_name(arena, func.name)?
+        ),
     )?;
     let empty_env = ScopeEnv::new();
     let mut default_loop_stack = Vec::new();
     for ((name, ty), default_expr) in canonical_params.iter().zip(func.param_defaults.iter()) {
         if let Some(default_expr) = default_expr {
-            let default_ty =
-                infer_expr_type(
-                    *default_expr,
-                    arena,
-                    &empty_env,
-                    table,
-                    record_table,
-                    adt_table,
-                    Type::Unit,
-                    &mut default_loop_stack,
-                )?;
+            let default_ty = infer_expr_type(
+                *default_expr,
+                arena,
+                &empty_env,
+                table,
+                record_table,
+                adt_table,
+                Type::Unit,
+                &mut default_loop_stack,
+            )?;
             if let Err(err) = ensure_const_initializer_safe(*default_expr, arena, &empty_env) {
                 return Err(FrontendError {
                     pos: err.pos,
@@ -470,10 +489,7 @@ fn ensure_contract_result_name_available(
     Ok(())
 }
 
-fn ensure_invariant_result_usage(
-    func: &Function,
-    arena: &AstArena,
-) -> Result<(), FrontendError> {
+fn ensure_invariant_result_usage(func: &Function, arena: &AstArena) -> Result<(), FrontendError> {
     if func.ret != Type::Unit {
         return Ok(());
     }
@@ -524,8 +540,7 @@ fn check_stmt(
             }
             ensure_const_initializer_safe(*value, arena, env)?;
             let final_ty = if let Some(ann) = ty {
-                let expected_ty =
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
                 let vt = infer_expr_type_with_expected(
                     *value,
                     arena,
@@ -577,8 +592,7 @@ fn check_stmt(
                 )?;
             }
             let final_ty = if let Some(ann) = ty {
-                let expected_ty =
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
                 let vt = infer_expr_type_with_expected(
                     *value,
                     arena,
@@ -630,8 +644,7 @@ fn check_stmt(
                 )?;
             }
             let final_ty = if let Some(ann) = ty {
-                let expected_ty =
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
                 let vt = infer_expr_type_with_expected(
                     *value,
                     arena,
@@ -720,16 +733,18 @@ fn check_stmt(
                 });
             }
             for item in items {
-                let field = record.fields.iter().find(|field| field.name == item.field).ok_or(
-                    FrontendError {
+                let field = record
+                    .fields
+                    .iter()
+                    .find(|field| field.name == item.field)
+                    .ok_or(FrontendError {
                         pos: 0,
                         message: format!(
                             "record type '{}' has no field named '{}' in destructuring bind",
                             resolve_symbol_name(arena, *record_name)?,
                             resolve_symbol_name(arena, item.field)?
                         ),
-                    },
-                )?;
+                    })?;
                 match item.target {
                     RecordPatternTarget::Bind(target) => {
                         env.insert(
@@ -795,16 +810,18 @@ fn check_stmt(
             )?;
             let mut saw_refutable_item = false;
             for item in items {
-                let field = record.fields.iter().find(|field| field.name == item.field).ok_or(
-                    FrontendError {
+                let field = record
+                    .fields
+                    .iter()
+                    .find(|field| field.name == item.field)
+                    .ok_or(FrontendError {
                         pos: 0,
                         message: format!(
                             "record type '{}' has no field named '{}' in let-else",
                             resolve_symbol_name(arena, *record_name)?,
                             resolve_symbol_name(arena, item.field)?
                         ),
-                    },
-                )?;
+                    })?;
                 match item.target {
                     RecordPatternTarget::Bind(target) => {
                         env.insert(
@@ -815,12 +832,19 @@ fn check_stmt(
                     RecordPatternTarget::Discard => {}
                     RecordPatternTarget::QuadLiteral(_) => {
                         saw_refutable_item = true;
-                        if canonicalize_declared_type(&field.ty, record_table, adt_table, arena)? != Type::Quad {
+                        if canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?
+                            != Type::Quad
+                        {
                             return Err(FrontendError {
                                 pos: 0,
                                 message: format!(
                                     "record let-else literal pattern requires quad field, got {:?}",
-                                    canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?
+                                    canonicalize_declared_type(
+                                        &field.ty,
+                                        record_table,
+                                        adt_table,
+                                        arena
+                                    )?
                                 ),
                             });
                         }
@@ -868,8 +892,7 @@ fn check_stmt(
                 loop_stack,
             )?;
             let final_ty = if let Some(ann) = ty {
-                let expected_ty =
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
                     vt,
@@ -928,7 +951,13 @@ fn check_stmt(
         }
         Stmt::Discard { ty, value } => {
             if let Some(ann) = ty {
-                ensure_type_resolved(ann, record_table, adt_table, arena, "discard binding".to_string())?;
+                ensure_type_resolved(
+                    ann,
+                    record_table,
+                    adt_table,
+                    arena,
+                    "discard binding".to_string(),
+                )?;
                 ensure_storage_type_supported(
                     &canonicalize_declared_type(ann, record_table, adt_table, arena)?,
                     arena,
@@ -936,8 +965,7 @@ fn check_stmt(
                 )?;
             }
             if let Some(ann) = ty {
-                let expected_ty =
-                    canonicalize_declared_type(ann, record_table, adt_table, arena)?;
+                let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
                 let vt = infer_expr_type_with_expected(
                     *value,
                     arena,
@@ -1091,17 +1119,16 @@ fn check_stmt(
             Ok(())
         }
         Stmt::Break(value) => {
-            let break_ty =
-                infer_expr_type(
-                    *value,
-                    arena,
-                    env,
-                    table,
-                    record_table,
-                    adt_table,
-                    ret_ty,
-                    loop_stack,
-                )?;
+            let break_ty = infer_expr_type(
+                *value,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty,
+                loop_stack,
+            )?;
             let frame = loop_stack.last_mut().ok_or(FrontendError {
                 pos: 0,
                 message: "break with value is allowed only inside loop expression".to_string(),
@@ -1225,7 +1252,10 @@ fn check_stmt(
                 ret_ty.clone(),
                 loop_stack,
             )?;
-            if !matches!(st, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
+            if !matches!(
+                st,
+                Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+            ) {
                 return Err(FrontendError {
                     pos: 0,
                     message:
@@ -1237,13 +1267,8 @@ fn check_stmt(
             for arm in arms {
                 let mut arm_env = env.clone();
                 arm_env.push_scope();
-                for (name, ty) in bind_match_pattern(
-                    &arm.pat,
-                    &st,
-                    arena,
-                    record_table,
-                    adt_table,
-                )? {
+                for (name, ty) in bind_match_pattern(&arm.pat, &st, arena, record_table, adt_table)?
+                {
                     arm_env.insert(name, ty);
                 }
                 check_match_guard(
@@ -1278,8 +1303,9 @@ fn check_stmt(
                     arena,
                     adt_table,
                 )? {
-                    Some((family_label, missing)) if !missing.is_empty() =>
-                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?),
+                    Some((family_label, missing)) if !missing.is_empty() => {
+                        return Err(non_exhaustive_match_error(&family_label, &missing, false)?)
+                    }
                     Some(_) => {}
                     None => {
                         return Err(FrontendError {
@@ -1468,18 +1494,16 @@ fn infer_expr_type(
             pos: 0,
             message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
         }),
-        Expr::Block(block) => {
-            infer_value_block_type(
-                block,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )
-        }
+        Expr::Block(block) => infer_value_block_type(
+            block,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty,
+            loop_stack,
+        ),
         Expr::If(if_expr) => {
             let cond_ty = infer_expr_type(
                 if_expr.condition,
@@ -1499,28 +1523,26 @@ fn infer_expr_type(
                             .to_string(),
                 });
             }
-            let then_ty =
-                infer_value_block_type(
-                    &if_expr.then_block,
-                    arena,
-                    env,
-                    table,
-                    record_table,
-                    adt_table,
-                    ret_ty.clone(),
-                    loop_stack,
-                )?;
-            let else_ty =
-                infer_value_block_type(
-                    &if_expr.else_block,
-                    arena,
-                    env,
-                    table,
-                    record_table,
-                    adt_table,
-                    ret_ty.clone(),
-                    loop_stack,
-                )?;
+            let then_ty = infer_value_block_type(
+                &if_expr.then_block,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+            )?;
+            let else_ty = infer_value_block_type(
+                &if_expr.else_block,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+            )?;
             if then_ty != else_ty {
                 return Err(FrontendError {
                     pos: 0,
@@ -1532,30 +1554,26 @@ fn infer_expr_type(
             }
             Ok(then_ty)
         }
-        Expr::Match(match_expr) => {
-            infer_match_expr_type(
-                match_expr,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )
-        }
-        Expr::Loop(loop_expr) => {
-            infer_loop_expr_type(
-                loop_expr,
-                arena,
-                env,
-                table,
-                record_table,
-                adt_table,
-                ret_ty,
-                loop_stack,
-            )
-        }
+        Expr::Match(match_expr) => infer_match_expr_type(
+            match_expr,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty,
+            loop_stack,
+        ),
+        Expr::Loop(loop_expr) => infer_loop_expr_type(
+            loop_expr,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty,
+            loop_stack,
+        ),
         Expr::Call(name, args) => {
             if is_builtin_assert_name(*name, arena, table)? {
                 return Err(FrontendError {
@@ -1692,9 +1710,8 @@ fn infer_expr_type(
                     if lt == Type::RangeI32 && rt == Type::RangeI32 {
                         return Err(FrontendError {
                             pos: 0,
-                            message:
-                                    "range equality is not part of the stable v0 range surface"
-                                    .to_string(),
+                            message: "range equality is not part of the stable v0 range surface"
+                                .to_string(),
                         });
                     }
                     if !supports_stable_equality_type(&lt, record_table, adt_table)? {
@@ -1743,7 +1760,23 @@ fn infer_expr_type(
                     }
                 }
                 BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
-                    if measured_numeric_parts(&lt).is_some() || measured_numeric_parts(&rt).is_some() {
+                    if lt == Type::Text || rt == Type::Text {
+                        let message = if *op == BinaryOp::Add
+                            && lt == Type::Text
+                            && rt == Type::Text
+                        {
+                            "text concatenation is not part of the current M8.1 Wave 2 contract"
+                        } else {
+                            "text values currently support only equality in the M8.1 Wave 2 surface"
+                        };
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: message.to_string(),
+                        });
+                    }
+                    if measured_numeric_parts(&lt).is_some()
+                        || measured_numeric_parts(&rt).is_some()
+                    {
                         if lt != rt {
                             return Err(FrontendError {
                                 pos: 0,
@@ -1803,7 +1836,9 @@ mod tests {
         type_check_program(&program)
     }
 
-    fn derive_validation_plans_from_source(src: &str) -> Result<(Program, ValidationPlanTable), FrontendError> {
+    fn derive_validation_plans_from_source(
+        src: &str,
+    ) -> Result<(Program, ValidationPlanTable), FrontendError> {
         let program = parse_program(src)?;
         let plans = derive_validation_plan_table(&program)?;
         Ok((program, plans))
@@ -1891,7 +1926,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("u32 range bounds must reject");
-        assert!(err.message.contains("range literal currently requires i32 bounds"));
+        assert!(err
+            .message
+            .contains("range literal currently requires i32 bounds"));
     }
 
     #[test]
@@ -1906,7 +1943,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("range equality must reject");
-        assert!(err.message.contains("range equality is not part of the stable v0 range surface"));
+        assert!(err
+            .message
+            .contains("range equality is not part of the stable v0 range surface"));
     }
 
     #[test]
@@ -1919,7 +1958,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("range tuple nesting must reject");
-        assert!(err.message.contains("range literal is not yet part of the stable tuple/user-data surface"));
+        assert!(err
+            .message
+            .contains("range literal is not yet part of the stable tuple/user-data surface"));
     }
 
     #[test]
@@ -1951,7 +1992,8 @@ mod tests {
             }
         "#;
 
-        typecheck_source(src).expect("plain fx arithmetic should typecheck in the first post-stable slice");
+        typecheck_source(src)
+            .expect("plain fx arithmetic should typecheck in the first post-stable slice");
     }
 
     #[test]
@@ -1965,10 +2007,44 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("measured fx arithmetic must stay outside the first slice");
+        let err = typecheck_source(src)
+            .expect_err("measured fx arithmetic must stay outside the first slice");
         assert!(err
             .message
             .contains("unit-carrying fx arithmetic is not part of the first post-stable fx arithmetic slice yet"));
+    }
+
+    #[test]
+    fn text_literal_and_equality_surface_typechecks() {
+        let src = r#"
+            fn id(message: text) -> text {
+                return message;
+            }
+
+            fn main() {
+                let left: text = "alpha";
+                let right: text = id("alpha");
+                let same = left == right;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("text literals and text equality should typecheck");
+    }
+
+    #[test]
+    fn text_concatenation_rejects_in_wave2() {
+        let src = r#"
+            fn main() {
+                let both = "a" + "b";
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("text concatenation must remain outside Wave 2");
+        assert!(err
+            .message
+            .contains("text concatenation is not part of the current M8.1 Wave 2 contract"));
     }
 
     #[test]
@@ -2111,7 +2187,8 @@ mod tests {
             }
         "#;
 
-        typecheck_source(src).expect("exhaustive ADT match expression without default should typecheck");
+        typecheck_source(src)
+            .expect("exhaustive ADT match expression without default should typecheck");
     }
 
     #[test]
@@ -2383,9 +2460,7 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("duplicate named arguments must reject");
-        assert!(err
-            .message
-            .contains("duplicate named argument 'x'"));
+        assert!(err.message.contains("duplicate named argument 'x'"));
     }
 
     #[test]
@@ -2433,9 +2508,7 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("non-const-safe default parameter must reject");
-        assert!(err
-            .message
-            .contains("default parameter 'factor'"));
+        assert!(err.message.contains("default parameter 'factor'"));
     }
 
     #[test]
@@ -2518,7 +2591,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("assignment to const must reject");
-        assert!(err.message.contains("cannot assign to const binding 'total'"));
+        assert!(err
+            .message
+            .contains("cannot assign to const binding 'total'"));
     }
 
     #[test]
@@ -2804,9 +2879,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("ensures clause should reject call surface");
-        assert!(err
-            .message
-            .contains("ensures clause currently allows only parameter references, optional result binding"));
+        assert!(err.message.contains(
+            "ensures clause currently allows only parameter references, optional result binding"
+        ));
     }
 
     #[test]
@@ -2880,9 +2955,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("invariant clause should reject call surface");
-        assert!(err
-            .message
-            .contains("invariant clause currently allows only parameter references, optional result binding"));
+        assert!(err.message.contains(
+            "invariant clause currently allows only parameter references, optional result binding"
+        ));
     }
 
     #[test]
@@ -2895,8 +2970,8 @@ mod tests {
             fn main() { return; }
         "#;
 
-        let err = typecheck_source(src)
-            .expect_err("invariant clause must reserve synthetic result name");
+        let err =
+            typecheck_source(src).expect_err("invariant clause must reserve synthetic result name");
         assert!(err
             .message
             .contains("parameter name 'result' is reserved while invariant clauses are present"));
@@ -2990,8 +3065,7 @@ mod tests {
             }
         "#;
 
-        let err =
-            typecheck_source(src).expect_err("non-quad let-else literal pattern must reject");
+        let err = typecheck_source(src).expect_err("non-quad let-else literal pattern must reject");
         assert!(err
             .message
             .contains("let-else tuple literal pattern requires quad element"));
@@ -3008,8 +3082,7 @@ mod tests {
             }
         "#;
 
-        let err =
-            typecheck_source(src).expect_err("let-else return type mismatch must reject");
+        let err = typecheck_source(src).expect_err("let-else return type mismatch must reject");
         assert!(err.message.contains("return type mismatch"));
     }
 
@@ -3023,7 +3096,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("non-tuple destructuring must reject");
-        assert!(err.message.contains("tuple destructuring bind requires tuple value"));
+        assert!(err
+            .message
+            .contains("tuple destructuring bind requires tuple value"));
     }
 
     #[test]
@@ -3105,9 +3180,7 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("for-range binding must be const");
-        assert!(err
-            .message
-            .contains("cannot assign to const binding 'i'"));
+        assert!(err.message.contains("cannot assign to const binding 'i'"));
     }
 
     #[test]
@@ -3123,8 +3196,7 @@ mod tests {
             }
         "#;
 
-        let err =
-            typecheck_source(src).expect_err("for-range in loop expression body must reject");
+        let err = typecheck_source(src).expect_err("for-range in loop expression body must reject");
         assert!(err
             .message
             .contains("loop expression body currently does not allow for-range"));
@@ -3413,7 +3485,10 @@ mod tests {
             panic!("expected measured u32 field in validation plan");
         };
         assert_eq!(**base, Type::U32);
-        assert_eq!(resolve_symbol_name(&program.arena, *unit).expect("unit symbol"), "ms");
+        assert_eq!(
+            resolve_symbol_name(&program.arena, *unit).expect("unit symbol"),
+            "ms"
+        );
         assert_eq!(
             plan.checks,
             vec![
@@ -3474,7 +3549,10 @@ mod tests {
         assert_eq!(variants.len(), 2);
         assert_eq!(variants[0].fields.len(), 0);
         assert_eq!(variants[1].fields.len(), 2);
-        assert_eq!(variants[1].fields[0].ty, Type::Record(program.records[0].name));
+        assert_eq!(
+            variants[1].fields[0].ty,
+            Type::Record(program.records[0].name)
+        );
         assert_eq!(
             variants[1].fields[1].ty,
             Type::Result(Box::new(Type::Quad), Box::new(Type::Bool))
@@ -3606,9 +3684,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("schema/record collision must reject");
-        assert!(err.message.contains(
-            "top-level name 'PointPayload' cannot be used for both record and schema"
-        ));
+        assert!(err
+            .message
+            .contains("top-level name 'PointPayload' cannot be used for both record and schema"));
     }
 
     #[test]
@@ -3690,7 +3768,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("missing record field must reject");
-        assert!(err.message.contains("record literal 'DecisionContext' is missing field 'quality'"));
+        assert!(err
+            .message
+            .contains("record literal 'DecisionContext' is missing field 'quality'"));
     }
 
     #[test]
@@ -3708,7 +3788,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("unknown record field must reject");
-        assert!(err.message.contains("record literal 'DecisionContext' has no field named 'badge'"));
+        assert!(err
+            .message
+            .contains("record literal 'DecisionContext' has no field named 'badge'"));
     }
 
     #[test]
@@ -3746,7 +3828,8 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("record equality subset must reject unsupported fields");
+        let err = typecheck_source(src)
+            .expect_err("record equality subset must reject unsupported fields");
         assert!(err
             .message
             .contains("record equality is allowed only when every field type already supports stable equality"));
@@ -3786,7 +3869,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("unknown record field must reject");
-        assert!(err.message.contains("record type 'DecisionContext' has no field named 'badge'"));
+        assert!(err
+            .message
+            .contains("record type 'DecisionContext' has no field named 'badge'"));
     }
 
     #[test]
@@ -3980,9 +4065,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("unknown record field must reject");
-        assert!(err
-            .message
-            .contains("record type 'DecisionContext' has no field named 'badge' in destructuring bind"));
+        assert!(err.message.contains(
+            "record type 'DecisionContext' has no field named 'badge' in destructuring bind"
+        ));
     }
 
     #[test]
@@ -4043,10 +4128,11 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("record let-else without refutable field must reject");
-        assert!(err
-            .message
-            .contains("record let-else requires at least one refutable quad literal field pattern"));
+        let err =
+            typecheck_source(src).expect_err("record let-else without refutable field must reject");
+        assert!(err.message.contains(
+            "record let-else requires at least one refutable quad literal field pattern"
+        ));
     }
 
     #[test]
@@ -4064,7 +4150,8 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("record let-else quad literal on non-quad field must reject");
+        let err = typecheck_source(src)
+            .expect_err("record let-else quad literal on non-quad field must reject");
         assert!(err
             .message
             .contains("record let-else literal pattern requires quad field"));
@@ -4251,8 +4338,8 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src)
-            .expect_err("mismatched standard-form match family must reject");
+        let err =
+            typecheck_source(src).expect_err("mismatched standard-form match family must reject");
         assert!(err
             .message
             .contains("match arm pattern type 'Option' does not match scrutinee Result(T, E)"));
@@ -4449,17 +4536,16 @@ fn infer_match_expr_type(
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<Type, FrontendError> {
-    let scrutinee_ty =
-        infer_expr_type(
-            match_expr.scrutinee,
-            arena,
-            env,
-            table,
-            record_table,
-            adt_table,
-            ret_ty.clone(),
-            loop_stack,
-        )?;
+    let scrutinee_ty = infer_expr_type(
+        match_expr.scrutinee,
+        arena,
+        env,
+        table,
+        record_table,
+        adt_table,
+        ret_ty.clone(),
+        loop_stack,
+    )?;
     if !matches!(
         scrutinee_ty,
         Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
@@ -4476,13 +4562,9 @@ fn infer_match_expr_type(
     for arm in &match_expr.arms {
         let mut arm_env = env.clone();
         arm_env.push_scope();
-        for (name, ty) in bind_match_pattern(
-            &arm.pat,
-            &scrutinee_ty,
-            arena,
-            record_table,
-            adt_table,
-        )? {
+        for (name, ty) in
+            bind_match_pattern(&arm.pat, &scrutinee_ty, arena, record_table, adt_table)?
+        {
             arm_env.insert(name, ty);
         }
         check_match_guard(
@@ -4552,10 +4634,13 @@ fn infer_match_expr_type(
             arena,
             adt_table,
         )? {
-            Some((family_label, missing)) if !missing.is_empty() =>
-                Err(non_exhaustive_match_error(&family_label, &missing, true)?),
-            Some(_) => Ok(result_ty
-                .expect("exhaustive enum match expression should have at least one arm")),
+            Some((family_label, missing)) if !missing.is_empty() => {
+                Err(non_exhaustive_match_error(&family_label, &missing, true)?)
+            }
+            Some(_) => {
+                Ok(result_ty
+                    .expect("exhaustive enum match expression should have at least one arm"))
+            }
             None => Err(FrontendError {
                 pos: 0,
                 message: "match expression requires default arm '_'".to_string(),
@@ -4692,7 +4777,10 @@ fn check_loop_expr_stmt(
                 ret_ty.clone(),
                 loop_stack,
             )?;
-            if !matches!(st, Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)) {
+            if !matches!(
+                st,
+                Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+            ) {
                 return Err(FrontendError {
                     pos: 0,
                     message:
@@ -4710,13 +4798,8 @@ fn check_loop_expr_stmt(
             for arm in arms {
                 let mut arm_env = env.clone();
                 arm_env.push_scope();
-                for (name, ty) in bind_match_pattern(
-                    &arm.pat,
-                    &st,
-                    arena,
-                    record_table,
-                    adt_table,
-                )? {
+                for (name, ty) in bind_match_pattern(&arm.pat, &st, arena, record_table, adt_table)?
+                {
                     arm_env.insert(name, ty);
                 }
                 check_match_guard(
@@ -4761,7 +4844,16 @@ fn check_loop_expr_stmt(
             def_env.pop_scope();
             Ok(())
         }
-        _ => check_stmt(stmt_id, arena, env, ret_ty, table, record_table, adt_table, loop_stack),
+        _ => check_stmt(
+            stmt_id,
+            arena,
+            env,
+            ret_ty,
+            table,
+            record_table,
+            adt_table,
+            loop_stack,
+        ),
     }
 }
 
@@ -5250,7 +5342,14 @@ fn validate_adt_acyclic(
     })?;
     for variant in &adt.variants {
         for item_ty in &variant.payload {
-            validate_nominal_type_acyclic(item_ty, record_table, adt_table, arena, active, visited)?;
+            validate_nominal_type_acyclic(
+                item_ty,
+                record_table,
+                adt_table,
+                arena,
+                active,
+                visited,
+            )?;
         }
     }
     active.remove(&adt_name);
@@ -5269,7 +5368,14 @@ fn validate_nominal_type_acyclic(
     match ty {
         Type::Tuple(items) => {
             for item in items {
-                validate_nominal_type_acyclic(item, record_table, adt_table, arena, active, visited)?;
+                validate_nominal_type_acyclic(
+                    item,
+                    record_table,
+                    adt_table,
+                    arena,
+                    active,
+                    visited,
+                )?;
             }
             Ok(())
         }
@@ -5280,7 +5386,9 @@ fn validate_nominal_type_acyclic(
                 validate_adt_acyclic(*name, record_table, adt_table, arena, active, visited)
             }
         }
-        Type::Adt(name) => validate_adt_acyclic(*name, record_table, adt_table, arena, active, visited),
+        Type::Adt(name) => {
+            validate_adt_acyclic(*name, record_table, adt_table, arena, active, visited)
+        }
         _ => Ok(()),
     }
 }
@@ -5341,9 +5449,7 @@ fn ensure_type_resolved(
                 })
             }
         }
-        Type::Option(item) => {
-            ensure_type_resolved(item, record_table, adt_table, arena, context)
-        }
+        Type::Option(item) => ensure_type_resolved(item, record_table, adt_table, arena, context),
         Type::Result(ok_ty, err_ty) => {
             ensure_type_resolved(ok_ty, record_table, adt_table, arena, context.clone())?;
             ensure_type_resolved(err_ty, record_table, adt_table, arena, context)
@@ -5424,12 +5530,7 @@ fn supports_stable_equality_type(
 }
 
 fn ensure_requires_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
-    ensure_contract_expr_supported(
-        expr_id,
-        arena,
-        "requires",
-        "parameter references",
-    )
+    ensure_contract_expr_supported(expr_id, arena, "requires", "parameter references")
 }
 
 fn ensure_ensures_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
@@ -5441,10 +5542,7 @@ fn ensure_ensures_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<()
     )
 }
 
-fn ensure_invariant_expr_supported(
-    expr_id: ExprId,
-    arena: &AstArena,
-) -> Result<(), FrontendError> {
+fn ensure_invariant_expr_supported(expr_id: ExprId, arena: &AstArena) -> Result<(), FrontendError> {
     ensure_contract_expr_supported(
         expr_id,
         arena,
@@ -5462,6 +5560,7 @@ fn ensure_contract_expr_supported(
     match arena.expr(expr_id) {
         Expr::QuadLiteral(_)
         | Expr::BoolLiteral(_)
+        | Expr::TextLiteral(_)
         | Expr::NumericLiteral(_)
         | Expr::Var(_) => Ok(()),
         Expr::Tuple(items) => {
@@ -5575,7 +5674,8 @@ fn supports_stable_equality_type_inner(
                 message: "record equality subset references unknown record type".to_string(),
             })?;
             for field in &record.fields {
-                if !supports_stable_equality_type_inner(&field.ty, record_table, adt_table, active)? {
+                if !supports_stable_equality_type_inner(&field.ty, record_table, adt_table, active)?
+                {
                     active.remove(name);
                     return Ok(false);
                 }
@@ -5597,13 +5697,15 @@ fn infer_record_literal_type(
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
 ) -> Result<Type, FrontendError> {
-    let record = record_table.get(&record_literal.name).ok_or(FrontendError {
-        pos: 0,
-        message: format!(
-            "unknown record type '{}' in record literal",
-            resolve_symbol_name(arena, record_literal.name)?
-        ),
-    })?;
+    let record = record_table
+        .get(&record_literal.name)
+        .ok_or(FrontendError {
+            pos: 0,
+            message: format!(
+                "unknown record type '{}' in record literal",
+                resolve_symbol_name(arena, record_literal.name)?
+            ),
+        })?;
     let record_name = resolve_symbol_name(arena, record_literal.name)?;
     let mut field_types = BTreeMap::new();
     for field in &record.fields {
@@ -5985,8 +6087,10 @@ fn infer_expr_type_with_expected(
                 ret_ty,
                 loop_stack,
             )?;
-            Ok(lift_literal_to_expected_type(expected.as_ref(), &actual, expr_id, arena)
-                .unwrap_or(actual))
+            Ok(
+                lift_literal_to_expected_type(expected.as_ref(), &actual, expr_id, arena)
+                    .unwrap_or(actual),
+            )
         }
     }
 }
@@ -6062,9 +6166,8 @@ fn infer_std_form_ctor_type(
                     }
                     _ => Err(FrontendError {
                         pos: 0,
-                        message:
-                            "Option::None currently requires contextual Option(T) type in v0"
-                                .to_string(),
+                        message: "Option::None currently requires contextual Option(T) type in v0"
+                            .to_string(),
                     }),
                 }
             }
@@ -6281,11 +6384,8 @@ fn bind_match_pattern(
 
             let mut seen = BTreeSet::new();
             let mut bindings = Vec::new();
-            for (index, (item, declared_ty)) in adt_pat
-                .items
-                .iter()
-                .zip(variant.payload.iter())
-                .enumerate()
+            for (index, (item, declared_ty)) in
+                adt_pat.items.iter().zip(variant.payload.iter()).enumerate()
             {
                 let payload_ty =
                     canonicalize_declared_type(declared_ty, record_table, adt_table, arena)?;
@@ -6326,8 +6426,7 @@ fn missing_exhaustive_sum_variants<'a>(
             continue;
         }
         if let MatchPattern::Adt(adt_pat) = pat {
-            if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name
-            {
+            if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name {
                 covered.insert(resolve_symbol_name(arena, adt_pat.variant_name)?.to_string());
             }
         }
@@ -6513,8 +6612,9 @@ fn ensure_const_initializer_safe(
         }
         _ => Err(FrontendError {
             pos: 0,
-            message: "const initializer currently supports only pure literal/const expression forms"
-                .to_string(),
+            message:
+                "const initializer currently supports only pure literal/const expression forms"
+                    .to_string(),
         }),
     }
 }

--- a/docs/roadmap/language_maturity/text_type_full_scope.md
+++ b/docs/roadmap/language_maturity/text_type_full_scope.md
@@ -85,17 +85,20 @@ its widened contract on `main`.
 
 ## Current Wave Reading
 
-Current branch scope for Wave 1:
+Current branch scope for Wave 2:
 
-- explicit `text` owner-layer type in `sm-front`
-- explicit double-quoted UTF-8 text literal family ownership in `sm-front`
-- public API and docs/snapshot sync for that owner layer
+- parser admission for double-quoted text literals in the Rust-like executable
+  source surface
+- parser admission for `text` in declared type positions
+- source typing for executable text literals
+- same-family equality admission for `text == text` and `text != text`
+- explicit source-level gap wording for text arithmetic beyond equality
 
-Still intentionally not included in Wave 1:
+Still intentionally not included in Wave 2:
 
-- parser admission for executable text literals
-- source typing/equality admission for executable text expressions
-- IR, verifier, or VM carrier/runtime work
+- IR, verifier, or VM text carrier/runtime work
+- text concatenation
+- formatting, interpolation, or host-facing text ABI widening
 
 ## Acceptance Reading
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -64,9 +64,10 @@ Current honest limit:
 
 - the repository does not yet claim that every parser diagnostic code or exact
   wording is frozen as a long-term compatibility promise
-- current `main` reserves a frontend text-literal owner family, but executable
-  text parser admission diagnostics remain a later `M8.1` wave rather than part
-  of the current executable syntax contract
+- current `main` now admits executable double-quoted text literals and `text`
+  type spelling in the source parser path
+- exact parse wording for text-surface gaps is not yet a long-term frozen
+  compatibility promise
 
 ## Policy Diagnostics
 
@@ -223,14 +224,17 @@ Current message families include:
   overflow in the widened post-stable execution path
 - explicit gap messages for unit-carrying `fx` arithmetic outside the first
   post-stable `fx` arithmetic slice
+- explicit gap messages for text concatenation or text arithmetic beyond the
+  current equality-only `M8.1` Wave 2 surface
 
 Current honest limit:
 
 - exact wording of type-check messages is not yet a fully frozen compatibility
   contract
-- current `main` reserves frontend owner-layer `text`/text-literal families,
-  but executable type-check admission and equality diagnostics for text values
-  remain later `M8.1` waves
+- current `main` now admits executable text literal typing and same-family
+  equality in the source type-check path
+- current `main` still reports explicit gap messages for text arithmetic beyond
+  equality until later `M8.1` waves land
 - generated validation failures are currently documented as deterministic plan
   categories, not yet as a separate runtime or CLI diagnostic family
 - generated API contract failures are currently documented as deterministic

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -692,6 +692,8 @@ Current v0 limits:
 Current operator meaning:
 
 - `==` and `!=` produce `bool`
+- same-family `text == text` and `text != text` are now admitted on current
+  `main`
 - `&&` and `||` work on `bool` and `quad` only when both operands are of the
   same family
 - `!` works on `bool` and `quad`
@@ -718,6 +720,9 @@ Current honest limit:
 - completed first-wave post-stable widening for general-purpose `fx`
   arithmetic is documented in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+- the published stable `v1.1.1` line still does not expose executable `text`
+- current `main` admits `text` in the source type/equality layer only
+- text concatenation and runtime text execution remain later `M8.1` waves
 
 ## Builtin Call Meaning
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -268,6 +268,9 @@ Current expression forms:
 - literals:
   - quad literals: `N`, `F`, `T`, `S`
   - bool literals: `true`, `false`
+  - text literals:
+    - double-quoted text `"hello"`
+    - empty text `""`
   - integer literals:
     - decimal `123`
     - decimal with separators `1_000`
@@ -318,6 +321,8 @@ Current expression forms:
 - tuple types:
   - `(i32, bool)`
   - `(f64, quad, bool)`
+- text type:
+  - `text`
 - first-wave units-of-measure annotations:
   - `f64[m]`
   - `u32[ms]`
@@ -356,6 +361,12 @@ Current v0 numeric-literal limits:
 - typed literal spelling does not imply new integer arithmetic beyond the
   already documented operator surface
 - tuple literal arity must be at least 2 in the current contract
+
+Current text-literal limits:
+
+- the current executable text surface is only double-quoted same-line text
+- interpolation and multi-line text blocks are not part of the current surface
+- text concatenation is not yet part of the current source contract
 
 Current v0 range-literal limits:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -27,6 +27,7 @@ Current source-visible types:
 
 - `quad`
 - `bool`
+- `text`
 - `i32`
 - `u32`
 - `f64`
@@ -74,13 +75,22 @@ Current honest baseline:
 
 - the published stable `v1.1.1` line does not expose `text` as an executable
   source-visible type family
-- current `main` now reserves `text` as an explicit frontend owner-layer type
-  in `sm-front`
-- current `main` also reserves a double-quoted UTF-8 text literal family in the
-  frontend owner layer
-- parser admission, source typing, equality execution, lowering, verifier
-  admission, and VM execution for executable text values remain later `M8.1`
-  waves
+- current `main` now admits `text` in declared source type positions in the
+  Rust-like executable path
+- current `main` also admits a narrow double-quoted UTF-8 text literal family
+  in the same source path
+- current `main` admits same-family equality on `text`
+- current `main` does not yet admit text concatenation or a canonical runtime
+  text carrier
+- lowering, verifier admission, and VM execution for executable text values
+  remain later `M8.1` waves
+
+Current text-surface limits:
+
+- the current literal spelling is narrow: double-quoted same-line UTF-8 text
+  only
+- interpolation, formatting, escape-rich string syntax, and host/runtime text
+  ABI widening are not part of the current contract
 
 ## Unit
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,8 @@ pub mod prom_state {
     pub use prom_state::{
         ContextWindow, FactResolution, FactValue, SemanticStateStore, StateEpoch, StateRecord,
         StateRollbackAdvance, StateRollbackArtifact, StateRollbackCheckpoint, StateRollbackCode,
-        StateRollbackError, StateSnapshot,
-        StateSnapshotArchive, StateSnapshotArchiveFormatError, StateTransitionMetadata,
-        StateUpdate, StateValidationCode, StateValidationError,
+        StateRollbackError, StateSnapshot, StateSnapshotArchive, StateSnapshotArchiveFormatError,
+        StateTransitionMetadata, StateUpdate, StateValidationCode, StateValidationError,
         STATE_ROLLBACK_ARTIFACT_FORMAT_VERSION, STATE_SNAPSHOT_ARCHIVE_FORMAT_VERSION,
     };
 }
@@ -106,9 +105,8 @@ pub mod prom_rules {
 pub mod prom_audit {
     pub use prom_audit::{
         AuditEvent, AuditEventId, AuditEventKind, AuditReplayArchive,
-        AuditReplayArchiveFormatError, AuditSessionMetadata, AuditTrail,
-        MultiSessionReplayArchive, MultiSessionReplayArchiveFormatError,
-        MultiSessionReplayArchiveSession, ReplayMetadata,
+        AuditReplayArchiveFormatError, AuditSessionMetadata, AuditTrail, MultiSessionReplayArchive,
+        MultiSessionReplayArchiveFormatError, MultiSessionReplayArchiveSession, ReplayMetadata,
         AUDIT_REPLAY_ARCHIVE_FORMAT_VERSION, MULTI_SESSION_REPLAY_ARCHIVE_FORMAT_VERSION,
     };
 }
@@ -207,7 +205,7 @@ pub mod frontend {
 Program      = { Function } ;
 Function     = "fn" Ident "(" [ Param { "," Param } ] ")" [ "->" Type ] Block ;
 Param        = Ident ":" Type ;
-Type         = "quad" | "bool" | "i32" | "u32" | "fx" | "f64" ;
+Type         = "quad" | "bool" | "text" | "i32" | "u32" | "fx" | "f64" ;
 Block        = "{" { Stmt } "}" ;
 Stmt         = LetStmt | IfStmt | MatchStmt | ReturnStmt | ExprStmt ;
 LetStmt      = "let" Ident [ ":" Type ] "=" Expr ";" ;
@@ -224,10 +222,11 @@ Eq           = Add { ("==" | "!=") Add } ;
 Add          = Mul { ("+" | "-") Mul } ;
 Mul          = Unary { ("*" | "/") Unary } ;
 Unary        = [ "!" | "+" | "-" ] Primary ;
-Primary      = QuadLit | BoolLit | Num | Float | Ident | Call | "(" Expr ")" ;
+Primary      = QuadLit | BoolLit | StringLit | Num | Float | Ident | Call | "(" Expr ")" ;
 Call         = Ident "(" [ Expr { "," Expr } ] ")" ;
 QuadLit      = "N" | "F" | "T" | "S" ;
 BoolLit      = "true" | "false" ;
+StringLit    = "\"" { ? any character except quote or newline ? } "\"" ;
 "#;
 }
 


### PR DESCRIPTION
# POST-M8.1 Wave 2: admit text literals and equality\n\nCloses part of: #217\nSlice type: code\nOne PR = one logical step.\n\n## What This PR Does\n\n- admits 	ext type spelling and narrow double-quoted text literals in the parser\n- admits same-family 	ext == text and 	ext != text in source typing\n- adds explicit Wave 2 diagnostics for text arithmetic and concatenation\n- syncs scope/spec wording and EBNF surface\n\n## What This PR Does Not Do\n\n- no runtime text carrier\n- no IR/verifier/VM text execution\n- no text concatenation\n\n## Stable Boundary Statement\n\nPublished 1.1.1:\n- still has no executable text surface\n\nCurrent main after this PR:\n- admits declared 	ext, narrow text literals, and same-family equality at source level only\n\nThis PR is:\n- [ ] release-maintenance only\n- [x] forward-only widening on main\n- [x] not a retroactive widening of published stable\n\n## Files / Ownership\n\nOwner crates or docs touched:\n\n- crates/sm-front/src/parser.rs\n- crates/sm-front/src/typecheck.rs\n- docs/spec/{syntax,types,source_semantics,diagnostics}.md\n- docs/roadmap/language_maturity/text_type_full_scope.md\n- src/lib.rs\n\n## Verification\n\n- [x] cargo test -p sm-front\n- [x] cargo test --test public_api_contracts\n- [x] cargo test --workspace\n- [x] docs/spec updated\n\nExact commands run:\n\n`powershell\ncargo test -p sm-front\ncargo test --test public_api_contracts\ncargo test --workspace\n`\n\n## Follow-Up\n\nNext honest step after this PR:\n\n- Wave 3: canonical IR/verifier/runtime text carrier admission\n