### PR TITLE
POST-M8.3 Wave 2: admit sequence literals and equality

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -6,8 +6,9 @@ use crate::types::{
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
     RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, SchemaVersion, Stmt, StmtId, SymbolId, TextLiteral,
-    TextLiteralFamily, Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceLiteral,
+    SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind,
+    TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -1170,6 +1171,9 @@ impl<'a> Parser<'a> {
             }
             return self.parse_paren_expr_or_tuple();
         }
+        if self.eat(TokenKind::LBracket) {
+            return self.parse_bracket_expr();
+        }
         if self.eat(TokenKind::QuadN) {
             return Ok(self.arena.alloc_expr(Expr::QuadLiteral(QuadVal::N)));
         }
@@ -1232,6 +1236,25 @@ impl<'a> Parser<'a> {
             pos: self.pos(),
             message: "expected primary expression".to_string(),
         })
+    }
+
+    fn parse_bracket_expr(&mut self) -> Result<ExprId, FrontendError> {
+        let mut items = Vec::new();
+        while !self.check(TokenKind::RBracket) {
+            items.push(self.parse_expr()?);
+            if self.eat(TokenKind::Comma) {
+                if self.check(TokenKind::RBracket) {
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+        self.expect(TokenKind::RBracket, "expected ']' after sequence literal")?;
+        Ok(self.arena.alloc_expr(Expr::SequenceLiteral(SequenceLiteral {
+            family: SequenceCollectionFamily::OrderedSequence,
+            items,
+        })))
     }
 
     fn parse_adt_ctor_payload_exprs(&mut self) -> Result<Vec<ExprId>, FrontendError> {
@@ -1946,6 +1969,26 @@ impl<'a> Parser<'a> {
                         "expected ')' after Result type arguments",
                     )?;
                     Type::Result(Box::new(ok_ty), Box::new(err_ty))
+                } else {
+                    let record_name = self.expect_symbol()?;
+                    Type::Record(record_name)
+                }
+            } else if t == "Sequence" {
+                let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
+                if self
+                    .tokens
+                    .get(lookahead)
+                    .map(|tok| tok.kind == TokenKind::LParen)
+                    .unwrap_or(false)
+                {
+                    let _ = self.advance();
+                    self.expect(TokenKind::LParen, "expected '(' after Sequence type name")?;
+                    let item = self.parse_type()?;
+                    self.expect(TokenKind::RParen, "expected ')' after Sequence type argument")?;
+                    Type::Sequence(SequenceType {
+                        family: SequenceCollectionFamily::OrderedSequence,
+                        item: Box::new(item),
+                    })
                 } else {
                     let record_name = self.expect_symbol()?;
                     Type::Record(record_name)
@@ -2946,6 +2989,40 @@ fn main() {
                 family: TextLiteralFamily::DoubleQuotedUtf8,
                 spelling,
             }) if spelling == "\"hello\""
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_sequence_literal_and_sequence_type_surface() {
+        let src = r#"
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("sequence literal and Sequence(type) should parse");
+        let func = &program.functions[0];
+
+        let Stmt::Let {
+            name,
+            ty: Some(Type::Sequence(sequence_ty)),
+            value,
+        } = program.arena.stmt(func.body[0])
+        else {
+            panic!("expected sequence-typed let binding");
+        };
+
+        assert_eq!(program.arena.symbol_name(*name), "values");
+        assert_eq!(sequence_ty.family, SequenceCollectionFamily::OrderedSequence);
+        assert_eq!(sequence_ty.item.as_ref(), &Type::I32);
+        assert!(matches!(
+            program.arena.expr(*value),
+            Expr::SequenceLiteral(SequenceLiteral {
+                family: SequenceCollectionFamily::OrderedSequence,
+                items,
+            }) if items.len() == 3
         ));
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1386,11 +1386,17 @@ fn infer_expr_type(
         Expr::QuadLiteral(_) => Ok(Type::Quad),
         Expr::BoolLiteral(_) => Ok(Type::Bool),
         Expr::TextLiteral(_) => Ok(Type::Text),
-        Expr::SequenceLiteral(_) => Err(FrontendError {
-            pos: 0,
-            message: "ordered sequence literals are not part of the current M8.3 Wave 1 type admission"
-                .to_string(),
-        }),
+        Expr::SequenceLiteral(sequence) => infer_sequence_literal_type(
+            sequence,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            None,
+            ret_ty,
+            loop_stack,
+        ),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
             NumericLiteral::U32(_) => Ok(Type::U32),
@@ -2057,6 +2063,54 @@ mod tests {
         assert!(err
             .message
             .contains("text concatenation is not part of the current M8.1 Wave 2 contract"));
+    }
+
+    #[test]
+    fn sequence_literal_and_equality_surface_typechecks_in_wave2() {
+        let src = r#"
+            fn id(values: Sequence(i32)) -> Sequence(i32) {
+                return values;
+            }
+
+            fn main() {
+                let left: Sequence(i32) = [1, 2, 3];
+                let right: Sequence(i32) = id([1, 2, 3]);
+                let same = left == right;
+                if same { return; } else { return; }
+            }
+        "#;
+
+        typecheck_source(src).expect("ordered sequence literals and equality should typecheck");
+    }
+
+    #[test]
+    fn empty_sequence_literal_requires_contextual_sequence_type() {
+        let src = r#"
+            fn main() {
+                let values = [];
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("empty ordered sequence literal without context must reject");
+        assert!(err.message.contains(
+            "empty ordered sequence literal currently requires contextual Sequence(type) in M8.3 Wave 2"
+        ));
+    }
+
+    #[test]
+    fn sequence_literal_rejects_heterogeneous_item_types() {
+        let src = r#"
+            fn main() {
+                let values: Sequence(i32) = [1, true];
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("heterogeneous ordered sequence items must reject");
+        assert!(err.message.contains("type mismatch"));
     }
 
     #[test]
@@ -5462,6 +5516,13 @@ fn ensure_type_resolved(
             }
         }
         Type::Option(item) => ensure_type_resolved(item, record_table, adt_table, arena, context),
+        Type::Sequence(sequence) => ensure_type_resolved(
+            sequence.item.as_ref(),
+            record_table,
+            adt_table,
+            arena,
+            context,
+        ),
         Type::Result(ok_ty, err_ty) => {
             ensure_type_resolved(ok_ty, record_table, adt_table, arena, context.clone())?;
             ensure_type_resolved(err_ty, record_table, adt_table, arena, context)
@@ -5481,6 +5542,9 @@ fn ensure_executable_type_supported(
                 ensure_executable_type_supported(item, arena, context.clone())?;
             }
             Ok(())
+        }
+        Type::Sequence(sequence) => {
+            ensure_executable_type_supported(sequence.item.as_ref(), arena, context)
         }
         Type::Measured(base, _) => ensure_executable_type_supported(base, arena, context),
         Type::Option(item) => ensure_executable_type_supported(item, arena, context),
@@ -5513,6 +5577,9 @@ fn ensure_storage_type_supported(
                 ensure_storage_type_supported(item, arena, context.clone())?;
             }
             Ok(())
+        }
+        Type::Sequence(sequence) => {
+            ensure_storage_type_supported(sequence.item.as_ref(), arena, context)
         }
         Type::Measured(base, _) => ensure_storage_type_supported(base, arena, context),
         Type::Option(item) => ensure_storage_type_supported(item, arena, context),
@@ -5658,7 +5725,12 @@ fn supports_stable_equality_type_inner(
         Type::Measured(base, _) => {
             supports_stable_equality_type_inner(base, record_table, adt_table, active)
         }
-        Type::Sequence(_) => Ok(false),
+        Type::Sequence(sequence) => supports_stable_equality_type_inner(
+            sequence.item.as_ref(),
+            record_table,
+            adt_table,
+            active,
+        ),
         Type::QVec(_) => Ok(false),
         Type::RangeI32 => Ok(false),
         Type::Tuple(items) => {
@@ -6078,6 +6150,17 @@ fn infer_expr_type_with_expected(
             }
             Ok(Type::Tuple(item_tys))
         }
+        Expr::SequenceLiteral(sequence) => infer_sequence_literal_type(
+            sequence,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            expected.as_ref(),
+            ret_ty,
+            loop_stack,
+        ),
         Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
             ctor_expr,
             arena,
@@ -6106,6 +6189,101 @@ fn infer_expr_type_with_expected(
             )
         }
     }
+}
+
+fn infer_sequence_literal_type(
+    sequence: &SequenceLiteral,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    expected: Option<&Type>,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+) -> Result<Type, FrontendError> {
+    let expected_item = match expected {
+        Some(Type::Sequence(sequence_ty))
+            if sequence_ty.family == SequenceCollectionFamily::OrderedSequence =>
+        {
+            Some(sequence_ty.item.as_ref())
+        }
+        _ => None,
+    };
+
+    if sequence.items.is_empty() {
+        let Some(expected_item) = expected_item else {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "empty ordered sequence literal currently requires contextual Sequence(type) in M8.3 Wave 2"
+                        .to_string(),
+            });
+        };
+        return Ok(Type::Sequence(SequenceType {
+            family: SequenceCollectionFamily::OrderedSequence,
+            item: Box::new(expected_item.clone()),
+        }));
+    }
+
+    let first_ty = if let Some(expected_item) = expected_item {
+        let actual_ty = infer_expr_type_with_expected(
+            sequence.items[0],
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            Some(expected_item.clone()),
+            ret_ty.clone(),
+            loop_stack,
+        )?;
+        ensure_binding_value_type(
+            expected_item.clone(),
+            actual_ty,
+            sequence.items[0],
+            arena,
+            "ordered sequence item 0".to_string(),
+        )?;
+        expected_item.clone()
+    } else {
+        infer_expr_type(
+            sequence.items[0],
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            ret_ty.clone(),
+            loop_stack,
+        )?
+    };
+
+    for (index, item) in sequence.items.iter().enumerate().skip(1) {
+        let actual_ty = infer_expr_type_with_expected(
+            *item,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            Some(first_ty.clone()),
+            ret_ty.clone(),
+            loop_stack,
+        )?;
+        ensure_binding_value_type(
+            first_ty.clone(),
+            actual_ty,
+            *item,
+            arena,
+            format!("ordered sequence item {}", index),
+        )?;
+    }
+
+    Ok(Type::Sequence(SequenceType {
+        family: SequenceCollectionFamily::OrderedSequence,
+        item: Box::new(first_ty),
+    }))
 }
 
 fn infer_std_form_ctor_type(

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2240,6 +2240,14 @@ fn lower_expr_with_expected(
                     return Ok((dst, Type::Quad));
                 }
                 BinaryOp::Eq => {
+                    if matches!(lt, Type::Sequence(_)) {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message:
+                                "ordered sequence equality is not part of the current M8.3 Wave 2 execution surface"
+                                    .to_string(),
+                        });
+                    }
                     out.push(IrInstr::CmpEq {
                         dst,
                         lhs: lr,
@@ -2248,6 +2256,14 @@ fn lower_expr_with_expected(
                     return Ok((dst, Type::Bool));
                 }
                 BinaryOp::Ne => {
+                    if matches!(lt, Type::Sequence(_)) {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message:
+                                "ordered sequence equality is not part of the current M8.3 Wave 2 execution surface"
+                                    .to_string(),
+                        });
+                    }
                     out.push(IrInstr::CmpNe {
                         dst,
                         lhs: lr,
@@ -6400,6 +6416,26 @@ mod opt_tests {
 
         let bytes = compile_program_to_semcode(src).expect("text semcode should emit");
         assert_eq!(&bytes[0..8], b"SEMCODE8");
+    }
+
+    #[test]
+    fn sequence_equality_stays_outside_wave2_execution_surface() {
+        let src = r#"
+            fn compare(left: Sequence(i32), right: Sequence(i32)) {
+                assert(left == right);
+                return;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = compile_program_to_ir(src)
+            .expect_err("ordered sequence equality must stay outside the Wave 2 execution path");
+        assert!(err.message.contains(
+            "ordered sequence equality is not part of the current M8.3 Wave 2 execution surface"
+        ));
     }
 
     #[test]

--- a/docs/roadmap/language_maturity/collections_surface_full_scope.md
+++ b/docs/roadmap/language_maturity/collections_surface_full_scope.md
@@ -85,18 +85,18 @@ its widened contract on `main`.
 
 ## Current Wave Reading
 
-Current branch scope for Wave 1:
+Current branch scope for Wave 2:
 
-- make the first admitted collection family explicit as an ordered sequence
-  owner-layer surface
-- define deterministic metadata for sequence family, sequence type, and
-  sequence literal ownership
-- keep parser, sema, and runtime admission explicitly outside the Wave 1 slice
+- admit `Sequence(type)` in declared source type positions
+- admit bracketed ordered sequence literals in the Rust-like source path
+- admit same-family equality for ordered sequence values when the item type
+  already supports stable equality
+- keep runtime lowering/indexing/iteration explicitly outside the Wave 2 slice
 
-Still intentionally not included in Wave 1:
+Still intentionally not included in Wave 2:
 
-- parser spelling for sequence literals or sequence types
-- executable typing/equality/indexing/iteration admission
+- indexing or length operations
+- iteration syntax or iterable loops
 - runtime carrier details or VM lowering
 - collection mutation policy beyond the first admitted baseline
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -226,8 +226,10 @@ Current message families include:
   post-stable `fx` arithmetic slice
 - explicit gap messages for text concatenation or text arithmetic beyond the
   current `M8.1` Wave 3 literal/equality/runtime surface
-- explicit gap messages for ordered sequence literals before `M8.3` parser,
-  type, and runtime admission lands
+- explicit gap messages for ordered sequence execution before the `M8.3`
+  runtime carrier slice lands
+- explicit gap messages for ordered sequence equality before the `M8.3` runtime
+  carrier slice lands
 
 Current honest limit:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -304,6 +304,9 @@ Current expression forms:
 - tuple literals:
   - `(1, true)`
   - `(value, ready, 1.0)`
+- ordered sequence literals:
+  - `[1, 2, 3]`
+  - `["alpha", "beta"]`
 - record literals:
   - `DecisionContext { camera: T, quality: 0.75 }`
   - `DecisionContext { quality: 0.75, camera: T }`
@@ -323,6 +326,8 @@ Current expression forms:
   - `(f64, quad, bool)`
 - text type:
   - `text`
+- ordered sequence type:
+  - `Sequence(i32)`
 - first-wave units-of-measure annotations:
   - `f64[m]`
   - `u32[ms]`
@@ -367,6 +372,17 @@ Current text-literal limits:
 - the current executable text surface is only double-quoted same-line text
 - interpolation and multi-line text blocks are not part of the current surface
 - text concatenation is not yet part of the current source contract
+
+Current active collections checkpoint on `main`:
+
+- one ordered sequence family is now admitted in declared type positions as
+  `Sequence(type)`
+- bracketed ordered sequence literals are now admitted in the Rust-like source
+  path
+- same-family equality is now admitted for ordered sequence values when the
+  item type already supports stable equality
+- indexing, iteration, maps, sets, and generic collection abstractions are not
+  part of the current `M8.3` Wave 2 syntax contract
 
 Current v0 range-literal limits:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -287,10 +287,14 @@ The current source type contract does not yet claim stable support for:
 Current active collections checkpoint on `main`:
 
 - `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-- current `main` now owns one ordered sequence collection family as metadata in
-  the frontend owner layer
-- current `main` does not yet admit parser spelling, executable typing, or
-  runtime carriers for that sequence family in the `M8.3` Wave 1 slice
+- current `main` now admits one ordered sequence collection family through
+  `Sequence(type)` in declared source type positions
+- current `main` now admits bracketed ordered sequence literals in the
+  Rust-like source path
+- current `main` now admits same-family equality for ordered sequence values
+  when the item type already supports stable equality
+- current `main` still does not admit runtime carriers, indexing, or iteration
+  for that sequence family in the `M8.3` Wave 2 slice
 
 ## Contract Rule
 


### PR DESCRIPTION
## What This PR Does\n- admits Sequence(type) parsing and bracket sequence literal parsing\n- admits homogeneous sequence literal typing and same-family == / != surface\n- keeps runtime out of scope by freezing explicit Wave 2 lowering gaps for sequence literals and equality\n- syncs collections docs/spec wording to the admitted Wave 2 source surface\n\n## What This PR Does Not Do\n- no runtime or VM sequence carrier\n- no indexing or iteration\n- no maps, sets, or generics\n\n## Stable Boundary Statement\nPublished 1.1.1:\n- no collection execution surface\n\nCurrent main after this PR:\n- widened source surface on main would admit declared Sequence(type), bracket sequence literals, and same-family equality\n- execution remains outside scope until the next slice\n\n## Verification\n- cargo test -p sm-front\n- cargo test -p sm-ir\n- cargo test --test public_api_contracts\n- cargo test --workspace\n\n## Follow-Up\nNext honest step after this PR: Wave 3 on canonical runtime carrier, indexing baseline, and deterministic sequence equality execution.\n\nCloses part of #229