### PR TITLE
POST-M7 Wave 1: UI capability denial path through prom-cap and sm-vm

### DIFF
--- a/crates/prom-cap/Cargo.toml
+++ b/crates/prom-cap/Cargo.toml
@@ -8,7 +8,8 @@ path = "src/lib.rs"
 
 [features]
 default = ["std"]
-std = ["prom-abi/std"]
+std = ["prom-abi/std", "prom-ui/std"]
 
 [dependencies]
 prom-abi = { path = "../prom-abi", default-features = false }
+prom-ui = { path = "../prom-ui", default-features = false }

--- a/crates/prom-cap/src/lib.rs
+++ b/crates/prom-cap/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use prom_abi::HostCallId;
+use prom_ui::{UiCapabilityKind, UiOperationId, required_ui_capability};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CapabilityKind {
@@ -138,6 +139,79 @@ pub trait CapabilityChecker {
     }
 }
 
+/// Denial result for a UI capability check.
+///
+/// Mirrors [`CapabilityDenied`] but carries UI-specific types from `prom-ui`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiCapabilityDenied {
+    pub capability: UiCapabilityKind,
+    pub operation: Option<UiOperationId>,
+    pub code: CapabilityDeniedCode,
+    pub manifest: CapabilityManifestMetadata,
+    pub message: String,
+}
+
+impl UiCapabilityDenied {
+    pub fn new(
+        capability: UiCapabilityKind,
+        operation: Option<UiOperationId>,
+        manifest: CapabilityManifestMetadata,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            capability,
+            operation,
+            code: CapabilityDeniedCode::MissingCapability,
+            manifest,
+            message: message.into(),
+        }
+    }
+}
+
+impl core::fmt::Display for UiCapabilityDenied {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self.operation {
+            Some(op) => write!(
+                f,
+                "UI capability {:?} denied for {:?} [{} {} {:?}]: {}",
+                self.capability,
+                op,
+                self.manifest.schema,
+                self.manifest.version.as_str(),
+                self.code,
+                self.message
+            ),
+            None => write!(
+                f,
+                "UI capability {:?} denied [{} {} {:?}]: {}",
+                self.capability,
+                self.manifest.schema,
+                self.manifest.version.as_str(),
+                self.code,
+                self.message
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for UiCapabilityDenied {}
+
+/// Checking contract for the UI application boundary capability surface.
+///
+/// Wired at Wave 1. This trait allows the VM host to deny UI operations
+/// when the required `UiCapabilityKind` is not admitted in the manifest.
+pub trait UiCapabilityChecker {
+    fn require_ui(&self, capability: UiCapabilityKind) -> Result<(), UiCapabilityDenied>;
+
+    fn require_ui_op(&self, op: UiOperationId) -> Result<(), UiCapabilityDenied> {
+        self.require_ui(required_ui_capability(op)).map_err(|mut denied| {
+            denied.operation = Some(op);
+            denied
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifestValidationCode {
     UnsupportedSchema,
@@ -164,6 +238,10 @@ pub struct CapabilityManifest {
     schema: String,
     version: CapabilityManifestVersion,
     allowed: BTreeSet<CapabilityKind>,
+    /// Admitted UI capabilities for the application boundary surface.
+    ///
+    /// Empty by default. Populated by `allow_ui()` at Wave 1.
+    allowed_ui: BTreeSet<UiCapabilityKind>,
 }
 
 impl CapabilityManifest {
@@ -175,6 +253,7 @@ impl CapabilityManifest {
             schema: Self::CURRENT_SCHEMA.into(),
             version: Self::CURRENT_VERSION,
             allowed: BTreeSet::new(),
+            allowed_ui: BTreeSet::new(),
         }
     }
 
@@ -186,6 +265,7 @@ impl CapabilityManifest {
             schema: schema.into(),
             version,
             allowed: BTreeSet::new(),
+            allowed_ui: BTreeSet::new(),
         }
     }
 
@@ -195,6 +275,18 @@ impl CapabilityManifest {
 
     pub fn allows(&self, capability: CapabilityKind) -> bool {
         self.allowed.contains(&capability)
+    }
+
+    /// Admit a UI capability into this manifest.
+    ///
+    /// UI capabilities are post-stable (Wave 1+) and must be explicitly
+    /// granted; they are never included in the default or gate surfaces.
+    pub fn allow_ui(&mut self, capability: UiCapabilityKind) {
+        self.allowed_ui.insert(capability);
+    }
+
+    pub fn allows_ui(&self, capability: UiCapabilityKind) -> bool {
+        self.allowed_ui.contains(&capability)
     }
 
     pub fn metadata(&self) -> CapabilityManifestMetadata {
@@ -263,6 +355,25 @@ impl CapabilityChecker for CapabilityManifest {
                 CapabilityDeniedCode::MissingCapability,
                 self.metadata(),
                 "manifest does not grant this capability",
+            ))
+        }
+    }
+}
+
+impl UiCapabilityChecker for CapabilityManifest {
+    fn require_ui(&self, capability: UiCapabilityKind) -> Result<(), UiCapabilityDenied> {
+        // Manifest schema/version validation applies to all capability checks.
+        self.validate().map_err(|report| {
+            UiCapabilityDenied::new(capability, None, self.metadata(), report.message)
+        })?;
+        if self.allows_ui(capability) {
+            Ok(())
+        } else {
+            Err(UiCapabilityDenied::new(
+                capability,
+                None,
+                self.metadata(),
+                "manifest does not grant this UI capability",
             ))
         }
     }
@@ -342,5 +453,58 @@ mod tests {
             .expect_err("must deny");
         assert_eq!(denied.call, Some(HostCallId::PulseEmit));
         assert_eq!(denied.capability, CapabilityKind::PulseEmit);
+    }
+
+    // --- M7 Wave 1: UI capability checker tests ---
+
+    #[test]
+    fn ui_manifest_denies_missing_ui_capability() {
+        let manifest = CapabilityManifest::new();
+        let denied = manifest
+            .require_ui(UiCapabilityKind::DesktopSession)
+            .expect_err("must deny UI capability when not granted");
+        assert_eq!(denied.capability, UiCapabilityKind::DesktopSession);
+        assert_eq!(denied.code, CapabilityDeniedCode::MissingCapability);
+        assert!(denied.operation.is_none());
+    }
+
+    #[test]
+    fn ui_manifest_admits_explicitly_granted_capability() {
+        let mut manifest = CapabilityManifest::new();
+        manifest.allow_ui(UiCapabilityKind::DesktopSession);
+        manifest.allow_ui(UiCapabilityKind::InputPoll);
+        assert!(manifest.allows_ui(UiCapabilityKind::DesktopSession));
+        assert!(manifest.allows_ui(UiCapabilityKind::InputPoll));
+        assert!(!manifest.allows_ui(UiCapabilityKind::FrameEmit));
+        manifest.require_ui(UiCapabilityKind::DesktopSession).expect("must admit");
+    }
+
+    #[test]
+    fn require_ui_op_attaches_operation_context() {
+        let manifest = CapabilityManifest::new();
+        let denied = manifest
+            .require_ui_op(UiOperationId::WindowCreate)
+            .expect_err("must deny");
+        assert_eq!(denied.capability, UiCapabilityKind::DesktopSession);
+        assert_eq!(denied.operation, Some(UiOperationId::WindowCreate));
+    }
+
+    #[test]
+    fn gate_surface_never_includes_ui_capabilities() {
+        let manifest = CapabilityManifest::gate_surface();
+        assert!(!manifest.allows_ui(UiCapabilityKind::DesktopSession));
+        assert!(!manifest.allows_ui(UiCapabilityKind::InputPoll));
+        assert!(!manifest.allows_ui(UiCapabilityKind::FrameEmit));
+    }
+
+    #[test]
+    fn ui_capability_denied_display_includes_capability_and_operation() {
+        let manifest = CapabilityManifest::new();
+        let denied = manifest
+            .require_ui_op(UiOperationId::FrameSubmit)
+            .expect_err("must deny");
+        let msg = format!("{}", denied);
+        assert!(msg.contains("FrameEmit"));
+        assert!(msg.contains("FrameSubmit"));
     }
 }

--- a/crates/sm-vm/Cargo.toml
+++ b/crates/sm-vm/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["std"]
-std = ["sm-emit/std", "sm-runtime-core/std", "sm-verify/std", "prom-abi/std", "prom-cap/std"]
+std = ["sm-emit/std", "sm-runtime-core/std", "sm-verify/std", "prom-abi/std", "prom-cap/std", "prom-ui/std"]
 
 [dependencies]
 sm-emit = { path = "../sm-emit", default-features = false, features = ["std"] }
@@ -16,3 +16,4 @@ sm-runtime-core = { path = "../sm-runtime-core", default-features = false, featu
 sm-verify = { path = "../sm-verify", default-features = false, features = ["std"] }
 prom-abi = { path = "../prom-abi", default-features = false, features = ["std"] }
 prom-cap = { path = "../prom-cap", default-features = false, features = ["std"] }
+prom-ui = { path = "../prom-ui", default-features = false, features = ["std"] }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -4,7 +4,8 @@ use crate::semcode_format::{
 };
 use crate::QuadVal;
 use prom_abi::{AbiError, AbiValue, HostCallId, PrometheusHostAbi};
-use prom_cap::{CapabilityChecker, CapabilityDenied};
+use prom_cap::{CapabilityChecker, CapabilityDenied, UiCapabilityChecker, UiCapabilityDenied};
+use prom_ui::UiOperationId;
 use sm_runtime_core::{
     AdtCarrier, ExecutionConfig, ExecutionContext, QuotaExceeded, QuotaKind, RecordCarrier,
     RuntimeQuotas, RuntimeSymbolTable, RuntimeTrap, SymbolId,
@@ -92,6 +93,9 @@ pub enum RuntimeError {
     InvalidStringId(u16),
     HostAbi(AbiError),
     CapabilityDenied(CapabilityDenied),
+    /// A UI operation was attempted but the required UI capability was not
+    /// admitted in the manifest. Wired at M7 Wave 1.
+    UiCapabilityDenied(UiCapabilityDenied),
     Trap(RuntimeTrap),
 }
 
@@ -122,6 +126,7 @@ impl core::fmt::Display for RuntimeError {
             RuntimeError::InvalidStringId(id) => write!(f, "invalid string id {}", id),
             RuntimeError::HostAbi(err) => write!(f, "{err}"),
             RuntimeError::CapabilityDenied(err) => write!(f, "{err}"),
+            RuntimeError::UiCapabilityDenied(err) => write!(f, "{err}"),
             RuntimeError::Trap(RuntimeTrap::AssertionFailed) => write!(f, "assertion failed"),
             RuntimeError::Trap(trap) => write!(f, "runtime trap: {:?}", trap),
         }
@@ -218,6 +223,36 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config<
     };
     push_frame(&mut vm, entry, Vec::new(), None)?;
     let mut bridge = PrometheusVmHost { host, capabilities };
+    exec_loop(&mut vm, &mut bridge)
+}
+
+/// Run verified SemCode with both a standard capability checker and a UI
+/// capability checker.
+///
+/// UI operations attempted without the corresponding `UiCapabilityKind` in
+/// `ui_capabilities` will return `RuntimeError::UiCapabilityDenied`. This is
+/// the Wave 1 denial path for the M7 UI application boundary track.
+pub fn run_verified_semcode_with_ui_capabilities<
+    H: PrometheusHostAbi,
+    C: CapabilityChecker,
+    U: UiCapabilityChecker,
+>(
+    bytes: &[u8],
+    host: &mut H,
+    capabilities: &C,
+    ui_capabilities: &U,
+) -> Result<(), RuntimeError> {
+    verify_semcode(bytes).map_err(RuntimeError::VerifierRejected)?;
+    let (_, symbols, functions) = parse_semcode(bytes)?;
+    let mut vm = VM {
+        functions,
+        callstack: Vec::new(),
+        config: ExecutionConfig::for_context(ExecutionContext::KernelBound),
+        effect_calls: 0,
+        symbols,
+    };
+    push_frame(&mut vm, "main", Vec::new(), None)?;
+    let mut bridge = PrometheusUiVmHost { host, capabilities, ui_capabilities };
     exec_loop(&mut vm, &mut bridge)
 }
 
@@ -666,6 +701,39 @@ trait VmHostBridge {
     fn state_update(&mut self, key: &str, value: Value) -> Result<(), RuntimeError>;
     fn event_post(&mut self, signal: &str) -> Result<(), RuntimeError>;
     fn clock_read(&mut self) -> Result<Value, RuntimeError>;
+
+    /// UI boundary operations — Wave 1 denial path.
+    ///
+    /// Default implementations return not-admitted. Overridden in
+    /// `PrometheusVmHost` when a `UiCapabilityChecker` is provided.
+    fn ui_window_create(&mut self) -> Result<(), RuntimeError> {
+        Err(RuntimeError::BadFormat(
+            "UI operations are not admitted in the current execution context; \
+             M7 UI boundary requires an explicit UiCapabilityChecker"
+                .to_string(),
+        ))
+    }
+    fn ui_window_run(&mut self) -> Result<(), RuntimeError> {
+        Err(RuntimeError::BadFormat(
+            "UI operations are not admitted in the current execution context; \
+             M7 UI boundary requires an explicit UiCapabilityChecker"
+                .to_string(),
+        ))
+    }
+    fn ui_event_poll(&mut self) -> Result<(), RuntimeError> {
+        Err(RuntimeError::BadFormat(
+            "UI operations are not admitted in the current execution context; \
+             M7 UI boundary requires an explicit UiCapabilityChecker"
+                .to_string(),
+        ))
+    }
+    fn ui_frame_submit(&mut self) -> Result<(), RuntimeError> {
+        Err(RuntimeError::BadFormat(
+            "UI operations are not admitted in the current execution context; \
+             M7 UI boundary requires an explicit UiCapabilityChecker"
+                .to_string(),
+        ))
+    }
 }
 
 struct LegacyVmHost;
@@ -773,6 +841,113 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker> VmHostBridge for Prometheus
             .clock_read()
             .map(Value::U32)
             .map_err(RuntimeError::HostAbi)
+    }
+}
+
+/// VM host bridge that also carries a `UiCapabilityChecker`.
+///
+/// Created when the caller provides an explicit UI capability manifest.
+/// UI operations check the `UiCapabilityChecker` and return
+/// `RuntimeError::UiCapabilityDenied` when the capability is absent.
+struct PrometheusUiVmHost<'a, H: PrometheusHostAbi, C: CapabilityChecker, U: UiCapabilityChecker> {
+    host: &'a mut H,
+    capabilities: &'a C,
+    ui_capabilities: &'a U,
+}
+
+impl<'a, H: PrometheusHostAbi, C: CapabilityChecker, U: UiCapabilityChecker> VmHostBridge
+    for PrometheusUiVmHost<'a, H, C, U>
+{
+    fn gate_read(&mut self, device_id: u16, port: u16) -> Result<Value, RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::GateRead)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .gate_read(device_id, port)
+            .map(value_from_abi)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn gate_write(&mut self, device_id: u16, port: u16, value: Value) -> Result<(), RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::GateWrite)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .gate_write(device_id, port, value_to_abi(value)?)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn pulse_emit(&mut self, signal: &str) -> Result<(), RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::PulseEmit)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host.pulse_emit(signal).map_err(RuntimeError::HostAbi)
+    }
+
+    fn state_query(&mut self, key: &str) -> Result<Value, RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::StateQuery)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .state_query(key)
+            .map(value_from_abi)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn state_update(&mut self, key: &str, value: Value) -> Result<(), RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::StateUpdate)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .state_update(key, value_to_abi(value)?)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn event_post(&mut self, signal: &str) -> Result<(), RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::EventPost)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .event_post(signal)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn clock_read(&mut self) -> Result<Value, RuntimeError> {
+        self.capabilities
+            .require_call(HostCallId::ClockRead)
+            .map_err(RuntimeError::CapabilityDenied)?;
+        self.host
+            .clock_read()
+            .map(Value::U32)
+            .map_err(RuntimeError::HostAbi)
+    }
+
+    fn ui_window_create(&mut self) -> Result<(), RuntimeError> {
+        self.ui_capabilities
+            .require_ui_op(UiOperationId::WindowCreate)
+            .map_err(RuntimeError::UiCapabilityDenied)
+        // Actual window creation is deferred to Wave 2 (desktop lifecycle).
+    }
+
+    fn ui_window_run(&mut self) -> Result<(), RuntimeError> {
+        self.ui_capabilities
+            .require_ui_op(UiOperationId::WindowRun)
+            .map_err(RuntimeError::UiCapabilityDenied)
+        // Actual event/frame loop is deferred to Wave 2.
+    }
+
+    fn ui_event_poll(&mut self) -> Result<(), RuntimeError> {
+        self.ui_capabilities
+            .require_ui_op(UiOperationId::EventPoll)
+            .map_err(RuntimeError::UiCapabilityDenied)
+        // Actual event polling is deferred to Wave 2.
+    }
+
+    fn ui_frame_submit(&mut self) -> Result<(), RuntimeError> {
+        self.ui_capabilities
+            .require_ui_op(UiOperationId::FrameSubmit)
+            .map_err(RuntimeError::UiCapabilityDenied)
+        // Actual frame submission is deferred to Wave 3 (drawing surface).
     }
 }
 

