### PR TITLE
POST-M8.2 Wave 2: admit package manifests and module roots

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -3,6 +3,7 @@ use crate::incremental::{
     emit_trace, module_graph_fingerprint, module_graph_module_count, read_graph_hash,
     update_cache_index, CacheEvent, CacheReason, ModuleGraphSnapshot,
 };
+use crate::package_manifest::admit_package_entry_module;
 use crate::{format_path, FormatterMode};
 use sm_emit::{
     compile_program_to_semcode, compile_program_to_semcode_with_options_debug,
@@ -28,8 +29,21 @@ struct CliFsModuleProvider;
 
 impl ModuleProvider for CliFsModuleProvider {
     fn read_module(&self, module_id: &str) -> Result<Vec<u8>, String> {
+        ensure_package_module_admission(Path::new(module_id))?;
         std::fs::read(module_id).map_err(|e| e.to_string())
     }
+}
+
+fn ensure_package_module_admission(path: &Path) -> Result<(), String> {
+    admit_package_entry_module(path)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
+    ensure_package_module_admission(path)?;
+    std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read '{}': {}", path.display(), e))
 }
 
 fn cli_profile() -> ParserProfile {
@@ -124,8 +138,7 @@ fn cmd_compile(args: &[String]) -> Result<(), String> {
     }
     let out = out.ok_or_else(|| "missing -o <out.smc>".to_string())?;
     let t0 = Instant::now();
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let t_read = Instant::now();
     let parser_profile = cli_profile();
     let bytes = compile_program_to_semcode_with_options_debug(&src, profile, opt, debug_symbols)
@@ -273,8 +286,7 @@ fn cmd_check(args: &[String]) -> Result<(), String> {
         );
     }
     let t0 = Instant::now();
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let t_read = Instant::now();
     let prev_graph_hash = read_graph_hash(Path::new(CACHE_GRAPH_FILE));
     let mut graph_hash_now = None;
@@ -651,8 +663,7 @@ fn cmd_lint(args: &[String]) -> Result<(), String> {
         );
     }
     let root = PathBuf::from(input);
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     if let Ok(snapshot) = ModuleGraphSnapshot::read_from_root(&root) {
         let _ = snapshot.write_to(Path::new(CACHE_GRAPH_FILE), CACHE_SCHEMA_VERSION);
     }
@@ -808,8 +819,7 @@ fn cmd_dump_ast(args: &[String]) -> Result<(), String> {
         return Err("usage: smc dump-ast <input.sm>".to_string());
     }
     let input = args[0].as_str();
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let parser_profile = cli_profile();
     let ast_key = ast_pack_key(Path::new(input), &src)?;
     let ast_pack = cache_ast_file_for_key(ast_key)?;
@@ -862,8 +872,7 @@ fn cmd_dump_ir(args: &[String]) -> Result<(), String> {
         }
         i += 1;
     }
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let parser_profile = cli_profile();
     let ir_key = ir_pack_key(Path::new(input), &src, profile, opt)?;
     let ir_pack = cache_ir_file_for_key(ir_key)?;
@@ -943,8 +952,7 @@ fn cmd_dump_bytecode(args: &[String]) -> Result<(), String> {
         }
         i += 1;
     }
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let _parser_profile = cli_profile();
     let exb_key = smc_pack_key(Path::new(input), &src, profile, opt, debug_symbols)?;
     let exb_pack = cache_smc_file_for_key(exb_key)?;
@@ -1547,8 +1555,7 @@ fn cmd_hash_ast(args: &[String]) -> Result<(), String> {
         return Err("usage: smc hash-ast <input.sm>".to_string());
     }
     let input = args[0].as_str();
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let parser_profile = cli_profile();
     let ast_key = ast_pack_key(Path::new(input), &src)?;
     let ast_pack = cache_ast_file_for_key(ast_key)?;
@@ -1602,8 +1609,7 @@ fn cmd_hash_ir(args: &[String]) -> Result<(), String> {
         }
         i += 1;
     }
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let parser_profile = cli_profile();
     let ir_key = ir_pack_key(Path::new(input), &src, profile, opt)?;
     let ir_pack = cache_ir_file_for_key(ir_key)?;
