### PR TITLE
POST-M8.3 Wave 1: add collection owner-layer surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -21,8 +21,9 @@ pub use types::{
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, TextLiteral,
-    TextLiteralFamily, Token, TokenKind, TuplePatternItem, Type,
+    SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceLiteral,
+    SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind,
+    TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
 };
@@ -249,6 +250,15 @@ pub fn canonicalize_declared_type(
                 .map(|item| canonicalize_declared_type(item, record_table, adt_table, arena))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
+        Type::Sequence(sequence) => Ok(Type::Sequence(SequenceType {
+            family: sequence.family,
+            item: Box::new(canonicalize_declared_type(
+                sequence.item.as_ref(),
+                record_table,
+                adt_table,
+                arena,
+            )?),
+        })),
         Type::Measured(base, unit) => {
             let canonical_base = canonicalize_declared_type(base, record_table, adt_table, arena)?;
             if !canonical_base.is_core_numeric_scalar() {

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1511,6 +1511,12 @@ impl<'a> Parser<'a> {
                 }
                 Ok(())
             }
+            Expr::SequenceLiteral(sequence) => {
+                for item in &sequence.items {
+                    self.ensure_short_lambda_expr_capture_free(*item, scopes)?;
+                }
+                Ok(())
+            }
             Expr::RecordLiteral(record) => {
                 for field in &record.fields {
                     self.ensure_short_lambda_expr_capture_free(field.value, scopes)?;

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1386,6 +1386,11 @@ fn infer_expr_type(
         Expr::QuadLiteral(_) => Ok(Type::Quad),
         Expr::BoolLiteral(_) => Ok(Type::Bool),
         Expr::TextLiteral(_) => Ok(Type::Text),
+        Expr::SequenceLiteral(_) => Err(FrontendError {
+            pos: 0,
+            message: "ordered sequence literals are not part of the current M8.3 Wave 1 type admission"
+                .to_string(),
+        }),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
             NumericLiteral::U32(_) => Ok(Type::U32),
@@ -1760,6 +1765,13 @@ fn infer_expr_type(
                     }
                 }
                 BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
+                    if matches!(lt, Type::Sequence(_)) || matches!(rt, Type::Sequence(_)) {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: "ordered sequence values are not part of the current M8.3 Wave 1 operator surface"
+                                .to_string(),
+                        });
+                    }
                     if lt == Type::Text || rt == Type::Text {
                         let message = if *op == BinaryOp::Add
                             && lt == Type::Text
@@ -5646,6 +5658,7 @@ fn supports_stable_equality_type_inner(
         Type::Measured(base, _) => {
             supports_stable_equality_type_inner(base, record_table, adt_table, active)
         }
+        Type::Sequence(_) => Ok(false),
         Type::QVec(_) => Ok(false),
         Type::RangeI32 => Ok(false),
         Type::Tuple(items) => {

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -10,6 +10,7 @@ pub enum Type {
     QVec(usize),
     Bool,
     Text,
+    Sequence(SequenceType),
     I32,
     U32,
     Fx,
@@ -29,6 +30,10 @@ impl Type {
         match self {
             Type::Measured(base, _) => base.erase_units(),
             Type::Tuple(items) => Type::Tuple(items.iter().map(Type::erase_units).collect()),
+            Type::Sequence(sequence) => Type::Sequence(SequenceType {
+                family: sequence.family,
+                item: Box::new(sequence.item.erase_units()),
+            }),
             Type::Option(item) => Type::Option(Box::new(item.erase_units())),
             Type::Result(ok_ty, err_ty) => Type::Result(
                 Box::new(ok_ty.erase_units()),
@@ -95,6 +100,23 @@ pub enum TextLiteralFamily {
 pub struct TextLiteral {
     pub family: TextLiteralFamily,
     pub spelling: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SequenceCollectionFamily {
+    OrderedSequence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SequenceType {
+    pub family: SequenceCollectionFamily,
+    pub item: Box<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SequenceLiteral {
+    pub family: SequenceCollectionFamily,
+    pub items: Vec<ExprId>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -165,6 +187,7 @@ pub enum Expr {
     QuadLiteral(QuadVal),
     BoolLiteral(bool),
     TextLiteral(TextLiteral),
+    SequenceLiteral(SequenceLiteral),
     NumericLiteral(NumericLiteral),
     Range(RangeExpr),
     Tuple(Vec<ExprId>),
@@ -710,6 +733,22 @@ mod tests {
     }
 
     #[test]
+    fn sequence_type_preserves_family_and_erases_nested_units() {
+        let ty = Type::Sequence(SequenceType {
+            family: SequenceCollectionFamily::OrderedSequence,
+            item: Box::new(Type::Measured(Box::new(Type::F64), SymbolId(7))),
+        });
+        assert_eq!(
+            ty.erase_units(),
+            Type::Sequence(SequenceType {
+                family: SequenceCollectionFamily::OrderedSequence,
+                item: Box::new(Type::F64),
+            })
+        );
+        assert!(!ty.is_core_numeric_scalar());
+    }
+
+    #[test]
     fn text_literal_owner_layer_is_stable_data() {
         let literal = TextLiteral {
             family: TextLiteralFamily::DoubleQuotedUtf8,
@@ -717,5 +756,15 @@ mod tests {
         };
         assert_eq!(literal.family, TextLiteralFamily::DoubleQuotedUtf8);
         assert_eq!(literal.spelling, "\"semantic\"");
+    }
+
+    #[test]
+    fn sequence_literal_owner_layer_is_stable_data() {
+        let literal = SequenceLiteral {
+            family: SequenceCollectionFamily::OrderedSequence,
+            items: vec![ExprId(2), ExprId(5)],
+        };
+        assert_eq!(literal.family, SequenceCollectionFamily::OrderedSequence);
+        assert_eq!(literal.items, vec![ExprId(2), ExprId(5)]);
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1433,6 +1433,12 @@ fn lower_expr_with_expected(
             });
             Ok((r, Type::Text))
         }
+        Expr::SequenceLiteral(_) => Err(FrontendError {
+            pos: 0,
+            message:
+                "ordered sequence literals are not part of the current M8.3 Wave 1 execution surface"
+                    .to_string(),
+        }),
         Expr::Range(range_expr) => {
             let (start_reg, start_ty) = lower_expr_with_expected(
                 range_expr.start,

--- a/crates/sm-sema/src/std_adapters.rs
+++ b/crates/sm-sema/src/std_adapters.rs
@@ -44,6 +44,7 @@ impl From<Type> for SemanticType {
             Type::QVec(n) => SemanticType::QVec(n),
             Type::Bool => SemanticType::Bool,
             Type::Text => SemanticType::Unknown,
+            Type::Sequence(_) => SemanticType::Unknown,
             Type::U32 => SemanticType::Int,
             Type::Unit => SemanticType::Unit,
             Type::Measured(base, _) => SemanticType::from((*base).clone()),

--- a/crates/smc-cli/src/api_contract.rs
+++ b/crates/smc-cli/src/api_contract.rs
@@ -254,6 +254,14 @@ fn display_generated_api_type(
                 .collect::<Result<Vec<_>, _>>()?
                 .join(", ")
         ),
+        Type::Sequence(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "ordered sequence types are not part of the current M8.3 Wave 1 generated API contract surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_generated_api_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/config.rs
+++ b/crates/smc-cli/src/config.rs
@@ -395,6 +395,7 @@ fn validate_value_against_type(
         }
         Type::Option(_)
         | Type::Result(_, _)
+        | Type::Sequence(_)
         | Type::Tuple(_)
         | Type::Adt(_)
         | Type::RangeI32
@@ -505,6 +506,9 @@ fn display_config_type(ty: &Type, contract: &ConfigContract) -> String {
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
+        Type::Sequence(sequence) => {
+            format!("ordered-sequence<{}>", display_config_type(sequence.item.as_ref(), contract))
+        }
         Type::Option(item) => format!("Option({})", display_config_type(item, contract)),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/schema_versioning.rs
+++ b/crates/smc-cli/src/schema_versioning.rs
@@ -737,6 +737,14 @@ fn display_schema_compatibility_type(
                 .collect::<Result<Vec<_>, _>>()?
                 .join(", ")
         ),
+        Type::Sequence(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "ordered sequence types are not part of the current M8.3 Wave 1 schema compatibility surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_schema_compatibility_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/wire_contract.rs
+++ b/crates/smc-cli/src/wire_contract.rs
@@ -226,6 +226,14 @@ fn display_generated_wire_type(ty: &Type, arena: &AstArena) -> Result<String, Fr
                 .collect::<Result<Vec<_>, _>>()?
                 .join(", ")
         ),
+        Type::Sequence(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "ordered sequence types are not part of the current M8.3 Wave 1 generated wire-contract surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_generated_wire_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/docs/roadmap/language_maturity/collections_surface_full_scope.md
+++ b/docs/roadmap/language_maturity/collections_surface_full_scope.md
@@ -85,17 +85,19 @@ its widened contract on `main`.
 
 ## Current Wave Reading
 
-Current branch scope for Wave 0:
+Current branch scope for Wave 1:
 
-- define the first-wave collection track as an ordered sequence baseline
-- keep maps, sets, and abstraction-heavy collection machinery explicitly out of
-  scope
-- align roadmap/planning/spec pointers with the new active `M8.3` track
+- make the first admitted collection family explicit as an ordered sequence
+  owner-layer surface
+- define deterministic metadata for sequence family, sequence type, and
+  sequence literal ownership
+- keep parser, sema, and runtime admission explicitly outside the Wave 1 slice
 
-Still intentionally not included in Wave 0:
+Still intentionally not included in Wave 1:
 
-- syntax choice finalization for every later operation
-- runtime carrier details
+- parser spelling for sequence literals or sequence types
+- executable typing/equality/indexing/iteration admission
+- runtime carrier details or VM lowering
 - collection mutation policy beyond the first admitted baseline
 
 ## Acceptance Reading

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -226,6 +226,8 @@ Current message families include:
   post-stable `fx` arithmetic slice
 - explicit gap messages for text concatenation or text arithmetic beyond the
   current `M8.1` Wave 3 literal/equality/runtime surface
+- explicit gap messages for ordered sequence literals before `M8.3` parser,
+  type, and runtime admission lands
 
 Current honest limit:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -287,6 +287,10 @@ The current source type contract does not yet claim stable support for:
 Current active collections checkpoint on `main`:
 
 - `docs/roadmap/language_maturity/collections_surface_full_scope.md`
+- current `main` now owns one ordered sequence collection family as metadata in
+  the frontend owner layer
+- current `main` does not yet admit parser spelling, executable typing, or
+  runtime carriers for that sequence family in the `M8.3` Wave 1 slice
 
 ## Contract Rule
 


### PR DESCRIPTION
Closes part of #229.
Slice type: code.
One PR = one logical step.

## What This PR Does

- adds the first ordered-sequence owner layer in `sm-front`
- introduces `Type::Sequence`, `SequenceType`, `SequenceCollectionFamily`, and `Expr::SequenceLiteral(...)`
- keeps Wave 1 honest by rejecting collection admission in typecheck/lowering and in `smc-cli` artifact/config surfaces
- syncs the active collections scope and spec notes

## What This PR Does Not Do

- parser spelling for sequence literals or sequence types
- executable sequence typing/equality/indexing/iteration admission
- VM/runtime carrier support
- maps, sets, generics, or iterator frameworks

## Stable Boundary Statement

Published `v1.1.1`:
- no first-class collection carriers are admitted

Current `main` after this PR:
- current `main` owns one ordered sequence collection family as frontend metadata only
- parser/type/runtime admission remains intentionally out of scope for Wave 1

This PR is:
- [ ] release-maintenance only
- [x] forward-only widening on `main`
- [x] not a retroactive widening of published stable

## Files / Ownership

Owner crates or docs touched:
- `crates/sm-front`
- `crates/sm-ir`
- `crates/sm-sema`
- `crates/smc-cli`
- `docs/roadmap/language_maturity/collections_surface_full_scope.md`
- `docs/spec/types.md`
- `docs/spec/diagnostics.md`

## Verification

- [x] `cargo test --workspace`
- [x] `cargo test --test public_api_contracts`
- [x] extra focused tests:
- [x] docs/spec updated if contract changed

Exact commands run:

```powershell
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-3-collections-wave1'; cargo test -p sm-front
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-3-collections-wave1'; cargo test -p sm-ir
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-3-collections-wave1'; cargo test --test public_api_contracts
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-3-collections-wave1'; cargo test --workspace
```

## Follow-Up

Next honest step after this PR:
- Wave 2 parser/sema/type admission for the first ordered-sequence source surface