### PR TITLE
docs(architecture): record sm-front consolidation decision

### DIFF
--- a/docs/architecture/dependency_boundary_rules.md
+++ b/docs/architecture/dependency_boundary_rules.md
@@ -8,6 +8,7 @@ Project zones:
 
 Current pending ownership notes:
 
+- `sm-front` consolidates lexer, AST, and source-level type-check in a single crate; the originally planned `sm-lexer` / `sm-ast` split was not carried forward; a future split would require an explicit decision and code move
 - optimizer surface is owned by `sm-ir` in the current `v1` baseline; a future `sm-opt` split would require an explicit follow-up decision and code move
 - SemCode format contract is owned by `sm-ir` in the current `v1` baseline; `sm-emit` remains a producer-facing facade and compatibility layer
 - public CLI contract is owned by `smc-cli` in the current `v1` baseline; root `smc` is a thin entrypoint wrapper over that owner

--- a/docs/architecture/module_ownership_map.md
+++ b/docs/architecture/module_ownership_map.md
@@ -4,8 +4,8 @@ One concept must have one owner module.
 
 Core ownership:
 
-- lexical model: `sm-lexer` / current frontend lexer layer
-- AST and syntax model: `sm-ast` / current frontend AST layer
+- lexical model: `sm-front` (consolidated frontend crate owns lexer layer)
+- AST and syntax model: `sm-front` (consolidated frontend crate owns AST layer)
 - parser profiles: `sm-profile`
 - compiler semantics: `sm-sema`
 - IR and lowering: `sm-ir`
@@ -29,6 +29,7 @@ Ownership rules:
 
 - no public contract may keep two long-term owners;
 - pending ownership decisions must be marked explicitly rather than implied as settled;
+- `sm-front` is the canonical frontend owner crate; the original split into `sm-lexer` + `sm-ast` was not carried forward — lexer, AST, and source-level type-check layers are intentionally consolidated in `sm-front` for the current `v1` baseline; if a later decision splits them out, that requires explicit crate creation with matching code movement and ownership transfer;
 - `sm-opt` is not a canonical owner crate for `v1`; optimizer contract lives in `sm-ir` unless a later architecture decision creates a separate owner with matching code movement;
 - `sm-emit` is a producer-facing facade in the current `v1` baseline; the SemCode header/opcode/capability contract is owned by `sm-ir`;
 - `smc-cli` is the canonical owner of the public CLI contract in the current `v1` baseline; root `smc` and `svm` binaries are process entrypoints and not second CLI owners;


### PR DESCRIPTION
## What This PR Does

Records the explicit architectural decision that `sm-front` consolidates the originally planned `sm-lexer` + `sm-ast` split.

**Changes:**
- `module_ownership_map.md`: lexical model and AST ownership entries now correctly point to `sm-front`; adds ownership rule explaining the consolidation and the condition under which a future split would be acceptable
- `dependency_boundary_rules.md`: adds pending ownership note documenting that the `sm-lexer` / `sm-ast` split was not carried forward

## Why

The spec defined `sm-lexer` and `sm-ast` as separate crates. The implementation consolidated both into `sm-front`. Without an explicit doc note, this reads as an open task or oversight rather than a settled decision — and will confuse future contributors or architecture reviews.

## What This Does Not Do

- No code changes
- Does not reopen the split question
- Does not change any ownership semantics