### PR TITLE
M9.2 Wave 2+3+4: parser admission, typecheck, and freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
-- No unreleased entries yet.
+### Added (post-v1.1.1 language-maturity subtracks)
+
+- **M9.2 Traits (static)**: traits/impls now have full owner-layer representation,
+  parser admission, and static typecheck support.
+  - `trait` and `impl` declarations admitted at top level
+  - `TraitDecl`, `ImplDecl`, `TraitBound`, `TraitMethodSig` AST nodes
+  - `<T: TraitName>` bound syntax on generic function type parameters
+  - `validate_trait_coherence`: rejects duplicate `(trait, for_type)` impl pairs
+  - `validate_impl_conformance`: rejects impls with missing methods or wrong return types
+  - bound satisfaction check at generic call sites
+  - runtime dispatch, trait objects, specialization, and blanket impls remain deferred
+  - done-boundary: `M9.2 closes at static trait admission + coherence/conformance + bound satisfaction`
 
 ## v1.1.1 - 2026-04-01
 

--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -305,6 +305,8 @@ fn tokenize_line(
                     "schema" => TokenKind::KwSchema,
                     "enum" => TokenKind::KwEnum,
                     "const" => TokenKind::KwConst,
+                    "trait" => TokenKind::KwTrait,
+                    "impl" => TokenKind::KwImpl,
                     "let" => TokenKind::KwLet,
                     "for" => TokenKind::KwFor,
                     "in" => TokenKind::KwIn,

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -251,6 +251,24 @@ pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError> {
+    let mut out = BTreeMap::new();
+    for t in &program.traits {
+        if out.contains_key(&t.name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "duplicate trait '{}'",
+                    resolve_symbol_name(&program.arena, t.name)?
+                ),
+            });
+        }
+        out.insert(t.name, t.clone());
+    }
+    Ok(out)
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
     let mut out = BTreeMap::new();
     for schema in &program.schemas {

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -18,13 +18,13 @@ pub mod types;
 pub use types::{
     AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg,
     ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,
-    FrontendError, FrontendErrorKind, Function, IfExpr, LogosEntity, LogosEntityField,
+    FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
     MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
     SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
     SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,
-    TokenKind, TuplePatternItem, Type,
+    TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
 };
@@ -51,6 +51,11 @@ pub struct FnSig {
     /// Non-empty signals a generic function. Call-site type-checking performs
     /// substitution map inference from arguments before checking param types.
     pub type_params: Vec<SymbolId>,
+    /// Trait bounds on the type parameters: `<T: TraitName>` constraints.
+    ///
+    /// Admitted at the owner layer (Wave 1). Bound checking at call sites
+    /// and impl resolution are deferred to Wave 3.
+    pub trait_bounds: Vec<TraitBound>,
     pub params: Vec<Type>,
     pub param_names: Option<Vec<SymbolId>>,
     pub param_defaults: Option<Vec<Option<ExprId>>>,
@@ -71,6 +76,21 @@ pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type ValidationPlanTable = BTreeMap<SymbolId, ValidationPlan>;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+/// Trait definitions indexed by trait name.
+///
+/// Admitted at the owner layer (Wave 1). Build function is deferred to Wave 2
+/// when parser admission lands.
+pub type TraitTable = BTreeMap<SymbolId, TraitDecl>;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+/// All impl blocks in the program, ordered by declaration.
+///
+/// Not keyed by a single SymbolId because the coherence key is
+/// (trait_name, for_type). Admitted at the owner layer (Wave 1).
+/// Build function and coherence checks are deferred to Wave 2/3.
+pub type ImplTable = Vec<ImplDecl>;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -175,6 +195,7 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
             f.name,
             FnSig {
                 type_params: f.type_params.clone(),
+                trait_bounds: f.trait_bounds.clone(),
                 params: f
                     .params
                     .iter()
@@ -466,6 +487,7 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
     match name {
         "sin" | "cos" | "tan" | "sqrt" | "abs" => Some(FnSig {
             type_params: Vec::new(),
+            trait_bounds: Vec::new(),
             params: vec![Type::F64],
             param_names: None,
             param_defaults: None,
@@ -473,6 +495,7 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
         }),
         "pow" => Some(FnSig {
             type_params: Vec::new(),
+            trait_bounds: Vec::new(),
             params: vec![Type::F64, Type::F64],
             param_names: None,
             param_defaults: None,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -164,6 +164,10 @@ impl<'a> Parser<'a> {
         Ok(Function {
             name,
             type_params,
+            // Wave 3 gap: trait-bound syntax (`<T: TraitName>`) is parsed in
+            // Wave 2 and bound-checked at call sites in Wave 3. Until then,
+            // all parsed functions carry an empty trait_bounds vec.
+            trait_bounds: Vec::new(),
             params,
             param_defaults,
             requires,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2,14 +2,14 @@ use crate::lexer::lex_tokens;
 use crate::types::{
     AdtCtorExpr, AdtDecl, AdtMatchPattern, AdtPatternItem, AdtVariant, AstArena, BinaryOp,
     BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily, Expr, ExprId,
-    FrontendError, Function, IfExpr, LogosEntity, LogosEntityField, LogosEntityFieldKind,
+    FrontendError, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField, LogosEntityFieldKind,
     LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm,
     MatchPattern, NumericLiteral, Program, QuadVal, RangeExpr, RecordDecl, RecordField,
     RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordPatternItem, RecordPatternTarget,
     RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
     SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType,
-    Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, TuplePatternItem,
-    Type, UnaryOp,
+    Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token, TokenKind, TraitBound,
+    TraitDecl, TraitMethodSig, TuplePatternItem, Type, UnaryOp,
 };
 use crate::CompilePolicyView;
 use alloc::format;
@@ -74,6 +74,8 @@ impl<'a> Parser<'a> {
         let mut records = Vec::new();
         let mut schemas = Vec::new();
         let mut functions = Vec::new();
+        let mut traits = Vec::new();
+        let mut impls = Vec::new();
         loop {
             let i = self.next_non_layout_idx();
             if i >= self.tokens.len() {
@@ -89,11 +91,13 @@ impl<'a> Parser<'a> {
                 TokenKind::KwFn => functions.push(self.parse_function()?),
                 TokenKind::KwRecord => records.push(self.parse_record_decl()?),
                 TokenKind::KwSchema => schemas.push(self.parse_schema_decl()?),
+                TokenKind::KwTrait => traits.push(self.parse_trait_decl()?),
+                TokenKind::KwImpl => impls.push(self.parse_impl_decl()?),
                 _ => {
                     return Err(FrontendError {
                         pos: self.tokens[i].pos,
                         message:
-                            "expected top-level 'enum', 'fn', 'record', 'schema', or role-marked schema declaration"
+                            "expected top-level 'enum', 'fn', 'impl', 'record', 'schema', 'trait', or role-marked schema declaration"
                                 .to_string(),
                     });
                 }
@@ -105,13 +109,15 @@ impl<'a> Parser<'a> {
             records,
             schemas,
             functions,
+            traits,
+            impls,
         })
     }
 
     fn parse_function(&mut self) -> Result<Function, FrontendError> {
         self.expect(TokenKind::KwFn, "expected 'fn'")?;
         let name = self.expect_symbol()?;
-        let type_params = self.parse_type_params()?;
+        let (type_params, trait_bounds) = self.parse_type_params_with_bounds()?;
         self.expect(TokenKind::LParen, "expected '('")?;
         let mut params = Vec::new();
         let mut param_defaults = Vec::new();
@@ -164,10 +170,7 @@ impl<'a> Parser<'a> {
         Ok(Function {
             name,
             type_params,
-            // Wave 3 gap: trait-bound syntax (`<T: TraitName>`) is parsed in
-            // Wave 2 and bound-checked at call sites in Wave 3. Until then,
-            // all parsed functions carry an empty trait_bounds vec.
-            trait_bounds: Vec::new(),
+            trait_bounds,
             params,
             param_defaults,
             requires,
@@ -205,17 +208,21 @@ impl<'a> Parser<'a> {
         Ok((requires, ensures, invariants))
     }
 
-    /// Parse an optional `<T, U, ...>` type parameter list.
+    /// Parse an optional `<T, U: Bound, ...>` type parameter list with
+    /// optional trait bounds.
     ///
-    /// Returns the interned `SymbolId`s for the declared type parameters and
-    /// pushes them into `self.type_param_scope` so that `parse_type` can emit
-    /// `Type::TypeVar` for matching names. The caller is responsible for
-    /// calling `self.pop_type_param_scope(count)` after parsing the body.
-    fn parse_type_params(&mut self) -> Result<Vec<SymbolId>, FrontendError> {
+    /// Returns `(type_params, trait_bounds)`. Type parameter names are pushed
+    /// into `self.type_param_scope` so `parse_type` can emit `Type::TypeVar`
+    /// for matching names. The caller must call `pop_type_param_scope(count)`
+    /// after parsing the body.
+    fn parse_type_params_with_bounds(
+        &mut self,
+    ) -> Result<(Vec<SymbolId>, Vec<TraitBound>), FrontendError> {
         if !self.eat(TokenKind::LAngle) {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
         let mut params = Vec::new();
+        let mut bounds = Vec::new();
         loop {
             if self.check(TokenKind::RAngle) {
                 break;
@@ -223,6 +230,11 @@ impl<'a> Parser<'a> {
             let param_id = self.expect_type_param_name()?;
             params.push(param_id);
             self.type_param_scope.push(param_id);
+            // Optional `: TraitName` bound on this parameter.
+            if self.eat(TokenKind::Colon) {
+                let bound_name = self.expect_symbol()?;
+                bounds.push(TraitBound { param: param_id, bound: bound_name });
+            }
             if self.eat(TokenKind::Comma) {
                 continue;
             }
@@ -235,6 +247,16 @@ impl<'a> Parser<'a> {
             });
         }
         self.expect(TokenKind::RAngle, "expected '>' after type parameter list")?;
+        Ok((params, bounds))
+    }
+
+    /// Parse an optional `<T, U, ...>` type parameter list (no bounds).
+    ///
+    /// Thin wrapper over `parse_type_params_with_bounds` that discards any
+    /// bounds. Used for record and ADT declarations where trait bounds on type
+    /// parameters are not admitted in first wave.
+    fn parse_type_params(&mut self) -> Result<Vec<SymbolId>, FrontendError> {
+        let (params, _bounds) = self.parse_type_params_with_bounds()?;
         Ok(params)
     }
 
@@ -242,6 +264,85 @@ impl<'a> Parser<'a> {
     fn pop_type_param_scope(&mut self, count: usize) {
         let new_len = self.type_param_scope.len().saturating_sub(count);
         self.type_param_scope.truncate(new_len);
+    }
+
+    /// Parse a `trait TraitName { fn method(params) -> ret; ... }` declaration.
+    fn parse_trait_decl(&mut self) -> Result<TraitDecl, FrontendError> {
+        self.expect(TokenKind::KwTrait, "expected 'trait'")?;
+        let name = self.expect_symbol()?;
+        let type_params = self.parse_type_params()?;
+        self.expect(TokenKind::LBrace, "expected '{' after trait name")?;
+        let mut methods = Vec::new();
+        loop {
+            let i = self.next_non_layout_idx();
+            if i >= self.tokens.len() {
+                break;
+            }
+            if self.tokens[i].kind == TokenKind::RBrace {
+                self.idx = i;
+                break;
+            }
+            self.idx = i;
+            methods.push(self.parse_trait_method_sig()?);
+        }
+        self.expect(TokenKind::RBrace, "expected '}' to close trait body")?;
+        self.pop_type_param_scope(type_params.len());
+        Ok(TraitDecl { name, type_params, methods })
+    }
+
+    /// Parse an abstract method signature inside a trait body:
+    /// `fn name(param: Type, ...) -> RetType;`
+    fn parse_trait_method_sig(&mut self) -> Result<TraitMethodSig, FrontendError> {
+        self.expect(TokenKind::KwFn, "expected 'fn' for trait method signature")?;
+        let name = self.expect_symbol()?;
+        self.expect(TokenKind::LParen, "expected '(' after trait method name")?;
+        let mut params = Vec::new();
+        if !self.check(TokenKind::RParen) {
+            loop {
+                let pname = self.expect_symbol()?;
+                self.expect(TokenKind::Colon, "expected ':' after parameter name")?;
+                let pty = self.parse_type()?;
+                params.push((pname, pty));
+                if self.eat(TokenKind::Comma) {
+                    continue;
+                }
+                break;
+            }
+        }
+        self.expect(TokenKind::RParen, "expected ')' after trait method parameters")?;
+        let ret = if self.eat(TokenKind::Implies) {
+            self.parse_type()?
+        } else {
+            Type::Unit
+        };
+        self.expect(TokenKind::Semi, "expected ';' after trait method signature")?;
+        Ok(TraitMethodSig { name, params, ret })
+    }
+
+    /// Parse an `impl TraitName for TypeName { fn method(...) { ... } ... }` block.
+    fn parse_impl_decl(&mut self) -> Result<ImplDecl, FrontendError> {
+        self.expect(TokenKind::KwImpl, "expected 'impl'")?;
+        let type_params = self.parse_type_params()?;
+        let trait_name = self.expect_symbol()?;
+        self.expect(TokenKind::KwFor, "expected 'for' after trait name in impl")?;
+        let for_type = self.expect_symbol()?;
+        self.expect(TokenKind::LBrace, "expected '{' after impl target type")?;
+        let mut methods = Vec::new();
+        loop {
+            let i = self.next_non_layout_idx();
+            if i >= self.tokens.len() {
+                break;
+            }
+            if self.tokens[i].kind == TokenKind::RBrace {
+                self.idx = i;
+                break;
+            }
+            self.idx = i;
+            methods.push(self.parse_function()?);
+        }
+        self.expect(TokenKind::RBrace, "expected '}' to close impl body")?;
+        self.pop_type_param_scope(type_params.len());
+        Ok(ImplDecl { trait_name, for_type, type_params, methods })
     }
 
     fn parse_record_decl(&mut self) -> Result<RecordDecl, FrontendError> {
@@ -5489,5 +5590,89 @@ fn main() { return; }
         let kinds: Vec<_> = tokens.iter().map(|t| t.kind).collect();
         assert!(kinds.contains(&TokenKind::LAngle));
         assert!(kinds.contains(&TokenKind::RAngle));
+    }
+
+    #[test]
+    fn trait_decl_with_one_method_sig_is_parsed() {
+        let src = r#"
+trait Display {
+    fn fmt(self: i32) -> i32;
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("trait declaration should parse");
+        assert_eq!(program.traits.len(), 1);
+        assert_eq!(program.impls.len(), 0);
+        let t = &program.traits[0];
+        assert_eq!(t.methods.len(), 1);
+        assert_eq!(t.type_params.len(), 0);
+        let method = &t.methods[0];
+        assert_eq!(method.params.len(), 1);
+        assert_eq!(method.ret, Type::I32);
+    }
+
+    #[test]
+    fn trait_decl_with_multiple_method_sigs_is_parsed() {
+        let src = r#"
+trait Printable {
+    fn format(self: i32) -> i32;
+    fn debug(self: i32) -> i32;
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("multi-method trait should parse");
+        assert_eq!(program.traits[0].methods.len(), 2);
+    }
+
+    #[test]
+    fn impl_decl_with_one_method_body_is_parsed() {
+        let src = r#"
+trait Display {
+    fn fmt(self: i32) -> i32;
+}
+record MyNum {
+    value: i32,
+}
+impl Display for MyNum {
+    fn fmt(self: i32) -> i32 {
+        return self;
+    }
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("impl block should parse");
+        assert_eq!(program.impls.len(), 1);
+        let imp = &program.impls[0];
+        assert_eq!(imp.methods.len(), 1);
+        assert_eq!(imp.type_params.len(), 0);
+    }
+
+    #[test]
+    fn function_with_trait_bound_is_parsed() {
+        let src = r#"
+fn print_all<T: Display>(x: T) -> i32 {
+    return 0;
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("function with trait bound should parse");
+        let func = &program.functions[0];
+        assert_eq!(func.type_params.len(), 1);
+        assert_eq!(func.trait_bounds.len(), 1);
+        assert_eq!(func.trait_bounds[0].param, func.type_params[0]);
+    }
+
+    #[test]
+    fn function_with_multiple_type_params_mixed_bounds_is_parsed() {
+        let src = r#"
+fn apply<T: Eq, U>(x: T, y: U) -> i32 {
+    return 0;
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("mixed-bound function should parse");
+        let func = &program.functions[0];
+        assert_eq!(func.type_params.len(), 2);
+        assert_eq!(func.trait_bounds.len(), 1);
     }
 }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -73,6 +73,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
         func.name,
         FnSig {
             type_params: Vec::new(),
+            trait_bounds: Vec::new(),
             params: func
                 .params
                 .iter()

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -90,7 +90,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
     validate_record_declarations(program, &record_table, &adt_table)?;
     validate_adt_declarations(program, &record_table, &adt_table)?;
     validate_schema_declarations(program, &schema_table, &record_table, &adt_table)?;
-    type_check_function_with_tables(func, &program.arena, &table, &record_table, &adt_table)
+    type_check_function_with_tables(func, &program.arena, &table, &record_table, &adt_table, &[])
 }
 
 pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
@@ -98,6 +98,10 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     let record_table = build_record_table(p)?;
     let adt_table = build_adt_table(p)?;
     let schema_table = build_schema_table(p)?;
+    // M9.2 Wave 3: trait coherence and impl conformance.
+    let trait_table = build_trait_table(p)?;
+    validate_trait_coherence(&p.impls, &p.arena)?;
+    validate_impl_conformance(&p.impls, &trait_table, &p.arena)?;
     validate_top_level_name_collisions(p, &table, &record_table, &adt_table, &schema_table)?;
     validate_record_declarations(p, &record_table, &adt_table)?;
     validate_adt_declarations(p, &record_table, &adt_table)?;
@@ -122,7 +126,7 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
         });
     }
     for f in &p.functions {
-        type_check_function_with_tables(f, &p.arena, &table, &record_table, &adt_table)?;
+        type_check_function_with_tables(f, &p.arena, &table, &record_table, &adt_table, &p.impls)?;
     }
     Ok(())
 }
@@ -196,7 +200,7 @@ pub fn type_check_function_with_table(
 ) -> Result<(), FrontendError> {
     let empty_records = RecordTable::new();
     let empty_adts = AdtTable::new();
-    type_check_function_with_tables(func, arena, table, &empty_records, &empty_adts)
+    type_check_function_with_tables(func, arena, table, &empty_records, &empty_adts, &[])
 }
 
 fn type_check_function_with_tables(
@@ -205,6 +209,7 @@ fn type_check_function_with_tables(
     table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     if func.params.len() != func.param_defaults.len() {
         return Err(FrontendError {
@@ -279,6 +284,7 @@ fn type_check_function_with_tables(
                 adt_table,
                 Type::Unit,
                 &mut default_loop_stack,
+            impl_list,
             )?;
             if let Err(err) = ensure_const_initializer_safe(*default_expr, arena, &empty_env) {
                 return Err(FrontendError {
@@ -299,9 +305,9 @@ fn type_check_function_with_tables(
             )?;
         }
     }
-    check_requires_clauses(func, arena, table, record_table, adt_table)?;
-    check_ensures_clauses(func, arena, table, record_table, adt_table, &canonical_ret)?;
-    check_invariant_clauses(func, arena, table, record_table, adt_table, &canonical_ret)?;
+    check_requires_clauses(func, arena, table, record_table, adt_table, impl_list)?;
+    check_ensures_clauses(func, arena, table, record_table, adt_table, &canonical_ret, impl_list)?;
+    check_invariant_clauses(func, arena, table, record_table, adt_table, &canonical_ret, impl_list)?;
     let mut env = ScopeEnv::with_params(&canonical_params);
     let mut loop_stack = Vec::new();
     for stmt in &func.body {
@@ -314,6 +320,7 @@ fn type_check_function_with_tables(
             record_table,
             adt_table,
             &mut loop_stack,
+        impl_list,
         )?;
     }
     Ok(())
@@ -325,6 +332,7 @@ fn check_requires_clauses(
     table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     if func.requires.is_empty() {
         return Ok(());
@@ -352,6 +360,7 @@ fn check_requires_clauses(
             adt_table,
             canonicalize_declared_type_generic(&func.ret, record_table, adt_table, arena, &func.type_params)?,
             &mut loop_stack,
+        impl_list,
         )?;
         if condition_ty != Type::Bool {
             return Err(FrontendError {
@@ -373,6 +382,7 @@ fn check_ensures_clauses(
     record_table: &RecordTable,
     adt_table: &AdtTable,
     canonical_ret: &Type,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     if func.ensures.is_empty() {
         return Ok(());
@@ -406,6 +416,7 @@ fn check_ensures_clauses(
             adt_table,
             canonical_ret.clone(),
             &mut loop_stack,
+        impl_list,
         )?;
         if condition_ty != Type::Bool {
             return Err(FrontendError {
@@ -427,6 +438,7 @@ fn check_invariant_clauses(
     record_table: &RecordTable,
     adt_table: &AdtTable,
     canonical_ret: &Type,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     if func.invariants.is_empty() {
         return Ok(());
@@ -461,6 +473,7 @@ fn check_invariant_clauses(
             adt_table,
             canonical_ret.clone(),
             &mut loop_stack,
+        impl_list,
         )?;
         if condition_ty != Type::Bool {
             return Err(FrontendError {
@@ -536,6 +549,7 @@ fn check_stmt(
     record_table: &RecordTable,
     adt_table: &AdtTable,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     let stmt = arena.stmt(stmt_id);
     match stmt {
@@ -567,6 +581,7 @@ fn check_stmt(
                     Some(expected_ty.clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
@@ -586,6 +601,7 @@ fn check_stmt(
                     adt_table,
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 vt
             };
@@ -619,6 +635,7 @@ fn check_stmt(
                     Some(expected_ty.clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
@@ -638,6 +655,7 @@ fn check_stmt(
                     adt_table,
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 vt
             };
@@ -671,6 +689,7 @@ fn check_stmt(
                     Some(expected_ty.clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     expected_ty.clone(),
@@ -690,6 +709,7 @@ fn check_stmt(
                     adt_table,
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 vt
             };
@@ -737,6 +757,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if value_ty != Type::Record(*record_name) {
                 return Err(FrontendError {
@@ -803,6 +824,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if value_ty != Type::Record(*record_name) {
                 return Err(FrontendError {
@@ -823,6 +845,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             let mut saw_refutable_item = false;
             for item in items {
@@ -906,6 +929,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let final_ty = if let Some(ann) = ty {
                 let expected_ty = canonicalize_declared_type(ann, record_table, adt_table, arena)?;
@@ -945,6 +969,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
                 match item {
@@ -992,6 +1017,7 @@ fn check_stmt(
                     Some(expected_ty.clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     expected_ty,
@@ -1030,6 +1056,7 @@ fn check_stmt(
                 Some(target_ty.clone()),
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             ensure_binding_value_type(
                 target_ty,
@@ -1049,6 +1076,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let Type::Tuple(item_tys) = value_ty else {
                 return Err(FrontendError {
@@ -1109,6 +1137,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if range_ty != Type::RangeI32 {
                 return Err(FrontendError {
@@ -1129,6 +1158,7 @@ fn check_stmt(
                     record_table,
                     adt_table,
                     loop_stack,
+                impl_list,
                 )?;
             }
             body_env.pop_scope();
@@ -1144,6 +1174,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             let frame = loop_stack.last_mut().ok_or(FrontendError {
                 pos: 0,
@@ -1177,6 +1208,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if condition_ty != Type::Bool {
                 return Err(FrontendError {
@@ -1195,6 +1227,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )
         }
         Stmt::If {
@@ -1211,6 +1244,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if ct != Type::Bool {
                 return Err(FrontendError {
@@ -1232,6 +1266,7 @@ fn check_stmt(
                     record_table,
                     adt_table,
                     loop_stack,
+                impl_list,
                 )?;
             }
             then_env.pop_scope();
@@ -1248,6 +1283,7 @@ fn check_stmt(
                     record_table,
                     adt_table,
                     loop_stack,
+                impl_list,
                 )?;
             }
             else_env.pop_scope();
@@ -1267,6 +1303,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if !matches!(
                 st,
@@ -1296,6 +1333,7 @@ fn check_stmt(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
                 for s in &arm.block {
                     check_stmt(
@@ -1307,6 +1345,7 @@ fn check_stmt(
                         record_table,
                         adt_table,
                         loop_stack,
+                    impl_list,
                     )?;
                 }
                 arm_env.pop_scope();
@@ -1343,6 +1382,7 @@ fn check_stmt(
                         record_table,
                         adt_table,
                         loop_stack,
+                    impl_list,
                     )?;
                 }
                 def_env.pop_scope();
@@ -1358,6 +1398,7 @@ fn check_stmt(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Stmt::Expr(e) => {
             if check_builtin_assert_stmt(
@@ -1369,6 +1410,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )? {
                 return Ok(());
             }
@@ -1381,6 +1423,7 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             Ok(())
         }
@@ -1398,6 +1441,15 @@ fn subst_apply(ty: &Type, subst: &BTreeMap<SymbolId, Type>) -> Type {
     }
 }
 
+/// Returns true if `concrete_ty` matches the `for_type` nominal name of an
+/// impl block. Used by the M9.2 Wave 3 trait bound satisfaction check.
+fn concrete_type_matches_impl_for(concrete_ty: &Type, for_type: SymbolId) -> bool {
+    match concrete_ty {
+        Type::Record(id) | Type::Adt(id) => *id == for_type,
+        _ => false,
+    }
+}
+
 fn infer_expr_type(
     expr_id: ExprId,
     arena: &AstArena,
@@ -1407,6 +1459,7 @@ fn infer_expr_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let expr = arena.expr(expr_id);
     match expr {
@@ -1423,6 +1476,7 @@ fn infer_expr_type(
             None,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::Closure(closure) => infer_closure_literal_type(
             closure,
@@ -1434,6 +1488,7 @@ fn infer_expr_type(
             None,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::NumericLiteral(literal) => match literal {
             NumericLiteral::I32(_) => Ok(Type::I32),
@@ -1451,6 +1506,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let end_ty = infer_expr_type(
                 range_expr.end,
@@ -1461,6 +1517,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             if start_ty != Type::I32 || end_ty != Type::I32 {
                 return Err(FrontendError {
@@ -1485,6 +1542,7 @@ fn infer_expr_type(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
                 if item_ty == Type::RangeI32 {
                     return Err(FrontendError {
@@ -1507,6 +1565,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::RecordField(field_expr) => infer_record_field_access_type(
             field_expr,
@@ -1517,6 +1576,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::SequenceIndex(index_expr) => infer_sequence_index_type(
             index_expr,
@@ -1527,6 +1587,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::RecordUpdate(update_expr) => infer_record_update_type(
             update_expr,
@@ -1537,6 +1598,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
             ctor_expr,
@@ -1548,6 +1610,7 @@ fn infer_expr_type(
             None,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::Var(v) => env.get(*v).ok_or(FrontendError {
             pos: 0,
@@ -1562,6 +1625,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::If(if_expr) => {
             let cond_ty = infer_expr_type(
@@ -1573,6 +1637,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if cond_ty != Type::Bool {
                 return Err(FrontendError {
@@ -1591,6 +1656,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let else_ty = infer_value_block_type(
                 &if_expr.else_block,
@@ -1601,6 +1667,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if then_ty != else_ty {
                 return Err(FrontendError {
@@ -1622,6 +1689,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::Loop(loop_expr) => infer_loop_expr_type(
             loop_expr,
@@ -1632,6 +1700,7 @@ fn infer_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::Call(name, args) => {
             if is_builtin_assert_name(*name, arena, table)? {
@@ -1675,6 +1744,7 @@ fn infer_expr_type(
                     Some(closure_ty.param.as_ref().clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     closure_ty.param.as_ref().clone(),
@@ -1718,6 +1788,7 @@ fn infer_expr_type(
                             adt_table,
                             ret_ty.clone(),
                             loop_stack,
+                        impl_list,
                         )?;
                         subst.insert(*tid, at);
                     }
@@ -1733,6 +1804,28 @@ fn infer_expr_type(
                                 fn_name,
                             ),
                         });
+                    }
+                }
+                // M9.2 Wave 3: trait bound satisfaction check.
+                // After substitution is fully inferred, verify that each bound
+                // T: TraitName is satisfied by the concrete type substituted for T.
+                for bound in &sig.trait_bounds {
+                    if let Some(concrete_ty) = subst.get(&bound.param) {
+                        let satisfied = impl_list.iter().any(|imp| {
+                            imp.trait_name == bound.bound
+                                && concrete_type_matches_impl_for(concrete_ty, imp.for_type)
+                        });
+                        if !satisfied {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: format!(
+                                    "type {:?} does not implement trait '{}' required by '{}'",
+                                    concrete_ty,
+                                    resolve_symbol_name(arena, bound.bound)?,
+                                    fn_name,
+                                ),
+                            });
+                        }
                     }
                 }
                 // Substitute TypeVar → concrete in all param types and ret.
@@ -1753,6 +1846,7 @@ fn infer_expr_type(
                         Some(expected_ty.clone()),
                         ret_ty.clone(),
                         loop_stack,
+                    impl_list,
                     )?;
                     if at != expected_ty {
                         if expected_ty == Type::Fx && is_numeric_for_fx_gap(&at) {
@@ -1792,6 +1886,7 @@ fn infer_expr_type(
                     Some(expected_ty.clone()),
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
                 if at != expected_ty {
                     if expected_ty == Type::Fx && is_numeric_for_fx_gap(&at) {
@@ -1832,6 +1927,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let measured = measured_numeric_parts(&t);
             match op {
@@ -1880,6 +1976,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             let rt = infer_expr_type(
                 *r,
@@ -1890,6 +1987,7 @@ fn infer_expr_type(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             match op {
                 BinaryOp::Eq | BinaryOp::Ne => {
@@ -4841,6 +4939,157 @@ mod tests {
             err.message
         );
     }
+
+    // M9.2 Wave 3 — trait coherence, conformance, and bound satisfaction
+
+    #[test]
+    fn duplicate_impl_same_trait_and_type_is_rejected() {
+        let src = r#"
+            trait Display {
+                fn show(self: MyType) -> i32;
+            }
+
+            record MyType { x: i32 }
+
+            impl Display for MyType {
+                fn show(self: MyType) -> i32 {
+                    return 0;
+                }
+            }
+
+            impl Display for MyType {
+                fn show(self: MyType) -> i32 {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("duplicate impl must be rejected by coherence check");
+        assert!(
+            err.message.contains("duplicate") || err.message.contains("impl"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_missing_required_method_is_rejected() {
+        let src = r#"
+            trait Greet {
+                fn hello(self: Greeter) -> i32;
+                fn bye(self: Greeter) -> i32;
+            }
+
+            record Greeter { x: i32 }
+
+            impl Greet for Greeter {
+                fn hello(self: Greeter) -> i32 {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl missing required method must be rejected");
+        assert!(
+            err.message.contains("bye") || err.message.contains("missing") || err.message.contains("method"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_method_wrong_return_type_is_rejected() {
+        let src = r#"
+            trait Counter {
+                fn count(self: Cnt) -> i32;
+            }
+
+            record Cnt { n: i32 }
+
+            impl Counter for Cnt {
+                fn count(self: Cnt) -> bool {
+                    return true;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl method with wrong return type must be rejected");
+        assert!(
+            err.message.contains("count") || err.message.contains("return type") || err.message.contains("mismatch"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn generic_fn_with_bound_and_satisfying_impl_typechecks() {
+        let src = r#"
+            trait Zeroable {
+                fn zero(v: ZeroInt) -> i32;
+            }
+
+            record ZeroInt { n: i32 }
+
+            impl Zeroable for ZeroInt {
+                fn zero(v: ZeroInt) -> i32 {
+                    return 0;
+                }
+            }
+
+            fn make_zero<T: Zeroable>(v: T) -> T {
+                return v;
+            }
+
+            fn main() {
+                let z: ZeroInt = ZeroInt { n: 0 };
+                let r: ZeroInt = make_zero(z);
+                let _ = r;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("bound satisfied by impl should typecheck");
+    }
+
+    #[test]
+    fn generic_fn_with_bound_and_missing_impl_rejects() {
+        let src = r#"
+            trait Printable {
+                fn print(v: NoPrint) -> i32;
+            }
+
+            record NoPrint { x: i32 }
+
+            fn show<T: Printable>(v: T) -> T {
+                return v;
+            }
+
+            fn main() {
+                let p: NoPrint = NoPrint { x: 1 };
+                let r: NoPrint = show(p);
+                let _ = r;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("call with unsatisfied trait bound must be rejected");
+        assert!(
+            err.message.contains("Printable") || err.message.contains("implement") || err.message.contains("trait"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
 }
 
 fn is_builtin_assert_name(
@@ -4860,6 +5109,7 @@ fn check_builtin_assert_stmt(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<bool, FrontendError> {
     let Expr::Call(name, args) = arena.expr(expr_id) else {
         return Ok(false);
@@ -4882,6 +5132,7 @@ fn check_builtin_assert_stmt(
         adt_table,
         ret_ty,
         loop_stack,
+    impl_list,
     )?;
     if cond_ty != Type::Bool {
         return Err(FrontendError {
@@ -4901,6 +5152,7 @@ fn infer_value_block_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let mut block_env = env.clone();
     block_env.push_scope();
@@ -4920,6 +5172,7 @@ fn infer_value_block_type(
                     record_table,
                     adt_table,
                     loop_stack,
+                impl_list,
                 )?;
             }
             _ => {
@@ -4939,6 +5192,7 @@ fn infer_value_block_type(
         adt_table,
         ret_ty,
         loop_stack,
+    impl_list,
     )?;
     block_env.pop_scope();
     Ok(tail_ty)
@@ -4953,6 +5207,7 @@ fn infer_match_expr_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let scrutinee_ty = infer_expr_type(
         match_expr.scrutinee,
@@ -4963,6 +5218,7 @@ fn infer_match_expr_type(
         adt_table,
         ret_ty.clone(),
         loop_stack,
+    impl_list,
     )?;
     if !matches!(
         scrutinee_ty,
@@ -4994,6 +5250,7 @@ fn infer_match_expr_type(
             adt_table,
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         let arm_ty = infer_value_block_type(
             &arm.block,
@@ -5004,6 +5261,7 @@ fn infer_match_expr_type(
             adt_table,
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         if let Some(ref expected) = result_ty {
             if *expected != arm_ty {
@@ -5030,6 +5288,7 @@ fn infer_match_expr_type(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         )?;
         if let Some(expected) = result_ty {
             if expected != default_ty {
@@ -5076,6 +5335,7 @@ fn infer_loop_expr_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let mut body_env = env.clone();
     body_env.push_scope();
@@ -5090,6 +5350,7 @@ fn infer_loop_expr_type(
             adt_table,
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
     }
     body_env.pop_scope();
@@ -5109,6 +5370,7 @@ fn check_loop_expr_stmt(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     match arena.stmt(stmt_id) {
         Stmt::LetElseTuple { .. } | Stmt::LetElseRecord { .. } => Err(FrontendError {
@@ -5138,6 +5400,7 @@ fn check_loop_expr_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if cond_ty != Type::Bool {
                 return Err(FrontendError {
@@ -5159,6 +5422,7 @@ fn check_loop_expr_stmt(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
             }
             then_env.pop_scope();
@@ -5175,6 +5439,7 @@ fn check_loop_expr_stmt(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
             }
             else_env.pop_scope();
@@ -5194,6 +5459,7 @@ fn check_loop_expr_stmt(
                 adt_table,
                 ret_ty.clone(),
                 loop_stack,
+            impl_list,
             )?;
             if !matches!(
                 st,
@@ -5229,6 +5495,7 @@ fn check_loop_expr_stmt(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
                 for stmt in &arm.block {
                     check_loop_expr_stmt(
@@ -5240,6 +5507,7 @@ fn check_loop_expr_stmt(
                         adt_table,
                         ret_ty.clone(),
                         loop_stack,
+                    impl_list,
                     )?;
                 }
                 arm_env.pop_scope();
@@ -5257,6 +5525,7 @@ fn check_loop_expr_stmt(
                     adt_table,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
             }
             def_env.pop_scope();
@@ -5271,8 +5540,84 @@ fn check_loop_expr_stmt(
             record_table,
             adt_table,
             loop_stack,
+        impl_list,
         ),
     }
+}
+
+/// Coherence check: at most one impl per (trait_name, for_type) pair.
+fn validate_trait_coherence(
+    impls: &[ImplDecl],
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    let mut seen: BTreeSet<(SymbolId, SymbolId)> = BTreeSet::new();
+    for imp in impls {
+        let key = (imp.trait_name, imp.for_type);
+        if !seen.insert(key) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "duplicate impl of trait '{}' for type '{}'",
+                    resolve_symbol_name(arena, imp.trait_name)?,
+                    resolve_symbol_name(arena, imp.for_type)?,
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Conformance check: each impl provides every method declared in its trait
+/// with a matching return type.
+fn validate_impl_conformance(
+    impls: &[ImplDecl],
+    trait_table: &TraitTable,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    for imp in impls {
+        let trait_decl = match trait_table.get(&imp.trait_name) {
+            Some(t) => t,
+            None => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "impl references unknown trait '{}'",
+                        resolve_symbol_name(arena, imp.trait_name)?,
+                    ),
+                });
+            }
+        };
+        for trait_method in &trait_decl.methods {
+            match imp.methods.iter().find(|m| m.name == trait_method.name) {
+                None => {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "impl of '{}' for '{}' is missing method '{}'",
+                            resolve_symbol_name(arena, imp.trait_name)?,
+                            resolve_symbol_name(arena, imp.for_type)?,
+                            resolve_symbol_name(arena, trait_method.name)?,
+                        ),
+                    });
+                }
+                Some(m) => {
+                    if m.ret != trait_method.ret {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "impl method '{}' has return type {:?}, expected {:?} from trait '{}'",
+                                resolve_symbol_name(arena, trait_method.name)?,
+                                m.ret,
+                                trait_method.ret,
+                                resolve_symbol_name(arena, imp.trait_name)?,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_top_level_name_collisions(
@@ -6147,6 +6492,7 @@ fn infer_record_literal_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let record = record_table
         .get(&record_literal.name)
@@ -6195,6 +6541,7 @@ fn infer_record_literal_type(
             Some(expected_ty.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         ensure_binding_value_type(
             expected_ty.clone(),
@@ -6232,6 +6579,7 @@ fn infer_record_field_access_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let base_ty = infer_expr_type(
         field_expr.base,
@@ -6242,6 +6590,7 @@ fn infer_record_field_access_type(
         adt_table,
         ret_ty,
         loop_stack,
+    impl_list,
     )?;
     let Type::Record(record_name) = base_ty else {
         return Err(FrontendError {
@@ -6284,6 +6633,7 @@ fn infer_sequence_index_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let base_ty = infer_expr_type(
         index_expr.base,
@@ -6294,6 +6644,7 @@ fn infer_sequence_index_type(
         adt_table,
         ret_ty.clone(),
         loop_stack,
+    impl_list,
     )?;
     let Type::Sequence(sequence_ty) = base_ty else {
         return Err(FrontendError {
@@ -6313,6 +6664,7 @@ fn infer_sequence_index_type(
         adt_table,
         ret_ty,
         loop_stack,
+    impl_list,
     )?;
     if index_ty != Type::I32 {
         return Err(FrontendError {
@@ -6335,6 +6687,7 @@ fn infer_record_update_type(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let base_ty = infer_expr_type(
         update_expr.base,
@@ -6345,6 +6698,7 @@ fn infer_record_update_type(
         adt_table,
         ret_ty.clone(),
         loop_stack,
+    impl_list,
     )?;
     let Type::Record(record_name) = base_ty else {
         return Err(FrontendError {
@@ -6406,6 +6760,7 @@ fn infer_record_update_type(
             Some(expected_ty.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         ensure_binding_value_type(
             expected_ty.clone(),
@@ -6432,6 +6787,7 @@ fn infer_adt_ctor_type(
     expected: Option<&Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     if let Some(ty) = infer_std_form_ctor_type(
         ctor_expr,
@@ -6443,6 +6799,7 @@ fn infer_adt_ctor_type(
         expected,
         ret_ty.clone(),
         loop_stack,
+    impl_list,
     )? {
         return Ok(ty);
     }
@@ -6495,6 +6852,7 @@ fn infer_adt_ctor_type(
             Some(canonical_expected.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         ensure_binding_value_type(
             canonical_expected,
@@ -6522,6 +6880,7 @@ fn infer_expr_type_with_expected(
     expected: Option<Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     match arena.expr(expr_id) {
         Expr::Tuple(items) => {
@@ -6554,6 +6913,7 @@ fn infer_expr_type_with_expected(
                     item_expected,
                     ret_ty.clone(),
                     loop_stack,
+                impl_list,
                 )?;
                 if item_ty == Type::RangeI32 {
                     return Err(FrontendError {
@@ -6577,6 +6937,7 @@ fn infer_expr_type_with_expected(
             expected.as_ref(),
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::SequenceIndex(index_expr) => infer_sequence_index_type(
             index_expr,
@@ -6587,6 +6948,7 @@ fn infer_expr_type_with_expected(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::Closure(closure) => infer_closure_literal_type(
             closure,
@@ -6598,6 +6960,7 @@ fn infer_expr_type_with_expected(
             expected.as_ref(),
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         Expr::AdtCtor(ctor_expr) => infer_adt_ctor_type(
             ctor_expr,
@@ -6609,6 +6972,7 @@ fn infer_expr_type_with_expected(
             expected.as_ref(),
             ret_ty,
             loop_stack,
+        impl_list,
         ),
         _ => {
             let actual = infer_expr_type(
@@ -6620,6 +6984,7 @@ fn infer_expr_type_with_expected(
                 adt_table,
                 ret_ty,
                 loop_stack,
+            impl_list,
             )?;
             Ok(
                 lift_literal_to_expected_type(expected.as_ref(), &actual, expr_id, arena)
@@ -6639,6 +7004,7 @@ fn infer_sequence_literal_type(
     expected: Option<&Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let expected_item = match expected {
         Some(Type::Sequence(sequence_ty))
@@ -6675,6 +7041,7 @@ fn infer_sequence_literal_type(
             Some(expected_item.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         ensure_binding_value_type(
             expected_item.clone(),
@@ -6694,6 +7061,7 @@ fn infer_sequence_literal_type(
             adt_table,
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?
     };
 
@@ -6708,6 +7076,7 @@ fn infer_sequence_literal_type(
             Some(first_ty.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?;
         ensure_binding_value_type(
             first_ty.clone(),
@@ -6734,6 +7103,7 @@ fn infer_closure_literal_type(
     expected: Option<&Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
     let Some(Type::Closure(expected_closure)) = expected else {
         return Err(FrontendError {
@@ -6778,6 +7148,7 @@ fn infer_closure_literal_type(
         Some(expected_closure.ret.as_ref().clone()),
         ret_ty,
         loop_stack,
+    impl_list,
     )?;
     ensure_binding_value_type(
         expected_closure.ret.as_ref().clone(),
@@ -6799,6 +7170,7 @@ fn infer_std_form_ctor_type(
     expected: Option<&Type>,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<Option<Type>, FrontendError> {
     let type_name = resolve_symbol_name(arena, ctor_expr.adt_name)?;
     let variant_name = resolve_symbol_name(arena, ctor_expr.variant_name)?;
@@ -6824,6 +7196,7 @@ fn infer_std_form_ctor_type(
                         Some(expected_item.clone()),
                         ret_ty,
                         loop_stack,
+                    impl_list,
                     )?;
                     ensure_binding_value_type(
                         expected_item.clone(),
@@ -6843,6 +7216,7 @@ fn infer_std_form_ctor_type(
                         adt_table,
                         ret_ty,
                         loop_stack,
+                    impl_list,
                     )?
                 };
                 Ok(Some(Type::Option(Box::new(item_ty))))
@@ -6908,6 +7282,7 @@ fn infer_std_form_ctor_type(
                     Some(expected_payload.clone()),
                     ret_ty,
                     loop_stack,
+                impl_list,
                 )?;
                 ensure_binding_value_type(
                     expected_payload,
@@ -7162,6 +7537,7 @@ fn check_match_guard(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     if let Some(expr_id) = guard {
         let guard_ty = infer_expr_type(
@@ -7173,6 +7549,7 @@ fn check_match_guard(
             adt_table,
             ret_ty,
             loop_stack,
+        impl_list,
         )?;
         if guard_ty != Type::Bool {
             return Err(FrontendError {
@@ -7195,6 +7572,7 @@ fn check_return_payload(
     adt_table: &AdtTable,
     ret_ty: Type,
     loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
 ) -> Result<(), FrontendError> {
     let got = if let Some(expr_id) = value {
         infer_expr_type_with_expected(
@@ -7207,6 +7585,7 @@ fn check_return_payload(
             Some(ret_ty.clone()),
             ret_ty.clone(),
             loop_stack,
+        impl_list,
         )?
     } else {
         Type::Unit

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -386,6 +386,68 @@ pub struct MatchArm {
     pub block: Vec<StmtId>,
 }
 
+/// A named behavior bound on a type parameter.
+///
+/// Represents the `T: TraitName` constraint in a `<T: TraitName>` parameter
+/// list. Admitted at the owner layer (Wave 1). Bound checking at call sites
+/// and impl resolution are deferred to Wave 3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraitBound {
+    /// The type parameter that carries the bound.
+    pub param: SymbolId,
+    /// The named trait the parameter must implement.
+    pub bound: SymbolId,
+}
+
+/// A method signature declared inside a `trait` definition body.
+///
+/// No default method bodies in first wave — each method is an abstract
+/// signature only. Admitted at the owner layer (Wave 1). Parser admission
+/// is deferred to Wave 2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraitMethodSig {
+    pub name: SymbolId,
+    pub params: Vec<(SymbolId, Type)>,
+    pub ret: Type,
+}
+
+/// A named behavior contract declared with the `trait` keyword.
+///
+/// First-wave shape: named trait with a list of abstract method signatures.
+/// No default bodies, no associated types, no higher-ranked bounds.
+///
+/// Admitted at the owner layer (Wave 1). Parser admission is deferred to
+/// Wave 2. Impl resolution and static dispatch are deferred to Wave 3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraitDecl {
+    pub name: SymbolId,
+    /// Generic type parameters on the trait itself (`trait Foo<T>`).
+    /// Empty in first-wave canonical form.
+    pub type_params: Vec<SymbolId>,
+    pub methods: Vec<TraitMethodSig>,
+}
+
+/// An explicit named impl block binding a concrete type to a trait.
+///
+/// First-wave shape: one impl per (trait, type) pair; type_params on impl
+/// blocks are empty in first-wave canonical form.
+///
+/// Admitted at the owner layer (Wave 1). Parser admission is deferred to
+/// Wave 2. Impl resolution and static dispatch are deferred to Wave 3.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImplDecl {
+    /// The trait being implemented.
+    pub trait_name: SymbolId,
+    /// The concrete nominal type that implements the trait.
+    pub for_type: SymbolId,
+    /// Type parameters on the impl block.
+    /// Empty in first-wave canonical form.
+    pub type_params: Vec<SymbolId>,
+    /// Concrete method implementations. Each method must match a signature in
+    /// the corresponding `TraitDecl`.
+    pub methods: Vec<Function>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub name: SymbolId,
@@ -394,6 +456,11 @@ pub struct Function {
     /// Admitted at the owner layer (Wave 1). Executable use (monomorphisation,
     /// instantiation) is deferred to Wave 2.
     pub type_params: Vec<SymbolId>,
+    /// Trait bounds on the type parameters: `<T: TraitName>` constraints.
+    ///
+    /// Admitted at the owner layer (Wave 1). Bound checking at call sites
+    /// and impl resolution are deferred to Wave 3.
+    pub trait_bounds: Vec<TraitBound>,
     pub params: Vec<(SymbolId, Type)>,
     pub param_defaults: Vec<Option<ExprId>>,
     pub requires: Vec<ExprId>,
@@ -582,6 +649,16 @@ pub enum TokenKind {
     KwSchema,
     KwEnum,
     KwConst,
+    /// `trait` — introduces a named behavior contract declaration.
+    ///
+    /// Admitted to the lexer at the owner layer (Wave 1).
+    /// Parser admission is deferred to Wave 2.
+    KwTrait,
+    /// `impl` — introduces an explicit named impl block.
+    ///
+    /// Admitted to the lexer at the owner layer (Wave 1).
+    /// Parser admission is deferred to Wave 2.
+    KwImpl,
     KwLet,
     KwFor,
     KwIn,
@@ -889,6 +966,7 @@ mod tests {
         let func = Function {
             name,
             type_params: vec![t_param],
+            trait_bounds: vec![],
             params: vec![(param, Type::TypeVar(t_param))],
             param_defaults: vec![None],
             requires: vec![],
@@ -934,5 +1012,92 @@ mod tests {
         assert_eq!(literal.ret_ty, Some(Type::Bool));
         assert_eq!(literal.captures, vec![SymbolId(5), SymbolId(7)]);
         assert_eq!(literal.body, ExprId(11));
+    }
+
+    #[test]
+    fn trait_bound_owner_layer_data_is_stable() {
+        let mut arena = AstArena::default();
+        let t = arena.intern_symbol("T");
+        let display = arena.intern_symbol("Display");
+        let bound = TraitBound { param: t, bound: display };
+        assert_eq!(bound.param, t);
+        assert_eq!(bound.bound, display);
+    }
+
+    #[test]
+    fn trait_decl_owner_layer_data_is_stable() {
+        let mut arena = AstArena::default();
+        let name = arena.intern_symbol("Display");
+        let method = arena.intern_symbol("fmt");
+        let self_param = arena.intern_symbol("self");
+        let sig = TraitMethodSig {
+            name: method,
+            params: vec![(self_param, Type::Unit)],
+            ret: Type::Text,
+        };
+        let decl = TraitDecl {
+            name,
+            type_params: vec![],
+            methods: vec![sig],
+        };
+        assert_eq!(decl.name, name);
+        assert_eq!(decl.methods.len(), 1);
+        assert_eq!(decl.methods[0].name, method);
+        assert_eq!(decl.methods[0].ret, Type::Text);
+    }
+
+    #[test]
+    fn impl_decl_owner_layer_data_is_stable() {
+        let mut arena = AstArena::default();
+        let trait_name = arena.intern_symbol("Display");
+        let for_type = arena.intern_symbol("MyRecord");
+        let decl = ImplDecl {
+            trait_name,
+            for_type,
+            type_params: vec![],
+            methods: vec![],
+        };
+        assert_eq!(decl.trait_name, trait_name);
+        assert_eq!(decl.for_type, for_type);
+        assert!(decl.methods.is_empty());
+    }
+
+    #[test]
+    fn function_trait_bound_owner_layer_is_stable() {
+        let mut arena = AstArena::default();
+        let name = arena.intern_symbol("print_all");
+        let t_param = arena.intern_symbol("T");
+        let display = arena.intern_symbol("Display");
+        let param = arena.intern_symbol("x");
+        let body_expr = arena.alloc_expr(Expr::Var(param));
+        let body = arena.alloc_stmt(Stmt::Return(Some(body_expr)));
+        let func = Function {
+            name,
+            type_params: vec![t_param],
+            trait_bounds: vec![TraitBound { param: t_param, bound: display }],
+            params: vec![(param, Type::TypeVar(t_param))],
+            param_defaults: vec![None],
+            requires: vec![],
+            ensures: vec![],
+            invariants: vec![],
+            ret: Type::Unit,
+            body: vec![body],
+        };
+        assert_eq!(func.trait_bounds.len(), 1);
+        assert_eq!(func.trait_bounds[0].bound, display);
+        assert!(func.type_params.contains(&t_param));
+    }
+
+    #[test]
+    fn kw_trait_and_kw_impl_lex_to_reserved_tokens() {
+        use crate::lexer::lex_tokens;
+        let tokens = lex_tokens("trait Display { }").unwrap();
+        assert!(tokens.iter().any(|t| t.kind == TokenKind::KwTrait),
+            "expected KwTrait token from 'trait'");
+        let tokens2 = lex_tokens("impl Display for MyRecord { }").unwrap();
+        assert!(tokens2.iter().any(|t| t.kind == TokenKind::KwImpl),
+            "expected KwImpl token from 'impl'");
+        assert!(tokens2.iter().any(|t| t.kind == TokenKind::KwFor),
+            "expected KwFor token from 'for'");
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -584,6 +584,10 @@ pub struct Program {
     pub records: Vec<RecordDecl>,
     pub schemas: Vec<SchemaDecl>,
     pub functions: Vec<Function>,
+    /// Trait definitions admitted by the parser (Wave 2+).
+    pub traits: Vec<TraitDecl>,
+    /// Impl blocks admitted by the parser (Wave 2+).
+    pub impls: Vec<ImplDecl>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/docs/roadmap/language_maturity/generics_full_scope.md
+++ b/docs/roadmap/language_maturity/generics_full_scope.md
@@ -65,7 +65,7 @@ its widened contract on `main`.
 
 - higher-kinded types
 - variance annotations (covariance, contravariance)
-- trait/protocol bounds on type parameters (deferred to M9.2)
+- trait/protocol bounds on type parameters (completed in M9.2)
 - associated types or type families
 - generic closures beyond what first-wave monomorphisation admits
 - specialisation or template-based optimisation

--- a/docs/roadmap/language_maturity/traits_full_scope.md
+++ b/docs/roadmap/language_maturity/traits_full_scope.md
@@ -1,0 +1,77 @@
+# Traits Full Scope
+
+Status: completed M9.2 post-stable subtrack
+Related roadmap package:
+`docs/roadmap/language_maturity/generics_full_scope.md`
+
+## Goal
+
+Introduce the first admitted static trait surface for Semantic without
+opening runtime dispatch, trait objects, or advanced method resolution
+ahead of schedule.
+
+This is a forward-only language-maturity subtrack for current `main`. It is not
+a claim that trait-based polymorphism was part of the published `v1.1.1` line.
+
+## Decision Check
+
+- [x] This is a new explicit post-stable track with its own scope decision
+- [x] This does not silently widen published `v1.1.1`
+- [x] This is one stream, not a mixture of multiple tracks
+- [x] This can be closed with a clear done-boundary
+
+## Done-Boundary
+
+`M9.2 closes at static trait admission + coherence/conformance + bound satisfaction`
+
+## Included In This Track
+
+### Wave 1 — Owner Layer
+- `TraitDecl`, `ImplDecl`, `TraitBound`, `TraitMethodSig` AST nodes
+- `KwTrait` and `KwImpl` token kinds and lexer keyword map
+- `trait_bounds: Vec<TraitBound>` field on `Function` and `FnSig`
+- `TraitTable` and `ImplTable` public type aliases
+
+### Wave 2 — Parser Admission
+- `trait TraitName { fn method(params) -> ret; }` admitted at top level
+- `impl TraitName for TypeName { fn method(...) { ... } }` admitted at top level
+- `<T: TraitName>` bound syntax on function type parameters
+- `Program.traits` and `Program.impls` fields
+- `build_trait_table()` public API function
+
+### Wave 3 — Typecheck
+- `validate_trait_coherence`: rejects duplicate `(trait, for_type)` impl pairs
+- `validate_impl_conformance`: rejects impls missing required methods or with wrong return types
+- Bound satisfaction check at generic call sites: after type-var substitution,
+  verifies `impl TraitName for ConcreteType` exists in the program's impl list
+- All checks run centrally in `type_check_program`
+
+## Explicit Non-Goals (out of scope)
+
+- runtime dispatch / vtable-based dynamic dispatch
+- trait objects (`dyn TraitName`)
+- specialization (overlapping impls with precedence rules)
+- advanced method resolution (inherent vs trait method precedence)
+- blanket impls (`impl<T: Foo> Bar for T`)
+- associated types or type families
+- default method implementations in trait bodies
+- negative impls
+- silent widening of published `v1.1.1`
+
+## Test Coverage
+
+- coherence: duplicate `(trait, for_type)` pair is rejected
+- conformance: impl missing a required method is rejected
+- conformance: impl method with wrong return type is rejected
+- bound satisfaction: generic call with satisfying impl typechecks
+- bound satisfaction: generic call with no impl is rejected
+
+## Wave Order
+
+```
+W0 governance   → scope decision recorded
+W1 owner layer  → AST nodes, TokenKind, type aliases
+W2 parser       → trait/impl admitted at top level, bound syntax
+W3 typecheck    → coherence, conformance, bound satisfaction
+W4 freeze       → changelog, milestone, scope doc marked complete
+```

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -125,9 +125,9 @@
   - iterable abstraction
   - richer pattern surface
   - current status: active post-stable language-maturity package
-  - current completed first subtrack:
-    `docs/roadmap/language_maturity/generics_full_scope.md`
+  - completed subtracks:
+    - M9.1: `docs/roadmap/language_maturity/generics_full_scope.md`
+    - M9.2: `docs/roadmap/language_maturity/traits_full_scope.md`
   - planning rule:
     - keep one active stream at a time
-    - do not open trait/protocol bounds before generics foundation is stable
     - keep UI/platform expansion separate from language-maturity work

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,8 @@ pub mod frontend {
             records: p.records,
             schemas: p.schemas,
             functions: p.functions,
+            traits: p.traits,
+            impls: p.impls,
         })
     }
 

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -55,6 +55,8 @@ pub fn build_record_table(program: &Program) -> Result<RecordTable, FrontendErro
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_adt_table(program: &Program) -> Result<AdtTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub fn build_trait_table(program: &Program) -> Result<TraitTable, FrontendError> {
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_schema_table(program: &Program) -> Result<SchemaTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn canonicalize_declared_type(

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -15,6 +15,7 @@ pub use typecheck::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FnSig {
 pub type_params: Vec<SymbolId>,
+pub trait_bounds: Vec<TraitBound>,
 pub params: Vec<Type>,
 pub param_names: Option<Vec<SymbolId>>,
 pub param_defaults: Option<Vec<Option<ExprId>>>,
@@ -29,6 +30,8 @@ pub type AdtTable = BTreeMap<SymbolId, AdtDecl>;
 pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type ValidationPlanTable = BTreeMap<SymbolId, ValidationPlan>;
+pub type TraitTable = BTreeMap<SymbolId, TraitDecl>;
+pub type ImplTable = Vec<ImplDecl>;
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeBinding {


### PR DESCRIPTION
## Summary

Follow-up to #260 (M9.2 Wave 1, merged). This PR lands the remaining waves that were pushed after the squash merge.

### Wave 2 — Parser Admission
- Parser admits `trait TraitName { fn method(params) -> ret; }` at top level
- Parser admits `impl TraitName for TypeName { fn method(...) { ... } }` at top level
- `<T: TraitName>` bound syntax on function type parameters
- `Program.traits` / `Program.impls` fields; `build_trait_table()` public API
- 5 parser tests

### Wave 3 — Typecheck
- `validate_trait_coherence`: rejects duplicate `(trait, for_type)` impl pairs
- `validate_impl_conformance`: rejects impls with missing methods or wrong return types
- Bound satisfaction check at generic call sites after type-var substitution
- Thread `impl_list` through all typecheck functions
- 5 Wave 3 tests

### Wave 4 — Freeze
- CHANGELOG entry with done-boundary
- `milestones.md`: M9.2 marked as completed subtrack
- `traits_full_scope.md`: scope doc with included/out-of-scope inventory
- `generics_full_scope.md`: non-goal updated to "completed in M9.2"

## Done-Boundary

`M9.2 closes at static trait admission + coherence/conformance + bound satisfaction`

## Test Result

281 sm-front tests pass, full workspace green.

## Decision Check

- [x] This is a new explicit post-stable track with its own scope decision
- [x] This does not silently widen published `v1.1.1`
- [x] This is one stream, not a mixture of multiple tracks
- [x] This can be closed with a clear done-boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)