### PR TITLE
docs: sync blueprint with ТехЗадание and add M8+ index

### DIFF
--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md
@@ -1,6 +1,6 @@
 # M8 Everyday Expressiveness Blueprint
 
-Status: proposed future post-stable language-maturity blueprint
+Status: active post-stable language-maturity blueprint (M8 completed, M9 active)
 
 Related documents:
 
@@ -124,3 +124,28 @@ M10 remains a separate class of work.
 If repository governance already carries a separately opened UI milestone, that
 milestone stays the canonical platform-track entry point rather than being
 silently absorbed by this language-maturity package.
+
+## Architectural Consequences
+
+The next phase should therefore preserve these practical rules:
+
+- do not mix UI/platform work into M8 or M9 language-maturity streams
+- do not open generics before text/packages/collections/closures exist as
+  stable first-wave carriers
+- do not open trait/protocol abstraction before a generic foundation is stable
+- do not interpret non-commitments as backlog by default
+- do not widen the published stable line silently while current `main` moves
+  forward
+- keep one active language-expansion stream at a time
+
+## Final Blueprint Reading
+
+The correct architectural progression is:
+
+1. preserve the stable semantic core
+2. strengthen everyday expressiveness (M8 — now completed)
+3. only then open reusable abstraction systems (M9 — now active)
+4. only after that widen into broader application/platform work (M10)
+
+That progression is the guardrail that keeps Semantic readable as one coherent
+program rather than a collection of unrelated expansions.

--- a/docs/roadmap/language_maturity/m8_everyday_expressiveness_index.md
+++ b/docs/roadmap/language_maturity/m8_everyday_expressiveness_index.md
@@ -1,0 +1,31 @@
+# M8+ Everyday Expressiveness — Index Document
+
+This document is a navigation bridge to the canonical split documents for the
+M8/M9/M10 language-maturity package.
+
+## Canonical Split Documents
+
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
+- `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
+
+## Why Split
+
+- the roadmap reads better as a standalone strategic document
+- the blueprint is easier to reason about when separated from milestone tables
+- the phased implementation plan is more useful when it focuses on milestone
+  sequencing, PR waves, and execution order
+
+## Current Status
+
+- M8 Everyday Expressiveness Foundation — **completed** (M8.1–M8.4 all landed)
+- M9 General Abstraction Layer — **active** (M9.1 Generics is the current stream)
+- M10 Application and Platform Expansion — proposed
+- M7 UI Application Boundary — active parallel platform track (separate from language-maturity)
+
+## Editorial Notes Applied in Split Set
+
+- `text → package ecosystem → collections → closures` is the M8 execution order
+- wave-based PR discipline is explicit rather than implied
+- UI remains a separate platform track (M7), not a language-maturity subtask
+- one active stream at a time is a hard rule, not a guideline


### PR DESCRIPTION
## What This PR Does

Closes the documentation gap between the formal ТехЗадание spec and the repo.

**`m8_everyday_expressiveness_blueprint.md`:**
- Status updated: `proposed` → `active (M8 completed, M9 active)`
- Restored **Architectural Consequences** section (was in spec, missing from repo):
  - do not mix UI/platform into M8/M9
  - do not open generics before M8 carriers are stable
  - do not open traits before generics
  - keep one active stream at a time
- Restored **Final Blueprint Reading** section with the 4-step progression guardrail

**`m8_everyday_expressiveness_index.md`** (new):
- Navigation bridge to the three canonical split documents
- Current status of M8/M9/M10/M7 tracks
- Editorial notes explaining why the split was made

## Why

The repo blueprint was ~43% shorter than the ТехЗадание spec version. Two full sections were missing. These sections define operational rules that prevent architectural drift during M9+ work.

## What This Does Not Do

- No code changes
- Does not change any existing roadmap decisions
- Does not reopen closed tracks