### PR TITLE
POST-M8.2 Wave 0: define package ecosystem baseline scope

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -33,6 +33,9 @@ Current post-`v1` wave:
   - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
 - `M8.1 Text / String Surface` is completed as first-wave baseline history in
   `docs/roadmap/language_maturity/text_type_full_scope.md`
+- `M8.2 Package Ecosystem Baseline` is now the active M8 subtrack and is
+  scoped in
+  `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -73,6 +73,10 @@ Current completed checkpoint:
 - Wave 3: resolution/lock baseline or explicit first-wave non-commitment
 - Wave 4: docs/tests/compatibility freeze
 
+Current active checkpoint:
+
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
 ### M8.3 Collections
 
 - Wave 0: collection scope checkpoint

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -96,9 +96,13 @@ Current completed first subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/text_type_full_scope.md`
 
-Current next candidate under this package:
+Current active second subtrack checkpoint:
 
-- package ecosystem baseline
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
+Current next candidate after package baseline:
+
+- collections
 
 ## Explicit Non-Goals
 

--- a/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
+++ b/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
@@ -1,0 +1,121 @@
+# Package Ecosystem Baseline Scope
+
+Status: active M8.2 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first package-level contract for Semantic without silently
+widening the published `v1.1.1` line and without turning the repository into a
+full registry or package-manager project.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that package manifests or dependency resolution already exist on the
+published stable line.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- the module/import contract is file-based and module-identifier based
+- current imports resolve through the active module provider rather than
+  through a package manifest boundary
+- the public source contract does not yet expose package manifests
+- the public source contract does not yet expose registries, semver dependency
+  solving, or lockfiles
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of a package manifest surface
+- deterministic package identity and package-root rules
+- local path dependency declaration and validation
+- explicit mapping between package roots and existing module resolution
+- deterministic package graph loading for admitted first-wave dependencies
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- remote registries
+- package publishing workflow
+- semver range solving
+- lockfiles as part of the first-wave public contract
+- vendoring or global cache design
+- build scripts or native dependency toolchains
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- manifest schema ownership
+- package identity ownership
+- package-root and dependency inventory
+
+### Wave 2 — Source Admission
+
+- manifest parsing
+- dependency declaration validation
+- module/package relationship admission
+
+### Wave 3 — Resolution Path
+
+- deterministic local path dependency loading
+- graph validation and narrow CLI/module-provider integration
+- explicit non-commitment for lockfiles in the first-wave baseline
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: manifest/package identity owner-layer surface
+3. PR 3: dependency declaration and module/package admission
+4. PR 4: deterministic local path resolution baseline
+5. PR 5: freeze and close-out
+
+## Current Wave Reading
+
+Current branch scope for Wave 0:
+
+- define the admitted first-wave package baseline as local path packages only
+- separate package identity/manifest work from registries and publishing
+- separate package graph loading from future lockfile or cache stories
+- keep the published `v1.1.1` line explicitly narrower than current `main`
+
+Still intentionally not included in Wave 0:
+
+- executable package implementation
+- registry or publishing semantics
+- lockfile or solver ownership
+- workspace-wide build orchestration beyond deterministic path loading
+
+## Acceptance Reading
+
+This subtrack is done only when:
+
+- package identity and manifest semantics are explicit and inspectable
+- package dependency declarations and module loading agree on one admitted
+  first-wave model
+- the first admitted dependency graph is deterministic and reproducible
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- remote package registries
+- semver dependency solving
+- lockfile stability guarantees
+- build-script or native-toolchain package hooks
+- package publishing/distribution workflows

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -113,6 +113,8 @@
     - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
   - current completed first subtrack:
     `docs/roadmap/language_maturity/text_type_full_scope.md`
+  - current active second subtrack:
+    `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -129,6 +129,10 @@ The current module contract does not yet claim stable support for:
 Those concerns belong to the future package ecosystem surface rather than the
 current source module baseline.
 
+Current active package-baseline checkpoint:
+
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
 ## Validation Evidence
 
 Current repository fixtures cover this surface in:


### PR DESCRIPTION
# POST-M8.2 Wave 0: define package ecosystem baseline scope

Closes part of: #223  
Slice type: docs-only
One PR = one logical step.

## What This PR Does

- adds the `M8.2 Package Ecosystem Baseline` scope checkpoint
- syncs M8 roadmap/phased-plan docs to show package baseline as the active M8 subtrack after completed `M8.1 Text`
- syncs backlog, milestones, and module-spec reading so package work is explicitly separated from the existing file/module contract

## What This PR Does Not Do

- no manifest implementation
- no dependency resolver
- no lockfile contract
- no registry or publishing semantics

## Stable Boundary Statement

Published `v1.1.1`:
- still has only the file/module-level import surface
- still has no package manifest or dependency contract

Current `main` after this PR:
- only documents the active post-stable package baseline scope
- does not yet admit package manifests or package resolution in code

This PR is:
- [x] release-maintenance only
- [ ] forward-only widening on `main`
- [x] not a retroactive widening of published stable

## Files / Ownership

Owner docs touched:

- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
- `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
- `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
- `docs/roadmap/backlog.md`
- `docs/roadmap/milestones.md`
- `docs/spec/modules.md`

## Verification

- [x] docs-only change
- [x] no code/tests changed

## Follow-Up

Next honest step after this PR:

- Wave 1 owner-layer surface for manifest schema, package identity, and package-root rules