### PR TITLE
POST-M8.4 Wave 2: admit closure literals and type surface

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1,14 +1,15 @@
 use crate::lexer::lex_tokens;
 use crate::types::{
     AdtCtorExpr, AdtDecl, AdtMatchPattern, AdtPatternItem, AdtVariant, AstArena, BinaryOp,
-    BlockExpr, CallArg, Expr, ExprId, FrontendError, Function, IfExpr, LogosEntity,
-    LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
-    LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
-    RangeExpr, RecordDecl, RecordField, RecordFieldExpr, RecordInitField, RecordLiteralExpr,
-    RecordPatternItem, RecordPatternTarget, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
-    SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily,
-    Token, TokenKind, TuplePatternItem, Type, UnaryOp,
+    BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily, Expr, ExprId,
+    FrontendError, Function, IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind,
+    LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm,
+    MatchPattern, NumericLiteral, Program, QuadVal, RangeExpr, RecordDecl, RecordField,
+    RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordPatternItem, RecordPatternTarget,
+    RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
+    SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType,
+    Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, TuplePatternItem,
+    Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -1457,25 +1458,27 @@ impl<'a> Parser<'a> {
         )?;
         let body = self.parse_expr()?;
         self.expect(TokenKind::RParen, "expected ')' after short lambda body")?;
-        self.ensure_short_lambda_capture_free(body, param)?;
 
-        let arg = if from_pipeline {
-            pipeline_input.expect("pipeline input must be provided for pipeline short lambda")
-        } else {
-            self.parse_short_lambda_immediate_arg()?
-        };
-        self.build_short_lambda_apply(param, body, arg)
+        if from_pipeline {
+            self.ensure_short_lambda_capture_free(body, param)?;
+            let arg = pipeline_input.expect("pipeline input must be provided for pipeline short lambda");
+            return self.build_short_lambda_apply(param, body, arg);
+        }
+
+        if self.check(TokenKind::LParen) {
+            self.ensure_short_lambda_capture_free(body, param)?;
+            let arg = self.parse_short_lambda_immediate_arg()?;
+            return self.build_short_lambda_apply(param, body, arg);
+        }
+
+        self.build_first_class_closure_literal(param, body)
     }
 
     fn parse_short_lambda_immediate_arg(&mut self) -> Result<ExprId, FrontendError> {
-        if !self.eat(TokenKind::LParen) {
-            return Err(FrontendError {
-                pos: self.pos(),
-                message:
-                    "short lambda is v0 call-site sugar only; use immediate invocation '(x => expr)(arg)' or pipeline stage 'value |> (x => expr)'"
-                        .to_string(),
-            });
-        }
+        self.expect(
+            TokenKind::LParen,
+            "short lambda direct call currently requires form '(x => expr)(arg)'",
+        )?;
         if self.check(TokenKind::RParen) {
             return Err(FrontendError {
                 pos: self.pos(),
@@ -1496,6 +1499,23 @@ impl<'a> Parser<'a> {
         Ok(arg)
     }
 
+    fn build_first_class_closure_literal(
+        &mut self,
+        param: SymbolId,
+        body: ExprId,
+    ) -> Result<ExprId, FrontendError> {
+        let captures = self.collect_short_lambda_captures(body, param)?;
+        Ok(self.arena.alloc_expr(Expr::Closure(ClosureLiteral {
+            family: ClosureValueFamily::UnaryDirect,
+            capture: ClosureCapturePolicy::Immutable,
+            param,
+            param_ty: None,
+            ret_ty: None,
+            captures,
+            body,
+        })))
+    }
+
     fn build_short_lambda_apply(
         &mut self,
         param: SymbolId,
@@ -1511,6 +1531,183 @@ impl<'a> Parser<'a> {
             statements: vec![binding],
             tail: body,
         })))
+    }
+
+    fn collect_short_lambda_captures(
+        &self,
+        body: ExprId,
+        param: SymbolId,
+    ) -> Result<Vec<SymbolId>, FrontendError> {
+        let mut scopes = vec![vec![param]];
+        let mut captures = Vec::new();
+        self.collect_short_lambda_expr_captures(body, &mut scopes, &mut captures)?;
+        Ok(captures)
+    }
+
+    fn collect_short_lambda_expr_captures(
+        &self,
+        expr_id: ExprId,
+        scopes: &mut Vec<Vec<SymbolId>>,
+        captures: &mut Vec<SymbolId>,
+    ) -> Result<(), FrontendError> {
+        match self.arena.expr(expr_id) {
+            Expr::QuadLiteral(_)
+            | Expr::BoolLiteral(_)
+            | Expr::TextLiteral(_)
+            | Expr::NumericLiteral(_) => Ok(()),
+            Expr::Range(range_expr) => {
+                self.collect_short_lambda_expr_captures(range_expr.start, scopes, captures)?;
+                self.collect_short_lambda_expr_captures(range_expr.end, scopes, captures)
+            }
+            Expr::Tuple(items) => {
+                for item in items {
+                    self.collect_short_lambda_expr_captures(*item, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::SequenceLiteral(sequence) => {
+                for item in &sequence.items {
+                    self.collect_short_lambda_expr_captures(*item, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::RecordLiteral(record) => {
+                for field in &record.fields {
+                    self.collect_short_lambda_expr_captures(field.value, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::AdtCtor(ctor) => {
+                for item in &ctor.payload {
+                    self.collect_short_lambda_expr_captures(*item, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::RecordField(field_expr) => {
+                self.collect_short_lambda_expr_captures(field_expr.base, scopes, captures)
+            }
+            Expr::SequenceIndex(index_expr) => {
+                self.collect_short_lambda_expr_captures(index_expr.base, scopes, captures)?;
+                self.collect_short_lambda_expr_captures(index_expr.index, scopes, captures)
+            }
+            Expr::Closure(_) => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "nested first-class closure literals are not yet admitted before M8.4 Wave 2"
+                        .to_string(),
+            }),
+            Expr::RecordUpdate(update_expr) => {
+                self.collect_short_lambda_expr_captures(update_expr.base, scopes, captures)?;
+                for field in &update_expr.fields {
+                    self.collect_short_lambda_expr_captures(field.value, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::Var(name) => {
+                if scopes.iter().rev().any(|scope| scope.contains(name)) {
+                    Ok(())
+                } else {
+                    if !captures.contains(name) {
+                        captures.push(*name);
+                    }
+                    Ok(())
+                }
+            }
+            Expr::Call(_, args) => {
+                for arg in args {
+                    self.collect_short_lambda_expr_captures(arg.value, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::Unary(_, inner) => self.collect_short_lambda_expr_captures(*inner, scopes, captures),
+            Expr::Binary(lhs, _, rhs) => {
+                self.collect_short_lambda_expr_captures(*lhs, scopes, captures)?;
+                self.collect_short_lambda_expr_captures(*rhs, scopes, captures)
+            }
+            Expr::Block(block) => self.collect_short_lambda_block_captures(block, scopes, captures),
+            Expr::If(if_expr) => {
+                self.collect_short_lambda_expr_captures(if_expr.condition, scopes, captures)?;
+                self.collect_short_lambda_block_captures(&if_expr.then_block, scopes, captures)?;
+                self.collect_short_lambda_block_captures(&if_expr.else_block, scopes, captures)
+            }
+            Expr::Match(match_expr) => {
+                self.collect_short_lambda_expr_captures(match_expr.scrutinee, scopes, captures)?;
+                for arm in &match_expr.arms {
+                    scopes.push(self.short_lambda_match_pattern_bindings(&arm.pat));
+                    if let Some(guard) = arm.guard {
+                        self.collect_short_lambda_expr_captures(guard, scopes, captures)?;
+                    }
+                    self.collect_short_lambda_block_captures(&arm.block, scopes, captures)?;
+                    let _ = scopes.pop();
+                }
+                if let Some(default) = &match_expr.default {
+                    self.collect_short_lambda_block_captures(default, scopes, captures)?;
+                }
+                Ok(())
+            }
+            Expr::Loop(_) => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "first-class closure literals do not yet admit loop expressions in the closure body"
+                        .to_string(),
+            }),
+        }
+    }
+
+    fn collect_short_lambda_block_captures(
+        &self,
+        block: &BlockExpr,
+        scopes: &mut Vec<Vec<SymbolId>>,
+        captures: &mut Vec<SymbolId>,
+    ) -> Result<(), FrontendError> {
+        scopes.push(Vec::new());
+        for stmt_id in &block.statements {
+            self.collect_short_lambda_stmt_captures(*stmt_id, scopes, captures)?;
+        }
+        self.collect_short_lambda_expr_captures(block.tail, scopes, captures)?;
+        let _ = scopes.pop();
+        Ok(())
+    }
+
+    fn collect_short_lambda_stmt_captures(
+        &self,
+        stmt_id: StmtId,
+        scopes: &mut Vec<Vec<SymbolId>>,
+        captures: &mut Vec<SymbolId>,
+    ) -> Result<(), FrontendError> {
+        match self.arena.stmt(stmt_id) {
+            Stmt::Const { name, value, .. } => {
+                self.collect_short_lambda_expr_captures(*value, scopes, captures)?;
+                if let Some(scope) = scopes.last_mut() {
+                    scope.push(*name);
+                }
+                Ok(())
+            }
+            Stmt::Let { name, value, .. } => {
+                self.collect_short_lambda_expr_captures(*value, scopes, captures)?;
+                if let Some(scope) = scopes.last_mut() {
+                    scope.push(*name);
+                }
+                Ok(())
+            }
+            Stmt::LetTuple { items, value, .. } => {
+                self.collect_short_lambda_expr_captures(*value, scopes, captures)?;
+                if let Some(scope) = scopes.last_mut() {
+                    scope.extend(items.iter().flatten().copied());
+                }
+                Ok(())
+            }
+            Stmt::Discard { value, .. } => {
+                self.collect_short_lambda_expr_captures(*value, scopes, captures)
+            }
+            Stmt::Expr(expr_id) => self.collect_short_lambda_expr_captures(*expr_id, scopes, captures),
+            _ => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "first-class closure literals currently support only expression-compatible block forms"
+                        .to_string(),
+            }),
+        }
     }
 
     fn ensure_short_lambda_capture_free(
@@ -2006,6 +2203,33 @@ impl<'a> Parser<'a> {
                     Type::Sequence(SequenceType {
                         family: SequenceCollectionFamily::OrderedSequence,
                         item: Box::new(item),
+                    })
+                } else {
+                    let record_name = self.expect_symbol()?;
+                    Type::Record(record_name)
+                }
+            } else if t == "Closure" {
+                let lookahead = self.next_non_layout_idx_from(self.next_non_layout_idx() + 1);
+                if self
+                    .tokens
+                    .get(lookahead)
+                    .map(|tok| tok.kind == TokenKind::LParen)
+                    .unwrap_or(false)
+                {
+                    let _ = self.advance();
+                    self.expect(TokenKind::LParen, "expected '(' after Closure type name")?;
+                    let param_ty = self.parse_type()?;
+                    self.expect(
+                        TokenKind::Implies,
+                        "expected '->' between Closure parameter and return types",
+                    )?;
+                    let ret_ty = self.parse_type()?;
+                    self.expect(TokenKind::RParen, "expected ')' after Closure type")?;
+                    Type::Closure(crate::types::ClosureType {
+                        family: ClosureValueFamily::UnaryDirect,
+                        capture: ClosureCapturePolicy::Immutable,
+                        param: Box::new(param_ty),
+                        ret: Box::new(ret_ty),
                     })
                 } else {
                     let record_name = self.expect_symbol()?;
@@ -3284,19 +3508,76 @@ fn main() {
     }
 
     #[test]
-    fn rustlike_parser_rejects_standalone_short_lambda_value() {
+    fn rustlike_parser_accepts_standalone_first_class_closure_value() {
         let src = r#"
 fn main() {
-    let value: f64 = (x => x + 1.0);
+    let value: Closure(f64 -> f64) = (x => x + 1.0);
     return;
 }
 "#;
 
-        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect_err("standalone short lambda must reject");
-        assert!(err
-            .message
-            .contains("short lambda is v0 call-site sugar only"));
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("standalone first-class closure should parse");
+        let func = &program.functions[0];
+        let Stmt::Let {
+            ty: Some(Type::Closure(closure_ty)),
+            value,
+            ..
+        } = program.arena.stmt(func.body[0]) else {
+            panic!("expected typed let closure statement");
+        };
+        assert_eq!(closure_ty.family, ClosureValueFamily::UnaryDirect);
+        assert_eq!(closure_ty.capture, ClosureCapturePolicy::Immutable);
+        let Expr::Closure(closure) = program.arena.expr(*value) else {
+            panic!("expected closure literal");
+        };
+        assert_eq!(closure.family, ClosureValueFamily::UnaryDirect);
+        assert_eq!(closure.capture, ClosureCapturePolicy::Immutable);
+        assert!(closure.captures.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_collects_first_class_closure_capture_inventory() {
+        let src = r#"
+fn main() {
+    let offset: f64 = 1.0;
+    let value: Closure(f64 -> f64) = (x => x + offset);
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("capturing closure literal should parse");
+        let func = &program.functions[0];
+        let Stmt::Let { value, .. } = program.arena.stmt(func.body[1]) else {
+            panic!("expected closure let statement");
+        };
+        let Expr::Closure(closure) = program.arena.expr(*value) else {
+            panic!("expected closure literal");
+        };
+        assert_eq!(closure.captures.len(), 1);
+        assert_eq!(program.arena.symbol_name(closure.captures[0]), "offset");
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_closure_type_in_function_signature() {
+        let src = r#"
+fn id(value: Closure(f64 -> f64)) -> Closure(f64 -> f64) = value;
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("closure type in signature should parse");
+        let func = &program.functions[0];
+        assert_eq!(
+            func.params[0].1,
+            Type::Closure(crate::types::ClosureType {
+                family: ClosureValueFamily::UnaryDirect,
+                capture: ClosureCapturePolicy::Immutable,
+                param: Box::new(Type::F64),
+                ret: Box::new(Type::F64),
+            })
+        );
+        assert_eq!(func.ret, func.params[0].1);
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1397,12 +1397,17 @@ fn infer_expr_type(
             ret_ty,
             loop_stack,
         ),
-        Expr::Closure(_) => Err(FrontendError {
-            pos: 0,
-            message:
-                "first-class closures are not yet admitted in executable source positions before M8.4 Wave 2"
-                    .to_string(),
-        }),
+        Expr::Closure(closure) => infer_closure_literal_type(
+            closure,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            None,
+            ret_ty,
+            loop_stack,
+        ),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
             NumericLiteral::U32(_) => Ok(Type::U32),
@@ -1614,6 +1619,13 @@ fn infer_expr_type(
                 s.clone()
             } else if let Some(s) = builtin_sig(resolve_symbol_name(arena, *name)?) {
                 s
+            } else if matches!(env.get(*name), Some(Type::Closure(_))) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "direct invocation of first-class closure values is not yet admitted before M8.4 Wave 3"
+                            .to_string(),
+                });
             } else {
                 return Err(FrontendError {
                     pos: 0,
@@ -2752,6 +2764,49 @@ mod tests {
 
         let err = typecheck_source(src).expect_err("captureful short lambda must reject");
         assert!(err.message.contains("capture-free only"));
+    }
+
+    #[test]
+    fn first_class_closure_literal_requires_contextual_type() {
+        let src = r#"
+            fn main() {
+                let value = (x => x);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("closure literal without context must reject");
+        assert!(err.message.contains("contextual Closure(T -> U) type"));
+    }
+
+    #[test]
+    fn first_class_closure_literal_typechecks_with_declared_signature_and_capture() {
+        let src = r#"
+            fn keep(f: Closure(f64 -> f64)) -> Closure(f64 -> f64) = f;
+
+            fn main() {
+                let offset: f64 = 1.0;
+                let f: Closure(f64 -> f64) = (x => x + offset);
+                let g: Closure(f64 -> f64) = keep(f);
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("contextual first-class closure should typecheck");
+    }
+
+    #[test]
+    fn direct_first_class_closure_invocation_is_deferred_to_wave3() {
+        let src = r#"
+            fn main() {
+                let f: Closure(f64 -> f64) = (x => x + 1.0);
+                let total: f64 = f(2.0);
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("closure invocation must stay deferred");
+        assert!(err.message.contains("not yet admitted before M8.4 Wave 3"));
     }
 
     #[test]
@@ -6295,6 +6350,17 @@ fn infer_expr_type_with_expected(
             ret_ty,
             loop_stack,
         ),
+        Expr::Closure(closure) => infer_closure_literal_type(
+            closure,
+            arena,
+            env,
+            table,
+            record_table,
+            adt_table,
+            expected.as_ref(),
+            ret_ty,
+            loop_stack,
+        ),
         Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
             ctor_expr,
             arena,
@@ -6418,6 +6484,71 @@ fn infer_sequence_literal_type(
         family: SequenceCollectionFamily::OrderedSequence,
         item: Box::new(first_ty),
     }))
+}
+
+fn infer_closure_literal_type(
+    closure: &ClosureLiteral,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    expected: Option<&Type>,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+) -> Result<Type, FrontendError> {
+    let Some(Type::Closure(expected_closure)) = expected else {
+        return Err(FrontendError {
+            pos: 0,
+            message:
+                "first-class closure literals currently require contextual Closure(T -> U) type in M8.4 Wave 2"
+                    .to_string(),
+        });
+    };
+
+    if expected_closure.family != closure.family || expected_closure.capture != closure.capture {
+        return Err(FrontendError {
+            pos: 0,
+            message:
+                "first-class closure literal does not match the current Wave 2 closure family/capture contract"
+                    .to_string(),
+        });
+    }
+
+    for capture in &closure.captures {
+        if env.get(*capture).is_none() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "unknown captured value '{}' in first-class closure literal",
+                    resolve_symbol_name(arena, *capture)?
+                ),
+            });
+        }
+    }
+
+    let mut closure_env = env.clone();
+    closure_env.push_scope();
+    closure_env.insert(closure.param, expected_closure.param.as_ref().clone());
+    let body_ty = infer_expr_type_with_expected(
+        closure.body,
+        arena,
+        &closure_env,
+        table,
+        record_table,
+        adt_table,
+        Some(expected_closure.ret.as_ref().clone()),
+        ret_ty,
+        loop_stack,
+    )?;
+    ensure_binding_value_type(
+        expected_closure.ret.as_ref().clone(),
+        body_ty,
+        closure.body,
+        arena,
+        "first-class closure body".to_string(),
+    )?;
+    Ok(Type::Closure(expected_closure.clone()))
 }
 
 fn infer_std_form_ctor_type(

--- a/docs/roadmap/language_maturity/first_class_closures_full_scope.md
+++ b/docs/roadmap/language_maturity/first_class_closures_full_scope.md
@@ -96,14 +96,16 @@ The first-wave closure contract is intentionally narrow:
 That keeps the track additive over the current short-lambda sugar without
 turning it into a general abstraction system in one step.
 
-Current Wave 1 reading on `main`:
+Current Wave 2 reading on `main`:
 
 - current `main` now owns one first-wave closure family in the frontend owner
   layer
-- current `main` does not yet admit first-class closures in executable parser or
-  source-typing positions
-- current `main` surfaces explicit Wave 1 gap diagnostics instead of silently
-  widening parsing or runtime behavior
+- current `main` now admits `Closure(T -> U)` in declared source type positions
+- current `main` now admits standalone first-class closure literals in
+  contextual closure-typed positions
+- current `main` records immutable capture inventory for admitted standalone
+  closure literals
+- direct invocation and runtime closure carriers still remain deferred to Wave 3
 
 ## Acceptance Reading
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -68,9 +68,10 @@ Current honest limit:
   type spelling in the source parser path
 - exact parse wording for text-surface gaps is not yet a long-term frozen
   compatibility promise
-- current `main` does not yet admit first-class closure syntax in the source
-  parser path; Wave 1 closure diagnostics are still explicit gap wording rather
-  than frozen parser-surface compatibility
+- current `main` now admits standalone first-class closure literal syntax in
+  contextual source positions
+- exact parse/type wording for closure-surface gaps is not yet a long-term
+  frozen compatibility promise
 
 ## Policy Diagnostics
 
@@ -139,7 +140,9 @@ Current message families include:
 - range literal requires `i32` bounds
 - range equality not part of stable v0 range surface
 - range literal rejected in tuple/user-data position
-- first-class closure values not yet admitted before `M8.4 Wave 2`
+- first-class closure literals without contextual `Closure(T -> U)` type
+- direct invocation of first-class closure values not yet admitted before
+  `M8.4 Wave 3`
 - for-range requires `i32` range expression
 - duplicate record declaration
 - duplicate schema declaration

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -672,20 +672,27 @@ Current v0 limit:
 
 Current short-lambda semantics:
 
-- short lambdas are currently capture-free call-site sugar only
+- the published stable `v1.1.1` line keeps short lambdas as capture-free
+  call-site sugar only
 - `(x => expr)(arg)` is interpreted as a fresh lexical block equivalent to
   `{ let x = arg; expr }`
 - `value |> (x => expr)` is interpreted as the same block sugar with `value` as
   the bound argument
 - the lambda body is checked and lowered through ordinary block-expression
   semantics; no alternate runtime callable representation is introduced
+- current `main` now also admits standalone first-class closure literals in
+  contextual `Closure(T -> U)` positions
+- admitted standalone closure literals record immutable capture inventory in
+  declaration order of first use
 
-Current v0 limits:
+Current active limits:
 
-- short lambdas are not first-class values
-- short lambdas currently support exactly one parameter and exactly one applied
-  argument
-- outer local-name capture is rejected in the current source contract
+- the published stable line still does not claim first-class closures
+- the current first-wave closure family still supports exactly one parameter
+- direct invocation of first-class closure values is still deferred until
+  `M8.4 Wave 3`
+- typed closure parameters, multi-argument closures, and async closure forms are
+  not part of the current contract
 
 Current active closures checkpoint on `main`:
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -471,12 +471,18 @@ Current precedence, from tighter to looser:
 Current short-lambda rules:
 
 - short lambda syntax is currently single-parameter only: `x => expr`
-- short lambdas are not first-class values in v0
+- the published stable `v1.1.1` line keeps short lambdas as non-first-class
+  call-site sugar only
+- current `main` now admits standalone first-class closure literals in
+  contextual positions such as `let f: Closure(f64 -> f64) = (x => x + 1.0);`
 - the stable v0 surface accepts short lambdas only as:
   - immediate call sugar: `(x => expr)(arg)`
   - pipeline stage sugar: `value |> (x => expr)`
-- short lambdas are capture-free in v0; they may not reference outer local
-  bindings
+- immediate-call and pipeline sugar remain capture-free in the stable line
+- current `main` admits immutable capture inventory for standalone first-class
+  closure literals
+- `Closure(T -> U)` is the current narrow declared type spelling for the
+  admitted first-wave closure family on `main`
 - typed lambda parameters and multi-argument lambda forms are not yet part of
   the stable source contract
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -100,14 +100,16 @@ Current honest baseline:
   or closure types
 - current `main` now owns one first-wave closure family in the frontend owner
   layer
-- current `main` does not yet admit first-class closures in executable parser
-  positions, declared type positions, or runtime carriers
+- current `main` now admits declared `Closure(T -> U)` type positions and
+  standalone closure literals in contextual closure-typed positions
+- current `main` does not yet admit runtime closure carriers or direct closure
+  invocation
 
 Current first-wave limits:
 
 - immutable capture only is the intended direction for the first-wave family
 - direct invocation only is the intended call model for that family
-- executable admission still begins in `M8.4 Wave 2`
+- direct invocation still remains deferred until `M8.4 Wave 3`
 - generic callable abstractions, traits/protocols, async closures, and host-ABI
   closure transport are not part of the current contract
 


### PR DESCRIPTION
# POST-M8.4 Wave 2: admit closure literals and type surface

Closes part of: #235
Slice type: code
One PR = one logical step.

## What This PR Does

- admits declared `Closure(T -> U)` type positions in the parser
- admits standalone first-class closure literals in contextual positions and records immutable capture inventory
- admits contextual closure literal typing while keeping direct closure invocation deferred

## What This PR Does Not Do

- does not add runtime closure carriers, lowering, verifier admission, or VM execution
- does not admit direct invocation of first-class closure values
- does not widen closures into generics, traits, async forms, or host ABI transport

## Stable Boundary Statement

Published `v1.1.1`:
- keeps short lambdas as capture-free immediate-call or pipeline sugar only
- does not claim first-class closures or declared `Closure(T -> U)` source positions

Current `main` after this PR:
- admits declared `Closure(T -> U)` type positions
- admits standalone closure literals in contextual closure-typed positions
- records immutable capture inventory for admitted closure literals
- still defers direct invocation to Wave 3

This PR is:
- [ ] release-maintenance only
- [x] forward-only widening on `main`
- [x] not a retroactive widening of published stable

## Files / Ownership

Owner crates or docs touched:

- `crates/sm-front/src/parser.rs`
- `crates/sm-front/src/typecheck.rs`
- `docs/spec/syntax.md`
- `docs/spec/source_semantics.md`
- `docs/spec/types.md`
- `docs/spec/diagnostics.md`
- `docs/roadmap/language_maturity/first_class_closures_full_scope.md`

## Verification

- [x] `cargo test --workspace`
- [x] `cargo test --test public_api_contracts`
- [x] extra focused tests
- [x] docs/spec updated if contract changed

Exact commands run:

```powershell
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-4-closures-wave2'; cargo test -p sm-front
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-4-closures-wave2'; cargo test -p sm-ir
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-4-closures-wave2'; cargo test --test public_api_contracts
$env:CARGO_TARGET_DIR='C:\Users\said3\Desktop\EXOcode\local_archives\target-m8-4-closures-wave2'; cargo test --workspace
```

## Follow-Up

Next honest step after this PR:

- Wave 3 runtime carrier and direct invocation admission