@@ -1686,8 +1692,7 @@ fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
         }
         i += 1;
     }
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let prev_graph_hash = read_graph_hash(Path::new(CACHE_GRAPH_FILE));
     let graph_hash_now = if let Ok(snapshot) = ModuleGraphSnapshot::read_from_root(Path::new(input)) {
         let hash = snapshot.hash(CACHE_SCHEMA_VERSION);
@@ -2092,8 +2097,7 @@ fn cmd_run(args: &[String]) -> Result<(), String> {
         return Err("usage: smc run <input.sm>".to_string());
     }
     let input = args[0].as_str();
-    let src =
-        std::fs::read_to_string(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let src = read_source_with_package_admission(Path::new(input))?;
     let bytes = compile_program_to_semcode(&src).map_err(|e| e.to_string())?;
     run_semcode(&bytes).map_err(|e| e.to_string())
 }

--- a/crates/smc-cli/src/incremental.rs
+++ b/crates/smc-cli/src/incremental.rs
@@ -1,3 +1,4 @@
+use crate::package_manifest::admit_package_entry_module;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -273,6 +274,9 @@ fn collect_module_graph(
     let canonical = path
         .canonicalize()
         .map_err(|e| format!("resolve '{}': {}", path.display(), e))?;
+    admit_package_entry_module(&canonical)
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
     if graph.contains_key(&canonical) {
         return Ok(());
     }

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -42,7 +42,7 @@ pub use config::{build_config_contract, parse_config_document, validate_config_d
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
-pub use package_manifest::{validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestValidationCode, PackageManifestValidationError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION};
+pub use package_manifest::{admit_package_entry_module, parse_package_manifest_baseline, validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestParseCode, PackageManifestParseError, PackageManifestValidationCode, PackageManifestValidationError, PackageModuleAdmission, PackageModuleAdmissionCode, PackageModuleAdmissionError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION, PACKAGE_MANIFEST_FILE_NAME};
 #[cfg(feature = "std")]
 pub use schema_versioning::{build_schema_migration_metadata, classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, format_schema_migration_metadata, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaMigrationChangeSet, SchemaMigrationMetadataArtifact, SchemaMigrationReviewKind, SchemaMigrationShapeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 #[cfg(feature = "std")]
@@ -54,6 +54,9 @@ struct CliFsProvider;
 #[cfg(feature = "std")]
 impl ModuleProvider for CliFsProvider {
     fn read_module(&self, module_id: &str) -> Result<Vec<u8>, String> {
+        package_manifest::admit_package_entry_module(Path::new(module_id))
+            .map(|_| ())
+            .map_err(|e| e.to_string())?;
         std::fs::read(module_id).map_err(|e| e.to_string())
     }
 }
@@ -102,6 +105,21 @@ impl CliPipeline {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn mk_temp_dir(prefix: &str) -> std::path::PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "{}_{}_{}",
+            prefix,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).expect("mkdir");
+        base
+    }
 
     #[test]
     fn compile_pipeline_smoke() {
@@ -126,5 +144,37 @@ Law "L" [priority 1]:
     fn explain_smoke() {
         let text = CliPipeline::explain("E0101").expect("known code");
         assert!(text.contains("indent"));
+    }
+
+    #[test]
+    fn semantic_check_file_admits_entry_within_package_module_root() {
+        let dir = mk_temp_dir("smc_cli_pkg_admit_ok");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            r#"
+format 1
+package app
+manifest_dir .
+module_root src
+"#,
+        )
+        .expect("write manifest");
+        let entry = src_dir.join("main.sm");
+        std::fs::write(
+            &entry,
+            r#"
+Law "L" [priority 1]:
+    When true ->
+        System.recovery()
+"#,
+        )
+        .expect("write source");
+
+        let report = CliPipeline::semantic_check_file(&entry).expect("check");
+        assert_eq!(report.scheduled_laws.len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1,7 +1,9 @@
 use std::error::Error;
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 pub const PACKAGE_MANIFEST_BASELINE_VERSION: u32 = 1;
+pub const PACKAGE_MANIFEST_FILE_NAME: &str = "Semantic.package";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackageRoot {
@@ -33,6 +35,36 @@ pub struct PackageManifest {
     pub package: PackageIdentity,
     pub dependencies: Vec<PackageDependency>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageManifestParseCode {
+    MissingFormatDirective,
+    MissingPackageDirective,
+    MissingManifestDirDirective,
+    MissingModuleRootDirective,
+    DuplicateDirective,
+    InvalidFormatVersion,
+    InvalidDirective,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageManifestParseError {
+    pub code: PackageManifestParseCode,
+    pub line: usize,
+    pub message: String,
+}
+
+impl fmt::Display for PackageManifestParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "package manifest parse error on line {}: {}",
+            self.line, self.message
+        )
+    }
+}
+
+impl Error for PackageManifestParseError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageManifestValidationCode {
@@ -68,6 +100,173 @@ impl PackageManifest {
             dependencies,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageModuleAdmission {
+    pub manifest_path: String,
+    pub package_name: String,
+    pub module_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageModuleAdmissionCode {
+    EntryResolutionFailed,
+    ManifestReadFailed,
+    ManifestParseFailed,
+    ManifestValidationFailed,
+    PackageRootResolutionFailed,
+    ModuleRootResolutionFailed,
+    EntryOutsideModuleRoot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageModuleAdmissionError {
+    pub code: PackageModuleAdmissionCode,
+    pub message: String,
+}
+
+impl fmt::Display for PackageModuleAdmissionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "package module admission error: {}", self.message)
+    }
+}
+
+impl Error for PackageModuleAdmissionError {}
+
+pub fn parse_package_manifest_baseline(
+    source: &str,
+) -> Result<PackageManifest, PackageManifestParseError> {
+    let mut format_version = None::<u32>;
+    let mut package_name = None::<String>;
+    let mut manifest_dir = None::<String>;
+    let mut module_root = None::<String>;
+    let mut dependencies = Vec::<PackageDependency>::new();
+
+    for (index, raw_line) in source.lines().enumerate() {
+        let line_no = index + 1;
+        let tokens = split_manifest_tokens(raw_line, line_no)?;
+        if tokens.is_empty() {
+            continue;
+        }
+        match tokens[0].as_str() {
+            "format" => {
+                ensure_unique_directive("format", &format_version, line_no)?;
+                if tokens.len() != 2 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "format directive must be: format <u32>",
+                    ));
+                }
+                let parsed = tokens[1].parse::<u32>().map_err(|_| {
+                    parse_error(
+                        PackageManifestParseCode::InvalidFormatVersion,
+                        line_no,
+                        "format directive requires a valid u32 version",
+                    )
+                })?;
+                format_version = Some(parsed);
+            }
+            "package" => {
+                ensure_unique_directive("package", &package_name, line_no)?;
+                if tokens.len() != 2 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "package directive must be: package <name>",
+                    ));
+                }
+                package_name = Some(tokens[1].clone());
+            }
+            "manifest_dir" => {
+                ensure_unique_directive("manifest_dir", &manifest_dir, line_no)?;
+                if tokens.len() != 2 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "manifest_dir directive must be: manifest_dir <path>",
+                    ));
+                }
+                manifest_dir = Some(tokens[1].clone());
+            }
+            "module_root" => {
+                ensure_unique_directive("module_root", &module_root, line_no)?;
+                if tokens.len() != 2 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "module_root directive must be: module_root <path>",
+                    ));
+                }
+                module_root = Some(tokens[1].clone());
+            }
+            "dep" => {
+                if tokens.len() != 4 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "dep directive must be: dep <alias> <package_name> <local_path>",
+                    ));
+                }
+                dependencies.push(PackageDependency {
+                    alias: tokens[1].clone(),
+                    package_name: tokens[2].clone(),
+                    source: PackageDependencySource::LocalPath {
+                        path: tokens[3].clone(),
+                    },
+                });
+            }
+            other => {
+                return Err(parse_error(
+                    PackageManifestParseCode::InvalidDirective,
+                    line_no,
+                    &format!("unknown package manifest directive '{}'", other),
+                ))
+            }
+        }
+    }
+
+    let format_version = format_version.ok_or_else(|| {
+        parse_error(
+            PackageManifestParseCode::MissingFormatDirective,
+            0,
+            "package manifest requires an explicit format directive",
+        )
+    })?;
+    let package_name = package_name.ok_or_else(|| {
+        parse_error(
+            PackageManifestParseCode::MissingPackageDirective,
+            0,
+            "package manifest requires an explicit package directive",
+        )
+    })?;
+    let manifest_dir = manifest_dir.ok_or_else(|| {
+        parse_error(
+            PackageManifestParseCode::MissingManifestDirDirective,
+            0,
+            "package manifest requires an explicit manifest_dir directive",
+        )
+    })?;
+    let module_root = module_root.ok_or_else(|| {
+        parse_error(
+            PackageManifestParseCode::MissingModuleRootDirective,
+            0,
+            "package manifest requires an explicit module_root directive",
+        )
+    })?;
+
+    Ok(PackageManifest {
+        format_version,
+        package: PackageIdentity {
+            name: package_name,
+            root: PackageRoot {
+                manifest_dir,
+                module_root,
+            },
+        },
+        dependencies,
+    })
 }
 
 pub fn validate_package_manifest_baseline(
@@ -144,15 +343,198 @@ pub fn validate_package_manifest_baseline(
     Ok(())
 }
 
+pub fn admit_package_entry_module(
+    entry: &Path,
+) -> Result<Option<PackageModuleAdmission>, PackageModuleAdmissionError> {
+    let entry_canonical = entry.canonicalize().map_err(|e| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::EntryResolutionFailed,
+        message: format!("failed to resolve entry module '{}': {}", entry.display(), e),
+    })?;
+    let manifest_path = match find_nearest_manifest(&entry_canonical) {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+    let manifest = load_and_validate_manifest(&manifest_path)?;
+    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let package_root =
+        manifest_dir
+            .join(&manifest.package.root.manifest_dir)
+            .canonicalize()
+            .map_err(|e| PackageModuleAdmissionError {
+                code: PackageModuleAdmissionCode::PackageRootResolutionFailed,
+                message: format!(
+                    "failed to resolve package root '{}' relative to '{}': {}",
+                    manifest.package.root.manifest_dir,
+                    manifest_path.display(),
+                    e
+                ),
+            })?;
+    let module_root =
+        package_root
+            .join(&manifest.package.root.module_root)
+            .canonicalize()
+            .map_err(|e| PackageModuleAdmissionError {
+                code: PackageModuleAdmissionCode::ModuleRootResolutionFailed,
+                message: format!(
+                    "failed to resolve package module_root '{}' relative to '{}': {}",
+                    manifest.package.root.module_root,
+                    package_root.display(),
+                    e
+                ),
+            })?;
+    let module_relative =
+        entry_canonical
+            .strip_prefix(&module_root)
+            .map_err(|_| PackageModuleAdmissionError {
+                code: PackageModuleAdmissionCode::EntryOutsideModuleRoot,
+                message: format!(
+                    "module '{}' is outside admitted package module_root '{}'",
+                    entry_canonical.display(),
+                    module_root.display()
+                ),
+            })?;
+
+    Ok(Some(PackageModuleAdmission {
+        manifest_path: normalize_path(&manifest_path),
+        package_name: manifest.package.name,
+        module_path: normalize_relative_path(module_relative),
+    }))
+}
+
+fn parse_error(code: PackageManifestParseCode, line: usize, message: &str) -> PackageManifestParseError {
+    PackageManifestParseError {
+        code,
+        line,
+        message: message.to_string(),
+    }
+}
+
+fn ensure_unique_directive<T>(
+    name: &str,
+    slot: &Option<T>,
+    line: usize,
+) -> Result<(), PackageManifestParseError> {
+    if slot.is_some() {
+        return Err(parse_error(
+            PackageManifestParseCode::DuplicateDirective,
+            line,
+            &format!("duplicate package manifest directive '{}'", name),
+        ));
+    }
+    Ok(())
+}
+
+fn split_manifest_tokens(
+    raw_line: &str,
+    line_no: usize,
+) -> Result<Vec<String>, PackageManifestParseError> {
+    let mut out = Vec::<String>::new();
+    let chars: Vec<char> = raw_line.chars().collect();
+    let mut i = 0usize;
+    while i < chars.len() {
+        while i < chars.len() && chars[i].is_whitespace() {
+            i += 1;
+        }
+        if i >= chars.len() || chars[i] == '#' {
+            break;
+        }
+        if chars[i] == '"' {
+            i += 1;
+            let start = i;
+            while i < chars.len() && chars[i] != '"' {
+                i += 1;
+            }
+            if i >= chars.len() {
+                return Err(parse_error(
+                    PackageManifestParseCode::InvalidDirective,
+                    line_no,
+                    "unterminated quoted value in package manifest",
+                ));
+            }
+            out.push(chars[start..i].iter().collect());
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < chars.len() && !chars[i].is_whitespace() && chars[i] != '#' {
+            i += 1;
+        }
+        out.push(chars[start..i].iter().collect());
+        if i < chars.len() && chars[i] == '#' {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+fn find_nearest_manifest(entry_canonical: &Path) -> Option<PathBuf> {
+    let mut current = entry_canonical.parent();
+    while let Some(dir) = current {
+        let candidate = dir.join(PACKAGE_MANIFEST_FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn load_and_validate_manifest(
+    manifest_path: &Path,
+) -> Result<PackageManifest, PackageModuleAdmissionError> {
+    let source = std::fs::read_to_string(manifest_path).map_err(|e| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::ManifestReadFailed,
+        message: format!("failed to read '{}': {}", manifest_path.display(), e),
+    })?;
+    let manifest =
+        parse_package_manifest_baseline(&source).map_err(|e| PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::ManifestParseFailed,
+            message: format!("failed to parse '{}': {}", manifest_path.display(), e),
+        })?;
+    validate_package_manifest_baseline(&manifest).map_err(|e| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::ManifestValidationFailed,
+        message: format!("failed to validate '{}': {}", manifest_path.display(), e),
+    })?;
+    Ok(manifest)
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn normalize_relative_path(path: &Path) -> String {
+    let value = normalize_path(path);
+    if value.is_empty() {
+        ".".to_string()
+    } else {
+        value
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn package_root() -> PackageRoot {
         PackageRoot {
             manifest_dir: ".".to_string(),
             module_root: "src".to_string(),
         }
+    }
+
+    fn mk_temp_dir(prefix: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "{}_{}_{}",
+            prefix,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&base).expect("mkdir");
+        base
     }
 
     #[test]
@@ -247,5 +629,105 @@ mod tests {
         );
         let err = validate_package_manifest_baseline(&manifest).expect_err("must reject");
         assert_eq!(err.code, PackageManifestValidationCode::EmptyManifestDir);
+    }
+
+    #[test]
+    fn parse_package_manifest_accepts_first_wave_directives() {
+        let manifest = parse_package_manifest_baseline(
+            r#"
+format 1
+package "app"
+manifest_dir "."
+module_root "src"
+dep math math "../math"
+dep ui ui "../ui"
+"#,
+        )
+        .expect("parse");
+        assert_eq!(manifest.package.name, "app");
+        assert_eq!(manifest.dependencies.len(), 2);
+        validate_package_manifest_baseline(&manifest).expect("validate");
+    }
+
+    #[test]
+    fn parse_package_manifest_rejects_duplicate_package_directive() {
+        let err = parse_package_manifest_baseline(
+            r#"
+format 1
+package app
+package other
+manifest_dir .
+module_root src
+"#,
+        )
+        .expect_err("must reject");
+        assert_eq!(err.code, PackageManifestParseCode::DuplicateDirective);
+        assert_eq!(err.line, 4);
+    }
+
+    #[test]
+    fn parse_package_manifest_rejects_missing_module_root() {
+        let err = parse_package_manifest_baseline(
+            r#"
+format 1
+package app
+manifest_dir .
+"#,
+        )
+        .expect_err("must reject");
+        assert_eq!(err.code, PackageManifestParseCode::MissingModuleRootDirective);
+    }
+
+    #[test]
+    fn admit_package_entry_module_maps_entry_into_package_context() {
+        let dir = mk_temp_dir("pkg_admit_ok");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(src_dir.join("nested")).expect("mkdir src");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            r#"
+format 1
+package app
+manifest_dir .
+module_root src
+dep math math ../math
+"#,
+        )
+        .expect("write manifest");
+        let entry = src_dir.join("nested").join("main.sm");
+        std::fs::write(&entry, "fn main() { return; }").expect("write entry");
+
+        let admitted = admit_package_entry_module(&entry)
+            .expect("admit")
+            .expect("manifest must exist");
+        assert_eq!(admitted.package_name, "app");
+        assert!(admitted.manifest_path.ends_with("/Semantic.package"));
+        assert_eq!(admitted.module_path, "nested/main.sm");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn admit_package_entry_module_rejects_entry_outside_module_root() {
+        let dir = mk_temp_dir("pkg_admit_outside");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            r#"
+format 1
+package app
+manifest_dir .
+module_root src
+"#,
+        )
+        .expect("write manifest");
+        let entry = dir.join("main.sm");
+        std::fs::write(&entry, "fn main() { return; }").expect("write entry");
+
+        let err = admit_package_entry_module(&entry).expect_err("must reject");
+        assert_eq!(err.code, PackageModuleAdmissionCode::EntryOutsideModuleRoot);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
+++ b/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
@@ -86,19 +86,19 @@ its widened contract on `main`.
 
 ## Current Wave Reading
 
-Current branch scope for Wave 1:
+Current branch scope for Wave 2:
 
-- explicit owner-layer types for package manifest, package identity, package
-  root, and local path dependencies
-- canonical baseline manifest version ownership
-- narrow inventory validation for duplicate dependency aliases and empty root or
-  path fields
-- no executable package loading path yet
+- canonical `Semantic.package` text parsing for the first-wave manifest surface
+- explicit admission of package entry modules against package root and
+  `module_root`
+- narrow CLI/module-provider validation hooks so source entrypoints and scanned
+  modules agree on the same package boundary
+- dependency declarations remain local-path only and still do not imply package
+  graph loading
 
-Still intentionally not included in Wave 1:
+Still intentionally not included in Wave 2:
 
-- manifest parser admission
-- module-provider/package integration
+- deterministic dependency loading across package boundaries
 - registry or publishing semantics
 - lockfile or solver ownership
 - workspace-wide build orchestration beyond deterministic path loading

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -133,15 +133,28 @@ Current active package-baseline checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 
-Current `main` also now owns an inert package-manifest baseline in `smc-cli`
-for:
+Current `main` also now owns a first-wave `Semantic.package` baseline in
+`smc-cli` for:
 
 - package identity
 - package root layout
 - local path dependency inventory
+- canonical package manifest parsing
+- package entry-module admission against `module_root`
 
-That owner-layer is not yet the same thing as admitted source/package
-resolution. Parser/loading integration remains a later `M8.2` wave.
+Current admitted manifest directives are:
+
+```text
+format <u32>
+package <name>
+manifest_dir <path>
+module_root <path>
+dep <alias> <package_name> <local_path>
+```
+
+That baseline is still not the same thing as admitted dependency resolution
+across package boundaries. Deterministic local-path dependency loading remains a
+later `M8.2` wave.
 
 ## Validation Evidence
 

--- a/tests/golden_snapshots/public_api/smc_cli_lib.txt
+++ b/tests/golden_snapshots/public_api/smc_cli_lib.txt
@@ -10,7 +10,7 @@ pub use config::{build_config_contract, parse_config_document, validate_config_d
 #[cfg(feature = "std")]
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
-pub use package_manifest::{validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestValidationCode, PackageManifestValidationError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION};
+pub use package_manifest::{admit_package_entry_module, parse_package_manifest_baseline, validate_package_manifest_baseline, PackageDependency, PackageDependencySource, PackageIdentity, PackageManifest, PackageManifestParseCode, PackageManifestParseError, PackageManifestValidationCode, PackageManifestValidationError, PackageModuleAdmission, PackageModuleAdmissionCode, PackageModuleAdmissionError, PackageRoot, PACKAGE_MANIFEST_BASELINE_VERSION, PACKAGE_MANIFEST_FILE_NAME};
 #[cfg(feature = "std")]
 pub use schema_versioning::{build_schema_migration_metadata, classify_record_schema_compatibility, classify_tagged_union_schema_compatibility, format_schema_migration_metadata, RecordSchemaCompatibilityReport, SchemaCompatibilityBuildError, SchemaCompatibilityKind, SchemaFieldChange, SchemaFieldChangeKind, SchemaMigrationChangeSet, SchemaMigrationMetadataArtifact, SchemaMigrationReviewKind, SchemaMigrationShapeKind, SchemaVariantChangeKind, TaggedUnionSchemaCompatibilityReport, TaggedUnionSchemaVariantChange};
 #[cfg(feature = "std")]


### PR DESCRIPTION
## What This PR Does

- adds canonical `Semantic.package` parsing for the first-wave package manifest surface
- admits package entry modules against package root and `module_root`
- threads narrow package-admission validation through `smc-cli` entry reads, module provider reads, and incremental graph scanning
- syncs package-baseline scope/spec wording and `smc-cli` public API snapshots

## What This PR Does Not Do

- deterministic dependency loading across package boundaries
- alias-based package imports
- registries, lockfiles, publishing, or semver solving

## Stable Boundary Statement

Published `v1.1.1`:
- has no admitted package manifest or package/module surface

Current `main` after this PR:
- admits first-wave `Semantic.package` parsing and package/module admission only
- still does not claim dependency loading or package graph resolution across local path packages

## Files / Ownership

- `crates/smc-cli/src/package_manifest.rs`
- `crates/smc-cli/src/app.rs`
- `crates/smc-cli/src/incremental.rs`
- `crates/smc-cli/src/lib.rs`
- `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
- `docs/spec/modules.md`
- `tests/golden_snapshots/public_api/smc_cli_lib.txt`

## Verification

- `cargo test -p smc-cli`
- `cargo test --test public_api_contracts`
- `cargo test --workspace`

## Follow-Up

- Wave 3: deterministic local path dependency loading baseline
