### PR TITLE
M9.2 Wave 0: traits and protocols scope checkpoint

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -44,6 +44,22 @@ Current post-`v1` wave:
   `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
 - `M9.1 Generics` is now completed as first-wave baseline history and is scoped
   in `docs/roadmap/language_maturity/generics_full_scope.md`
+- `M9.2 Traits/Protocols` is now the active `M9` second subtrack and is scoped
+  in `docs/roadmap/language_maturity/traits_protocols_full_scope.md`
+- `M9.3 Iterable Abstraction` is a proposed `M9` third subtrack scoped in
+  `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
+- `M9.4 Richer Pattern Surface` is a proposed `M9` fourth subtrack scoped in
+  `docs/roadmap/language_maturity/richer_pattern_surface_full_scope.md`
+- `M9.5 Option/Result Standard Forms` is a proposed `M9` fifth subtrack scoped in
+  `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
+- `NEXT-1 Import/Re-export Closure` is now an active post-stable closure track
+  scoped in `docs/roadmap/language_maturity/import_reexport_full_scope.md`
+- `Tooling: smc explain` is a proposed tooling track scoped in
+  `docs/roadmap/language_maturity/smc_explain_scope.md`
+- `Tooling: smc repl` is a proposed tooling track scoped in
+  `docs/roadmap/language_maturity/smc_repl_scope.md`
+- `Tooling: Rich Diagnostics` is a proposed tooling track scoped in
+  `docs/roadmap/language_maturity/rich_diagnostics_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now

--- a/docs/roadmap/language_maturity/traits_protocols_full_scope.md
+++ b/docs/roadmap/language_maturity/traits_protocols_full_scope.md
@@ -1,0 +1,163 @@
+# Traits Protocols Full Scope
+
+Status: proposed M9.2 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
+
+## Goal
+
+Introduce the first admitted structural trait/protocol surface for Semantic —
+named behavior contracts with explicit impl blocks, static dispatch only in
+first wave — without opening vtable dispatch, async traits, or higher-ranked
+abstractions ahead of schedule.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that traits or protocols already exist on the published stable line.
+
+## Why This Track Exists
+
+Semantic now has generics/parametric polymorphism on `main` (M9.1 completed).
+The current state has type-parametric definitions but no mechanism to constrain
+type parameters to a named behavior contract. Without traits/protocols:
+
+- `<T>` type parameters carry no static guarantees beyond what the call site
+  can check structurally
+- there is no named abstraction boundary for reusable behavior sets
+- generic code cannot express "T must support these operations" in a
+  checkable, doc-able form
+- polymorphism remains purely structural with no behavior abstraction layer
+
+This track opens the minimum first-class trait/protocol surface without mixing
+in vtable dispatch, async traits, or higher-ranked bounds.
+
+## Decision Check
+
+- [ ] This is a new explicit post-stable track with its own scope decision
+- [ ] This does not silently widen published `v1.1.1`
+- [ ] This is one stream, not a mixture of multiple tracks
+- [ ] This can be closed with a clear done-boundary
+
+## Stable Baseline Before This Track
+
+The current `main` baseline (after M9.1) already freezes these facts:
+
+- generics/parametric polymorphism are admitted for functions and record/ADT
+  definitions on `main`
+- all polymorphism remains structural; there is no trait or protocol syntax in
+  the published language contract
+- type parameters carry no named behavior bounds in the current baseline
+- there is no `trait`, `protocol`, or `impl` keyword in the admitted source
+  grammar
+- `dyn Trait` vtable dispatch does not exist and is not claimed
+- published `v1.1.1` does not claim any behavior-contract or trait-based
+  abstraction
+
+That baseline remains the source of truth until this subtrack explicitly lands
+its widened contract on `main`.
+
+## Included In This Track
+
+- `trait Foo { fn method(&self) -> T; }` syntax for declaring named behavior
+  contracts
+- `impl Foo for MyType { ... }` syntax for explicit, named impl blocks
+- static dispatch only: call-site monomorphic resolution through trait bounds
+- trait bounds on type parameters: `<T: Foo>` spelling admitted in first wave
+- basic trait object syntax `dyn Foo` is DEFERRED to a later wave
+- docs/spec/tests/compatibility wording for the widened contract
+
+## Explicit Non-Goals
+
+- `dyn Trait` / vtable dispatch (deferred to a later wave)
+- async traits or `async fn` in trait definitions
+- associated types or associated type families
+- default method bodies with complex generic constraints
+- higher-ranked trait bounds (`for<'a> Fn(&'a T)` style)
+- derive macros or procedural macro integration
+- orphan rules enforcement in first wave
+- trait aliases
+- negative impls
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+
+- scope checkpoint
+- roadmap/milestone/plan linkage
+
+### Wave 1 — Owner Layer
+
+- trait and impl syntax ownership
+- behavior-contract and impl-block metadata inventory
+- static dispatch and bound-resolution policy boundaries
+- explicit typecheck/lowering gap markers before executable admission
+
+### Wave 2 — Source Admission
+
+- parser admission for `trait`, `impl`, and `dyn` keyword stubs
+- sema/type admission for trait definitions and impl blocks
+- explicit diagnostics for unsupported trait forms
+
+### Wave 3 — Typecheck
+
+- impl resolution at call sites
+- trait bound checking on type parameters
+- coherence checking (single impl per type/trait pair in first wave)
+- verifier compatibility for statically dispatched trait calls
+
+### Wave 4 — Freeze
+
+- docs/spec/tests/compatibility freeze
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint
+2. PR 2: owner-layer trait/impl surface
+3. PR 3: parser/sema/type admission
+4. PR 4: typecheck, impl resolution, and bound checking
+5. PR 5: freeze and close-out
+
+## Initial First-Wave Reading
+
+The first-wave trait/protocol contract is intentionally narrow:
+
+- named behavior contracts only; structural polymorphism remains valid outside
+  trait bounds
+- static dispatch only; no vtable or dynamic dispatch in Wave 1–3
+- no `dyn Trait` in first wave
+- trait bounds on type parameters admitted; higher-ranked bounds deferred
+- one impl per type/trait pair enforced; orphan rules deferred to a later wave
+- no default method bodies with complex constraints
+
+That keeps the track additive over the current generic surface without opening
+a full abstraction system in one step.
+
+## Acceptance Reading
+
+This track is done only when:
+
+- one first-wave trait/protocol surface is explicit and inspectable
+- `trait` definitions, `impl` blocks, and bound-checked call sites agree on
+  one deterministic first-wave model
+- docs/spec/tests describe the same admitted baseline
+- published `v1.1.1` and widened `main` are explicitly distinguished
+
+## Non-Commitments After Close-Out
+
+Even after this first wave lands, the repository still does not claim:
+
+- `dyn Trait` / vtable dispatch or dynamic polymorphism
+- async traits or `async fn` in trait definitions
+- higher-ranked trait bounds or lifetime-parameterised traits
+- associated types, type families, or generic associated types
+- derive macros or procedural macro trait expansion
+- that traits were already part of the published `v1.1.1` line
+
+## Merge Gate
+
+Before closing this track:
+
+- [ ] code/tests are green
+- [ ] spec/docs are synced
+- [ ] public API or golden snapshots are updated if needed
+- [ ] compatibility/release-facing wording is honest

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -127,7 +127,33 @@
   - current status: active post-stable language-maturity package
   - current completed first subtrack:
     `docs/roadmap/language_maturity/generics_full_scope.md`
