### PR TITLE
POST-M8.4 Wave 4: close out first-class closures track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -39,9 +39,10 @@ Current post-`v1` wave:
 - `M8.3 Collections Surface` is now completed as first-wave baseline history
   and is scoped in
   `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-- `M8.4 First-Class Closures` is now the active `M8` subtrack and is scoped
-  in
+- `M8.4 First-Class Closures` is now completed as first-wave baseline history
+  and is scoped in
   `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
+- the next active candidate inside `M8` is `M9.1 Generics`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -22,6 +22,7 @@ Current post-stable admitted families on `main`:
 - `SEMCODE7`
 - `SEMCODE8`
 - `SEMCODE9`
+- `SEMCODE10`
 
 Current compatibility rule:
 
@@ -98,6 +99,9 @@ Current `v1` scope commitment:
 - the same forward-only reading also applies to the first-wave ordered
   sequence collection surface on current `main`, including `Sequence(type)`,
   bracketed literals, same-family equality, `expr[index]`, and `SEMCODE9`
+- the same forward-only reading also applies to the first-wave first-class
+  closure surface on current `main`, including `Closure(T -> U)`, standalone
+  closure literals, immutable capture, direct invocation, and `SEMCODE10`
 
 ## Explicit Non-Commitments
 
@@ -119,6 +123,8 @@ The repository does not yet claim final compatibility guarantees for:
   manifest/dependency baseline on `main`
 - collection semantics beyond the current admitted first-wave ordered sequence
   carrier/index/equality contract on `main`
+- closure semantics beyond the current admitted first-wave `Closure(T -> U)`
+  family, immutable capture, and direct invocation contract on `main`
 - broader packaged release layout beyond the current stable assets
 
 ## Release Honesty Rule

--- a/docs/roadmap/language_maturity/first_class_closures_full_scope.md
+++ b/docs/roadmap/language_maturity/first_class_closures_full_scope.md
@@ -1,6 +1,6 @@
 # First-Class Closures Full Scope
 
-Status: active M8.4 post-stable subtrack
+Status: completed M8.4 first-wave post-stable subtrack
 Related roadmap package:
 `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
 
@@ -96,23 +96,32 @@ The first-wave closure contract is intentionally narrow:
 That keeps the track additive over the current short-lambda sugar without
 turning it into a general abstraction system in one step.
 
-Current Wave 3 reading on `main`:
+## Final First-Wave Reading
 
-- current `main` now owns one first-wave closure family in the frontend owner
+Completed `M8.4` first-wave contract on current `main`:
+
+- one first-wave closure family is explicit and owned in the frontend owner
   layer
-- current `main` now admits `Closure(T -> U)` in declared source type positions
-- current `main` now admits standalone first-class closure literals in
-  contextual closure-typed positions
-- current `main` records immutable capture inventory for admitted standalone
-  closure literals
-- current `main` now admits one canonical runtime closure carrier for that same
-  first-wave family
-- current `main` now admits direct invocation of admitted closure values
-- current `main` keeps closure execution narrow:
+- `Closure(T -> U)` is admitted in declared source type positions
+- standalone first-class closure literals are admitted in contextual
+  closure-typed positions
+- immutable capture inventory is recorded for admitted standalone closure
+  literals
+- one canonical runtime closure carrier is admitted for that first-wave family
+- direct invocation of admitted closure values is admitted
+- closure execution is kept narrow:
   - exactly one positional argument
   - immutable capture only
   - no closure equality
   - no PROMETHEUS host-ABI closure transport
+
+Still intentionally not included after close-out:
+
+- multi-argument closure syntax
+- async or mutable-capture closure semantics
+- trait/protocol-based callable abstractions
+- generic closure signatures
+- host-ABI widening for closure values
 
 ## Acceptance Reading
 
@@ -133,3 +142,10 @@ Even after this first wave lands, the repository still does not claim:
 - async/generator closure semantics
 - multi-argument or variadic closure families
 - that first-class closures were already part of the published `v1.1.1` line
+
+## Close-Out Reading
+
+`M8.4` is now frozen as completed first-wave baseline history.
+
+The next language-facing candidate inside the `M8` package is `M9.1
+Generics`.

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -97,7 +97,7 @@ Current completed checkpoint:
 - Wave 3: lowering/runtime representation
 - Wave 4: docs/tests/compatibility freeze
 
-Current active checkpoint:
+Current completed checkpoint:
 
 - `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -117,7 +117,7 @@
     `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
   - current completed third subtrack:
     `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-  - current active fourth subtrack:
+  - current completed fourth subtrack:
     `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -109,6 +109,10 @@ The following limits remain explicit and should be treated as release-facing hon
   sequence collection surface, even though current `main` now admits
   `Sequence(type)`, bracketed literals, same-family equality, `expr[index]`,
   and canonical verified execution through `SEMCODE9`
+- the published `v1.1.1` line intentionally excludes the first-wave first-class
+  closure surface, even though current `main` now admits `Closure(T -> U)`,
+  standalone closure literals, immutable capture, direct invocation, and
+  canonical verified execution through `SEMCODE10`
 - current `main` still does not claim rollback, retry/compensation, or generic
   mixed-family rule-effect execution semantics
 - current `main` still does not claim rollback, migration, recovery, or


### PR DESCRIPTION
## What This PR Does

- freezes `M8.4 First-Class Closures` as completed first-wave baseline history
- updates `first_class_closures_full_scope.md`: status → completed, final first-wave reading, close-out section
- updates `backlog.md`: M8.4 → completed, next candidate listed as M9.1 Generics
- updates `compatibility_statement.md`: adds `SEMCODE10` to post-stable admitted families and closure non-commitment
- updates `milestones.md`: M8 active fourth subtrack → completed fourth subtrack
- updates `v1_readiness.md`: adds closure known-limits entry consistent with the forward-only reading
- updates `m8_everyday_expressiveness_phased_implementation_plan.md`: M8.4 active → completed checkpoint

## What This PR Does Not Do

- change any code, tests, or golden snapshots
- widen any spec beyond what Wave 3 already admitted
- claim that first-class closures were part of the published `v1.1.1` line

## Stable Boundary Statement

Published `v1.1.1`:
- still does not claim first-class closure values or closure runtime carriers

Current `main` after this PR:
- `M8.4` is frozen as completed first-wave baseline history
- all roadmap/compat/readiness docs agree on the same admitted contract