### PR TITLE
POST-M8.3 Wave 4: close out collections track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -36,9 +36,10 @@ Current post-`v1` wave:
 - `M8.2 Package Ecosystem Baseline` is now completed as first-wave baseline
   history and is scoped in
   `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-- `M8.3 Collections Surface` is now the active `M8` subtrack and is scoped in
+- `M8.3 Collections Surface` is now completed as first-wave baseline history
+  and is scoped in
   `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-- the next candidate inside `M8` after collections is `M8.4 First-Class Closures`
+- the next active candidate inside `M8` is `M8.4 First-Class Closures`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -21,6 +21,7 @@ Current post-stable admitted families on `main`:
 - `SEMCODE6`
 - `SEMCODE7`
 - `SEMCODE8`
+- `SEMCODE9`
 
 Current compatibility rule:
 
@@ -94,6 +95,9 @@ Current `v1` scope commitment:
 - the same forward-only reading also applies to the first-wave package
   ecosystem baseline on current `main`, including `Semantic.package`,
   deterministic local-path dependency loading, and package-qualified imports
+- the same forward-only reading also applies to the first-wave ordered
+  sequence collection surface on current `main`, including `Sequence(type)`,
+  bracketed literals, same-family equality, `expr[index]`, and `SEMCODE9`
 
 ## Explicit Non-Commitments
 
@@ -113,6 +117,8 @@ The repository does not yet claim final compatibility guarantees for:
   contract on `main`
 - package ecosystem semantics beyond the current admitted first-wave local-path
   manifest/dependency baseline on `main`
+- collection semantics beyond the current admitted first-wave ordered sequence
+  carrier/index/equality contract on `main`
 - broader packaged release layout beyond the current stable assets
 
 ## Release Honesty Rule

--- a/docs/roadmap/language_maturity/collections_surface_full_scope.md
+++ b/docs/roadmap/language_maturity/collections_surface_full_scope.md
@@ -1,6 +1,6 @@
 # Collections Surface Full Scope
 
-Status: active M8.3 post-stable subtrack
+Status: completed M8.3 first-wave post-stable subtrack
 Related roadmap package:
 `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
 
@@ -83,35 +83,23 @@ its widened contract on `main`.
 4. PR 4: runtime/VM iteration and indexing baseline
 5. PR 5: freeze and close-out
 
-## Current Wave Reading
+## Final First-Wave Reading
 
-Current branch scope for Wave 2:
+Completed `M8.3` first-wave contract on current `main`:
 
-- admit `Sequence(type)` in declared source type positions
-- admit bracketed ordered sequence literals in the Rust-like source path
-- admit same-family equality for ordered sequence values when the item type
-  already supports stable equality
-- keep runtime lowering/indexing/iteration explicitly outside the Wave 2 slice
+- one ordered sequence family is explicit in declared type positions through
+  `Sequence(type)`
+- bracketed ordered sequence literals are admitted in the Rust-like source path
+- same-family equality is admitted when the item type already supports stable
+  equality
+- `expr[index]` is admitted with `i32` index operands
+- canonical verified execution is admitted through the promoted `SEMCODE9` /
+  `CAP_SEQUENCE_VALUES` contract
 
-Still intentionally not included in Wave 2:
+Still intentionally not included after close-out:
 
-- indexing or length operations
-- iteration syntax or iterable loops
-- runtime carrier details or VM lowering
-- collection mutation policy beyond the first admitted baseline
-
-Current branch scope for Wave 3:
-
-- canonical runtime carrier for admitted ordered sequence values
-- deterministic `expr[index]` execution with `i32` index operands
-- same-family verified runtime equality for admitted ordered sequence values
-- promoted `SEMCODE9` / `CAP_SEQUENCE_VALUES` contract for programs that
-  actually require the widened sequence carrier
-
-Still intentionally not included in Wave 3:
-
-- `len` / `is_empty` surface
-- `for value in sequence` or any general iterable loop story
+- `len` / `is_empty`
+- `for value in sequence` or any iterable loop story
 - maps, sets, or generic collection abstractions
 - host-ABI widening for sequence values
 
@@ -134,3 +122,10 @@ Even after this first wave lands, the repository still does not claim:
 - generic iterator/protocol frameworks
 - lazy collection pipelines or comprehensions
 - that collection support was already part of the published `v1.1.1` line
+
+## Close-Out Reading
+
+`M8.3` is now frozen as completed first-wave baseline history.
+
+The next language-facing candidate inside the `M8` package is `M8.4
+First-Class Closures`.

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -85,7 +85,7 @@ Current completed checkpoint:
 - Wave 3: iteration/runtime/VM path
 - Wave 4: docs/tests/compatibility freeze
 
-Current active checkpoint:
+Current completed checkpoint:
 
 - `docs/roadmap/language_maturity/collections_surface_full_scope.md`
 

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -100,11 +100,11 @@ Current completed second subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
 
-Current active third subtrack checkpoint:
+Current completed third subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/collections_surface_full_scope.md`
 
