### PR TITLE
POST-M8.2 Wave 1: add package manifest owner-layer

### DIFF
--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -11,6 +11,8 @@ mod formatter;
 #[cfg(feature = "std")]
 mod incremental;
 #[cfg(feature = "std")]
+mod package_manifest;
+#[cfg(feature = "std")]
 mod schema_versioning;
 #[cfg(feature = "std")]
 mod wire_contract;
@@ -39,6 +41,8 @@ pub use api_contract::{build_generated_api_contract, format_generated_api_contra
 pub use config::{build_config_contract, parse_config_document, validate_config_document, ConfigContract, ConfigContractBuildError, ConfigDocument, ConfigEntry, ConfigNumber, ConfigNumberKind, ConfigParseError, ConfigValidationDiagnostic, ConfigValidationError, ConfigValue};
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
+#[cfg(feature = "std")]
+pub use package_manifest::{validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestValidationCode, PackageManifestValidationError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION};
 #[cfg(feature = "std")]
 pub use schema_versioning::{build_schema_migration_metadata, classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, format_schema_migration_metadata, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaMigrationChangeSet, SchemaMigrationMetadataArtifact, SchemaMigrationReviewKind, SchemaMigrationShapeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 #[cfg(feature = "std")]

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1,0 +1,251 @@
+use std::error::Error;
+use std::fmt;
+
+pub const PACKAGE_MANIFEST_BASELINE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageRoot {
+    pub manifest_dir: String,
+    pub module_root: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageIdentity {
+    pub name: String,
+    pub root: PackageRoot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PackageDependencySource {
+    LocalPath { path: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageDependency {
+    pub alias: String,
+    pub package_name: String,
+    pub source: PackageDependencySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageManifest {
+    pub format_version: u32,
+    pub package: PackageIdentity,
+    pub dependencies: Vec<PackageDependency>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageManifestValidationCode {
+    UnsupportedFormatVersion,
+    EmptyPackageName,
+    EmptyManifestDir,
+    EmptyModuleRoot,
+    EmptyDependencyAlias,
+    DuplicateDependencyAlias,
+    EmptyDependencyPackageName,
+    EmptyLocalDependencyPath,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageManifestValidationError {
+    pub code: PackageManifestValidationCode,
+    pub message: String,
+}
+
+impl fmt::Display for PackageManifestValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "package manifest validation error: {}", self.message)
+    }
+}
+
+impl Error for PackageManifestValidationError {}
+
+impl PackageManifest {
+    pub fn new(package: PackageIdentity, dependencies: Vec<PackageDependency>) -> Self {
+        Self {
+            format_version: PACKAGE_MANIFEST_BASELINE_VERSION,
+            package,
+            dependencies,
+        }
+    }
+}
+
+pub fn validate_package_manifest_baseline(
+    manifest: &PackageManifest,
+) -> Result<(), PackageManifestValidationError> {
+    if manifest.format_version != PACKAGE_MANIFEST_BASELINE_VERSION {
+        return Err(PackageManifestValidationError {
+            code: PackageManifestValidationCode::UnsupportedFormatVersion,
+            message: format!(
+                "unsupported package manifest format version {}; expected {}",
+                manifest.format_version, PACKAGE_MANIFEST_BASELINE_VERSION
+            ),
+        });
+    }
+
+    if manifest.package.name.trim().is_empty() {
+        return Err(PackageManifestValidationError {
+            code: PackageManifestValidationCode::EmptyPackageName,
+            message: "package name must not be empty".to_string(),
+        });
+    }
+
+    if manifest.package.root.manifest_dir.trim().is_empty() {
+        return Err(PackageManifestValidationError {
+            code: PackageManifestValidationCode::EmptyManifestDir,
+            message: "package manifest_dir must not be empty".to_string(),
+        });
+    }
+
+    if manifest.package.root.module_root.trim().is_empty() {
+        return Err(PackageManifestValidationError {
+            code: PackageManifestValidationCode::EmptyModuleRoot,
+            message: "package module_root must not be empty".to_string(),
+        });
+    }
+
+    let mut seen_aliases = std::collections::BTreeSet::new();
+    for dependency in &manifest.dependencies {
+        if dependency.alias.trim().is_empty() {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::EmptyDependencyAlias,
+                message: "package dependency alias must not be empty".to_string(),
+            });
+        }
+        if !seen_aliases.insert(dependency.alias.as_str()) {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::DuplicateDependencyAlias,
+                message: format!(
+                    "duplicate package dependency alias '{}'",
+                    dependency.alias
+                ),
+            });
+        }
+        if dependency.package_name.trim().is_empty() {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::EmptyDependencyPackageName,
+                message: "package dependency package_name must not be empty".to_string(),
+            });
+        }
+        match &dependency.source {
+            PackageDependencySource::LocalPath { path } if path.trim().is_empty() => {
+                return Err(PackageManifestValidationError {
+                    code: PackageManifestValidationCode::EmptyLocalDependencyPath,
+                    message: format!(
+                        "package dependency '{}' requires a non-empty local path",
+                        dependency.alias
+                    ),
+                });
+            }
+            PackageDependencySource::LocalPath { .. } => {}
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package_root() -> PackageRoot {
+        PackageRoot {
+            manifest_dir: ".".to_string(),
+            module_root: "src".to_string(),
+        }
+    }
+
+    #[test]
+    fn new_manifest_uses_canonical_baseline_version() {
+        let manifest = PackageManifest::new(
+            PackageIdentity {
+                name: "app".to_string(),
+                root: package_root(),
+            },
+            Vec::new(),
+        );
+        assert_eq!(manifest.format_version, PACKAGE_MANIFEST_BASELINE_VERSION);
+    }
+
+    #[test]
+    fn validate_package_manifest_accepts_local_path_dependency_inventory() {
+        let manifest = PackageManifest::new(
+            PackageIdentity {
+                name: "app".to_string(),
+                root: package_root(),
+            },
+            vec![
+                PackageDependency {
+                    alias: "math".to_string(),
+                    package_name: "math".to_string(),
+                    source: PackageDependencySource::LocalPath {
+                        path: "../math".to_string(),
+                    },
+                },
+                PackageDependency {
+                    alias: "ui".to_string(),
+                    package_name: "ui".to_string(),
+                    source: PackageDependencySource::LocalPath {
+                        path: "../ui".to_string(),
+                    },
+                },
+            ],
+        );
+        assert_eq!(
+            manifest
+                .dependencies
+                .iter()
+                .map(|dep| dep.alias.as_str())
+                .collect::<Vec<_>>(),
+            vec!["math", "ui"]
+        );
+        validate_package_manifest_baseline(&manifest).expect("valid local path manifest");
+    }
+
+    #[test]
+    fn validate_package_manifest_rejects_duplicate_dependency_alias() {
+        let manifest = PackageManifest::new(
+            PackageIdentity {
+                name: "app".to_string(),
+                root: package_root(),
+            },
+            vec![
+                PackageDependency {
+                    alias: "shared".to_string(),
+                    package_name: "first".to_string(),
+                    source: PackageDependencySource::LocalPath {
+                        path: "../first".to_string(),
+                    },
+                },
+                PackageDependency {
+                    alias: "shared".to_string(),
+                    package_name: "second".to_string(),
+                    source: PackageDependencySource::LocalPath {
+                        path: "../second".to_string(),
+                    },
+                },
+            ],
+        );
+        let err = validate_package_manifest_baseline(&manifest).expect_err("must reject");
+        assert_eq!(
+            err.code,
+            PackageManifestValidationCode::DuplicateDependencyAlias
+        );
+    }
+
+    #[test]
+    fn validate_package_manifest_rejects_empty_package_root_fields() {
+        let manifest = PackageManifest::new(
+            PackageIdentity {
+                name: "app".to_string(),
+                root: PackageRoot {
+                    manifest_dir: "".to_string(),
+                    module_root: "src".to_string(),
+                },
+            },
+            Vec::new(),
+        );
+        let err = validate_package_manifest_baseline(&manifest).expect_err("must reject");
+        assert_eq!(err.code, PackageManifestValidationCode::EmptyManifestDir);
+    }
+}

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -33,6 +33,9 @@ Current post-`v1` wave:
   - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
 - `M8.1 Text / String Surface` is completed as first-wave baseline history in
   `docs/roadmap/language_maturity/text_type_full_scope.md`
+- `M8.2 Package Ecosystem Baseline` is now the active M8 subtrack and is
+  scoped in
+  `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -73,6 +73,10 @@ Current completed checkpoint:
 - Wave 3: resolution/lock baseline or explicit first-wave non-commitment
 - Wave 4: docs/tests/compatibility freeze
 
+Current active checkpoint:
+
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
 ### M8.3 Collections
 
 - Wave 0: collection scope checkpoint

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -96,9 +96,13 @@ Current completed first subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/text_type_full_scope.md`
 
-Current next candidate under this package:
+Current active second subtrack checkpoint:
 
-- package ecosystem baseline
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
+Current next candidate after package baseline:
+
+- collections
 
 ## Explicit Non-Goals
 

--- a/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
+++ b/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
@@ -86,16 +86,19 @@ its widened contract on `main`.
 
 ## Current Wave Reading
 
-Current branch scope for Wave 0:
+Current branch scope for Wave 1:
 
-- define the admitted first-wave package baseline as local path packages only
-- separate package identity/manifest work from registries and publishing
-- separate package graph loading from future lockfile or cache stories
-- keep the published `v1.1.1` line explicitly narrower than current `main`
+- explicit owner-layer types for package manifest, package identity, package
+  root, and local path dependencies
+- canonical baseline manifest version ownership
+- narrow inventory validation for duplicate dependency aliases and empty root or
+  path fields
+- no executable package loading path yet
 
-Still intentionally not included in Wave 0:
+Still intentionally not included in Wave 1:
 
-- executable package implementation
+- manifest parser admission
+- module-provider/package integration
 - registry or publishing semantics
 - lockfile or solver ownership
 - workspace-wide build orchestration beyond deterministic path loading

--- a/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
+++ b/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
@@ -1,0 +1,121 @@
+# Package Ecosystem Baseline Scope
+
+Status: active M8.2 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first package-level contract for Semantic without silently
+widening the published `v1.1.1` line and without turning the repository into a
+full registry or package-manager project.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that package manifests or dependency resolution already exist on the
+published stable line.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- the module/import contract is file-based and module-identifier based
+- current imports resolve through the active module provider rather than
+  through a package manifest boundary
+- the public source contract does not yet expose package manifests
+- the public source contract does not yet expose registries, semver dependency
+  solving, or lockfiles
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of a package manifest surface
+- deterministic package identity and package-root rules
+- local path dependency declaration and validation
+- explicit mapping between package roots and existing module resolution
+- deterministic package graph loading for admitted first-wave dependencies
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- remote registries
+- package publishing workflow
+- semver range solving
+- lockfiles as part of the first-wave public contract
+- vendoring or global cache design
+- build scripts or native dependency toolchains
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- manifest schema ownership
+- package identity ownership
+- package-root and dependency inventory
+
+### Wave 2 — Source Admission
+
+- manifest parsing
+- dependency declaration validation
+- module/package relationship admission
+
+### Wave 3 — Resolution Path
+
+- deterministic local path dependency loading
+- graph validation and narrow CLI/module-provider integration
+- explicit non-commitment for lockfiles in the first-wave baseline
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: manifest/package identity owner-layer surface
+3. PR 3: dependency declaration and module/package admission
+4. PR 4: deterministic local path resolution baseline
+5. PR 5: freeze and close-out
+
+## Current Wave Reading
+
+Current branch scope for Wave 0:
+
+- define the admitted first-wave package baseline as local path packages only
+- separate package identity/manifest work from registries and publishing
+- separate package graph loading from future lockfile or cache stories
+- keep the published `v1.1.1` line explicitly narrower than current `main`
+
+Still intentionally not included in Wave 0:
+
+- executable package implementation
+- registry or publishing semantics
+- lockfile or solver ownership
+- workspace-wide build orchestration beyond deterministic path loading
+
+## Acceptance Reading
+
+This subtrack is done only when:
+
+- package identity and manifest semantics are explicit and inspectable
+- package dependency declarations and module loading agree on one admitted
+  first-wave model
+- the first admitted dependency graph is deterministic and reproducible
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- remote package registries
+- semver dependency solving
+- lockfile stability guarantees
+- build-script or native-toolchain package hooks
+- package publishing/distribution workflows

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -113,6 +113,8 @@
     - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
   - current completed first subtrack:
     `docs/roadmap/language_maturity/text_type_full_scope.md`
+  - current active second subtrack:
+    `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -133,6 +133,16 @@ Current active package-baseline checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 
+Current `main` also now owns an inert package-manifest baseline in `smc-cli`
+for:
+
+- package identity
+- package root layout
+- local path dependency inventory
+
+That owner-layer is not yet the same thing as admitted source/package
+resolution. Parser/loading integration remains a later `M8.2` wave.
+
 ## Validation Evidence
 
 Current repository fixtures cover this surface in:

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -129,6 +129,10 @@ The current module contract does not yet claim stable support for:
 Those concerns belong to the future package ecosystem surface rather than the
 current source module baseline.
 
+Current active package-baseline checkpoint:
+
+- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+
 ## Validation Evidence
 
 Current repository fixtures cover this surface in:

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -10,6 +10,8 @@ pub use config::{build_config_contract, parse_config_document, validate_config_d
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
+pub use package_manifest::{validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestValidationCode, PackageManifestValidationError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION};
+#[cfg(feature = "std")]
 pub use schema_versioning::{build_schema_migration_metadata, classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, format_schema_migration_metadata, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaMigrationChangeSet, SchemaMigrationMetadataArtifact, SchemaMigrationReviewKind, SchemaMigrationShapeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 #[cfg(feature = "std")]
 pub use wire_contract::{build_generated_wire_contract, format_generated_wire_contract, GeneratedWireContractArtifact, GeneratedWireContractBuildError, TaggedWireUnionContract, TaggedWireUnionField, TaggedWireUnionVariant, WirePatchField, WirePatchTypeContract, GENERATED_WIRE_CONTRACT_FORMAT_VERSION, GENERATED_WIRE_CONTRACT_GENERATOR, GENERATED_WIRE_CONTRACT_GENERATOR_VERSION};


### PR DESCRIPTION
## What This PR Does

- replays the Wave 0 package-baseline scope checkpoint on the current branch
- adds the Wave 1 `smc-cli` owner-layer for package manifest identity, roots, and local-path dependencies
- adds narrow baseline validation and syncs `smc-cli` public API/docs snapshots

## What This PR Does Not Do

- manifest parser admission
- package/module resolver integration
- registries, lockfiles, publishing, or semver solving

## Stable Boundary Statement

Published `v1.1.1`:
- has no admitted package manifest surface

Current `main` after this PR:
- owns an inert package-manifest baseline in `smc-cli` only
- does not yet admit package parsing or resolution as executable source behavior

## Files / Ownership

- `crates/smc-cli/src/package_manifest.rs`
- `crates/smc-cli/src/lib.rs`
- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
- `docs/spec/modules.md`
- `tests/golden_snapshots/public_api/smc_cli_lib.txt`

## Verification

- `cargo test -p smc-cli`
- `cargo test --test public_api_contracts`
- `cargo test --workspace`

## Follow-Up

- Wave 2: manifest parsing plus package/module admission
