### PR TITLE
POST-M9.1 Wave 0: define generics scope checkpoint

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -42,7 +42,8 @@ Current post-`v1` wave:
 - `M8.4 First-Class Closures` is now completed as first-wave baseline history
   and is scoped in
   `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
-- the next active candidate inside `M8` is `M9.1 Generics`
+- `M9.1 Generics` is now the active `M9` subtrack and is scoped in
+  `docs/roadmap/language_maturity/generics_full_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/generics_full_scope.md
+++ b/docs/roadmap/language_maturity/generics_full_scope.md
@@ -1,0 +1,156 @@
+# Generics Full Scope
+
+Status: proposed M9.1 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first admitted parametric polymorphism surface for Semantic
+without silently widening the published `v1.1.1` line and without opening
+trait-based abstraction, async, or runtime machinery ahead of schedule.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that generics already exist on the published stable line.
+
+## Why This Track Exists
+
+Semantic now has text, packages, collections, and first-class closures on
+`main`. All four foundations are completed first-wave baselines. The next
+barrier to practical code reuse is the inability to write type-parametric
+definitions. Without generics:
+
+- `Sequence(T)` cannot be written generically over user-defined types
+- `Closure(T -> U)` cannot be composed generically
+- `Option(T)` and `Result(T, E)` cannot be opened to user-defined type families
+- record and ADT definitions must be duplicated for each concrete type
+
+This track opens the minimum first-class generic surface without mixing in
+trait dispatch, async abstractions, or higher-kinded types.
+
+## Decision Check
+
+- [ ] This is a new explicit post-stable track with its own scope decision
+- [ ] This does not silently widen published `v1.1.1`
+- [ ] This is one stream, not a mixture of multiple tracks
+- [ ] This can be closed with a clear done-boundary
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- there are no type parameters in the public language contract
+- all concrete types (`i32`, `u32`, `f64`, `fx`, `bool`, `quad`, `text`,
+  `Sequence(T)`, `Closure(T -> U)`) use fixed or structurally admitted forms
+- `Option(T)` and `Result(T, E)` exist as standard library forms but are not
+  user-parameterisable in the published stable baseline
+- record and ADT definitions take no type parameters in the published stable
+  line
+- published `v1.1.1` does not claim user-defined generic types or generic
+  functions
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- one first-wave type-parameter family for functions and record/ADT definitions
+- a narrow type-parameter spelling for admitted source positions
+- deterministic monomorphisation policy
+- generic function definitions and call-site instantiation
+- generic record and ADT definitions
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- higher-kinded types
+- variance annotations (covariance, contravariance)
+- trait/protocol bounds on type parameters (deferred to M9.2)
+- associated types or type families
+- generic closures beyond what first-wave monomorphisation admits
+- specialisation or template-based optimisation
+- implicit type-class dispatch
+- variadic generics
+- lifetime or region annotations
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- type-parameter syntax ownership
+- generic definition and instantiation metadata inventory
+- monomorphisation policy boundaries
+- explicit typecheck/lowering gap markers before executable admission
+
+### Wave 2 — Source Admission
+
+- parser admission for type-parameter syntax
+- sema/type admission for generic definitions and call-site instantiation
+- explicit diagnostics for unsupported generic forms
+
+### Wave 3 — Lowering Path
+
+- IR monomorphisation pass
+- lowering of generic definitions to concrete SemCode paths
+- verifier and VM compatibility for monomorphised output
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: owner-layer type-parameter surface
+3. PR 3: parser/sema/type admission
+4. PR 4: IR monomorphisation and lowering path
+5. PR 5: freeze and close-out
+
+## Initial First-Wave Reading
+
+The first-wave generic contract is intentionally narrow:
+
+- one type-parameter per definition site only
+- monomorphisation only (no runtime generic dispatch)
+- no trait/protocol bounds in Wave 1–3
+- generic functions, records, and ADTs admitted; generic closures follow from
+  monomorphisation automatically
+- no implicit coercion across generic boundaries
+
+That keeps the track additive over the current concrete type surfaces without
+opening a full abstraction system in one step.
+
+## Acceptance Reading
+
+This track is done only when:
+
+- one first-wave type-parameter family is explicit and inspectable
+- generic definitions, monomorphisation, and call-site instantiation agree on
+  one deterministic first-wave model
+- docs/spec/tests describe the same admitted baseline
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- trait/protocol-based generic bounds or dispatch
+- higher-kinded types or type constructors
+- variance, lifetimes, or region-based memory semantics
+- specialisation or template metaprogramming
+- that generics were already part of the published `v1.1.1` line
+
+## Merge Gate
+
+Before closing this track:
+
+- [ ] code/tests are green
+- [ ] spec/docs are synced
+- [ ] public API or golden snapshots are updated if needed
+- [ ] compatibility/release-facing wording is honest

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md
@@ -101,6 +101,18 @@ Current completed checkpoint:
 
 - `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
 
+### M9.1 Generics
+
+- Wave 0: generics scope checkpoint
+- Wave 1: type-parameter ownership and monomorphisation policy
+- Wave 2: parser/sema/type admission
+- Wave 3: IR monomorphisation and lowering path
+- Wave 4: docs/tests/compatibility freeze
+
+Current active checkpoint:
+
+- `docs/roadmap/language_maturity/generics_full_scope.md`
+
 ## Primary Recommended Order
 
 1. M8.1 Text / strings

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -106,7 +106,7 @@
   - package ecosystem baseline
   - collections
   - first-class closures
-  - current status: active post-stable language-maturity package
+  - current status: completed post-stable language-maturity package
   - planning docs:
     - `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
     - `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
@@ -122,4 +122,16 @@
   - planning rule:
     - keep package baseline earlier than broad abstraction machinery
     - keep one active stream at a time
+    - keep UI/platform expansion separate from language-maturity work
+- `M9 General Abstraction Layer`
+  - generics / parametric polymorphism
+  - traits / protocols / interfaces
+  - iterable abstraction
+  - richer pattern surface
+  - current status: active post-stable language-maturity package
+  - current active first subtrack:
+    `docs/roadmap/language_maturity/generics_full_scope.md`
+  - planning rule:
+    - keep one active stream at a time
+    - do not open trait/protocol bounds before generics foundation is stable
     - keep UI/platform expansion separate from language-maturity work


### PR DESCRIPTION
## What This PR Does

Opens the M9.1 Generics track as the next active post-stable language-maturity subtrack.

**New file:**
- `docs/roadmap/language_maturity/generics_full_scope.md` — full scope definition for M9.1 first-wave parametric polymorphism

**Updated files:**
- `backlog.md` — M9.1 Generics is now the active M9 subtrack
- `milestones.md` — M8 marked completed; M9 block added with M9.1 as active first subtrack
- `m8_everyday_expressiveness_phased_implementation_plan.md` — M9.1 wave plan added

## Scope Summary

**Included:**
- one first-wave type-parameter family for functions, records, and ADTs
- deterministic monomorphisation policy
- generic call-site instantiation
- no trait/protocol bounds (deferred to M9.2)

**Explicit non-goals:**
- higher-kinded types, variance, lifetimes
- trait/protocol bounds or dispatch
- specialisation or template metaprogramming
- silent widening of `v1.1.1`

## Why Now

M8 is fully completed (M8.1–M8.4 all landed). The roadmap explicitly names M9.1 Generics as the next active candidate. This PR is the governance Wave 0 — no code changes, scope only.

## What This Does Not Do

- No code changes
- No parser/sema/IR/VM changes
- Does not open trait/protocol machinery