### PR TITLE
Docs: define M8.3 collections scope checkpoint

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -36,7 +36,9 @@ Current post-`v1` wave:
 - `M8.2 Package Ecosystem Baseline` is now completed as first-wave baseline
   history and is scoped in
   `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-- the next candidate inside `M8` is `M8.3 Collections Surface`
+- `M8.3 Collections Surface` is now the active `M8` subtrack and is scoped in
+  `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+- the next candidate inside `M8` after collections is `M8.4 First-Class Closures`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/collections_surface_full_scope.md
+++ b/docs/roadmap/language_maturity/collections_surface_full_scope.md
@@ -1,0 +1,119 @@
+# Collections Surface Full Scope
+
+Status: active M8.3 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first admitted collection surface for Semantic without silently
+widening the published `v1.1.1` line and without opening full abstraction
+machinery ahead of schedule.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that first-class collections already exist on the published stable
+line.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- there are no first-class collection carriers in the public language contract
+- tuple and record surfaces exist, but they do not imply general-purpose
+  sequence or lookup collections
+- current syntax/types docs still treat collections as outside the admitted
+  stable subset
+- published `v1.1.1` does not claim list, map, set, or iterable abstractions
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of one first-wave ordered sequence collection family
+- deterministic construction/literal surface for that collection family
+- narrow indexing, length, emptiness, and same-family equality semantics
+- deterministic iteration surface over that admitted sequence family
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- map/dictionary carriers
+- set carriers
+- user-defined generic collections
+- collection traits, protocols, or iterator frameworks
+- comprehensions, lazy pipelines, or query-language syntax
+- mutation-heavy collection APIs beyond the first admitted baseline
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- collection family ownership
+- literal and operation inventory
+- deterministic value-model metadata
+
+### Wave 2 — Source Admission
+
+- parser admission
+- sema/type admission
+- explicit diagnostics for unsupported collection forms
+
+### Wave 3 — Execution Path
+
+- IR/lowering/VM carrier path
+- deterministic iteration/index behavior
+- docs/tests/goldens for the admitted baseline
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: owner-layer collection family surface
+3. PR 3: parser/sema/type admission
+4. PR 4: runtime/VM iteration and indexing baseline
+5. PR 5: freeze and close-out
+
+## Current Wave Reading
+
+Current branch scope for Wave 0:
+
+- define the first-wave collection track as an ordered sequence baseline
+- keep maps, sets, and abstraction-heavy collection machinery explicitly out of
+  scope
+- align roadmap/planning/spec pointers with the new active `M8.3` track
+
+Still intentionally not included in Wave 0:
+
+- syntax choice finalization for every later operation
+- runtime carrier details
+- collection mutation policy beyond the first admitted baseline
+
+## Acceptance Reading
+
+This subtrack is done only when:
+
+- one ordered sequence collection family is explicit and inspectable
+- collection construction, indexing, and iteration agree on one deterministic
+  first-wave model
+- docs/spec/tests describe the same admitted baseline
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- general-purpose map/set ecosystems
+- user-defined parametric collection types
+- generic iterator/protocol frameworks
+- lazy collection pipelines or comprehensions
+- that collection support was already part of the published `v1.1.1` line

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -85,6 +85,10 @@ Current completed checkpoint:
 - Wave 3: iteration/runtime/VM path
 - Wave 4: docs/tests/compatibility freeze
 
+Current active checkpoint:
+
+- `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+
 ### M8.4 Closures
 
 - Wave 0: closure scope checkpoint

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -100,9 +100,13 @@ Current completed second subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 
-Current next candidate after package baseline:
+Current active third subtrack checkpoint:
 
-- collections
+- `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+
+Current next candidate after collections:
+
+- first-class closures
 
 ## Explicit Non-Goals
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -115,8 +115,10 @@
     `docs/roadmap/language_maturity/text_type_full_scope.md`
   - current completed second subtrack:
     `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-  - current next candidate:
-    `M8.3 Collections Surface`
+  - current active third subtrack:
+    `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+  - current next candidate after collections:
+    `M8.4 First-Class Closures`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -585,6 +585,10 @@ The current source contract does not yet claim stable support for:
 - collections as first-class language forms
 - generics or trait-like abstraction
 - exceptions or Python-style dynamic execution
+
+Current active collections checkpoint on `main`:
+
+- `docs/roadmap/language_maturity/collections_surface_full_scope.md`
 - concurrency-oriented source constructs
 
 ## Contract Rule

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -284,6 +284,10 @@ The current source type contract does not yet claim stable support for:
 - implicit numeric widening across unrelated families
 - a broad collection type ecosystem
 
+Current active collections checkpoint on `main`:
+
+- `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+
 ## Contract Rule
 
 Any public change to source-visible type meaning or source type-checking rules


### PR DESCRIPTION
## What This PR Does

- adds `M8.3 Collections Surface` as the next active language-maturity subtrack
- introduces a dedicated collections scope checkpoint
- syncs roadmap/planning/backlog/milestone docs and spec pointers

## What This PR Does Not Do

- no collection code or parser changes
- no map/set/generics/iterator framework work
- no retroactive widening of published `v1.1.1`

## Stable Boundary Statement

Published `v1.1.1`:
- still has no first-class collection surface

Current `main` after this PR:
- only gains the planning/scope checkpoint for `M8.3`
- does not yet admit collection syntax or execution

## Verification

No tests rerun. This is a docs-only scope checkpoint.

## Follow-Up

Next honest step after this PR:
- Wave 1 owner-layer collection family surface for `M8.3`