### PR TITLE
Tooling Wave 0: smc repl scope checkpoint

### DIFF
--- a/docs/architecture/blueprint.md
+++ b/docs/architecture/blueprint.md
@@ -30,9 +30,30 @@ Current release-line state:
 - release validation runs through boundary guards, public API inventory, runtime matrix/goldens, and the release-bundle verifier
 - published stable releases are expected to ship `smc.exe`, `svm.exe`, and a bundled Windows archive
 
+Planned post-stable UI application boundary:
+
+- UI is treated as a host/runtime boundary product, not as an extension of the
+  compiler core
+- the planned first-wave owner split is:
+  - `prom-ui` for boundary types, capabilities, and admitted UI operation IDs
+  - `prom-ui-runtime` for desktop lifecycle, event polling, frame ownership,
+    and backend adapter implementation
+  - `examples/` or `apps/` for demo consumers, not runtime ownership
+- the first-wave UI contract is expected to stay narrow:
+  - single-window desktop lifecycle
+  - input polling
+  - frame begin/end ownership
+  - minimal draw-command surface
+- no graphics backend library becomes a language-level promise in the first
+  wave; backend choice remains an internal runtime detail
+- the planning checkpoint for this track is
+  `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
+
 Non-negotiable architecture rules:
 
 - compiler semantics and runtime semantics must stay separate;
 - VM mechanics and semantic state/rule logic must stay separate;
 - all host effects must cross a formal ABI boundary;
-- verifier is a public admission layer, not an internal VM detail.
+- verifier is a public admission layer, not an internal VM detail;
+- desktop UI, if admitted, must stay behind an explicit host/runtime boundary
+  and must not leak backend ownership into compiler or VM crates.

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -23,6 +23,9 @@ Current remaining `v1` wave:
 
 Current post-`v1` wave:
 
+- `UI application boundary for Semantic desktop applications` is the current
+  active post-stable track and is scoped in
+  `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
 - `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
   frozen baseline history in `docs/roadmap_next.md`
 - the retained non-owning TON618 compatibility perimeter is completed and now
@@ -46,8 +49,6 @@ Current post-`v1` wave:
 - the first-wave `fx` arithmetic expansion track is completed and now lives as
   frozen baseline history in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
-
-No additional post-`v1` feature track is currently active.
 
 Foundational work already in place:
 

--- a/docs/roadmap/language_maturity/smc_repl_scope.md
+++ b/docs/roadmap/language_maturity/smc_repl_scope.md
@@ -1,0 +1,93 @@
+# smc repl Interactive Mode Scope
+
+Status: proposed tooling track
+
+## Goal
+
+Introduce `smc repl` — a read-eval-print loop that accepts Semantic expressions
+and statements one at a time, evaluates them through the existing pipeline, and
+prints results. A persistent environment is maintained across lines within a
+session.
+
+This is a forward-only tooling track. It does not reinterpret the published
+`v1.1.1` CLI baseline as if an interactive mode already shipped there.
+
+## Why This Track Exists
+
+`smc check` and `smc run` operate on complete program files. Without a REPL:
+
+- exploring language behaviour requires writing, saving, and running whole files
+- incremental experimentation with types and expressions is not possible
+- onboarding new users is friction-heavy
+
+This track adds the minimum interactive surface without adding a new language
+dialect, hidden evaluation semantics, or persistent session storage.
+
+## Decision Check
+
+- [ ] This is a new explicit tooling track with its own scope decision
+- [ ] This does not silently widen published `v1.1.1`
+- [ ] This is one stream, not a mixture of multiple tracks
+- [ ] This can be closed with a clear done-boundary
+
+## Stable Baseline Before This Track
+
+- `smc check <file>` and `smc run <file>` work for file input
+- parser operates on complete program strings
+- no incremental/single-input parse mode exists
+- published `v1.1.1` does not claim a REPL mode
+
+## Included In This Track
+
+- incremental parse mode in `sm-front` accepting a single expression or
+  statement without requiring a full program wrapper
+- REPL loop in `smc-cli`: read line → parse → typecheck → execute → print result
+- persistent type environment across lines within a session
+- `quit` and `exit` commands to end the session
+- expression value printing (debug representation in first wave)
+
+## Explicit Non-Goals
+
+- persistent session save/load to disk
+- notebook format or literate programming mode
+- history search or readline-style editing in first wave
+- syntax highlighting or tab completion in first wave
+- multi-line expression continuation (deferred to a later wave)
+- silent widening of published `v1.1.1`
+
+## Intended Wave Order
+
+### Wave 0 — Governance
+- scope checkpoint and backlog/milestone linkage
+
+### Wave 1 — Incremental parser mode
+- single-expression/statement parse mode in `sm-front`
+- `parse_expr` and `parse_stmt` entry points without full program wrapper
+
+### Wave 2 — REPL loop in smc-cli
+- `smc repl` subcommand with read/print loop
+- line dispatch through typecheck and VM
+
+### Wave 3 — Environment persistence and value printing
+- persistent scope env across REPL lines
+- value display for primitive types and records
+
+### Wave 4 — Freeze
+- docs/spec/tests/golden freeze for the widened contract
+
+## Suggested Narrow PR Plan
+
+1. PR 1: scope checkpoint (this PR)
+2. PR 2: incremental parser entry points in `sm-front`
+3. PR 3: `smc repl` loop in `smc-cli`
+4. PR 4: environment persistence + value printing
+5. PR 5: freeze and close-out
+
+## Merge Gate
+
+Before closing this track:
+
+- [ ] code/tests are green
+- [ ] spec/docs are synced
+- [ ] public API or golden snapshots are updated if needed
+- [ ] compatibility/release-facing wording is honest

--- a/docs/roadmap/language_maturity/ui_application_boundary_scope.md
+++ b/docs/roadmap/language_maturity/ui_application_boundary_scope.md
@@ -1,0 +1,126 @@
+# UI Application Boundary Scope
+
+Status: proposed post-stable track
+Related backlog item: `UI application boundary for Semantic desktop applications`
+
+## Goal
+
+Introduce a narrow UI/application boundary that lets a Semantic program own a
+desktop window, process input events, and emit a minimal frame of drawing
+commands through an explicit host/runtime contract.
+
+This is a post-stable expansion track. It does not reinterpret the published
+`v1.1.1` line as if desktop UI support already shipped there.
+
+## Stable Baseline Before This Track
+
+The current stable line already freezes these facts:
+
+- published `v1.1.1` is a CLI-first toolchain and runtime baseline
+- current compiler, verifier, VM, and PROMETHEUS boundary do not admit a
+  dedicated UI/window host family
+- no crate in the current baseline owns a desktop event loop or frame-oriented
+  drawing surface
+- no graphics backend library is part of the language-level contract
+
+That stable reading remains the source of truth until this track explicitly
+lands a widened post-stable contract on `main`.
+
+## Included In This Track
+
+- explicit ownership of a desktop UI boundary and its narrow runtime surface
+- single-window lifecycle ownership for create, run, and close
+- deterministic input-event polling and frame/tick ownership
+- a minimal drawing command family sufficient for a canonical demo program
+- capability/admission wiring for the UI family through the existing boundary
+- docs/spec/tests/demo coverage for the widened post-stable contract
+
+## Explicit Non-Goals
+
+- forking `wgpu`
+- designing a general widget toolkit or retained UI framework
+- browser, mobile, or multi-window targets
+- shader, resource-binding, or GPU-pipeline surface design
+- CSS/layout/theme systems, accessibility framework, or asset pipeline design
+- silently widening `v1.1.1`
+
+## Planned Architecture Reading
+
+The first-wave owner split is expected to stay narrow and explicit:
+
+- `prom-ui`: UI boundary types, capability surface, and admitted operation IDs
+- `prom-ui-runtime`: desktop session ownership, input polling, frame lifecycle,
+  and backend adapter implementation
+- `examples/` or `apps/`: one canonical UI demo application, kept as a
+  consumer rather than an owner of the runtime boundary
+
+No backend library becomes a language-level promise in this first wave.
+Backend selection stays an internal implementation detail of the UI runtime
+owner.
+
+## Milestone Reading
+
+Proposed milestone: `M7 UI Application Boundary`
+
+This milestone is complete only when:
+
+- a Semantic program can open a single desktop window through the admitted UI
+  boundary
+- deterministic input polling and frame lifecycle behavior are explicit and
+  tested
+- a minimal draw-command family is owned by the runtime boundary and exercised
+  by a canonical demo
+- release-facing docs keep the widened `main` behavior distinct from published
+  `v1.1.1`
+
+## PR Waves
+
+### Wave 0 - Governance and Owner Split
+
+- PR 1: scope checkpoint, backlog/blueprint/milestone/WBS sync
+- PR 2: owner-layer crate scaffolding and inert UI boundary types
+
+### Wave 1 - Boundary Admission
+
+- PR 3: UI capability taxonomy and operation identity ownership
+- PR 4: verifier/VM/runtime denial-path ownership when UI capability is absent
+
+### Wave 2 - Desktop Lifecycle
+
+- PR 5: single-window session ownership and lifecycle API
+- PR 6: deterministic event polling and frame-token ownership
+
+### Wave 3 - Minimal Drawing Surface
+
+- PR 7: minimal draw-command family such as clear/rect/text
+- PR 8: backend adapter plus one canonical demo application
+
+### Wave 4 - Freeze and Close-Out
+
+- PR 9: docs/spec/tests/golden freeze for the widened contract
+
+One PR still equals one logical step. Waves describe delivery grouping, not a
+license to batch unrelated work.
+
+## Acceptance Reading
+
+This track is done only when:
+
+- the admitted UI surface is explicit, inspectable, and capability-gated
+- desktop lifecycle, event polling, and frame behavior agree across docs,
+  runtime, and tests
+- the first-wave draw surface stays narrow and sufficient for one canonical
+  demo application
+- backend choice remains an internal runtime detail rather than a language
+  promise
+- release-facing docs distinguish widened `main` from published `v1.1.1`
+
+## Non-Commitments After Close-Out
+
+Even after this track lands, the repository still does not claim:
+
+- a general widget/layout framework
+- multi-window, browser, or mobile UI support
+- a forked graphics stack
+- shader-language ownership
+- a promise that UI support is already part of the published `v1.1.1` line

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -89,3 +89,15 @@
   - current stable-note checkpoints:
     - `docs/roadmap/language_maturity/release_version_cut_decision.md`
     - `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`
+- `M7 UI Application Boundary`
+  - desktop window lifecycle
+  - explicit UI capability/admission ownership
+  - deterministic event polling and frame lifecycle
+  - minimal draw-command family and one canonical demo application
+  - current status: proposed post-stable milestone
+  - scope checkpoint:
+    `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
+  - current planning rule:
+    - keep backend choice internal to the runtime owner
+    - keep published `v1.1.1` separate from widened `main`
+    - deliver through PR waves rather than one large integration PR

