### PR TITLE
POST-M8.4 Wave 1: add closure owner-layer surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -16,14 +16,15 @@ use alloc::vec::Vec;
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use types::{
-    AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg, Expr, ExprId,
+    AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg,
+    ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,
     FrontendError, FrontendErrorKind, Function, IfExpr, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
     SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
-    SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily,
-    Token, TokenKind, TuplePatternItem, Type,
+    SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,
+    TokenKind, TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
 };

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1567,6 +1567,12 @@ impl<'a> Parser<'a> {
                 self.ensure_short_lambda_expr_capture_free(index_expr.base, scopes)?;
                 self.ensure_short_lambda_expr_capture_free(index_expr.index, scopes)
             }
+            Expr::Closure(_) => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "short lambda v0 does not currently allow nested first-class closure values in the lambda body"
+                        .to_string(),
+            }),
             Expr::RecordUpdate(update_expr) => {
                 self.ensure_short_lambda_expr_capture_free(update_expr.base, scopes)?;
                 for field in &update_expr.fields {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1397,6 +1397,12 @@ fn infer_expr_type(
             ret_ty,
             loop_stack,
         ),
+        Expr::Closure(_) => Err(FrontendError {
+            pos: 0,
+            message:
+                "first-class closures are not yet admitted in executable source positions before M8.4 Wave 2"
+                    .to_string(),
+        }),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
             NumericLiteral::U32(_) => Ok(Type::U32),
@@ -5834,6 +5840,7 @@ fn supports_stable_equality_type_inner(
             active.remove(name);
             Ok(true)
         }
+        Type::Closure(_) => Ok(false),
         Type::Adt(_) => Ok(false),
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -11,6 +11,7 @@ pub enum Type {
     Bool,
     Text,
     Sequence(SequenceType),
+    Closure(ClosureType),
     I32,
     U32,
     Fx,
@@ -33,6 +34,12 @@ impl Type {
             Type::Sequence(sequence) => Type::Sequence(SequenceType {
                 family: sequence.family,
                 item: Box::new(sequence.item.erase_units()),
+            }),
+            Type::Closure(closure) => Type::Closure(ClosureType {
+                family: closure.family,
+                capture: closure.capture,
+                param: Box::new(closure.param.erase_units()),
+                ret: Box::new(closure.ret.erase_units()),
             }),
             Type::Option(item) => Type::Option(Box::new(item.erase_units())),
             Type::Result(ok_ty, err_ty) => Type::Result(
@@ -125,6 +132,35 @@ pub struct SequenceIndexExpr {
     pub index: ExprId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClosureValueFamily {
+    UnaryDirect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClosureCapturePolicy {
+    Immutable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ClosureType {
+    pub family: ClosureValueFamily,
+    pub capture: ClosureCapturePolicy,
+    pub param: Box<Type>,
+    pub ret: Box<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ClosureLiteral {
+    pub family: ClosureValueFamily,
+    pub capture: ClosureCapturePolicy,
+    pub param: SymbolId,
+    pub param_ty: Option<Type>,
+    pub ret_ty: Option<Type>,
+    pub captures: Vec<SymbolId>,
+    pub body: ExprId,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CallArg {
     pub name: Option<SymbolId>,
@@ -200,6 +236,7 @@ pub enum Expr {
     RecordLiteral(RecordLiteralExpr),
     RecordField(RecordFieldExpr),
     SequenceIndex(SequenceIndexExpr),
+    Closure(ClosureLiteral),
     RecordUpdate(RecordUpdateExpr),
     AdtCtor(AdtCtorExpr),
     Var(SymbolId),
@@ -783,5 +820,45 @@ mod tests {
         };
         assert_eq!(expr.base, ExprId(3));
         assert_eq!(expr.index, ExprId(4));
+    }
+
+    #[test]
+    fn closure_type_preserves_family_and_erases_nested_units() {
+        let ty = Type::Closure(ClosureType {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: Box::new(Type::Measured(Box::new(Type::Fx), SymbolId(9))),
+            ret: Box::new(Type::Measured(Box::new(Type::F64), SymbolId(10))),
+        });
+        assert_eq!(
+            ty.erase_units(),
+            Type::Closure(ClosureType {
+                family: ClosureValueFamily::UnaryDirect,
+                capture: ClosureCapturePolicy::Immutable,
+                param: Box::new(Type::Fx),
+                ret: Box::new(Type::F64),
+            })
+        );
+        assert!(!ty.is_core_numeric_scalar());
+    }
+
+    #[test]
+    fn closure_literal_owner_layer_is_stable_data() {
+        let literal = ClosureLiteral {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param: SymbolId(2),
+            param_ty: Some(Type::Text),
+            ret_ty: Some(Type::Bool),
+            captures: vec![SymbolId(5), SymbolId(7)],
+            body: ExprId(11),
+        };
+        assert_eq!(literal.family, ClosureValueFamily::UnaryDirect);
+        assert_eq!(literal.capture, ClosureCapturePolicy::Immutable);
+        assert_eq!(literal.param, SymbolId(2));
+        assert_eq!(literal.param_ty, Some(Type::Text));
+        assert_eq!(literal.ret_ty, Some(Type::Bool));
+        assert_eq!(literal.captures, vec![SymbolId(5), SymbolId(7)]);
+        assert_eq!(literal.body, ExprId(11));
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1537,6 +1537,12 @@ fn lower_expr_with_expected(
                 }),
             ))
         }
+        Expr::Closure(_) => Err(FrontendError {
+            pos: 0,
+            message:
+                "first-class closures are not yet admitted in the canonical lowering path before M8.4 Wave 3"
+                    .to_string(),
+        }),
         Expr::Range(range_expr) => {
             let (start_reg, start_ty) = lower_expr_with_expected(
                 range_expr.start,

--- a/crates/sm-sema/src/std_adapters.rs
+++ b/crates/sm-sema/src/std_adapters.rs
@@ -45,6 +45,7 @@ impl From<Type> for SemanticType {
             Type::Bool => SemanticType::Bool,
             Type::Text => SemanticType::Unknown,
             Type::Sequence(_) => SemanticType::Unknown,
+            Type::Closure(_) => SemanticType::Unknown,
             Type::U32 => SemanticType::Int,
             Type::Unit => SemanticType::Unit,
             Type::Measured(base, _) => SemanticType::from((*base).clone()),

--- a/crates/smc-cli/src/api_contract.rs
+++ b/crates/smc-cli/src/api_contract.rs
@@ -262,6 +262,14 @@ fn display_generated_api_type(
                         .to_string(),
             })
         }
+        Type::Closure(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "first-class closure types are not part of the current M8.4 Wave 1 generated API contract surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_generated_api_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/config.rs
+++ b/crates/smc-cli/src/config.rs
@@ -396,6 +396,7 @@ fn validate_value_against_type(
         Type::Option(_)
         | Type::Result(_, _)
         | Type::Sequence(_)
+        | Type::Closure(_)
         | Type::Tuple(_)
         | Type::Adt(_)
         | Type::RangeI32
@@ -509,6 +510,7 @@ fn display_config_type(ty: &Type, contract: &ConfigContract) -> String {
         Type::Sequence(sequence) => {
             format!("ordered-sequence<{}>", display_config_type(sequence.item.as_ref(), contract))
         }
+        Type::Closure(_) => "closure".to_string(),
         Type::Option(item) => format!("Option({})", display_config_type(item, contract)),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/schema_versioning.rs
+++ b/crates/smc-cli/src/schema_versioning.rs
@@ -745,6 +745,14 @@ fn display_schema_compatibility_type(
                         .to_string(),
             })
         }
+        Type::Closure(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "first-class closure types are not part of the current M8.4 Wave 1 schema compatibility surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_schema_compatibility_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/crates/smc-cli/src/wire_contract.rs
+++ b/crates/smc-cli/src/wire_contract.rs
@@ -234,6 +234,14 @@ fn display_generated_wire_type(ty: &Type, arena: &AstArena) -> Result<String, Fr
                         .to_string(),
             })
         }
+        Type::Closure(_) => {
+            return Err(FrontendError {
+                pos: 0,
+                message:
+                    "first-class closure types are not part of the current M8.4 Wave 1 generated wire-contract surface"
+                        .to_string(),
+            })
+        }
         Type::Option(item) => format!("Option({})", display_generated_wire_type(item, arena)?),
         Type::Result(ok_ty, err_ty) => format!(
             "Result({}, {})",

--- a/docs/roadmap/language_maturity/first_class_closures_full_scope.md
+++ b/docs/roadmap/language_maturity/first_class_closures_full_scope.md
@@ -57,6 +57,7 @@ its widened contract on `main`.
 - closure family ownership
 - closure type/literal/capture metadata inventory
 - deterministic closure value-model boundaries
+- explicit typecheck/lowering gap diagnostics before executable admission
 
 ### Wave 2 — Source Admission
 
@@ -94,6 +95,15 @@ The first-wave closure contract is intentionally narrow:
 
 That keeps the track additive over the current short-lambda sugar without
 turning it into a general abstraction system in one step.
+
+Current Wave 1 reading on `main`:
+
+- current `main` now owns one first-wave closure family in the frontend owner
+  layer
+- current `main` does not yet admit first-class closures in executable parser or
+  source-typing positions
+- current `main` surfaces explicit Wave 1 gap diagnostics instead of silently
+  widening parsing or runtime behavior
 
 ## Acceptance Reading
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -68,6 +68,9 @@ Current honest limit:
   type spelling in the source parser path
 - exact parse wording for text-surface gaps is not yet a long-term frozen
   compatibility promise
+- current `main` does not yet admit first-class closure syntax in the source
+  parser path; Wave 1 closure diagnostics are still explicit gap wording rather
+  than frozen parser-surface compatibility
 
 ## Policy Diagnostics
 
@@ -136,6 +139,7 @@ Current message families include:
 - range literal requires `i32` bounds
 - range equality not part of stable v0 range surface
 - range literal rejected in tuple/user-data position
+- first-class closure values not yet admitted before `M8.4 Wave 2`
 - for-range requires `i32` range expression
 - duplicate record declaration
 - duplicate schema declaration

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -92,6 +92,25 @@ Current text-surface limits:
 - interpolation, formatting, escape-rich string syntax, and host/runtime text
   ABI widening are not part of the current contract
 
+## First-Class Closures
+
+Current honest baseline:
+
+- the published stable `v1.1.1` line does not claim first-class closure values
+  or closure types
+- current `main` now owns one first-wave closure family in the frontend owner
+  layer
+- current `main` does not yet admit first-class closures in executable parser
+  positions, declared type positions, or runtime carriers
+
+Current first-wave limits:
+
+- immutable capture only is the intended direction for the first-wave family
+- direct invocation only is the intended call model for that family
+- executable admission still begins in `M8.4 Wave 2`
+- generic callable abstractions, traits/protocols, async closures, and host-ABI
+  closure transport are not part of the current contract
+
 ## Unit
 
 `unit` is the implicit type of functions without an explicit return type.


### PR DESCRIPTION
## What This PR Does
- adds one first-wave closure owner layer in \\sm-front\\
- introduces closure family/type/literal/capture metadata without parser admission
- adds explicit Wave 1 typecheck/lowering gaps instead of widening runtime behavior
- syncs docs/spec wording for the Wave 1 reading

## What This PR Does Not Do
- no parser admission
- no executable source typing/invocation
- no runtime/VM closure carrier
- no generics, traits, async, or host-ABI widening

## Stable Boundary Statement
Published \\1.1.1\\:
- no first-class closures

Current \\main\\ after this PR:
- one owner-layer closure family exists in the frontend model, but executable admission still starts in Wave 2

## Verification
- \\cargo test -p sm-front\\
- \\cargo test -p sm-ir\\
- \\cargo test --test public_api_contracts\\
- \\cargo test --workspace\\

## Follow-Up
- Wave 2 parser/sema/type admission for first-class closures