-Current next candidate after collections:
+Current next candidate after the completed collections first wave:
 
 - first-class closures
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -115,9 +115,9 @@
     `docs/roadmap/language_maturity/text_type_full_scope.md`
   - current completed second subtrack:
     `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-  - current active third subtrack:
+  - current completed third subtrack:
     `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-  - current next candidate after collections:
+  - current next candidate after the completed collections first wave:
     `M8.4 First-Class Closures`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -105,6 +105,10 @@ The following limits remain explicit and should be treated as release-facing hon
   ecosystem baseline, even though current `main` now admits `Semantic.package`
   parsing, package entry-module admission, and deterministic local-path
   dependency loading for package-qualified imports
+- the published `v1.1.1` line intentionally excludes the first-wave ordered
+  sequence collection surface, even though current `main` now admits
+  `Sequence(type)`, bracketed literals, same-family equality, `expr[index]`,
+  and canonical verified execution through `SEMCODE9`
 - current `main` still does not claim rollback, retry/compensation, or generic
   mixed-family rule-effect execution semantics
 - current `main` still does not claim rollback, migration, recovery, or


### PR DESCRIPTION
# POST-M8.3 Wave 4: close out collections track

Closes part of: #229
Slice type: docs-only
One PR = one logical step.

## What This PR Does

- marks M8.3 Collections Surface as completed first-wave history
- syncs M8 roadmap/planning docs so M8.4 First-Class Closures reads as the next candidate
- updates release-facing honesty so published 1.1.1 and widened main remain explicitly distinguished for collections

## What This PR Does Not Do

- any new collection semantics
- iteration, len, or is_empty
- any code or runtime widening

## Stable Boundary Statement

Published 1.1.1:
- still has no executable collection carrier surface

Current main after prior Wave 3 and this close-out:
- admits one ordered sequence family with literals, xpr[index], same-family equality, and canonical verified execution under SEMCODE9

This PR is:
- [x] release-maintenance only
- [ ] forward-only widening on main
- [x] not a retroactive widening of published stable

## Files / Ownership

Owner docs touched:

- docs/roadmap/language_maturity/collections_surface_full_scope.md
- docs/roadmap/language_maturity/m8_everyday_expressiveness_*
- docs/roadmap/backlog.md
- docs/roadmap/milestones.md
- docs/roadmap/v1_readiness.md
- docs/roadmap/compatibility_statement.md

## Verification

- [ ] cargo test --workspace
- [ ] cargo test --test public_api_contracts
- [x] docs/spec updated if contract changed

Exact commands run:

`powershell
# docs-only slice; no additional code tests rerun
`

## Follow-Up

Next honest step after this PR:

- open M8.4 First-Class Closures through a new scope checkpoint, or stop at a clean baseline