+  - current active second subtrack:
+    `docs/roadmap/language_maturity/traits_protocols_full_scope.md`
+  - current proposed third subtrack:
+    `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
+  - current proposed fourth subtrack:
+    `docs/roadmap/language_maturity/richer_pattern_surface_full_scope.md`
+  - current proposed fifth subtrack:
+    `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
   - planning rule:
     - keep one active stream at a time
     - do not open trait/protocol bounds before generics foundation is stable
     - keep UI/platform expansion separate from language-maturity work
+- `Tooling Tracks`
+  - rich diagnostics (rustc-style line:col + caret)
+  - `smc explain <error-code>`
+  - `smc repl` interactive mode
+  - import/re-export closure (`NEXT-1`)
+  - current status: proposed tooling tracks (parallel to M9, independent)
+  - smc explain scope:
+    `docs/roadmap/language_maturity/smc_explain_scope.md`
+  - smc repl scope:
+    `docs/roadmap/language_maturity/smc_repl_scope.md`
+  - rich diagnostics scope:
+    `docs/roadmap/language_maturity/rich_diagnostics_scope.md`
+  - import/re-export closure scope:
+    `docs/roadmap/language_maturity/import_reexport_full_scope.md`
+  - planning rule:
+    - tooling tracks are independent of language-maturity subtracks
+    - smc-explain and rich-diagnostics share the ErrorCode enum — coordinate
+    - keep one tooling stream active at a time


### PR DESCRIPTION
## Summary

- Add `docs/roadmap/language_maturity/traits_protocols_full_scope.md` — scope boundary for M9.2 Traits/Protocols post-stable subtrack
- Update `milestones.md` with M9.3, M9.4, M9.5 proposed subtracks and new Tooling Tracks section
- Update `backlog.md` with all new proposed post-stable track entries

## Wave

Wave 0 (governance) — scope doc only, no code changes.

## Decision Check

- [x] This is a new explicit post-stable track with its own scope decision
- [x] This does not silently widen published `v1.1.1`
- [x] This is one stream, not a mixture of multiple tracks
- [x] This can be closed with a clear done-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)