--- a/tests/golden_snapshots/public_api/prom_cap_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_cap_lib.txt
@@ -23,6 +23,15 @@ pub manifest: CapabilityManifestMetadata,
 pub message: String,
 pub fn new(
 pub trait CapabilityChecker {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiCapabilityDenied {
+pub capability: UiCapabilityKind,
+pub operation: Option<UiOperationId>,
+pub code: CapabilityDeniedCode,
+pub manifest: CapabilityManifestMetadata,
+pub message: String,
+pub fn new(
+pub trait UiCapabilityChecker {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifestValidationCode {
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,6 +47,8 @@ pub fn new() -> Self {
 pub fn with_contract(
 pub fn allow(&mut self, capability: CapabilityKind) {
 pub fn allows(&self, capability: CapabilityKind) -> bool {
+pub fn allow_ui(&mut self, capability: UiCapabilityKind) {
+pub fn allows_ui(&self, capability: UiCapabilityKind) -> bool {
 pub fn metadata(&self) -> CapabilityManifestMetadata {
 pub fn validate(&self) -> Result<(), ManifestValidationReport> {
 pub fn gate_surface() -> Self {

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -43,5 +43,6 @@ pub fn run_verified_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), 
 pub fn run_verified_semcode_with_entry_and_config(
 pub fn run_verified_semcode_with_host_and_capabilities<
 pub fn run_verified_semcode_with_host_and_capabilities_and_config<
+pub fn run_verified_semcode_with_ui_capabilities<
 pub fn run_semcode_with_entry_and_config(
 pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {


### PR DESCRIPTION
## Summary

- Adds `UiCapabilityDenied` + `UiCapabilityChecker` trait to `prom-cap`, parallel to existing `CapabilityDenied` / `CapabilityChecker`
- Extends `CapabilityManifest` with `allow_ui()` / `allows_ui()` for UI capability grant — not included in `gate_surface()` by default
- Wires UI denial path into `sm-vm`: new `PrometheusUiVmHost` struct, `UiCapabilityDenied` variant in `RuntimeError`, `run_verified_semcode_with_ui_capabilities` entry point
- UI operations in `VmHostBridge` default to not-admitted when no `UiCapabilityChecker` provided
- Public API snapshots updated for `prom-cap` and `sm-vm`

## Wave reading

Wave 1 establishes the denial path. Actual desktop session creation, event polling, and draw submission are deferred to Wave 2 (lifecycle) and Wave 3 (drawing surface). The VM stubs check capability and return `UiCapabilityDenied` when absent — executable surface comes in subsequent waves.

## Test plan

- [x] `cargo test --workspace` — 70 suites pass, 0 failures
- [x] `ui_manifest_denies_missing_ui_capability` — empty manifest denies
- [x] `ui_manifest_admits_explicitly_granted_capability` — allow_ui() admits correctly
- [x] `require_ui_op_attaches_operation_context` — op attached to denial
- [x] `gate_surface_never_includes_ui_capabilities` — gate surface remains narrow
- [x] `ui_capability_denied_display_includes_capability_and_operation` — display format correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)