### PR TITLE
Docs: define M8.4 closures scope checkpoint

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -39,7 +39,9 @@ Current post-`v1` wave:
 - `M8.3 Collections Surface` is now completed as first-wave baseline history
   and is scoped in
   `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-- the next active candidate inside `M8` is `M8.4 First-Class Closures`
+- `M8.4 First-Class Closures` is now the active `M8` subtrack and is scoped
+  in
+  `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/first_class_closures_full_scope.md
+++ b/docs/roadmap/language_maturity/first_class_closures_full_scope.md
@@ -1,0 +1,116 @@
+# First-Class Closures Full Scope
+
+Status: active M8.4 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first admitted first-class closure surface for Semantic without
+silently widening the published `v1.1.1` line and without opening generics,
+traits, or async/runtime machinery ahead of schedule.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that first-class closures already exist on the published stable line.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- short lambdas exist only as immediate-call or pipeline sugar
+- short lambdas are not first-class values in the public language contract
+- short lambdas are capture-free in the current stable source contract
+- the published `v1.1.1` line does not claim closure values, closure types, or
+  closure runtime carriers
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of one first-wave closure value family
+- a narrow closure type spelling for admitted source positions
+- deterministic immutable capture policy for admitted closure values
+- direct invocation of admitted closure values
+- local binding, parameter, and return transport for admitted closures
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- multi-argument closure syntax
+- async closures or coroutine semantics
+- mutable capture or by-reference capture semantics
+- trait/protocol-based callable abstractions
+- generic closure signatures or higher-kinded callable machinery
+- host-ABI widening for closure values
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- closure family ownership
+- closure type/literal/capture metadata inventory
+- deterministic closure value-model boundaries
+
+### Wave 2 — Source Admission
+
+- parser admission
+- sema/type admission
+- explicit diagnostics for unsupported closure forms
+
+### Wave 3 — Execution Path
+
+- lowering/runtime/VM closure carrier path
+- deterministic immutable capture materialization
+- direct invocation path for admitted closure values
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: owner-layer closure family surface
+3. PR 3: parser/sema/type admission
+4. PR 4: runtime/VM closure carrier and invocation path
+5. PR 5: freeze and close-out
+
+## Initial First-Wave Reading
+
+The first-wave closure contract is intentionally narrow:
+
+- one parameter only
+- one closure value family only
+- immutable capture only
+- direct call syntax only
+- no trait-based callable overloading
+
+That keeps the track additive over the current short-lambda sugar without
+turning it into a general abstraction system in one step.
+
+## Acceptance Reading
+
+This subtrack is done only when:
+
+- one first-wave closure family is explicit and inspectable
+- closure values, immutable capture, and direct invocation agree on one
+  deterministic first-wave model
+- docs/spec/tests describe the same admitted baseline
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- generic callable abstractions
+- trait/protocol-based closure polymorphism
+- async/generator closure semantics
+- multi-argument or variadic closure families
+- that first-class closures were already part of the published `v1.1.1` line

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -97,6 +97,10 @@ Current completed checkpoint:
 - Wave 3: lowering/runtime representation
 - Wave 4: docs/tests/compatibility freeze
 
+Current active checkpoint:
+
+- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
+
 ## Primary Recommended Order
 
 1. M8.1 Text / strings

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md
@@ -104,9 +104,9 @@ Current completed third subtrack checkpoint:
 
 - `docs/roadmap/language_maturity/collections_surface_full_scope.md`
 
-Current next candidate after the completed collections first wave:
+Current active fourth subtrack checkpoint:
 
-- first-class closures
+- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
 
 ## Explicit Non-Goals
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -117,8 +117,8 @@
     `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
   - current completed third subtrack:
     `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-  - current next candidate after the completed collections first wave:
-    `M8.4 First-Class Closures`
+  - current active fourth subtrack:
+    `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -687,6 +687,12 @@ Current v0 limits:
   argument
 - outer local-name capture is rejected in the current source contract
 
+Current active closures checkpoint on `main`:
+
+- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
+- published `v1.1.1` still keeps short lambdas as capture-free sugar rather
+  than as runtime closure values
+
 ## Operator Meaning
 
 Current operator meaning:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -480,6 +480,12 @@ Current short-lambda rules:
 - typed lambda parameters and multi-argument lambda forms are not yet part of
   the stable source contract
 
+Current active closures checkpoint on `main`:
+
+- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
+- published `v1.1.1` still keeps short lambdas as non-first-class call-site
+  sugar only
+
 Current named-argument rules:
 
 - ordinary user-defined calls may use named arguments

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -300,6 +300,12 @@ Current active collections checkpoint on `main`:
 - current `main` still does not admit iteration, `len`, or `is_empty` for
   that sequence family in the current `M8.3` first-wave surface
 
+Current active closures checkpoint on `main`:
+
+- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
+- published `v1.1.1` still does not claim first-class closure values or
+  closure types in the public source type contract
+
 ## Contract Rule
 
 Any public change to source-visible type meaning or source type-checking rules


### PR DESCRIPTION
# POST-M8.4 Wave 0: define closures scope checkpoint

Closes part of: #235
Slice type: docs-only
One PR = one logical step.

## What This PR Does

- opens M8.4 First-Class Closures through a dedicated scope checkpoint
- syncs M8 roadmap/planning docs so closures become the active M8 subtrack
- adds spec pointers so the current short-lambda baseline and the new closure track are explicitly distinguished

## What This PR Does Not Do

- any closure runtime or typing implementation
- any widening of current short-lambda behavior
- generics, traits, async, or UI/platform work

## Stable Boundary Statement

Published 1.1.1:
- keeps short lambdas as capture-free immediate-call / pipeline sugar only

Current main after this PR:
- still has the same executable behavior, but now has an explicit M8.4 scope checkpoint for first-class closures

This PR is:
- [x] release-maintenance only
- [ ] forward-only widening on main
- [x] not a retroactive widening of published stable

## Files / Ownership

Owner docs touched:

- docs/roadmap/language_maturity/first_class_closures_full_scope.md
- docs/roadmap/language_maturity/m8_everyday_expressiveness_*
- docs/roadmap/backlog.md
- docs/roadmap/milestones.md
- docs/spec/syntax.md
- docs/spec/source_semantics.md
- docs/spec/types.md

## Verification

- [ ] cargo test --workspace
- [ ] cargo test --test public_api_contracts
- [x] docs/spec updated if contract changed

Exact commands run:

`powershell
# docs-only slice; no code tests run in this step
`

## Follow-Up

Next honest step after this PR:

- Wave 1 owner-layer closure family surface