### PR TITLE
M7 Wave 4: close out UI application boundary track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -23,8 +23,8 @@ Current remaining `v1` wave:
 
 Current post-`v1` wave:
 
-- `UI application boundary for Semantic desktop applications` is a separate
-  active platform track and is scoped in
+- `M7 UI Application Boundary` is now completed as first-wave baseline history
+  and is scoped in
   `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
 - the language-maturity package after the completed post-stable runtime waves
   is documented in:

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -106,6 +106,11 @@ Current `v1` scope commitment:
   on current `main`, including type-parameter syntax for functions, records, and
   ADTs, deterministic call-site monomorphisation, and the narrow
   `TypeVar`-to-concrete substitution model
+- the same forward-only reading also applies to the first-wave UI application
+  boundary on current `main`, including single-window session ownership
+  (`DesktopSession`), deterministic event polling (`EventBuffer`), frame-token
+  ownership (`FrameToken`), and the minimal draw-command family (`DrawCommand`,
+  `DrawFrame`) as exercised by the canonical `prom-ui-demo` application
 
 ## Explicit Non-Commitments
 
@@ -133,6 +138,10 @@ The repository does not yet claim final compatibility guarantees for:
   family, call-site substitution, and monomorphisation contract on `main`
   (trait/protocol bounds, higher-kinded types, variance, and specialisation are
   not claimed)
+- UI application boundary semantics beyond the current admitted first-wave
+  owner-layer contract on `main` (general widget framework, multi-window,
+  browser/mobile targets, forked graphics stack, and shader-language ownership
+  are not claimed)
 - broader packaged release layout beyond the current stable assets
 
 ## Release Honesty Rule

--- a/docs/roadmap/language_maturity/ui_application_boundary_scope.md
+++ b/docs/roadmap/language_maturity/ui_application_boundary_scope.md
@@ -1,6 +1,6 @@
 # UI Application Boundary Scope
 
-Status: proposed post-stable track
+Status: completed M7 first-wave post-stable track
 Related backlog item: `UI application boundary for Semantic desktop applications`
 
 ## Goal
@@ -60,18 +60,18 @@ owner.
 
 ## Milestone Reading
 
-Proposed milestone: `M7 UI Application Boundary`
+Completed milestone: `M7 UI Application Boundary`
 
-This milestone is complete only when:
+This milestone is complete:
 
-- a Semantic program can open a single desktop window through the admitted UI
-  boundary
-- deterministic input polling and frame lifecycle behavior are explicit and
-  tested
-- a minimal draw-command family is owned by the runtime boundary and exercised
-  by a canonical demo
-- release-facing docs keep the widened `main` behavior distinct from published
-  `v1.1.1`
+- [x] a Semantic program can open a single desktop window through the admitted
+  UI boundary (`DesktopSession<B>` + `UiBackendAdapter`)
+- [x] deterministic input polling and frame lifecycle behavior are explicit and
+  tested (`EventBuffer`, `FrameToken`, `FrameTokenIssuer`, 10 unit tests)
+- [x] a minimal draw-command family is owned by the runtime boundary and
+  exercised by a canonical demo (`DrawCommand`, `DrawFrame`, `prom-ui-demo`)
+- [x] release-facing docs keep the widened `main` behavior distinct from
+  published `v1.1.1`
 
 ## PR Waves
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -94,13 +94,9 @@
   - explicit UI capability/admission ownership
   - deterministic event polling and frame lifecycle
   - minimal draw-command family and one canonical demo application
-  - current status: proposed post-stable milestone
+  - current status: completed post-stable milestone
   - scope checkpoint:
     `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
-  - current planning rule:
-    - keep backend choice internal to the runtime owner
-    - keep published `v1.1.1` separate from widened `main`
-    - deliver through PR waves rather than one large integration PR
 - `M8 Everyday Expressiveness Foundation`
   - text / strings
   - package ecosystem baseline

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -117,6 +117,10 @@ The following limits remain explicit and should be treated as release-facing hon
   surface, even though current `main` now admits type-parameter syntax for
   functions, records, and ADTs, and deterministic call-site monomorphisation
   under the narrow `TypeVar`-to-concrete substitution model
+- the published `v1.1.1` line intentionally excludes the first-wave UI
+  application boundary, even though current `main` now admits single-window
+  session ownership, deterministic event polling, frame-token ownership, and
+  the minimal `DrawCommand`/`DrawFrame` family as exercised by `prom-ui-demo`
 - current `main` still does not claim rollback, retry/compensation, or generic
   mixed-family rule-effect execution semantics
 - current `main` still does not claim rollback, migration, recovery, or


### PR DESCRIPTION
## Summary

Docs/spec freeze for the completed M7 UI Application Boundary track.

- `ui_application_boundary_scope.md`: status → completed; milestone acceptance checklist ticked (all four criteria met)
- `milestones.md`: M7 status → completed
- `backlog.md`: M7 marked completed baseline history
- `compatibility_statement.md`: add UI boundary forward-only paragraph under current post-stable admitted surfaces; add non-commitment for widget framework / multi-window / graphics stack
- `v1_readiness.md`: add UI boundary exclusion under Current Known Limits

## Test plan

- [x] No code changes — docs only
- [x] `cargo test --workspace` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)