--- a/docs/roadmap/wbs.md
+++ b/docs/roadmap/wbs.md
@@ -13,6 +13,7 @@ Milestones:
 - `1.5` PROMETHEUS boundary
 - `1.6` semantic runtime
 - `1.7` v1 lockdown
+- `1.8` UI application boundary (post-stable)
 
 Current post-stable focus:
 
@@ -22,6 +23,14 @@ Current post-stable focus:
 
 Current non-blocking follow-up work:
 
+- the active post-stable UI application boundary track is scoped in
+  `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
+- its planned delivery waves are:
+  - Wave 0: governance and owner split
+  - Wave 1: boundary admission
+  - Wave 2: desktop lifecycle
+  - Wave 3: minimal drawing surface
+  - Wave 4: freeze and close-out
 - the retained non-owning TON618 compatibility perimeter is frozen as completed
   post-stable baseline history in
   `docs/roadmap/language_maturity/ton618_compatibility_perimeter_scope.md`


### PR DESCRIPTION
## Summary

- Add `docs/roadmap/language_maturity/smc_repl_scope.md` — scope boundary for `smc repl` interactive mode proposed tooling track

## Wave

Wave 0 (governance) — scope doc only, no code changes.

Parallel to M9 language-maturity tracks, independent of them.

## Decision Check

- [x] This is a new explicit tooling track with its own scope decision
- [x] This does not silently widen published `v1.1.1`
- [x] This is one stream, not a mixture of multiple tracks
- [x] This can be closed with a clear done-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)