### PR TITLE
POST-M8.2 Wave 4: close out package ecosystem baseline

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -33,9 +33,10 @@ Current post-`v1` wave:
   - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
 - `M8.1 Text / String Surface` is completed as first-wave baseline history in
   `docs/roadmap/language_maturity/text_type_full_scope.md`
-- `M8.2 Package Ecosystem Baseline` is now the active M8 subtrack and is
-  scoped in
+- `M8.2 Package Ecosystem Baseline` is now completed as first-wave baseline
+  history and is scoped in
   `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+- the next candidate inside `M8` is `M8.3 Collections Surface`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -91,6 +91,9 @@ Current `v1` scope commitment:
 - the same forward-only reading also applies to first-wave executable `text`
   through `SEMCODE8` and the narrow literal/equality runtime carrier on
   current `main`
+- the same forward-only reading also applies to the first-wave package
+  ecosystem baseline on current `main`, including `Semantic.package`,
+  deterministic local-path dependency loading, and package-qualified imports
 
 ## Explicit Non-Commitments
 
@@ -108,6 +111,8 @@ The repository does not yet claim final compatibility guarantees for:
   declared `StateWrite` / `AuditNote` contract
 - text semantics beyond the current admitted first-wave literal/equality
   contract on `main`
+- package ecosystem semantics beyond the current admitted first-wave local-path
+  manifest/dependency baseline on `main`
 - broader packaged release layout beyond the current stable assets
 
 ## Release Honesty Rule

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -73,7 +73,7 @@ Current completed checkpoint:
 - Wave 3: resolution/lock baseline or explicit first-wave non-commitment
 - Wave 4: docs/tests/compatibility freeze
 
-Current active checkpoint:
+Current completed checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -96,7 +96,7 @@ Current completed first subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/text_type_full_scope.md`
 
-Current active second subtrack checkpoint:
+Current completed second subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 

--- a/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
+++ b/docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md
@@ -1,6 +1,6 @@
 # Package Ecosystem Baseline Scope
 
-Status: active M8.2 post-stable subtrack
+Status: completed M8.2 first-wave post-stable subtrack
 Related roadmap package:
 `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
 
@@ -84,24 +84,26 @@ its widened contract on `main`.
 4. PR 4: deterministic local path resolution baseline
 5. PR 5: freeze and close-out
 
-## Current Wave Reading
+## Close-Out Reading
 
-Current branch scope for Wave 3:
+`M8.2` is now completed on current `main` as a first-wave package baseline.
 
-- deterministic local-path dependency loading for package-qualified import specs
-  of the form `"alias::module/path.sm"`
+Completed first-wave contract:
+
+- canonical `Semantic.package` parsing and validation
+- explicit package identity, package-root, and dependency inventory ownership
+- package entry-module admission against admitted `module_root`
+- deterministic local-path dependency loading for package-qualified imports
+  such as `"alias::module/path.sm"`
 - one canonical resolution path shared by `smc-cli`, `sm-sema`, and the
   incremental module graph
-- dependency manifest validation and package-name matching before dependency
-  modules are admitted
-- package graph loading that remains local-path only and deterministic by the
-  declared manifest inventory
 
-Still intentionally not included in Wave 3:
+Still intentionally not included after close-out:
 
 - registry or publishing semantics
 - semver or lockfile ownership
-- workspaces beyond deterministic local-path loading
+- workspace/package-manager orchestration beyond deterministic local-path
+  loading
 - package solver heuristics or alternate dependency sources
 
 ## Acceptance Reading

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -113,8 +113,10 @@
     - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
   - current completed first subtrack:
     `docs/roadmap/language_maturity/text_type_full_scope.md`
-  - current active second subtrack:
+  - current completed second subtrack:
     `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+  - current next candidate:
+    `M8.3 Collections Surface`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -101,6 +101,10 @@ The following limits remain explicit and should be treated as release-facing hon
 - the published `v1.1.1` line intentionally excludes executable `text`, even
   though current `main` now admits first-wave text literals/equality through
   canonical `SEMCODE8`, verifier admission, and VM execution
+- the published `v1.1.1` line intentionally excludes the first-wave package
+  ecosystem baseline, even though current `main` now admits `Semantic.package`
+  parsing, package entry-module admission, and deterministic local-path
+  dependency loading for package-qualified imports
 - current `main` still does not claim rollback, retry/compensation, or generic
   mixed-family rule-effect execution semantics
 - current `main` still does not claim rollback, migration, recovery, or


### PR DESCRIPTION
## What This PR Does

- marks `M8.2 Package Ecosystem Baseline` completed as first-wave baseline history
- syncs `M8` roadmap/planning docs so `M8.3 Collections Surface` reads as the next candidate
- syncs release-facing honesty for published `v1.1.1` versus widened `main`

## What This PR Does Not Do

- no package runtime or loader changes
- no registry/solver/lockfile work
- no new language surface beyond the already landed `M8.2` baseline

## Stable Boundary Statement

Published `v1.1.1`:
- still has no package ecosystem baseline

Current `main` after this PR:
- keeps the first-wave package baseline as completed history
- keeps package loading limited to deterministic local-path dependencies only

This PR is:
- release/docs honesty only
- not a retroactive widening of the published stable line

## Verification

No tests rerun. This is a docs-only close-out.
Wave 3 was already verified through:

```powershell
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-2-package-wave3'; cargo test --workspace
```

## Follow-Up

Next honest step after this PR:
- open `M8.3 Collections Surface` only if we want to continue the M8 language-maturity package