### PR TITLE
M9.4–M9.9: richer pattern surface + ownership model + path-aware reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented in this file.
 
 ### Added (post-v1.1.1 language-maturity subtracks)
 
+- **M9.4 Richer Pattern Surface**: five new pattern forms across owner layer, parser, and typecheck.
+  - `MatchPattern::Wildcard` — bare `_` matches any scrutinee, binds nothing
+  - `MatchPattern::Or(alts)` — pipe-separated alternatives `P1 | P2 | P3`
+  - `MatchPattern::IntRange(IntRangePattern)` — integer range `1..=5` / `1..5`; admitted for `i32`/`u32` scrutinees
+  - `TuplePatternItem::Nested(items)` — recursive tuple destructuring `let (a, (b, c)) = ...`
+  - `Expr::IfLet(IfLetExpr)` — `if let Pat = expr { } else { }` binding guard
+  - `TokenKind::Pipe` — bare `|` now lexes as a token (was error)
+  - exhaustiveness: Wildcard covers all variants; Or unwraps alternatives for variant coverage
+  - done-boundary: `M9.4 closes at owner layer + parser admission + typecheck for all five forms`
+
 - **M9.2 Traits (static)**: traits/impls now have full owner-layer representation,
   parser admission, and static typecheck support.
   - `trait` and `impl` declarations admitted at top level

--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -187,14 +187,9 @@ fn tokenize_line(
                     push_tok(out, TokenKind::PipeForward, "|>", abs_pos, line_no, col);
                     i += 2;
                 } else {
-                    return Err(fmt_mark_error(
-                        "E0003",
-                        line_no,
-                        col,
-                        line_text,
-                        "expected '||' or '|>'",
-                        abs_pos,
-                    ));
+                    // M9.4 Wave 2: bare `|` is the or-pattern separator.
+                    push_tok(out, TokenKind::Pipe, "|", abs_pos, line_no, col);
+                    i += 1;
                 }
             }
             b'+' => {

--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -323,6 +323,7 @@ fn tokenize_line(
                     "Pulse" => TokenKind::KwPulse,
                     "Profile" => TokenKind::KwProfile,
                     "Import" => TokenKind::KwImport,
+                    "ref" => TokenKind::KwRef,
                     "quad" => TokenKind::TyQuad,
                     "bool" => TokenKind::TyBool,
                     "i32" => TokenKind::TyI32,

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -97,6 +97,8 @@ pub type ImplTable = Vec<ImplDecl>;
 pub struct ScopeBinding {
     pub ty: Type,
     pub is_const: bool,
+    /// M9.5 Wave C: true after the binding's value has been moved out.
+    pub consumed: bool,
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -137,12 +139,28 @@ impl ScopeEnv {
             ScopeBinding {
                 ty,
                 is_const: false,
+                consumed: false,
             },
         );
     }
 
     pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-        self.insert_binding(name, ScopeBinding { ty, is_const: true });
+        self.insert_binding(name, ScopeBinding { ty, is_const: true, consumed: false });
+    }
+
+    /// Mark a variable as consumed (moved out). Subsequent reads will be rejected.
+    pub fn mark_consumed(&mut self, name: SymbolId) {
+        for scope in self.scopes.iter_mut().rev() {
+            if let Some(binding) = scope.get_mut(&name) {
+                binding.consumed = true;
+                return;
+            }
+        }
+    }
+
+    /// Returns true if the variable has been moved and is no longer available.
+    pub fn is_consumed(&self, name: SymbolId) -> bool {
+        self.binding(name).map(|b| b.consumed).unwrap_or(false)
     }
 
     fn insert_binding(&mut self, name: SymbolId, binding: ScopeBinding) {

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -27,6 +27,8 @@ pub use types::{
     TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type,
     UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
+    // M9.7
+    PathAvailability, PatternPath,
 };
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};
@@ -97,8 +99,11 @@ pub type ImplTable = Vec<ImplDecl>;
 pub struct ScopeBinding {
     pub ty: Type,
     pub is_const: bool,
-    /// M9.5 Wave C: true after the binding's value has been moved out.
+    /// M9.5 Wave C: true after the binding's value has been moved out (whole-variable).
     pub consumed: bool,
+    /// M9.7: per-path availability for partial-move tracking.
+    /// Empty means the whole variable is fully available.
+    pub path_state: Vec<(crate::types::PatternPath, crate::types::PathAvailability)>,
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -140,12 +145,15 @@ impl ScopeEnv {
                 ty,
                 is_const: false,
                 consumed: false,
+                path_state: Vec::new(),
             },
         );
     }
 
     pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-        self.insert_binding(name, ScopeBinding { ty, is_const: true, consumed: false });
+        self.insert_binding(name, ScopeBinding {
+            ty, is_const: true, consumed: false, path_state: Vec::new(),
+        });
     }
 
     /// Mark a variable as consumed (moved out). Subsequent reads will be rejected.
@@ -161,6 +169,65 @@ impl ScopeEnv {
     /// Returns true if the variable has been moved and is no longer available.
     pub fn is_consumed(&self, name: SymbolId) -> bool {
         self.binding(name).map(|b| b.consumed).unwrap_or(false)
+    }
+
+    /// M9.7: Record that `path` within variable `name` has been moved or borrowed.
+    pub fn mark_path_state(
+        &mut self,
+        name: SymbolId,
+        path: crate::types::PatternPath,
+        state: crate::types::PathAvailability,
+    ) {
+        for scope in self.scopes.iter_mut().rev() {
+            if let Some(binding) = scope.get_mut(&name) {
+                binding.path_state.push((path, state));
+                return;
+            }
+        }
+    }
+
+    /// M9.7: Check that accessing `access_path` within `name` is allowed.
+    ///
+    /// Rejects if any stored path overlaps `access_path` with state `Moved`.
+    /// Conservative: borrows are not currently enforced as blocking reads.
+    pub fn check_path_available(
+        &self,
+        name: SymbolId,
+        access_path: &crate::types::PatternPath,
+    ) -> Result<(), crate::types::FrontendError> {
+        use crate::types::{PathAvailability, PatternPath};
+
+        fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
+            if a.elems.len() > b.elems.len() { return false; }
+            a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
+        }
+        fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
+            path_is_prefix(a, b) || path_is_prefix(b, a)
+        }
+
+        if let Some(binding) = self.binding(name) {
+            // Whole-variable consumed takes priority.
+            if binding.consumed {
+                return Err(crate::types::FrontendError {
+                    pos: 0,
+                    message: format!("use of moved value '{}'", name.0),
+                });
+            }
+            for (stored_path, avail) in &binding.path_state {
+                if paths_overlap(stored_path, access_path) {
+                    if *avail == PathAvailability::Moved {
+                        return Err(crate::types::FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "use of partially moved value (path {:?} was moved)",
+                                stored_path.elems
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     fn insert_binding(&mut self, name: SymbolId, binding: ScopeBinding) {

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -178,9 +178,31 @@ impl ScopeEnv {
         path: crate::types::PatternPath,
         state: crate::types::PathAvailability,
     ) {
+        use crate::types::PatternPath;
+
+        fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
+            if a.elems.len() > b.elems.len() { return false; }
+            a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
+        }
+
         for scope in self.scopes.iter_mut().rev() {
             if let Some(binding) = scope.get_mut(&name) {
-                binding.path_state.push((path, state));
+                // M9.9 Wave C: normalise path-state to keep it compact.
+                //
+                // Rule 1 — new path subsumes longer existing entries of the same state:
+                //   e.g. adding Moved(root) while Moved(root.0) exists → drop root.0.
+                binding.path_state.retain(|(existing, existing_state)| {
+                    if *existing_state != state { return true; }
+                    !path_is_prefix(&path, existing)
+                });
+                // Rule 2 — if an existing entry already covers the new path (same state,
+                //   existing is a prefix of new path), the new entry is redundant.
+                let redundant = binding.path_state.iter().any(|(existing, existing_state)| {
+                    *existing_state == state && path_is_prefix(existing, &path)
+                });
+                if !redundant {
+                    binding.path_state.push((path, state));
+                }
                 return;
             }
         }

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -230,6 +230,58 @@ impl ScopeEnv {
         Ok(())
     }
 
+    /// M9.8: Check that a new capture of `path` with `capture` mode is compatible
+    /// with the existing path-state of variable `name`.
+    ///
+    /// Rules:
+    ///   prior Borrowed + new Move   → error ("cannot move from borrowed value")
+    ///   prior Moved   + new Borrow  → error ("cannot borrow from moved value")
+    ///   prior Moved   + new Move    → error ("cannot move from moved value")
+    ///   prior Borrowed + new Borrow → ok
+    ///   prior Available + anything  → ok
+    pub fn check_capture_allowed(
+        &self,
+        name: SymbolId,
+        path: &crate::types::PatternPath,
+        capture: crate::types::CaptureMode,
+    ) -> Result<(), crate::types::FrontendError> {
+        use crate::types::{CaptureMode, PathAvailability, PatternPath};
+
+        fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
+            if a.elems.len() > b.elems.len() { return false; }
+            a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
+        }
+        fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
+            path_is_prefix(a, b) || path_is_prefix(b, a)
+        }
+
+        let Some(binding) = self.binding(name) else { return Ok(()); };
+
+        if binding.consumed {
+            return Err(crate::types::FrontendError {
+                pos: 0,
+                message: format!("cannot capture moved value '{}'", name.0),
+            });
+        }
+
+        for (stored_path, stored_state) in &binding.path_state {
+            if !paths_overlap(stored_path, path) { continue; }
+            let msg: Option<&str> = match (stored_state, capture) {
+                (PathAvailability::Borrowed, CaptureMode::Move) =>
+                    Some("cannot move from borrowed path"),
+                (PathAvailability::Moved, CaptureMode::Borrow) =>
+                    Some("cannot borrow from moved path"),
+                (PathAvailability::Moved, CaptureMode::Move) =>
+                    Some("cannot move from already-moved path"),
+                _ => None,
+            };
+            if let Some(m) = msg {
+                return Err(crate::types::FrontendError { pos: 0, message: m.to_string() });
+            }
+        }
+        Ok(())
+    }
+
     fn insert_binding(&mut self, name: SymbolId, binding: ScopeBinding) {
         if let Some(last) = self.scopes.last_mut() {
             last.insert(name, binding);

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -238,13 +238,23 @@ impl ScopeEnv {
             for (stored_path, avail) in &binding.path_state {
                 if paths_overlap(stored_path, access_path) {
                     if *avail == PathAvailability::Moved {
-                        return Err(crate::types::FrontendError {
-                            pos: 0,
-                            message: format!(
-                                "use of partially moved value (path {:?} was moved)",
+                        // M9.9 Wave D: more precise diagnostic.
+                        // Distinguish "accessing moved path" from "accessing parent of moved child".
+                        let msg = if path_is_prefix(stored_path, access_path) {
+                            // stored = root.0, access = root.0 or root.0.x → moved path
+                            format!(
+                                "use of moved value: path was moved earlier (moved path {:?})",
                                 stored_path.elems
-                            ),
-                        });
+                            )
+                        } else {
+                            // stored = root.0, access = root → whole-var after partial move
+                            format!(
+                                "use of partially moved value: cannot use whole variable because \
+                                 child path {:?} was moved",
+                                stored_path.elems
+                            )
+                        };
+                        return Err(crate::types::FrontendError { pos: 0, message: msg });
                     }
                 }
             }

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1,8 +1,8 @@
 use crate::lexer::lex_tokens;
 use crate::types::{
     AdtCtorExpr, AdtDecl, AdtMatchPattern, AdtPatternItem, AdtVariant, AstArena, BinaryOp,
-    BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily, Expr, ExprId,
-    FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, LogosEntity,
+    BlockExpr, CallArg, CaptureMode, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily,
+    Expr, ExprId, FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, LogosEntity,
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField,
@@ -902,11 +902,11 @@ impl<'a> Parser<'a> {
             } else if self.eat(TokenKind::QuadS) {
                 TuplePatternItem::QuadLiteral(QuadVal::S)
             } else {
-                TuplePatternItem::Bind(self.expect_symbol()?)
+                TuplePatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Move }
             };
-            if let TuplePatternItem::Bind(name) = item {
+            if let TuplePatternItem::Bind { name, .. } = item {
                 if items.iter().any(|existing| {
-                    matches!(existing, TuplePatternItem::Bind(existing_name) if *existing_name == name)
+                    matches!(existing, TuplePatternItem::Bind { name: existing_name, .. } if *existing_name == name)
                 }) {
                     return Err(FrontendError {
                         pos: self.pos(),
@@ -946,7 +946,7 @@ impl<'a> Parser<'a> {
         let mut bind_items = Vec::with_capacity(items.len());
         for item in items {
             match item {
-                TuplePatternItem::Bind(name) => bind_items.push(Some(name)),
+                TuplePatternItem::Bind { name, .. } => bind_items.push(Some(name)),
                 TuplePatternItem::Discard => bind_items.push(None),
                 TuplePatternItem::QuadLiteral(_) => {
                     return Err(FrontendError {
@@ -2029,7 +2029,7 @@ impl<'a> Parser<'a> {
                 .items
                 .iter()
                 .filter_map(|item| match item {
-                    AdtPatternItem::Bind(name) => Some(*name),
+                    AdtPatternItem::Bind { name, .. } => Some(*name),
                     AdtPatternItem::Discard => None,
                 })
                 .collect(),
@@ -2320,7 +2320,7 @@ impl<'a> Parser<'a> {
             if self.eat(TokenKind::Underscore) {
                 items.push(AdtPatternItem::Discard);
             } else if self.check(TokenKind::Ident) {
-                items.push(AdtPatternItem::Bind(self.expect_symbol()?));
+                items.push(AdtPatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Move });
             } else {
                 return Err(FrontendError {
                     pos: self.pos(),
@@ -4241,7 +4241,7 @@ fn main() {
         };
         assert_eq!(program.arena.symbol_name(pat.adt_name), "Maybe");
         assert_eq!(program.arena.symbol_name(pat.variant_name), "Some");
-        assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind(_)]));
+        assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind { .. }]));
         assert!(match_expr.default.is_some());
     }
 
@@ -4427,7 +4427,7 @@ fn main() {
             panic!("expected tuple let-else statement");
         };
         assert_eq!(items.len(), 2);
-        assert!(matches!(items[0], TuplePatternItem::Bind(_)));
+        assert!(matches!(items[0], TuplePatternItem::Bind { .. }));
         assert!(matches!(
             items[1],
             TuplePatternItem::QuadLiteral(QuadVal::T)
@@ -4838,7 +4838,7 @@ fn main() {
                 };
                 assert_eq!(program.arena.symbol_name(pat.adt_name), "Option");
                 assert_eq!(program.arena.symbol_name(pat.variant_name), "Some");
-                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind(_)]));
+                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind { .. }]));
             }
             other => panic!("expected match stmt, got {:?}", other),
         }
@@ -4853,7 +4853,7 @@ fn main() {
                 };
                 assert_eq!(program.arena.symbol_name(pat.adt_name), "Result");
                 assert_eq!(program.arena.symbol_name(pat.variant_name), "Err");
-                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind(_)]));
+                assert!(matches!(pat.items.as_slice(), [AdtPatternItem::Bind { .. }]));
             }
             other => panic!("expected match stmt, got {:?}", other),
         }

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -693,6 +693,19 @@ impl<'a> Parser<'a> {
                         else_return,
                     }));
                 }
+                // M9.4 Wave 3: if any item is Nested, emit LetElseTuple (no else arm)
+                // so the typecheck path can handle recursive binding.
+                // Note: `=` and `value` are already consumed above.
+                let has_nested = items.iter().any(|i| matches!(i, TuplePatternItem::Nested(_)));
+                if has_nested {
+                    self.expect(TokenKind::Semi, "expected ';'")?;
+                    return Ok(self.arena.alloc_stmt(Stmt::LetElseTuple {
+                        items,
+                        ty,
+                        value,
+                        else_return: None,
+                    }));
+                }
                 let items = self.lower_tuple_pattern_items_to_bind(items)?;
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::LetTuple { items, ty, value }));

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -946,6 +946,14 @@ impl<'a> Parser<'a> {
                                 .to_string(),
                     })
                 }
+                TuplePatternItem::Nested(_) => {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "nested tuple patterns are not yet supported in plain let bindings; use let-else form"
+                                .to_string(),
+                    })
+                }
             }
         }
         Ok(bind_items)
@@ -1804,6 +1812,12 @@ impl<'a> Parser<'a> {
                 }
                 Ok(())
             }
+            Expr::IfLet(_) => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "first-class closure literals do not yet admit if-let expressions in the closure body"
+                        .to_string(),
+            }),
             Expr::Loop(_) => Err(FrontendError {
                 pos: self.pos(),
                 message:
@@ -1981,6 +1995,12 @@ impl<'a> Parser<'a> {
                 }
                 Ok(())
             }
+            Expr::IfLet(_) => Err(FrontendError {
+                pos: self.pos(),
+                message:
+                    "short lambda v0 does not currently allow if-let expressions in the lambda body"
+                        .to_string(),
+            }),
             Expr::Loop(_) => Err(FrontendError {
                 pos: self.pos(),
                 message:
@@ -1992,7 +2012,9 @@ impl<'a> Parser<'a> {
 
     fn short_lambda_match_pattern_bindings(&self, pat: &MatchPattern) -> Vec<SymbolId> {
         match pat {
-            MatchPattern::Quad(_) => Vec::new(),
+            MatchPattern::Quad(_) | MatchPattern::Wildcard | MatchPattern::IntRange(_) => {
+                Vec::new()
+            }
             MatchPattern::Adt(adt_pat) => adt_pat
                 .items
                 .iter()
@@ -2001,6 +2023,12 @@ impl<'a> Parser<'a> {
                     AdtPatternItem::Discard => None,
                 })
                 .collect(),
+            MatchPattern::Or(alts) => {
+                // Bindings from the first alternative (Wave 2/3 will enforce same names across alts).
+                alts.first()
+                    .map(|p| self.short_lambda_match_pattern_bindings(p))
+                    .unwrap_or_default()
+            }
         }
     }
 

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2,9 +2,10 @@ use crate::lexer::lex_tokens;
 use crate::types::{
     AdtCtorExpr, AdtDecl, AdtMatchPattern, AdtPatternItem, AdtVariant, AstArena, BinaryOp,
     BlockExpr, CallArg, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily, Expr, ExprId,
-    FrontendError, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField, LogosEntityFieldKind,
-    LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm, MatchExpr, MatchExprArm,
-    MatchPattern, NumericLiteral, Program, QuadVal, RangeExpr, RecordDecl, RecordField,
+    FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, LogosEntity,
+    LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
+    LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
+    RangeExpr, RecordDecl, RecordField,
     RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordPatternItem, RecordPatternTarget,
     RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
     SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType,
@@ -873,15 +874,11 @@ impl<'a> Parser<'a> {
     ) -> Result<Vec<TuplePatternItem>, FrontendError> {
         let mut items = Vec::new();
         loop {
-            if self.check(TokenKind::LParen) {
-                return Err(FrontendError {
-                    pos: self.pos(),
-                    message:
-                        "tuple destructuring pattern v0 currently supports only flat name/_/quad-literal items"
-                            .to_string(),
-                });
-            }
-            let item = if self.eat(TokenKind::Underscore) {
+            // M9.4 Wave 2: nested tuple destructuring `(a, (b, c))`.
+            let item = if self.eat(TokenKind::LParen) {
+                let nested = self.parse_tuple_pattern_items_after_lparen()?;
+                TuplePatternItem::Nested(nested)
+            } else if self.eat(TokenKind::Underscore) {
                 TuplePatternItem::Discard
             } else if self.eat(TokenKind::QuadN) {
                 TuplePatternItem::QuadLiteral(QuadVal::N)
@@ -2105,6 +2102,26 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_if_expr_after_kw_if(&mut self) -> Result<ExprId, FrontendError> {
+        // M9.4 Wave 2: if-let expression `if let Pattern = expr { ... } else { ... }`
+        if self.eat(TokenKind::KwLet) {
+            let pattern = self.parse_match_pattern()?;
+            self.expect(TokenKind::Assign, "expected '=' after pattern in if-let")?;
+            let value = self.parse_expr()?;
+            let then_block = self.parse_value_block()?;
+            if !self.eat(TokenKind::KwElse) {
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message: "if-let expression requires explicit else branch".to_string(),
+                });
+            }
+            let else_block = self.parse_value_block()?;
+            return Ok(self.arena.alloc_expr(Expr::IfLet(IfLetExpr {
+                pattern,
+                value,
+                then_block,
+                else_block,
+            })));
+        }
         let condition = self.parse_expr()?;
         let then_block = self.parse_value_block()?;
         if !self.eat(TokenKind::KwElse) {
@@ -2194,15 +2211,70 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_match_pattern(&mut self) -> Result<MatchPattern, FrontendError> {
+        let first = self.parse_match_pattern_single()?;
+        // M9.4 Wave 2: or-pattern — collect alternatives separated by `|`.
+        if !self.check(TokenKind::Pipe) {
+            return Ok(first);
+        }
+        let mut alts = vec![first];
+        while self.eat(TokenKind::Pipe) {
+            alts.push(self.parse_match_pattern_single()?);
+        }
+        Ok(MatchPattern::Or(alts))
+    }
+
+    /// Parse a single (non-or) match pattern.
+    fn parse_match_pattern_single(&mut self) -> Result<MatchPattern, FrontendError> {
+        // M9.4 Wave 2: wildcard `_`
+        if self.eat(TokenKind::Underscore) {
+            return Ok(MatchPattern::Wildcard);
+        }
         if self.eat(TokenKind::QuadN) {
-            Ok(MatchPattern::Quad(QuadVal::N))
+            return Ok(MatchPattern::Quad(QuadVal::N));
         } else if self.eat(TokenKind::QuadF) {
-            Ok(MatchPattern::Quad(QuadVal::F))
+            return Ok(MatchPattern::Quad(QuadVal::F));
         } else if self.eat(TokenKind::QuadT) {
-            Ok(MatchPattern::Quad(QuadVal::T))
+            return Ok(MatchPattern::Quad(QuadVal::T));
         } else if self.eat(TokenKind::QuadS) {
-            Ok(MatchPattern::Quad(QuadVal::S))
-        } else if self.check(TokenKind::Ident) {
+            return Ok(MatchPattern::Quad(QuadVal::S));
+        }
+        // M9.4 Wave 2: integer range patterns `1..=5` or `1..5`
+        if self.check(TokenKind::Num) {
+            let text = self.peek().text.clone();
+            // Only admit plain integer literals (no suffix, no decimal point).
+            let is_plain_int = !text.contains('.') && !text.contains("i32") && !text.contains("u32");
+            if is_plain_int {
+                // Lookahead: is the token after the number `..` or `..=`?
+                // We need to consume the number then check.
+                let num_text = self.advance().text;
+                if self.check(TokenKind::DotDot) || self.check(TokenKind::DotDotEq) {
+                    let inclusive = self.eat(TokenKind::DotDotEq);
+                    if !inclusive {
+                        self.expect(TokenKind::DotDot, "expected '..' or '..=' in range pattern")?;
+                    }
+                    if !self.check(TokenKind::Num) {
+                        return Err(FrontendError {
+                            pos: self.pos(),
+                            message: "expected integer literal after '..' in range pattern".to_string(),
+                        });
+                    }
+                    let end_text = self.advance().text;
+                    let start = parse_i64_pattern_bound(&num_text)?;
+                    let end = parse_i64_pattern_bound(&end_text)?;
+                    return Ok(MatchPattern::IntRange(IntRangePattern { start, end, inclusive }));
+                }
+                // Not a range — put the number back by returning an error explaining
+                // plain numeric patterns aren't supported outside ranges.
+                return Err(FrontendError {
+                    pos: self.pos(),
+                    message: format!(
+                        "plain integer literal '{}' is not a valid match pattern; use a range like {}..={} or an ADT pattern",
+                        num_text, num_text, num_text
+                    ),
+                });
+            }
+        }
+        if self.check(TokenKind::Ident) {
             let adt_name = self.expect_symbol()?;
             self.expect(TokenKind::PathSep, "expected '::' in enum match pattern")?;
             let variant_name = self.expect_symbol()?;
@@ -2211,17 +2283,16 @@ impl<'a> Parser<'a> {
             } else {
                 Vec::new()
             };
-            Ok(MatchPattern::Adt(AdtMatchPattern {
+            return Ok(MatchPattern::Adt(AdtMatchPattern {
                 adt_name,
                 variant_name,
                 items,
-            }))
-        } else {
-            Err(FrontendError {
-                pos: self.pos(),
-                message: "expected match pattern N|F|T|S|Type::Variant|_".to_string(),
-            })
+            }));
         }
+        Err(FrontendError {
+            pos: self.pos(),
+            message: "expected match pattern: N|F|T|S | _ | Type::Variant | int..int | pat | pat".to_string(),
+        })
     }
 
     fn parse_adt_match_pattern_items(&mut self) -> Result<Vec<AdtPatternItem>, FrontendError> {
@@ -3077,6 +3148,47 @@ impl<'a> Parser<'a> {
         self.idx = i + 1;
         t
     }
+
+    /// Peek at the current non-layout token without consuming it.
+    fn peek(&self) -> Token {
+        let i = self.next_non_layout_idx();
+        self.tokens.get(i).cloned().unwrap_or(Token {
+            kind: TokenKind::Dedent,
+            text: String::new(),
+            pos: 0,
+            mark: Default::default(),
+        })
+    }
+}
+
+/// Parse a plain integer literal as an i64 range bound.
+/// Only decimal and hex (`0x`) forms are accepted; no suffixes, no decimals.
+fn parse_i64_pattern_bound(text: &str) -> Result<i64, FrontendError> {
+    if text.contains('.') {
+        return Err(FrontendError {
+            pos: 0,
+            message: "range pattern bound must be an integer literal, not a float".to_string(),
+        });
+    }
+    let (core, suffix) = split_numeric_suffix(text);
+    if suffix.is_some() {
+        return Err(FrontendError {
+            pos: 0,
+            message: "range pattern bound does not accept a type suffix; use a plain integer".to_string(),
+        });
+    }
+    if let Some(hex) = core.strip_prefix("0x").or_else(|| core.strip_prefix("0X")) {
+        let digits = strip_digit_separators(hex);
+        return i64::from_str_radix(&digits, 16).map_err(|_| FrontendError {
+            pos: 0,
+            message: "invalid hexadecimal range pattern bound".to_string(),
+        });
+    }
+    let digits = strip_digit_separators(core);
+    digits.parse::<i64>().map_err(|_| FrontendError {
+        pos: 0,
+        message: format!("invalid integer range pattern bound '{}'", text),
+    })
 }
 
 fn split_numeric_suffix(text: &str) -> (&str, Option<&str>) {
@@ -5217,23 +5329,22 @@ fn main() {
     }
 
     #[test]
-    fn rustlike_parser_rejects_nested_tuple_destructuring_bind() {
+    fn rustlike_parser_admits_nested_tuple_destructuring_bind() {
+        // M9.4 Wave 2: nested tuple destructuring is now admitted at parse level.
+        // Typecheck support is deferred to Wave 3.
         let src = r#"
 fn main() {
     let ((x, y), z) = ((1, true), false);
     return;
 }
 "#;
-
-        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect_err("nested tuple destructuring must reject");
-        assert!(err
-            .message
-            .contains("tuple destructuring pattern v0 currently supports only flat"));
+        // Parser must accept the shape (typecheck will later reject at Wave 3 stub).
+        let _ = parse_rustlike_with_profile(src, &ParserProfile::foundation_default());
     }
 
     #[test]
-    fn rustlike_parser_rejects_nested_tuple_destructuring_assignment() {
+    fn rustlike_parser_admits_nested_tuple_destructuring_assignment() {
+        // M9.4 Wave 2: nested tuple destructuring admitted at parse level.
         let src = r#"
 fn main() {
     let x: i32 = 0;
@@ -5243,12 +5354,8 @@ fn main() {
     return;
 }
 "#;
-
-        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect_err("nested tuple destructuring assignment must reject");
-        assert!(err
-            .message
-            .contains("tuple destructuring pattern v0 currently supports only flat"));
+        // Parser must accept the shape.
+        let _ = parse_rustlike_with_profile(src, &ParserProfile::foundation_default());
     }
 
     #[test]
@@ -5702,5 +5809,126 @@ fn apply<T: Eq, U>(x: T, y: U) -> i32 {
         let func = &program.functions[0];
         assert_eq!(func.type_params.len(), 2);
         assert_eq!(func.trait_bounds.len(), 1);
+    }
+
+    // M9.4 Wave 2 — richer pattern surface parser admission
+
+    fn parse_src(src: &str) -> Result<Program, crate::FrontendError> {
+        parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+    }
+
+    #[test]
+    fn wildcard_match_pattern_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        _ => { 0 }
+    };
+    return v;
+}
+"#;
+        let p = parse_src(src).expect("wildcard match pattern should parse");
+        assert!(!p.functions[0].body.is_empty());
+    }
+
+    #[test]
+    fn or_pattern_two_alternatives_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        Color::Red | Color::Blue => { 1 }
+    };
+    return v;
+}
+"#;
+        let p = parse_src(src).expect("or-pattern should parse");
+        assert!(!p.functions[0].body.is_empty());
+    }
+
+    #[test]
+    fn or_pattern_three_alternatives_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        Color::Red | Color::Blue | Color::Green => { 1 }
+    };
+    return v;
+}
+"#;
+        let p = parse_src(src).expect("three-way or-pattern should parse");
+        assert!(!p.functions[0].body.is_empty());
+    }
+
+    #[test]
+    fn int_range_inclusive_pattern_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        1..=5 => { 1 }
+    };
+    return v;
+}
+"#;
+        let p = parse_src(src).expect("inclusive range pattern should parse");
+        assert!(!p.functions[0].body.is_empty());
+    }
+
+    #[test]
+    fn int_range_exclusive_pattern_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        0..10 => { 2 }
+    };
+    return v;
+}
+"#;
+        let p = parse_src(src).expect("exclusive range pattern should parse");
+        assert!(!p.functions[0].body.is_empty());
+    }
+
+    #[test]
+    fn nested_tuple_destructuring_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let (a, (b, c)) = pair;
+    let _ = a;
+    let _ = b;
+    let _ = c;
+    return 0;
+}
+"#;
+        // Parser should admit the shape without panicking. Typecheck may reject.
+        let _ = parse_src(src);
+    }
+
+    #[test]
+    fn if_let_adt_pattern_is_parsed() {
+        let src = r#"
+fn main() -> i32 {
+    let r = if let Color::Red = x { 1 } else { 0 };
+    return r;
+}
+"#;
+        // Parser should admit the shape. Typecheck stub will reject at Wave 3.
+        let _ = parse_src(src);
+    }
+
+    #[test]
+    fn range_pattern_missing_end_rejects() {
+        let src = r#"
+fn main() -> i32 {
+    let v = match Color::Red {
+        1.. => 1
+    };
+    return v;
+}
+"#;
+        let err = parse_src(src)
+            .expect_err("range pattern missing end bound must reject");
+        assert!(
+            err.message.contains("integer literal") || err.message.contains("range"),
+            "unexpected error: {}", err.message
+        );
     }
 }

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -901,6 +901,9 @@ impl<'a> Parser<'a> {
                 TuplePatternItem::QuadLiteral(QuadVal::T)
             } else if self.eat(TokenKind::QuadS) {
                 TuplePatternItem::QuadLiteral(QuadVal::S)
+            } else if self.eat(TokenKind::KwRef) {
+                // M9.5 Wave B: `ref x` — borrow binding in tuple patterns.
+                TuplePatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Borrow }
             } else {
                 TuplePatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Move }
             };
@@ -2319,12 +2322,15 @@ impl<'a> Parser<'a> {
         loop {
             if self.eat(TokenKind::Underscore) {
                 items.push(AdtPatternItem::Discard);
+            } else if self.eat(TokenKind::KwRef) {
+                // M9.5 Wave B: `ref x` — borrow binding in ADT patterns.
+                items.push(AdtPatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Borrow });
             } else if self.check(TokenKind::Ident) {
                 items.push(AdtPatternItem::Bind { name: self.expect_symbol()?, capture: CaptureMode::Move });
             } else {
                 return Err(FrontendError {
                     pos: self.pos(),
-                    message: "enum match payload patterns currently support only flat name/_ items"
+                    message: "enum match payload patterns currently support name/ref name/_ items"
                         .to_string(),
                 });
             }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -5599,6 +5599,88 @@ mod tests {
         });
         validate_binding_plan_conflicts(&plan).expect("double-borrow same path must not conflict");
     }
+
+    // M9.6 — prefix-overlap conflict detection
+
+    #[test]
+    fn prefix_overlap_move_and_borrow_rejects() {
+        // root.0 is a prefix of root.0.1 — move + borrow should conflict.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let parent = PatternPath::root().tuple_index(0);
+        let child  = PatternPath::root().tuple_index(0).tuple_index(1);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move, path: parent, ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path: child, ty: Type::I32,
+        });
+        let err = validate_binding_plan_conflicts(&plan)
+            .expect_err("prefix-overlap move+borrow must conflict");
+        assert!(
+            err.message.contains("conflicting") || err.message.contains("overlapping"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn prefix_overlap_two_moves_rejects() {
+        // root and root.0 — both moved is also a conflict.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let parent = PatternPath::root();
+        let child  = PatternPath::root().tuple_index(0);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move, path: parent, ty: Type::Quad,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Move, path: child, ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan)
+            .expect_err("prefix-overlap double-move must conflict");
+    }
+
+    #[test]
+    fn distinct_paths_no_conflict() {
+        // root.0 and root.1 share the root prefix but diverge at index — no overlap.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move,
+            path: PatternPath::root().tuple_index(0), ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Move,
+            path: PatternPath::root().tuple_index(1), ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan)
+            .expect("distinct sibling paths must not conflict");
+    }
+
+    #[test]
+    fn prefix_overlap_two_borrows_ok() {
+        // root.0 borrows and root.0.1 also borrows — allowed.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let parent = PatternPath::root().tuple_index(0);
+        let child  = PatternPath::root().tuple_index(0).tuple_index(1);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Borrow, path: parent, ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path: child, ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan)
+            .expect("prefix-overlap double-borrow must not conflict");
+    }
 }
 
 fn is_builtin_assert_name(
@@ -8335,32 +8417,42 @@ fn ensure_const_initializer_safe(
 /// Validate that no two items in the plan access the same path via conflicting
 /// capture modes (borrow vs. move, or duplicate move).
 /// Multiple borrows of the same path are allowed.
-pub(crate) fn validate_binding_plan_conflicts(plan: &BindingPlan) -> Result<(), FrontendError> {
-    let mut seen: BTreeMap<Vec<u8>, AccessKind> = BTreeMap::new();
+/// M9.6: returns true if every element of `a` is a prefix of `b`.
+fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
+    if a.elems.len() > b.elems.len() { return false; }
+    a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
+}
 
-    for item in &plan.items {
-        // Encode path as bytes for BTreeMap key (no Hash needed).
-        let key = encode_path_key(&item.path);
-        let next = match item.capture {
-            CaptureMode::Borrow => AccessKind::Borrow,
-            CaptureMode::Move   => AccessKind::Move,
-        };
-        if let Some(&prev) = seen.get(&key) {
-            let conflict = match (prev, next) {
-                (AccessKind::Borrow, AccessKind::Borrow) => false,
-                _ => true,
-            };
-            if conflict {
+/// M9.6: two paths conflict (overlap) if one is a prefix of the other or they are equal.
+fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
+    path_is_prefix(a, b) || path_is_prefix(b, a)
+}
+
+fn captures_conflict(a: CaptureMode, b: CaptureMode) -> bool {
+    !matches!((a, b), (CaptureMode::Borrow, CaptureMode::Borrow))
+}
+
+/// Validate that no two items in the plan access overlapping paths via conflicting
+/// capture modes.  Two paths overlap when one is a prefix of the other (or equal).
+/// Multiple borrows of the same or ancestor/descendant path are allowed.
+///
+/// NOTE (M9.5/M9.6): overlap check is prefix-based only.
+/// Alias analysis and field-sensitivity beyond the current PatternPath model are deferred.
+pub(crate) fn validate_binding_plan_conflicts(plan: &BindingPlan) -> Result<(), FrontendError> {
+    for (i, a) in plan.items.iter().enumerate() {
+        for b in plan.items.iter().skip(i + 1) {
+            if !paths_overlap(&a.path, &b.path) {
+                continue;
+            }
+            if captures_conflict(a.capture, b.capture) {
                 return Err(FrontendError {
                     pos: 0,
                     message: format!(
-                        "conflicting capture modes on the same pattern path for binding '{}'",
-                        item.name.0
+                        "conflicting captures on overlapping pattern paths for '{}' and '{}'",
+                        a.name.0, b.name.0
                     ),
                 });
             }
-        } else {
-            seen.insert(key, next);
         }
     }
     Ok(())

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -986,6 +986,12 @@ fn check_stmt(
                             });
                         }
                     }
+                    TuplePatternItem::Nested(_) => {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: "nested tuple patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
+                        });
+                    }
                 }
             }
             Ok(())
@@ -1702,6 +1708,10 @@ fn infer_expr_type(
             loop_stack,
         impl_list,
         ),
+        Expr::IfLet(_) => Err(FrontendError {
+            pos: 0,
+            message: "if-let expressions are not yet supported in typecheck; Wave 3 will add full support".to_string(),
+        }),
         Expr::Call(name, args) => {
             if is_builtin_assert_name(*name, arena, table)? {
                 return Err(FrontendError {
@@ -7476,6 +7486,16 @@ fn bind_match_pattern(
             }
             Ok(bindings)
         }
+        // M9.4 Wave 1: stubs — Wave 3 will add full typecheck support.
+        (_, MatchPattern::Wildcard) => Ok(Vec::new()),
+        (_, MatchPattern::Or(_)) => Err(FrontendError {
+            pos: 0,
+            message: "or-patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
+        }),
+        (_, MatchPattern::IntRange(_)) => Err(FrontendError {
+            pos: 0,
+            message: "integer range patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
+        }),
     }
 }
 
@@ -7493,6 +7513,10 @@ fn missing_exhaustive_sum_variants<'a>(
     for (pat, guard) in patterns {
         if guard.is_some() {
             continue;
+        }
+        // M9.4 Wave 1: wildcard covers all variants.
+        if matches!(pat, MatchPattern::Wildcard) {
+            return Ok(Some((family.display_label, Vec::new())));
         }
         if let MatchPattern::Adt(adt_pat) = pat {
             if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1325,12 +1325,13 @@ fn check_stmt(
                 });
             }
 
+            // M9.5 Wave D: migrate to BindingPlan ownership pipeline.
+            let mut any_arm_moves = false;
             for arm in arms {
-                let mut arm_env = env.clone();
-                arm_env.push_scope();
-                for (name, ty) in bind_match_pattern(&arm.pat, &st, arena, record_table, adt_table)?
-                {
-                    arm_env.insert(name, ty);
+                let (plan, mut arm_env) =
+                    build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
+                if scrutinee_use_from_plan(&plan) == ScrutineeUse::Consumed {
+                    any_arm_moves = true;
                 }
                 check_match_guard(
                     arm.guard,
@@ -1357,6 +1358,12 @@ fn check_stmt(
                     )?;
                 }
                 arm_env.pop_scope();
+            }
+            // Conservative: if any reachable arm moved from scrutinee variable → consumed.
+            if any_arm_moves {
+                if let Expr::Var(name) = arena.expr(*scrutinee) {
+                    env.mark_consumed(*name);
+                }
             }
 
             if default.is_empty() {
@@ -5474,6 +5481,124 @@ mod tests {
         // This test just validates the checker doesn't false-positive on i32.
         typecheck_source(src).expect("plain i32 variable reuse should typecheck fine");
     }
+
+    // M9.5 Wave D — match ownership pipeline
+
+    #[test]
+    fn match_borrow_binding_does_not_consume_scrutinee() {
+        // All-borrow match: scrutinee variable stays available after the match.
+        let src = r#"
+            enum Maybe { Some(i32), None }
+            fn make() -> Maybe { return Maybe::None; }
+            fn main() {
+                let v: Maybe = make();
+                match v {
+                    Maybe::Some(ref x) => { let _ = x; }
+                    Maybe::None => { let r: i32 = 0; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("all-borrow match should not consume scrutinee");
+    }
+
+    #[test]
+    fn match_move_binding_typechecks() {
+        // Move binding in match arm: the binding captures the payload.
+        let src = r#"
+            enum Wrap { Val(i32) }
+            fn make() -> Wrap { return Wrap::Val(5); }
+            fn main() {
+                let w: Wrap = make();
+                match w {
+                    Wrap::Val(x) => { let r: i32 = x; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("move binding in match arm should typecheck");
+    }
+
+    #[test]
+    fn match_or_pattern_all_borrow_ok() {
+        // Or-pattern where all alternatives borrow: ok.
+        let src = r#"
+            enum Flag { A, B, C }
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A | Flag::B => { let r: i32 = 0; let _ = r; }
+                    Flag::C => { let r: i32 = 1; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("or-pattern match should typecheck");
+    }
+
+    #[test]
+    fn match_inconsistent_or_pattern_capture_rejects() {
+        // One arm binds with ref, the other without — must be same shape.
+        let src = r#"
+            enum Wrap { Val(i32) }
+            fn make() -> Wrap { return Wrap::Val(1); }
+            fn main() {
+                let w: Wrap = make();
+                match w {
+                    Wrap::Val(ref x) | Wrap::Val(y) => { let _ = y; }
+                }
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("inconsistent or-pattern capture modes must reject");
+        assert!(
+            err.message.contains("same") || err.message.contains("capture") || err.message.contains("alternative"),
+            "unexpected error: {}", err.message
+        );
+    }
+
+    #[test]
+    fn match_same_path_move_and_borrow_rejects() {
+        // A single arm with two bindings for the same payload slot (move + borrow conflict).
+        // This is enforced by validate_binding_plan_conflicts.
+        // Note: parser currently only allows one binding per payload slot,
+        // so this test validates the plan-level conflict check via direct API.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let path = PatternPath::root().variant(SymbolId(0)).variant_field(0);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move, path: path.clone(), ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path, ty: Type::I32,
+        });
+        let err = validate_binding_plan_conflicts(&plan)
+            .expect_err("move+borrow same path must conflict");
+        assert!(
+            err.message.contains("conflicting") || err.message.contains("capture"),
+            "unexpected error: {}", err.message
+        );
+    }
+
+    #[test]
+    fn match_all_arms_borrow_path_ok() {
+        // Two bindings for the same path both borrowing: allowed.
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let path = PatternPath::root().tuple_index(0);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Borrow, path: path.clone(), ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path, ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan).expect("double-borrow same path must not conflict");
+    }
 }
 
 fn is_builtin_assert_name(
@@ -5618,15 +5743,13 @@ fn infer_match_expr_type(
         });
     }
 
+    // M9.5 Wave D: migrate to BindingPlan ownership pipeline.
+    // NOTE: infer_match_expr_type receives &ScopeEnv (not mut), so consumed-state
+    // marking is skipped here; it is enforced at statement-level match sites instead.
     let mut result_ty = None;
     for arm in &match_expr.arms {
-        let mut arm_env = env.clone();
-        arm_env.push_scope();
-        for (name, ty) in
-            bind_match_pattern(&arm.pat, &scrutinee_ty, arena, record_table, adt_table)?
-        {
-            arm_env.insert(name, ty);
-        }
+        let (_, arm_env) =
+            build_and_apply_match_plan(&arm.pat, &scrutinee_ty, env, arena, adt_table)?;
         check_match_guard(
             arm.guard,
             arena,
@@ -5867,12 +5990,13 @@ fn check_loop_expr_stmt(
                 });
             }
 
+            // M9.5 Wave D: migrate to BindingPlan ownership pipeline.
+            let mut any_arm_moves = false;
             for arm in arms {
-                let mut arm_env = env.clone();
-                arm_env.push_scope();
-                for (name, ty) in bind_match_pattern(&arm.pat, &st, arena, record_table, adt_table)?
-                {
-                    arm_env.insert(name, ty);
+                let (plan, mut arm_env) =
+                    build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
+                if scrutinee_use_from_plan(&plan) == ScrutineeUse::Consumed {
+                    any_arm_moves = true;
                 }
                 check_match_guard(
                     arm.guard,
@@ -5899,6 +6023,11 @@ fn check_loop_expr_stmt(
                     )?;
                 }
                 arm_env.pop_scope();
+            }
+            if any_arm_moves {
+                if let Expr::Var(name) = arena.expr(*scrutinee) {
+                    env.mark_consumed(*name);
+                }
             }
 
             let mut def_env = env.clone();
@@ -8325,6 +8454,17 @@ pub(crate) fn build_adt_pattern_plan(
             pos: 0,
             message: "ADT pattern plan: scrutinee is not a sum type".to_string(),
         })?;
+    // Verify that the pattern's enum name matches the scrutinee family.
+    let pattern_family_name = resolve_symbol_name(arena, pat.adt_name)?.to_string();
+    if pattern_family_name != family.family_name {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "match arm pattern type '{}' does not match scrutinee {}",
+                pattern_family_name, family.display_label
+            ),
+        });
+    }
     let variant_name_str = resolve_symbol_name(arena, pat.variant_name)?;
     let variant = family
         .variants
@@ -8333,8 +8473,8 @@ pub(crate) fn build_adt_pattern_plan(
         .ok_or_else(|| FrontendError {
             pos: 0,
             message: format!(
-                "unknown variant '{}' in ADT pattern plan",
-                variant_name_str
+                "{} has no variant named '{}' in match pattern",
+                family.display_label, variant_name_str
             ),
         })?;
 
@@ -8380,7 +8520,19 @@ pub(crate) fn build_match_pattern_plan(
     adt_table: &AdtTable,
 ) -> Result<(), FrontendError> {
     match pat {
-        MatchPattern::Wildcard | MatchPattern::Quad(_) | MatchPattern::IntRange(_) => Ok(()),
+        MatchPattern::Wildcard | MatchPattern::Quad(_) => Ok(()),
+        MatchPattern::IntRange(range) => {
+            if range.start > range.end {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "int range pattern start ({}) must be <= end ({})",
+                        range.start, range.end
+                    ),
+                });
+            }
+            Ok(())
+        }
         MatchPattern::Adt(adt_pat) => {
             build_adt_pattern_plan(adt_pat, expected_ty, base, out, arena, adt_table)
         }
@@ -8456,4 +8608,45 @@ pub(crate) fn check_var_not_consumed(
         });
     }
     Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────
+// M9.5 Wave D: match integration helpers
+// ──────────────────────────────────────────────────────────────
+
+/// Build a binding plan for one match arm pattern, validate conflicts,
+/// clone `env`, and apply the plan to the clone. Returns `(plan, arm_env)`.
+///
+/// NOTE (M9.5): PatternPath overlap (e.g., root vs root.0) is NOT checked yet.
+/// Only exact-path conflicts are validated.
+pub(crate) fn build_and_apply_match_plan<'e>(
+    pattern: &MatchPattern,
+    scrutinee_ty: &Type,
+    env: &'e ScopeEnv,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<(BindingPlan, ScopeEnv), FrontendError> {
+    let mut plan = BindingPlan::default();
+    build_match_pattern_plan(pattern, scrutinee_ty, &PatternPath::root(), &mut plan, arena, adt_table)?;
+    validate_binding_plan_conflicts(&plan)?;
+    let mut arm_env = env.clone();
+    arm_env.push_scope();
+    apply_binding_plan(&mut arm_env, &plan);
+    Ok((plan, arm_env))
+}
+
+/// Mark the scrutinee variable consumed if the plan moved any value from it.
+/// Only acts when scrutinee_expr is a plain `Expr::Var`.
+/// Used at statement level where `env` is `&mut ScopeEnv`.
+pub(crate) fn mark_scrutinee_if_moved(
+    scrutinee_expr: ExprId,
+    plan: &BindingPlan,
+    arena: &AstArena,
+    env: &mut ScopeEnv,
+) {
+    if scrutinee_use_from_plan(plan) == ScrutineeUse::Consumed {
+        if let Expr::Var(name) = arena.expr(scrutinee_expr) {
+            env.mark_consumed(*name);
+        }
+    }
 }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1,5 +1,7 @@
 use crate::types::{
-    AdtCtorExpr, AdtPatternItem, MatchPattern, NumericLiteral, RecordPatternTarget,
+    AccessKind, AdtCtorExpr, AdtMatchPattern, AdtPatternItem, BindingPlan, BindingPlanItem,
+    CaptureMode, MatchPattern, NumericLiteral, PatternPath, RecordPatternTarget, ScrutineeUse,
+    ValueAvailability,
 };
 use crate::*;
 use alloc::collections::{BTreeMap, BTreeSet};
@@ -1618,10 +1620,14 @@ fn infer_expr_type(
             loop_stack,
         impl_list,
         ),
-        Expr::Var(v) => env.get(*v).ok_or(FrontendError {
-            pos: 0,
-            message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
-        }),
+        Expr::Var(v) => {
+            // M9.5 Wave C: reject use of moved values.
+            check_var_not_consumed(*v, env, arena)?;
+            env.get(*v).ok_or(FrontendError {
+                pos: 0,
+                message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
+            })
+        }
         Expr::Block(block) => infer_value_block_type(
             block,
             arena,
@@ -1724,15 +1730,19 @@ fn infer_expr_type(
                 loop_stack,
                 impl_list,
             )?;
-            // Typecheck pattern against value type — collect bindings.
-            let bindings =
-                bind_match_pattern(&if_let.pattern, &value_ty, arena, record_table, adt_table)?;
+            // M9.5 Wave C: build binding plan, validate conflicts, apply to then-env.
+            let mut plan = BindingPlan::default();
+            build_match_pattern_plan(
+                &if_let.pattern, &value_ty, &PatternPath::root(),
+                &mut plan, arena, adt_table,
+            )?;
+            validate_binding_plan_conflicts(&plan)?;
             // then-block sees the bindings.
             let mut then_env = env.clone();
             then_env.push_scope();
-            for (name, ty) in bindings {
-                then_env.insert(name, ty);
-            }
+            apply_binding_plan(&mut then_env, &plan);
+            // NOTE: scrutinee consumed-state is enforced at statement level only
+            // (infer_expr_type receives &ScopeEnv, which is immutable).
             let then_ty = infer_value_block_type(
                 &if_let.then_block,
                 arena,
@@ -5335,6 +5345,135 @@ mod tests {
             "unexpected error: {}", err.message
         );
     }
+
+    // M9.5 Wave B — parser admits `ref x` binding syntax
+
+    #[test]
+    fn ref_binding_in_tuple_pattern_parses() {
+        let src = r#"
+            fn make_pair() -> (i32, i32) { return (1, 2); }
+            fn main() {
+                let (ref a, b) = make_pair();
+                let _ = b;
+                return;
+            }
+        "#;
+        // Wave B: parser must admit `ref x` without error.
+        // CaptureMode::Borrow is stored but not yet enforced in typecheck (Wave C).
+        typecheck_source(src).expect("ref binding in tuple pattern should parse and typecheck");
+    }
+
+    #[test]
+    fn ref_binding_in_adt_pattern_parses() {
+        let src = r#"
+            enum Wrap { Val(i32) }
+            fn make() -> Wrap { return Wrap::Val(1); }
+            fn main() {
+                let w: Wrap = make();
+                match w {
+                    Wrap::Val(ref x) => { let _ = x; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("ref binding in ADT pattern should parse and typecheck");
+    }
+
+    // M9.5 Wave C — binding plan builders + conflict detection + consumed-state
+
+    #[test]
+    fn binding_plan_tuple_move_ok() {
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        plan.push(BindingPlanItem {
+            name: SymbolId(1),
+            capture: CaptureMode::Move,
+            path: PatternPath::root().tuple_index(0),
+            ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan).expect("single move binding should not conflict");
+    }
+
+    #[test]
+    fn binding_plan_two_borrows_same_path_ok() {
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let path = PatternPath::root().tuple_index(0);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Borrow, path: path.clone(), ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path, ty: Type::I32,
+        });
+        validate_binding_plan_conflicts(&plan).expect("two borrows of same path should not conflict");
+    }
+
+    #[test]
+    fn binding_plan_move_and_borrow_same_path_rejects() {
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        let path = PatternPath::root().tuple_index(0);
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move, path: path.clone(), ty: Type::I32,
+        });
+        plan.push(BindingPlanItem {
+            name: SymbolId(2), capture: CaptureMode::Borrow, path, ty: Type::I32,
+        });
+        let err = validate_binding_plan_conflicts(&plan)
+            .expect_err("move+borrow same path must conflict");
+        assert!(
+            err.message.contains("conflicting") || err.message.contains("capture"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn scrutinee_use_move_gives_consumed() {
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, ScrutineeUse, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Move,
+            path: PatternPath::root().tuple_index(0), ty: Type::I32,
+        });
+        assert_eq!(scrutinee_use_from_plan(&plan), ScrutineeUse::Consumed);
+    }
+
+    #[test]
+    fn scrutinee_use_all_borrow_gives_preserved() {
+        use crate::types::{
+            BindingPlan, BindingPlanItem, CaptureMode, PatternPath, ScrutineeUse, SymbolId, Type,
+        };
+        let mut plan = BindingPlan::default();
+        plan.push(BindingPlanItem {
+            name: SymbolId(1), capture: CaptureMode::Borrow,
+            path: PatternPath::root().tuple_index(0), ty: Type::I32,
+        });
+        assert_eq!(scrutinee_use_from_plan(&plan), ScrutineeUse::Preserved);
+    }
+
+    #[test]
+    fn use_after_move_rejects() {
+        let src = r#"
+            fn take_val() -> i32 { return 5; }
+            fn main() {
+                let x: i32 = take_val();
+                let _ = x;
+                let _ = x;
+                return;
+            }
+        "#;
+        // i32 is Copy — use-after-move semantics only apply to non-Copy types.
+        // This test just validates the checker doesn't false-positive on i32.
+        typecheck_source(src).expect("plain i32 variable reuse should typecheck fine");
+    }
 }
 
 fn is_builtin_assert_name(
@@ -8058,4 +8197,263 @@ fn ensure_const_initializer_safe(
                     .to_string(),
         }),
     }
+}
+
+// ──────────────────────────────────────────────────────────────
+// M9.5 Wave C: binding plan builders + conflict validation
+// ──────────────────────────────────────────────────────────────
+
+/// Validate that no two items in the plan access the same path via conflicting
+/// capture modes (borrow vs. move, or duplicate move).
+/// Multiple borrows of the same path are allowed.
+pub(crate) fn validate_binding_plan_conflicts(plan: &BindingPlan) -> Result<(), FrontendError> {
+    let mut seen: BTreeMap<Vec<u8>, AccessKind> = BTreeMap::new();
+
+    for item in &plan.items {
+        // Encode path as bytes for BTreeMap key (no Hash needed).
+        let key = encode_path_key(&item.path);
+        let next = match item.capture {
+            CaptureMode::Borrow => AccessKind::Borrow,
+            CaptureMode::Move   => AccessKind::Move,
+        };
+        if let Some(&prev) = seen.get(&key) {
+            let conflict = match (prev, next) {
+                (AccessKind::Borrow, AccessKind::Borrow) => false,
+                _ => true,
+            };
+            if conflict {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "conflicting capture modes on the same pattern path for binding '{}'",
+                        item.name.0
+                    ),
+                });
+            }
+        } else {
+            seen.insert(key, next);
+        }
+    }
+    Ok(())
+}
+
+fn encode_path_key(path: &PatternPath) -> Vec<u8> {
+    use crate::types::PatternPathElem;
+    let mut out = Vec::new();
+    for elem in &path.elems {
+        match elem {
+            PatternPathElem::TupleIndex(i)  => { out.push(0); out.extend_from_slice(&(*i as u32).to_le_bytes()); }
+            PatternPathElem::Variant(s)     => { out.push(1); out.extend_from_slice(&s.0.to_le_bytes()); }
+            PatternPathElem::VariantField(i)=> { out.push(2); out.extend_from_slice(&(*i as u32).to_le_bytes()); }
+            PatternPathElem::RecordField(s) => { out.push(3); out.extend_from_slice(&s.0.to_le_bytes()); }
+        }
+    }
+    out
+}
+
+/// Determine whether the scrutinee is consumed (moved) by the plan.
+pub(crate) fn scrutinee_use_from_plan(plan: &BindingPlan) -> ScrutineeUse {
+    if plan.items.iter().any(|it| it.capture == CaptureMode::Move) {
+        ScrutineeUse::Consumed
+    } else {
+        ScrutineeUse::Preserved
+    }
+}
+
+/// Apply a binding plan to an env scope (insert all bindings as mutable locals).
+pub(crate) fn apply_binding_plan(env: &mut ScopeEnv, plan: &BindingPlan) {
+    for item in &plan.items {
+        env.insert(item.name, item.ty.clone());
+    }
+}
+
+/// Build a `BindingPlan` from tuple pattern items against a known tuple type.
+pub(crate) fn build_tuple_pattern_plan(
+    items: &[TuplePatternItem],
+    expected_ty: &Type,
+    base: &PatternPath,
+    out: &mut BindingPlan,
+) -> Result<(), FrontendError> {
+    let Type::Tuple(tuple_items) = expected_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "tuple pattern requires tuple scrutinee, got {:?}", expected_ty
+            ),
+        });
+    };
+    if items.len() != tuple_items.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "tuple pattern arity mismatch: pattern has {} items, value has {}",
+                items.len(), tuple_items.len()
+            ),
+        });
+    }
+    for (idx, (item, item_ty)) in items.iter().zip(tuple_items.iter()).enumerate() {
+        let path = base.tuple_index(idx);
+        match item {
+            TuplePatternItem::Discard | TuplePatternItem::QuadLiteral(_) => {}
+            TuplePatternItem::Nested(nested) => {
+                build_tuple_pattern_plan(nested, item_ty, &path, out)?;
+            }
+            TuplePatternItem::Bind { name, capture } => {
+                out.push(BindingPlanItem {
+                    name: *name,
+                    capture: *capture,
+                    path,
+                    ty: item_ty.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a `BindingPlan` from an ADT match pattern against a known ADT type.
+pub(crate) fn build_adt_pattern_plan(
+    pat: &AdtMatchPattern,
+    expected_ty: &Type,
+    base: &PatternPath,
+    out: &mut BindingPlan,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let family = resolve_match_family_spec(expected_ty, arena, adt_table)?
+        .ok_or_else(|| FrontendError {
+            pos: 0,
+            message: "ADT pattern plan: scrutinee is not a sum type".to_string(),
+        })?;
+    let variant_name_str = resolve_symbol_name(arena, pat.variant_name)?;
+    let variant = family
+        .variants
+        .iter()
+        .find(|v| v.name == variant_name_str)
+        .ok_or_else(|| FrontendError {
+            pos: 0,
+            message: format!(
+                "unknown variant '{}' in ADT pattern plan",
+                variant_name_str
+            ),
+        })?;
+
+    if pat.items.len() != variant.payload.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "ADT pattern '{}::{}' arity mismatch: pattern has {} items, variant has {}",
+                family.family_name, variant_name_str,
+                pat.items.len(), variant.payload.len()
+            ),
+        });
+    }
+
+    let variant_root = base.variant(pat.variant_name);
+    for (idx, (item, item_ty)) in pat.items.iter().zip(variant.payload.iter()).enumerate() {
+        let path = variant_root.variant_field(idx);
+        match item {
+            AdtPatternItem::Discard => {}
+            AdtPatternItem::Bind { name, capture } => {
+                out.push(BindingPlanItem {
+                    name: *name,
+                    capture: *capture,
+                    path,
+                    ty: item_ty.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a `BindingPlan` from any `MatchPattern`.
+///
+/// For `Or`, takes the first alternative as the canonical binding shape and
+/// validates that all other alternatives bind the same names/modes/types.
+pub(crate) fn build_match_pattern_plan(
+    pat: &MatchPattern,
+    expected_ty: &Type,
+    base: &PatternPath,
+    out: &mut BindingPlan,
+    arena: &AstArena,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    match pat {
+        MatchPattern::Wildcard | MatchPattern::Quad(_) | MatchPattern::IntRange(_) => Ok(()),
+        MatchPattern::Adt(adt_pat) => {
+            build_adt_pattern_plan(adt_pat, expected_ty, base, out, arena, adt_table)
+        }
+        MatchPattern::Or(alts) => {
+            if alts.is_empty() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "or-pattern must contain at least one alternative".to_string(),
+                });
+            }
+            let mut first_plan = BindingPlan::default();
+            build_match_pattern_plan(&alts[0], expected_ty, base, &mut first_plan, arena, adt_table)?;
+            validate_binding_plan_conflicts(&first_plan)?;
+
+            let baseline: Vec<(u32, CaptureMode)> = first_plan.items.iter()
+                .map(|it| (it.name.0, it.capture))
+                .collect();
+
+            for alt in &alts[1..] {
+                let mut alt_plan = BindingPlan::default();
+                build_match_pattern_plan(alt, expected_ty, base, &mut alt_plan, arena, adt_table)?;
+                validate_binding_plan_conflicts(&alt_plan)?;
+
+                let shape: Vec<(u32, CaptureMode)> = alt_plan.items.iter()
+                    .map(|it| (it.name.0, it.capture))
+                    .collect();
+
+                if shape != baseline {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: "all or-pattern alternatives must bind the same names with the same capture modes".to_string(),
+                    });
+                }
+            }
+            out.items.extend(first_plan.items);
+            Ok(())
+        }
+    }
+}
+
+/// If the scrutinee expression is a plain variable and the plan consumed it,
+/// mark it unavailable in `env` so subsequent reads are rejected.
+pub(crate) fn maybe_mark_scrutinee_consumed(
+    scrutinee_id: ExprId,
+    plan: &BindingPlan,
+    arena: &AstArena,
+    env: &mut ScopeEnv,
+) {
+    if scrutinee_use_from_plan(plan) == ScrutineeUse::Consumed {
+        if let Expr::Var(name) = arena.expr(scrutinee_id) {
+            env.mark_consumed(*name);
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// M9.5 Wave C: use-after-move guard for Expr::Var
+// ──────────────────────────────────────────────────────────────
+
+/// Call at every `Expr::Var` site in inference to reject use of moved values.
+pub(crate) fn check_var_not_consumed(
+    name: SymbolId,
+    env: &ScopeEnv,
+    arena: &AstArena,
+) -> Result<(), FrontendError> {
+    if env.is_consumed(name) {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "use of moved value '{}'",
+                resolve_symbol_name(arena, name)?
+            ),
+        });
+    }
+    Ok(())
 }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1472,6 +1472,13 @@ fn infer_expr_type(
     loop_stack: &mut Vec<LoopTypeFrame>,
     impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
+    // M9.9: path-aware read check. Extract the most specific path reachable
+    // from this expression and verify it is available. Base expressions used
+    // inside field/index helpers go through infer_expr_type_no_check, which
+    // skips this guard for intermediate Var nodes.
+    if let Some((name, path)) = expr_access_path(expr_id, arena) {
+        env.check_path_available(name, &path)?;
+    }
     let expr = arena.expr(expr_id);
     match expr {
         Expr::QuadLiteral(_) => Ok(Type::Quad),
@@ -1624,8 +1631,7 @@ fn infer_expr_type(
         impl_list,
         ),
         Expr::Var(v) => {
-            // M9.7: path-based availability check (root = whole variable).
-            env.check_path_available(*v, &PatternPath::root())?;
+            // M9.9: path check moved to top of infer_expr_type via expr_access_path.
             env.get(*v).ok_or(FrontendError {
                 pos: 0,
                 message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
@@ -5729,6 +5735,117 @@ mod tests {
             .expect("move of sibling of borrowed path must be ok");
     }
 
+    // M9.9 — expr_access_path + path-state normalization
+
+    #[test]
+    fn expr_access_path_var_is_root() {
+        use crate::types::PatternPath;
+        let mut arena = AstArena::default();
+        let sym = SymbolId(99);
+        let var_id = arena.alloc_expr(Expr::Var(sym));
+        let result = expr_access_path(var_id, &arena);
+        assert_eq!(result, Some((sym, PatternPath::root())));
+    }
+
+    #[test]
+    fn expr_access_path_literal_is_none() {
+        let mut arena = AstArena::default();
+        let lit_id = arena.alloc_expr(Expr::BoolLiteral(true));
+        assert_eq!(expr_access_path(lit_id, &arena), None);
+    }
+
+    #[test]
+    fn expr_access_path_sequence_index_literal() {
+        use crate::types::{NumericLiteral, PatternPath, SequenceIndexExpr};
+        let mut arena = AstArena::default();
+        let sym = SymbolId(7);
+        let base = arena.alloc_expr(Expr::Var(sym));
+        let idx  = arena.alloc_expr(Expr::NumericLiteral(NumericLiteral::I32(2)));
+        let expr = arena.alloc_expr(Expr::SequenceIndex(SequenceIndexExpr { base, index: idx }));
+        let result = expr_access_path(expr, &arena);
+        assert_eq!(result, Some((sym, PatternPath::root().tuple_index(2))));
+    }
+
+    #[test]
+    fn expr_access_path_sequence_index_non_literal_is_none() {
+        use crate::types::{SequenceIndexExpr};
+        let mut arena = AstArena::default();
+        let sym = SymbolId(7);
+        let base     = arena.alloc_expr(Expr::Var(sym));
+        let dyn_idx  = arena.alloc_expr(Expr::Var(SymbolId(8)));
+        let expr = arena.alloc_expr(Expr::SequenceIndex(SequenceIndexExpr { base, index: dyn_idx }));
+        // dynamic index → cannot determine path statically
+        assert_eq!(expr_access_path(expr, &arena), None);
+    }
+
+    #[test]
+    fn path_state_normalization_root_subsumes_children() {
+        // Adding Moved(root) when Moved(root.0) already exists → root.0 is dropped.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(50);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(1), PathAvailability::Moved);
+        // Now add root — should subsume both children.
+        env.mark_path_state(sym, PatternPath::root(), PathAvailability::Moved);
+        // Only one entry should remain: root.
+        let binding = env.binding(sym).expect("binding must exist");
+        assert_eq!(binding.path_state.len(), 1, "root should subsume child entries");
+        assert_eq!(binding.path_state[0].0, PatternPath::root());
+    }
+
+    #[test]
+    fn path_state_normalization_child_redundant_if_parent_present() {
+        // If Moved(root) exists, adding Moved(root.0) should be a no-op.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(51);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root(), PathAvailability::Moved);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        let binding = env.binding(sym).expect("binding must exist");
+        assert_eq!(binding.path_state.len(), 1, "child must be suppressed when parent already present");
+    }
+
+    #[test]
+    fn check_path_available_sibling_of_moved_is_ok() {
+        // After moving root.0, accessing root.1 must succeed.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(60);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        env.check_path_available(sym, &PatternPath::root().tuple_index(1))
+            .expect("sibling of moved path must be accessible");
+    }
+
+    #[test]
+    fn check_path_available_whole_var_blocked_after_child_move() {
+        // After moving root.0, accessing root (whole var) must fail.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(61);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        let err = env.check_path_available(sym, &PatternPath::root())
+            .expect_err("whole-var access after child move must be blocked");
+        assert!(err.message.contains("moved"), "error must mention moved: {}", err.message);
+    }
+
+    #[test]
+    fn check_path_available_moved_child_blocked() {
+        // After moving root.0, accessing root.0 itself must fail.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(62);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        let err = env.check_path_available(sym, &PatternPath::root().tuple_index(0))
+            .expect_err("access of moved path must be blocked");
+        assert!(err.message.contains("moved"), "error must mention moved: {}", err.message);
+    }
+
     // M9.6 — prefix-overlap conflict detection
 
     #[test]
@@ -7305,7 +7422,8 @@ fn infer_record_field_access_type(
     loop_stack: &mut Vec<LoopTypeFrame>,
     impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
-    let base_ty = infer_expr_type(
+    // M9.9: use no-check variant for the base; caller already verified full path.
+    let base_ty = infer_expr_type_no_check(
         field_expr.base,
         arena,
         env,
@@ -7359,7 +7477,8 @@ fn infer_sequence_index_type(
     loop_stack: &mut Vec<LoopTypeFrame>,
     impl_list: &[ImplDecl],
 ) -> Result<Type, FrontendError> {
-    let base_ty = infer_expr_type(
+    // M9.9: use no-check variant for the base; caller already verified full path.
+    let base_ty = infer_expr_type_no_check(
         index_expr.base,
         arena,
         env,
@@ -8889,6 +9008,99 @@ pub(crate) fn validate_plan_against_scrutinee_state(
 /// onto the scrutinee variable (if it is a plain Expr::Var).
 ///
 /// Conservative: we union the paths across all arms. A path moved in any arm
+// ──────────────────────────────────────────────────────────────
+// M9.9 Wave A: path-aware expression access helpers
+// ──────────────────────────────────────────────────────────────
+
+/// Attempt to extract a `(base_variable, PatternPath)` pair from an expression.
+///
+/// Returns `Some` for:
+///   * `Expr::Var(x)`                          → `(x, root)`
+///   * `Expr::RecordField { base, field }`      → recurse + `RecordField(field)`
+///   * `Expr::SequenceIndex { base, index }`    → recurse + `TupleIndex(n)` for
+///                                                 literal `i32` index only
+///
+/// Returns `None` for calls, computed indices, closures, and anything not
+/// expressible as a single static path from a local variable.
+pub(crate) fn expr_access_path(
+    expr_id: ExprId,
+    arena: &AstArena,
+) -> Option<(SymbolId, PatternPath)> {
+    match arena.expr(expr_id) {
+        Expr::Var(name) => Some((*name, PatternPath::root())),
+        Expr::RecordField(field_expr) => {
+            let (base_sym, base_path) = expr_access_path(field_expr.base, arena)?;
+            Some((base_sym, base_path.record_field(field_expr.field)))
+        }
+        Expr::SequenceIndex(index_expr) => {
+            if let Expr::NumericLiteral(crate::types::NumericLiteral::I32(idx)) =
+                arena.expr(index_expr.index)
+            {
+                if *idx >= 0 {
+                    let (base_sym, base_path) = expr_access_path(index_expr.base, arena)?;
+                    return Some((base_sym, base_path.tuple_index(*idx as usize)));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Format a path as a human-readable access string (e.g. `"v"`, `"v.0"`, `"v.field"`).
+///
+/// Field name symbols are rendered as `.<numeric_id>` since this layer has no
+/// arena access. Pass `arena` at a higher level if readable names are needed.
+pub(crate) fn path_to_string(base_name: &str, path: &PatternPath) -> String {
+    use crate::types::PatternPathElem;
+    let mut s = alloc::string::String::from(base_name);
+    for elem in &path.elems {
+        match elem {
+            PatternPathElem::TupleIndex(i) | PatternPathElem::VariantField(i) => {
+                s.push('.');
+                s.push_str(&i.to_string());
+            }
+            PatternPathElem::RecordField(sym) | PatternPathElem::Variant(sym) => {
+                s.push('.');
+                s.push_str(&sym.0.to_string());
+            }
+        }
+    }
+    s
+}
+
+/// Infer the type of `expr_id` **without** running the top-level path-availability
+/// check from M9.9.  Used internally when `expr_id` is the *base* of a field or
+/// index access whose **caller** has already verified the full access path.
+///
+/// Only skips the path check for `Expr::Var`; all other expressions fall through
+/// to the normal `infer_expr_type` (which includes their own path check).
+fn infer_expr_type_no_check(
+    expr_id: ExprId,
+    arena: &AstArena,
+    env: &ScopeEnv,
+    table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+    ret_ty: Type,
+    loop_stack: &mut Vec<LoopTypeFrame>,
+    impl_list: &[ImplDecl],
+) -> Result<Type, FrontendError> {
+    match arena.expr(expr_id) {
+        Expr::Var(v) => {
+            // No path check here; the outer infer_expr_type call for the full
+            // field/index expression already checked the correct sub-path.
+            env.get(*v).ok_or(FrontendError {
+                pos: 0,
+                message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
+            })
+        }
+        _ => infer_expr_type(
+            expr_id, arena, env, table, record_table, adt_table, ret_ty, loop_stack, impl_list,
+        ),
+    }
+}
+
 /// is considered moved after the match.
 pub(crate) fn apply_plans_to_scrutinee(
     scrutinee_expr: ExprId,

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -986,11 +986,9 @@ fn check_stmt(
                             });
                         }
                     }
-                    TuplePatternItem::Nested(_) => {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message: "nested tuple patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
-                        });
+                    TuplePatternItem::Nested(nested_items) => {
+                        // M9.4 Wave 3: recursive nested tuple destructuring.
+                        bind_tuple_pattern_items(nested_items, item_ty, env)?;
                     }
                 }
             }
@@ -1311,14 +1309,16 @@ fn check_stmt(
                 loop_stack,
             impl_list,
             )?;
+            // M9.4 Wave 3: widen to also allow i32/u32 (for int range patterns).
             if !matches!(
                 st,
                 Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+                    | Type::I32 | Type::U32
             ) {
                 return Err(FrontendError {
                     pos: 0,
                     message:
-                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                        "match is allowed only for quad, enum, Option(T), Result(T, E), i32, or u32 scrutinee"
                             .to_string(),
                 });
             }
@@ -1708,10 +1708,63 @@ fn infer_expr_type(
             loop_stack,
         impl_list,
         ),
-        Expr::IfLet(_) => Err(FrontendError {
-            pos: 0,
-            message: "if-let expressions are not yet supported in typecheck; Wave 3 will add full support".to_string(),
-        }),
+        // M9.4 Wave 3: if-let expression typecheck.
+        Expr::IfLet(if_let) => {
+            // Infer value type.
+            let value_ty = infer_expr_type(
+                if_let.value,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+                impl_list,
+            )?;
+            // Typecheck pattern against value type — collect bindings.
+            let bindings =
+                bind_match_pattern(&if_let.pattern, &value_ty, arena, record_table, adt_table)?;
+            // then-block sees the bindings.
+            let mut then_env = env.clone();
+            then_env.push_scope();
+            for (name, ty) in bindings {
+                then_env.insert(name, ty);
+            }
+            let then_ty = infer_value_block_type(
+                &if_let.then_block,
+                arena,
+                &then_env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+                impl_list,
+            )?;
+            // else-block uses original env (no bindings).
+            let else_ty = infer_value_block_type(
+                &if_let.else_block,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty,
+                loop_stack,
+                impl_list,
+            )?;
+            if then_ty != else_ty {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "if-let branch type mismatch: then is {:?}, else is {:?}",
+                        then_ty, else_ty
+                    ),
+                });
+            }
+            Ok(then_ty)
+        }
         Expr::Call(name, args) => {
             if is_builtin_assert_name(*name, arena, table)? {
                 return Err(FrontendError {
@@ -5100,6 +5153,186 @@ mod tests {
             err.message
         );
     }
+
+    // M9.4 Wave 3 — richer pattern surface typecheck
+
+    #[test]
+    fn wildcard_match_pattern_typechecks() {
+        let src = r#"
+            enum Color { Red, Blue, Green }
+
+            fn main() {
+                let c: Color = Color::Red;
+                match c {
+                    Color::Red => { let r: i32 = 0; let _ = r; }
+                    Color::Blue => { let r: i32 = 1; let _ = r; }
+                    Color::Green => { let r: i32 = 2; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("exhaustive ADT match should typecheck");
+    }
+
+    #[test]
+    fn or_pattern_two_variants_covers_both() {
+        let src = r#"
+            enum Color { Red, Blue, Green }
+
+            fn main() {
+                let c: Color = Color::Red;
+                match c {
+                    Color::Red | Color::Blue => { let r: i32 = 0; let _ = r; }
+                    Color::Green => { let r: i32 = 2; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("or-pattern covering two variants should typecheck");
+    }
+
+    #[test]
+    fn or_pattern_covers_all_variants_exhaustive() {
+        let src = r#"
+            enum Flag { A, B }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                match f {
+                    Flag::A | Flag::B => { let r: i32 = 0; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("or-pattern covering all variants should be exhaustive");
+    }
+
+    #[test]
+    fn int_range_pattern_typechecks_on_i32() {
+        let src = r#"
+            fn main() {
+                let x: i32 = 3;
+                match x {
+                    1..=5 => { let y: i32 = 1; let _ = y; }
+                    _ => { let y: i32 = 0; let _ = y; }
+                }
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("int range pattern on i32 should typecheck");
+    }
+
+    #[test]
+    fn int_range_pattern_rejects_non_integer_scrutinee() {
+        let src = r#"
+            fn main() {
+                let x: bool = true;
+                match x {
+                    1..=5 => { let r: i32 = 0; let _ = r; }
+                    _ => { let r: i32 = 1; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("int range pattern on bool must reject");
+        assert!(
+            err.message.contains("i32") || err.message.contains("u32") || err.message.contains("scrutinee"),
+            "unexpected error: {}", err.message
+        );
+    }
+
+    #[test]
+    fn int_range_inverted_bounds_rejects() {
+        let src = r#"
+            fn main() {
+                let x: i32 = 3;
+                match x {
+                    5..=1 => { let r: i32 = 0; let _ = r; }
+                    _ => { let r: i32 = 1; let _ = r; }
+                }
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("inverted range bounds must reject");
+        assert!(
+            err.message.contains("start") || err.message.contains("end") || err.message.contains("<="),
+            "unexpected error: {}", err.message
+        );
+    }
+
+    #[test]
+    fn nested_tuple_destructuring_typechecks() {
+        let src = r#"
+            fn main() {
+                let (a, (b, c)) = (1, (2, 3));
+                let ra: i32 = a;
+                let rb: i32 = b;
+                let rc: i32 = c;
+                let _ = ra;
+                let _ = rb;
+                let _ = rc;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("nested tuple destructuring should typecheck");
+    }
+
+    #[test]
+    fn nested_tuple_arity_mismatch_rejects() {
+        let src = r#"
+            fn main() {
+                let (a, (b, c)) = (1, (2, 3, 4));
+                let _ = a;
+                let _ = b;
+                let _ = c;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("nested tuple arity mismatch must reject");
+        assert!(
+            err.message.contains("arity") || err.message.contains("mismatch"),
+            "unexpected error: {}", err.message
+        );
+    }
+
+    #[test]
+    fn if_let_wildcard_typechecks() {
+        let src = r#"
+            fn make_int() -> i32 {
+                return 1;
+            }
+
+            fn main() {
+                let r: i32 = if let _ = make_int() { 1 } else { 0 };
+                let _ = r;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("if-let wildcard should typecheck");
+    }
+
+    #[test]
+    fn if_let_branch_type_mismatch_rejects() {
+        let src = r#"
+            enum Flag { A, B }
+
+            fn main() {
+                let f: Flag = Flag::A;
+                let r: i32 = if let Flag::A = f { 1 } else { true };
+                let _ = r;
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("if-let branch type mismatch must reject");
+        assert!(
+            err.message.contains("mismatch") || err.message.contains("bool") || err.message.contains("i32"),
+            "unexpected error: {}", err.message
+        );
+    }
 }
 
 fn is_builtin_assert_name(
@@ -5230,14 +5463,16 @@ fn infer_match_expr_type(
         loop_stack,
     impl_list,
     )?;
+    // M9.4 Wave 3: widen to also allow i32/u32 (for int range patterns).
     if !matches!(
         scrutinee_ty,
         Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+            | Type::I32 | Type::U32
     ) {
         return Err(FrontendError {
             pos: 0,
             message:
-                "match expression is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                "match expression is allowed only for quad, enum, Option(T), Result(T, E), i32, or u32 scrutinee"
                     .to_string(),
         });
     }
@@ -5471,14 +5706,16 @@ fn check_loop_expr_stmt(
                 loop_stack,
             impl_list,
             )?;
+            // M9.4 Wave 3: widen to also allow i32/u32 (for int range patterns).
             if !matches!(
                 st,
                 Type::Quad | Type::Adt(_) | Type::Option(_) | Type::Result(_, _)
+                    | Type::I32 | Type::U32
             ) {
                 return Err(FrontendError {
                     pos: 0,
                     message:
-                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                        "match is allowed only for quad, enum, Option(T), Result(T, E), i32, or u32 scrutinee"
                             .to_string(),
                 });
             }
@@ -7389,6 +7626,56 @@ fn resolve_match_family_spec(
     }
 }
 
+/// M9.4 Wave 3: recursively bind tuple pattern items into `env`.
+///
+/// Called for `LetElseTuple` with `Nested` items. Recurses into sub-tuples.
+fn bind_tuple_pattern_items(
+    items: &[TuplePatternItem],
+    tuple_ty: Type,
+    env: &mut ScopeEnv,
+) -> Result<(), FrontendError> {
+    let Type::Tuple(item_tys) = tuple_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "nested tuple destructuring requires a tuple value, got {:?}",
+                tuple_ty
+            ),
+        });
+    };
+    if item_tys.len() != items.len() {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "nested tuple arity mismatch: pattern has {} items, value has {}",
+                items.len(),
+                item_tys.len()
+            ),
+        });
+    }
+    for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+        match item {
+            TuplePatternItem::Bind(name) => env.insert(*name, item_ty),
+            TuplePatternItem::Discard => {}
+            TuplePatternItem::QuadLiteral(_) => {
+                if item_ty != Type::Quad {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "nested tuple quad pattern requires quad element, got {:?}",
+                            item_ty
+                        ),
+                    });
+                }
+            }
+            TuplePatternItem::Nested(nested_items) => {
+                bind_tuple_pattern_items(nested_items, item_ty, env)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn bind_match_pattern(
     pat: &MatchPattern,
     scrutinee_ty: &Type,
@@ -7422,7 +7709,7 @@ fn bind_match_pattern(
                 return Err(FrontendError {
                     pos: 0,
                     message:
-                        "match is allowed only for quad, enum, Option(T), or Result(T, E) scrutinee"
+                        "match is allowed only for quad, enum, Option(T), Result(T, E), i32, or u32 scrutinee"
                             .to_string(),
                 });
             };
@@ -7486,16 +7773,50 @@ fn bind_match_pattern(
             }
             Ok(bindings)
         }
-        // M9.4 Wave 1: stubs — Wave 3 will add full typecheck support.
+        // M9.4 Wave 3: wildcard — no bindings, compatible with any scrutinee.
         (_, MatchPattern::Wildcard) => Ok(Vec::new()),
-        (_, MatchPattern::Or(_)) => Err(FrontendError {
-            pos: 0,
-            message: "or-patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
-        }),
-        (_, MatchPattern::IntRange(_)) => Err(FrontendError {
-            pos: 0,
-            message: "integer range patterns are not yet supported in typecheck; Wave 3 will add full support".to_string(),
-        }),
+
+        // M9.4 Wave 3: or-pattern — all alternatives must typecheck against the
+        // same scrutinee; bindings from the first alternative are used (Wave 3
+        // does not enforce identical binding sets across alternatives).
+        (_, MatchPattern::Or(alts)) => {
+            if alts.is_empty() {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "or-pattern must have at least one alternative".to_string(),
+                });
+            }
+            // Typecheck each alternative against the scrutinee.
+            for alt in alts {
+                bind_match_pattern(alt, scrutinee_ty, arena, record_table, adt_table)?;
+            }
+            // Bindings come from the first alternative only.
+            bind_match_pattern(&alts[0], scrutinee_ty, arena, record_table, adt_table)
+        }
+
+        // M9.4 Wave 3: integer range pattern — scrutinee must be i32 or u32;
+        // start must be <= end.
+        (ty, MatchPattern::IntRange(range)) => {
+            if !matches!(ty, Type::I32 | Type::U32) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "integer range pattern requires i32 or u32 scrutinee, got {:?}",
+                        ty
+                    ),
+                });
+            }
+            if range.start > range.end {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "integer range pattern start ({}) must be <= end ({})",
+                        range.start, range.end
+                    ),
+                });
+            }
+            Ok(Vec::new())
+        }
     }
 }
 
@@ -7514,9 +7835,25 @@ fn missing_exhaustive_sum_variants<'a>(
         if guard.is_some() {
             continue;
         }
-        // M9.4 Wave 1: wildcard covers all variants.
+        // M9.4 Wave 3: wildcard covers all variants.
         if matches!(pat, MatchPattern::Wildcard) {
             return Ok(Some((family.display_label, Vec::new())));
+        }
+        // M9.4 Wave 3: or-pattern — expand alternatives into coverage.
+        if let MatchPattern::Or(alts) = pat {
+            for alt in alts {
+                if matches!(alt, MatchPattern::Wildcard) {
+                    return Ok(Some((family.display_label, Vec::new())));
+                }
+                if let MatchPattern::Adt(adt_pat) = alt {
+                    if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name {
+                        covered.insert(
+                            resolve_symbol_name(arena, adt_pat.variant_name)?.to_string(),
+                        );
+                    }
+                }
+            }
+            continue;
         }
         if let MatchPattern::Adt(adt_pat) = pat {
             if resolve_symbol_name(arena, adt_pat.adt_name)? == family.family_name {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1325,11 +1325,13 @@ fn check_stmt(
                 });
             }
 
-            // M9.5 Wave D / M9.7: BindingPlan pipeline + path-based ownership.
+            // M9.5 Wave D / M9.7 / M9.8: BindingPlan pipeline + path-based ownership.
             let mut arm_plans: Vec<BindingPlan> = Vec::new();
             for arm in arms {
                 let (plan, mut arm_env) =
                     build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
+                // M9.8: reject if new plan conflicts with prior path-state of scrutinee.
+                validate_plan_against_scrutinee_state(env, *scrutinee, arena, &plan)?;
                 arm_plans.push(plan);
                 check_match_guard(
                     arm.guard,
@@ -1358,7 +1360,6 @@ fn check_stmt(
                 arm_env.pop_scope();
             }
             // M9.7: apply path-based state for each arm's moves/borrows to scrutinee.
-            // Conservative: if any arm moves/borrows a path, record it on the variable.
             apply_plans_to_scrutinee(*scrutinee, &arm_plans, arena, env);
 
             if default.is_empty() {
@@ -1739,6 +1740,8 @@ fn infer_expr_type(
                 &mut plan, arena, adt_table,
             )?;
             validate_binding_plan_conflicts(&plan)?;
+            // M9.8: reject if new plan conflicts with prior path-state of scrutinee.
+            validate_plan_against_scrutinee_state(env, if_let.value, arena, &plan)?;
             // then-block sees the bindings.
             let mut then_env = env.clone();
             then_env.push_scope();
@@ -5669,6 +5672,63 @@ mod tests {
             .expect("borrow-only path should not block reads");
     }
 
+    // M9.8 — borrow enforcement against prior path-state
+
+    #[test]
+    fn check_capture_allowed_borrow_then_move_rejects() {
+        use crate::types::{CaptureMode, PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(10);
+        env.insert(sym, Type::I32);
+        // Borrow root.0
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Borrowed);
+        // Now try to move root.0 — must reject
+        let err = env.check_capture_allowed(sym, &PatternPath::root().tuple_index(0), CaptureMode::Move)
+            .expect_err("move after borrow of same path must reject");
+        assert!(
+            err.message.contains("borrow") || err.message.contains("cannot move"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn check_capture_allowed_move_then_borrow_rejects() {
+        use crate::types::{CaptureMode, PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(11);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        let err = env.check_capture_allowed(sym, &PatternPath::root().tuple_index(0), CaptureMode::Borrow)
+            .expect_err("borrow after move of same path must reject");
+        assert!(
+            err.message.contains("moved") || err.message.contains("cannot borrow"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn check_capture_allowed_borrow_then_borrow_ok() {
+        use crate::types::{CaptureMode, PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(12);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Borrowed);
+        env.check_capture_allowed(sym, &PatternPath::root().tuple_index(0), CaptureMode::Borrow)
+            .expect("borrow after borrow of same path must be ok");
+    }
+
+    #[test]
+    fn check_capture_allowed_borrow_then_move_sibling_ok() {
+        // Borrow root.0, then move root.1 — different sibling, no overlap, ok.
+        use crate::types::{CaptureMode, PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(13);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Borrowed);
+        env.check_capture_allowed(sym, &PatternPath::root().tuple_index(1), CaptureMode::Move)
+            .expect("move of sibling of borrowed path must be ok");
+    }
+
     // M9.6 — prefix-overlap conflict detection
 
     #[test]
@@ -6141,11 +6201,13 @@ fn check_loop_expr_stmt(
                 });
             }
 
-            // M9.5 Wave D / M9.7: BindingPlan pipeline + path-based ownership.
+            // M9.5 Wave D / M9.7 / M9.8: BindingPlan pipeline + path-based ownership.
             let mut arm_plans: Vec<BindingPlan> = Vec::new();
             for arm in arms {
                 let (plan, mut arm_env) =
                     build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
+                // M9.8: reject if new plan conflicts with prior path-state of scrutinee.
+                validate_plan_against_scrutinee_state(env, *scrutinee, arena, &plan)?;
                 arm_plans.push(plan);
                 check_match_guard(
                     arm.guard,
@@ -8804,6 +8866,23 @@ pub(crate) fn mark_scrutinee_if_moved(
             env.mark_consumed(*name);
         }
     }
+}
+
+/// M9.8: Validate that all items in `plan` are capture-compatible with the
+/// existing path-state of the scrutinee variable (if it is a plain Expr::Var).
+///
+/// Prevents: move after borrow, borrow after move, move after move on same/overlapping path.
+pub(crate) fn validate_plan_against_scrutinee_state(
+    env: &ScopeEnv,
+    scrutinee_expr: ExprId,
+    arena: &AstArena,
+    plan: &BindingPlan,
+) -> Result<(), FrontendError> {
+    let Expr::Var(name) = arena.expr(scrutinee_expr) else { return Ok(()); };
+    for item in &plan.items {
+        env.check_capture_allowed(*name, &item.path, item.capture)?;
+    }
+    Ok(())
 }
 
 /// M9.7: For each arm plan, record the capture state of every binding path

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -973,7 +973,7 @@ fn check_stmt(
             )?;
             for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
                 match item {
-                    TuplePatternItem::Bind(name) => env.insert(*name, item_ty),
+                    TuplePatternItem::Bind { name, .. } => env.insert(*name, item_ty),
                     TuplePatternItem::Discard => {}
                     TuplePatternItem::QuadLiteral(_) => {
                         if item_ty != Type::Quad {
@@ -1710,6 +1710,8 @@ fn infer_expr_type(
         ),
         // M9.4 Wave 3: if-let expression typecheck.
         Expr::IfLet(if_let) => {
+            // TODO(M9.5): disambiguate expr parsing for scrutinee to avoid record-literal conflict
+            // (e.g. `if let Pat = v { ... }` where `v { ... }` is parsed as a record literal).
             // Infer value type.
             let value_ty = infer_expr_type(
                 if_let.value,
@@ -7629,6 +7631,10 @@ fn resolve_match_family_spec(
 /// M9.4 Wave 3: recursively bind tuple pattern items into `env`.
 ///
 /// Called for `LetElseTuple` with `Nested` items. Recurses into sub-tuples.
+///
+/// NOTE(M9.4 strategy): `let (a, (b, c)) = ...` is lowered to `LetElseTuple` (no else arm)
+/// instead of `LetTuple`, so this recursive helper can handle the nested binding.
+/// This is a temporary bridge — M9.5+ move/borrow semantics will revisit this path.
 fn bind_tuple_pattern_items(
     items: &[TuplePatternItem],
     tuple_ty: Type,
@@ -7655,7 +7661,7 @@ fn bind_tuple_pattern_items(
     }
     for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
         match item {
-            TuplePatternItem::Bind(name) => env.insert(*name, item_ty),
+            TuplePatternItem::Bind { name, .. } => env.insert(*name, item_ty),
             TuplePatternItem::Discard => {}
             TuplePatternItem::QuadLiteral(_) => {
                 if item_ty != Type::Quad {
@@ -7755,7 +7761,7 @@ fn bind_match_pattern(
             {
                 let payload_ty =
                     canonicalize_declared_type(declared_ty, record_table, adt_table, arena)?;
-                if let AdtPatternItem::Bind(name) = item {
+                if let AdtPatternItem::Bind { name, .. } = item {
                     if !seen.insert(*name) {
                         return Err(FrontendError {
                             pos: 0,
@@ -7835,7 +7841,8 @@ fn missing_exhaustive_sum_variants<'a>(
         if guard.is_some() {
             continue;
         }
-        // M9.4 Wave 3: wildcard covers all variants.
+        // NOTE: Range and tuple patterns are not included in exhaustiveness (M9.4 Wave 3 boundary).
+        // Wildcard covers all variants.
         if matches!(pat, MatchPattern::Wildcard) {
             return Ok(Some((family.display_label, Vec::new())));
         }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     AccessKind, AdtCtorExpr, AdtMatchPattern, AdtPatternItem, BindingPlan, BindingPlanItem,
-    CaptureMode, MatchPattern, NumericLiteral, PatternPath, RecordPatternTarget, ScrutineeUse,
-    ValueAvailability,
+    CaptureMode, MatchPattern, NumericLiteral, PathAvailability, PatternPath, RecordPatternTarget,
+    ScrutineeUse, ValueAvailability,
 };
 use crate::*;
 use alloc::collections::{BTreeMap, BTreeSet};
@@ -1325,14 +1325,12 @@ fn check_stmt(
                 });
             }
 
-            // M9.5 Wave D: migrate to BindingPlan ownership pipeline.
-            let mut any_arm_moves = false;
+            // M9.5 Wave D / M9.7: BindingPlan pipeline + path-based ownership.
+            let mut arm_plans: Vec<BindingPlan> = Vec::new();
             for arm in arms {
                 let (plan, mut arm_env) =
                     build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
-                if scrutinee_use_from_plan(&plan) == ScrutineeUse::Consumed {
-                    any_arm_moves = true;
-                }
+                arm_plans.push(plan);
                 check_match_guard(
                     arm.guard,
                     arena,
@@ -1359,12 +1357,9 @@ fn check_stmt(
                 }
                 arm_env.pop_scope();
             }
-            // Conservative: if any reachable arm moved from scrutinee variable → consumed.
-            if any_arm_moves {
-                if let Expr::Var(name) = arena.expr(*scrutinee) {
-                    env.mark_consumed(*name);
-                }
-            }
+            // M9.7: apply path-based state for each arm's moves/borrows to scrutinee.
+            // Conservative: if any arm moves/borrows a path, record it on the variable.
+            apply_plans_to_scrutinee(*scrutinee, &arm_plans, arena, env);
 
             if default.is_empty() {
                 match missing_exhaustive_sum_variants(
@@ -1628,8 +1623,8 @@ fn infer_expr_type(
         impl_list,
         ),
         Expr::Var(v) => {
-            // M9.5 Wave C: reject use of moved values.
-            check_var_not_consumed(*v, env, arena)?;
+            // M9.7: path-based availability check (root = whole variable).
+            env.check_path_available(*v, &PatternPath::root())?;
             env.get(*v).ok_or(FrontendError {
                 pos: 0,
                 message: format!("unknown variable '{}'", resolve_symbol_name(arena, *v)?),
@@ -5600,6 +5595,80 @@ mod tests {
         validate_binding_plan_conflicts(&plan).expect("double-borrow same path must not conflict");
     }
 
+    // M9.7 — partial move: path-based availability in ScopeEnv
+
+    #[test]
+    fn partial_move_sibling_path_still_usable() {
+        // Move root.0 (first element), then use root.1 (second element) — ok.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(1);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        // Accessing root.1 (different sibling) should be allowed.
+        env.check_path_available(sym, &PatternPath::root().tuple_index(1))
+            .expect("sibling path of moved path should remain available");
+    }
+
+    #[test]
+    fn partial_move_root_blocks_whole_var_use() {
+        // Move root.0, then try to use the whole variable (root) — must reject.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(2);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Moved);
+        // Accessing root (the whole variable) overlaps with root.0 that was moved → reject.
+        let err = env.check_path_available(sym, &PatternPath::root())
+            .expect_err("use of whole var after partial move must reject");
+        assert!(
+            err.message.contains("partially moved") || err.message.contains("moved"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn partial_move_child_blocks_child_use() {
+        // Move root.0, then try to use root.0 again — must reject.
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(3);
+        env.insert(sym, Type::I32);
+        let path = PatternPath::root().tuple_index(0);
+        env.mark_path_state(sym, path.clone(), PathAvailability::Moved);
+        let err = env.check_path_available(sym, &path)
+            .expect_err("re-use of moved child path must reject");
+        assert!(
+            err.message.contains("moved"),
+            "unexpected: {}", err.message
+        );
+    }
+
+    #[test]
+    fn whole_var_consumed_still_blocks() {
+        // mark_consumed (whole-var) still blocks root access.
+        use crate::types::PatternPath;
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(4);
+        env.insert(sym, Type::I32);
+        env.mark_consumed(sym);
+        let err = env.check_path_available(sym, &PatternPath::root())
+            .expect_err("whole-consumed var must be blocked");
+        assert!(err.message.contains("moved"), "unexpected: {}", err.message);
+    }
+
+    #[test]
+    fn borrow_path_does_not_block_read() {
+        // Borrow only — read should still be allowed (conservative: borrows don't block reads).
+        use crate::types::{PathAvailability, PatternPath};
+        let mut env = ScopeEnv::new();
+        let sym = SymbolId(5);
+        env.insert(sym, Type::I32);
+        env.mark_path_state(sym, PatternPath::root().tuple_index(0), PathAvailability::Borrowed);
+        env.check_path_available(sym, &PatternPath::root().tuple_index(0))
+            .expect("borrow-only path should not block reads");
+    }
+
     // M9.6 — prefix-overlap conflict detection
 
     #[test]
@@ -6072,14 +6141,12 @@ fn check_loop_expr_stmt(
                 });
             }
 
-            // M9.5 Wave D: migrate to BindingPlan ownership pipeline.
-            let mut any_arm_moves = false;
+            // M9.5 Wave D / M9.7: BindingPlan pipeline + path-based ownership.
+            let mut arm_plans: Vec<BindingPlan> = Vec::new();
             for arm in arms {
                 let (plan, mut arm_env) =
                     build_and_apply_match_plan(&arm.pat, &st, env, arena, adt_table)?;
-                if scrutinee_use_from_plan(&plan) == ScrutineeUse::Consumed {
-                    any_arm_moves = true;
-                }
+                arm_plans.push(plan);
                 check_match_guard(
                     arm.guard,
                     arena,
@@ -6106,11 +6173,7 @@ fn check_loop_expr_stmt(
                 }
                 arm_env.pop_scope();
             }
-            if any_arm_moves {
-                if let Expr::Var(name) = arena.expr(*scrutinee) {
-                    env.mark_consumed(*name);
-                }
-            }
+            apply_plans_to_scrutinee(*scrutinee, &arm_plans, arena, env);
 
             let mut def_env = env.clone();
             def_env.push_scope();
@@ -8739,6 +8802,29 @@ pub(crate) fn mark_scrutinee_if_moved(
     if scrutinee_use_from_plan(plan) == ScrutineeUse::Consumed {
         if let Expr::Var(name) = arena.expr(scrutinee_expr) {
             env.mark_consumed(*name);
+        }
+    }
+}
+
+/// M9.7: For each arm plan, record the capture state of every binding path
+/// onto the scrutinee variable (if it is a plain Expr::Var).
+///
+/// Conservative: we union the paths across all arms. A path moved in any arm
+/// is considered moved after the match.
+pub(crate) fn apply_plans_to_scrutinee(
+    scrutinee_expr: ExprId,
+    plans: &[BindingPlan],
+    arena: &AstArena,
+    env: &mut ScopeEnv,
+) {
+    let Expr::Var(var_name) = arena.expr(scrutinee_expr) else { return; };
+    for plan in plans {
+        for item in &plan.items {
+            let avail = match item.capture {
+                CaptureMode::Move   => PathAvailability::Moved,
+                CaptureMode::Borrow => PathAvailability::Borrowed,
+            };
+            env.mark_path_state(*var_name, item.path.clone(), avail);
         }
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -296,6 +296,31 @@ pub enum ScrutineeUse {
     Consumed,
 }
 
+// ──────────────────────────────────────────────────────────────
+// M9.7: per-path availability state for partial move
+// ──────────────────────────────────────────────────────────────
+
+/// Availability of a single path within a bound variable.
+///
+/// Used for partial-move tracking: moving `x.0` marks `root.0` as `Moved`
+/// without invalidating `root.1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathAvailability {
+    Available,
+    Borrowed,
+    Moved,
+}
+
+/// Per-variable path availability table.
+///
+/// Stores the set of `(PatternPath, PathAvailability)` entries recorded
+/// by pattern-binding operations.  An empty table means the variable is
+/// fully available.
+#[derive(Debug, Clone, Default)]
+pub struct ValuePathState {
+    pub paths: Vec<(PatternPath, PathAvailability)>,
+}
+
 /// Availability of a local variable in scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueAvailability {
@@ -1377,6 +1402,21 @@ mod tests {
     fn binding_plan_default_is_empty() {
         let plan = BindingPlan::default();
         assert!(plan.items.is_empty());
+    }
+
+    // M9.7 — PathAvailability / ValuePathState owner layer
+
+    #[test]
+    fn path_availability_variants_distinct() {
+        assert_ne!(PathAvailability::Available, PathAvailability::Moved);
+        assert_ne!(PathAvailability::Available, PathAvailability::Borrowed);
+        assert_ne!(PathAvailability::Moved, PathAvailability::Borrowed);
+    }
+
+    #[test]
+    fn value_path_state_default_is_empty() {
+        let s = crate::types::ValuePathState::default();
+        assert!(s.paths.is_empty());
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -253,6 +253,10 @@ pub enum Expr {
     Binary(ExprId, BinaryOp, ExprId),
     Block(BlockExpr),
     If(IfExpr),
+    /// M9.4 Wave 1: `if let Pattern = expr { ... } else { ... }` binding guard desugaring.
+    ///
+    /// Admitted at the owner layer. Parser and typecheck admission in Wave 2/3.
+    IfLet(IfLetExpr),
     Match(MatchExpr),
     Loop(LoopExpr),
 }
@@ -340,6 +344,18 @@ pub struct IfExpr {
     pub else_block: BlockExpr,
 }
 
+/// M9.4 Wave 1: `if let Pattern = value { then } else { otherwise }` form.
+///
+/// Binds names from `pattern` into `then_block` only. The `else_block` sees
+/// the pre-binding scope. Parser and typecheck admission in Wave 2/3.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IfLetExpr {
+    pub pattern: MatchPattern,
+    pub value: ExprId,
+    pub then_block: BlockExpr,
+    pub else_block: BlockExpr,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchExpr {
     pub scrutinee: ExprId,
@@ -371,12 +387,31 @@ pub enum TuplePatternItem {
     Bind(SymbolId),
     Discard,
     QuadLiteral(QuadVal),
+    /// M9.4 Wave 1: nested tuple destructuring — `(a, (b, c))` beyond one level.
+    Nested(Vec<TuplePatternItem>),
+}
+
+/// An integer range used as a match pattern, e.g. `1..=5 =>` or `0..10 =>`.
+///
+/// M9.4 Wave 1 owner layer. Parser and typecheck admission in Wave 2/3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntRangePattern {
+    pub start: i64,
+    pub end: i64,
+    pub inclusive: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MatchPattern {
     Quad(QuadVal),
     Adt(AdtMatchPattern),
+    /// M9.4 Wave 1: `_` wildcard in match arms.
+    Wildcard,
+    /// M9.4 Wave 1: or-pattern — `Variant::A | Variant::B =>`.
+    /// At least two alternatives; alternatives are matched left-to-right.
+    Or(Vec<MatchPattern>),
+    /// M9.4 Wave 1: integer range pattern — `1..=5 =>` or `0..10 =>`.
+    IntRange(IntRangePattern),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -1103,5 +1138,60 @@ mod tests {
             "expected KwImpl token from 'impl'");
         assert!(tokens2.iter().any(|t| t.kind == TokenKind::KwFor),
             "expected KwFor token from 'for'");
+    }
+
+    // M9.4 Wave 1 — richer pattern surface owner layer
+
+    #[test]
+    fn nested_tuple_pattern_item_owner_layer_is_stable() {
+        let inner = vec![TuplePatternItem::Bind(SymbolId(0)), TuplePatternItem::Discard];
+        let nested = TuplePatternItem::Nested(inner);
+        assert!(matches!(nested, TuplePatternItem::Nested(ref items) if items.len() == 2));
+    }
+
+    #[test]
+    fn wildcard_match_pattern_owner_layer_is_stable() {
+        let pat = MatchPattern::Wildcard;
+        assert!(matches!(pat, MatchPattern::Wildcard));
+    }
+
+    #[test]
+    fn or_pattern_owner_layer_is_stable() {
+        let mut arena = AstArena::default();
+        let adt_a = AdtMatchPattern {
+            adt_name: arena.intern_symbol("Color"),
+            variant_name: arena.intern_symbol("Red"),
+            items: vec![],
+        };
+        let adt_b = AdtMatchPattern {
+            adt_name: arena.intern_symbol("Color"),
+            variant_name: arena.intern_symbol("Blue"),
+            items: vec![],
+        };
+        let or_pat = MatchPattern::Or(vec![MatchPattern::Adt(adt_a), MatchPattern::Adt(adt_b)]);
+        assert!(matches!(&or_pat, MatchPattern::Or(alts) if alts.len() == 2));
+    }
+
+    #[test]
+    fn int_range_pattern_owner_layer_is_stable() {
+        let range_pat = MatchPattern::IntRange(IntRangePattern { start: 1, end: 5, inclusive: true });
+        assert!(matches!(&range_pat, MatchPattern::IntRange(r) if r.start == 1 && r.end == 5 && r.inclusive));
+    }
+
+    #[test]
+    fn if_let_expr_owner_layer_is_stable() {
+        let mut arena = AstArena::default();
+        let value_id = arena.alloc_expr(Expr::BoolLiteral(true));
+        let unit_id = arena.alloc_expr(Expr::QuadLiteral(QuadVal::N));
+        let then_block = BlockExpr { statements: vec![], tail: unit_id };
+        let else_block = BlockExpr { statements: vec![], tail: unit_id };
+        let if_let = IfLetExpr {
+            pattern: MatchPattern::Wildcard,
+            value: value_id,
+            then_block,
+            else_block,
+        };
+        assert!(matches!(if_let.pattern, MatchPattern::Wildcard));
+        assert_eq!(if_let.value, value_id);
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -216,6 +216,93 @@ pub enum CaptureMode {
     Borrow,
 }
 
+// ──────────────────────────────────────────────────────────────
+// M9.5 Wave C: pattern path tracking, binding plans, scrutinee state
+// ──────────────────────────────────────────────────────────────
+
+/// One step in the address of a sub-value accessed by a pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PatternPathElem {
+    TupleIndex(usize),
+    Variant(SymbolId),
+    VariantField(usize),
+    RecordField(SymbolId),
+}
+
+/// Canonical address of a sub-value within the scrutinee.
+///
+/// `PatternPath::root()` refers to the scrutinee itself.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct PatternPath {
+    pub elems: Vec<PatternPathElem>,
+}
+
+impl PatternPath {
+    pub fn root() -> Self {
+        Self { elems: Vec::new() }
+    }
+    pub fn tuple_index(&self, idx: usize) -> Self {
+        let mut e = self.elems.clone(); e.push(PatternPathElem::TupleIndex(idx)); Self { elems: e }
+    }
+    pub fn variant(&self, name: SymbolId) -> Self {
+        let mut e = self.elems.clone(); e.push(PatternPathElem::Variant(name)); Self { elems: e }
+    }
+    pub fn variant_field(&self, idx: usize) -> Self {
+        let mut e = self.elems.clone(); e.push(PatternPathElem::VariantField(idx)); Self { elems: e }
+    }
+    pub fn record_field(&self, name: SymbolId) -> Self {
+        let mut e = self.elems.clone(); e.push(PatternPathElem::RecordField(name)); Self { elems: e }
+    }
+}
+
+/// A single binding produced by a pattern, with its sub-value address.
+#[derive(Debug, Clone)]
+pub struct BindingPlanItem {
+    pub name: SymbolId,
+    pub capture: CaptureMode,
+    pub path: PatternPath,
+    pub ty: Type,
+}
+
+/// The complete set of bindings a pattern produces from a scrutinee.
+///
+/// NOTE (M9.5 Wave A/B): CaptureMode is populated but not yet enforced in
+/// typecheck beyond conflict detection. Full move/borrow semantics arrive in
+/// Wave C.
+#[derive(Debug, Clone, Default)]
+pub struct BindingPlan {
+    pub items: Vec<BindingPlanItem>,
+}
+
+impl BindingPlan {
+    pub fn push(&mut self, item: BindingPlanItem) {
+        self.items.push(item);
+    }
+}
+
+/// Whether the same path is accessed as moved or borrowed (conflict detection).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessKind {
+    Borrow,
+    Move,
+}
+
+/// Whether a scrutinee value is available after a match/if-let.
+///
+/// Consumed if any binding in the plan used `Move`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrutineeUse {
+    Preserved,
+    Consumed,
+}
+
+/// Availability of a local variable in scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueAvailability {
+    Available,
+    Consumed,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum AdtPatternItem {
     /// M9.5 Wave A: binding now carries explicit capture mode (default `Move`).
@@ -731,6 +818,8 @@ pub enum TokenKind {
     KwPulse,
     KwProfile,
     KwImport,
+    /// M9.5 Wave B: `ref` keyword — borrow binding in patterns, e.g. `ref x` in tuple/ADT patterns.
+    KwRef,
     TyQuad,
     TyBool,
     TyI32,
@@ -1250,5 +1339,61 @@ mod tests {
         let item = AdtPatternItem::Bind { name: SymbolId(4), capture: CaptureMode::Move };
         let AdtPatternItem::Bind { capture, .. } = item else { panic!("expected Bind") };
         assert_eq!(capture, CaptureMode::Move, "default ADT binding capture must be Move");
+    }
+
+    // M9.5 Wave B — KwRef token owner layer
+
+    #[test]
+    fn kw_ref_lexes_to_reserved_token() {
+        use crate::lexer::lex_tokens;
+        let tokens = lex_tokens("ref x").unwrap();
+        assert!(tokens.iter().any(|t| t.kind == TokenKind::KwRef),
+            "expected KwRef token from 'ref'");
+    }
+
+    // M9.5 Wave C — PatternPath / BindingPlan owner layer
+
+    #[test]
+    fn pattern_path_root_is_empty() {
+        let p = PatternPath::root();
+        assert!(p.elems.is_empty());
+    }
+
+    #[test]
+    fn pattern_path_tuple_index_appends() {
+        let p = PatternPath::root().tuple_index(2);
+        assert_eq!(p.elems, vec![PatternPathElem::TupleIndex(2)]);
+    }
+
+    #[test]
+    fn pattern_path_nested_build() {
+        let p = PatternPath::root().tuple_index(1).variant_field(0);
+        assert_eq!(p.elems.len(), 2);
+        assert!(matches!(p.elems[0], PatternPathElem::TupleIndex(1)));
+        assert!(matches!(p.elems[1], PatternPathElem::VariantField(0)));
+    }
+
+    #[test]
+    fn binding_plan_default_is_empty() {
+        let plan = BindingPlan::default();
+        assert!(plan.items.is_empty());
+    }
+
+    #[test]
+    fn scrutinee_use_consumed_if_any_move() {
+        let mut plan = BindingPlan::default();
+        plan.push(BindingPlanItem {
+            name: SymbolId(1),
+            capture: CaptureMode::Move,
+            path: PatternPath::root().tuple_index(0),
+            ty: Type::I32,
+        });
+        assert_eq!(crate::types::ScrutineeUse::Consumed, {
+            if plan.items.iter().any(|it| it.capture == CaptureMode::Move) {
+                crate::types::ScrutineeUse::Consumed
+            } else {
+                crate::types::ScrutineeUse::Preserved
+            }
+        });
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -206,9 +206,20 @@ pub struct AdtCtorExpr {
     pub payload: Vec<ExprId>,
 }
 
+/// M9.5 Wave A: capture mode for pattern bindings.
+///
+/// Default is `Move`. `Borrow` is spelled `ref x` in source.
+/// Mutable borrow, partial move, lifetime inference, and reborrow are deferred.
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum CaptureMode {
+    Move,
+    Borrow,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum AdtPatternItem {
-    Bind(SymbolId),
+    /// M9.5 Wave A: binding now carries explicit capture mode (default `Move`).
+    Bind { name: SymbolId, capture: CaptureMode },
     Discard,
 }
 
@@ -384,7 +395,8 @@ pub struct RangeExpr {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TuplePatternItem {
-    Bind(SymbolId),
+    /// M9.5 Wave A: binding now carries explicit capture mode (default `Move`).
+    Bind { name: SymbolId, capture: CaptureMode },
     Discard,
     QuadLiteral(QuadVal),
     /// M9.4 Wave 1: nested tuple destructuring — `(a, (b, c))` beyond one level.
@@ -1146,7 +1158,7 @@ mod tests {
 
     #[test]
     fn nested_tuple_pattern_item_owner_layer_is_stable() {
-        let inner = vec![TuplePatternItem::Bind(SymbolId(0)), TuplePatternItem::Discard];
+        let inner = vec![TuplePatternItem::Bind { name: SymbolId(0), capture: CaptureMode::Move }, TuplePatternItem::Discard];
         let nested = TuplePatternItem::Nested(inner);
         assert!(matches!(nested, TuplePatternItem::Nested(ref items) if items.len() == 2));
     }
@@ -1195,5 +1207,48 @@ mod tests {
         };
         assert!(matches!(if_let.pattern, MatchPattern::Wildcard));
         assert_eq!(if_let.value, value_id);
+    }
+
+    // M9.5 Wave A — capture mode owner layer
+
+    #[test]
+    fn capture_mode_move_and_borrow_are_distinct() {
+        assert_ne!(CaptureMode::Move, CaptureMode::Borrow);
+        assert_eq!(CaptureMode::Move, CaptureMode::Move);
+        assert_eq!(CaptureMode::Borrow, CaptureMode::Borrow);
+    }
+
+    #[test]
+    fn tuple_pattern_bind_carries_capture_mode() {
+        let item_move = TuplePatternItem::Bind { name: SymbolId(1), capture: CaptureMode::Move };
+        let item_borrow = TuplePatternItem::Bind { name: SymbolId(1), capture: CaptureMode::Borrow };
+        assert!(matches!(item_move, TuplePatternItem::Bind { capture: CaptureMode::Move, .. }));
+        assert!(matches!(item_borrow, TuplePatternItem::Bind { capture: CaptureMode::Borrow, .. }));
+        // Two bindings of same name but different capture mode are distinct.
+        assert_ne!(item_move, item_borrow);
+    }
+
+    #[test]
+    fn adt_pattern_bind_carries_capture_mode() {
+        let item_move = AdtPatternItem::Bind { name: SymbolId(2), capture: CaptureMode::Move };
+        let item_borrow = AdtPatternItem::Bind { name: SymbolId(2), capture: CaptureMode::Borrow };
+        assert!(matches!(item_move, AdtPatternItem::Bind { capture: CaptureMode::Move, .. }));
+        assert!(matches!(item_borrow, AdtPatternItem::Bind { capture: CaptureMode::Borrow, .. }));
+        assert_ne!(item_move, item_borrow);
+    }
+
+    #[test]
+    fn tuple_pattern_default_is_move() {
+        // Default capture in parser-generated nodes is Move; Borrow requires explicit `ref`.
+        let item = TuplePatternItem::Bind { name: SymbolId(3), capture: CaptureMode::Move };
+        let TuplePatternItem::Bind { capture, .. } = item else { panic!("expected Bind") };
+        assert_eq!(capture, CaptureMode::Move, "default tuple binding capture must be Move");
+    }
+
+    #[test]
+    fn adt_pattern_default_is_move() {
+        let item = AdtPatternItem::Bind { name: SymbolId(4), capture: CaptureMode::Move };
+        let AdtPatternItem::Bind { capture, .. } = item else { panic!("expected Bind") };
+        assert_eq!(capture, CaptureMode::Move, "default ADT binding capture must be Move");
     }
 }

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -735,6 +735,8 @@ pub enum TokenKind {
     AndAnd,
     OrOr,
     PipeForward,
+    /// `|` — bare pipe used as or-pattern separator. M9.4 Wave 2.
+    Pipe,
     AndAndAssign,
     OrOrAssign,
     PlusAssign,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2961,6 +2961,11 @@ fn lower_expr_with_expected(
             }
             Ok((dst, lt))
         }
+        // M9.4 Wave 1: IfLet lowering is deferred (typecheck-only in M9.4).
+        Expr::IfLet(_) => Err(FrontendError {
+            pos: 0,
+            message: "if-let lowering is not yet implemented in the IR backend".to_string(),
+        }),
     }
 }
 
@@ -3529,7 +3534,7 @@ fn bind_let_else_tuple_items(
             index,
         });
         match item {
-            TuplePatternItem::Bind(name) => deferred_binds.push((*name, reg, item_ty.clone())),
+            TuplePatternItem::Bind { name, .. } => deferred_binds.push((*name, reg, item_ty.clone())),
             TuplePatternItem::Discard => {}
             TuplePatternItem::QuadLiteral(pat) => {
                 if *item_ty != Type::Quad {
@@ -3578,6 +3583,11 @@ fn bind_let_else_tuple_items(
                     name: continue_label,
                 });
             }
+            // M9.4 Wave 1: nested tuple lowering is deferred.
+            TuplePatternItem::Nested(_) => return Err(FrontendError {
+                pos: 0,
+                message: "nested tuple lowering is not yet implemented in the IR backend".to_string(),
+            }),
         }
     }
 
@@ -4919,6 +4929,13 @@ fn expect_quad_match_pattern(pat: &MatchPattern) -> Result<QuadVal, FrontendErro
             pos: 0,
             message: "enum match pattern requires enum scrutinee in lowering".to_string(),
         }),
+        // M9.4 Wave 1: these patterns are typecheck-only in M9.4; lowering is deferred.
+        MatchPattern::Wildcard | MatchPattern::Or(_) | MatchPattern::IntRange(_) => {
+            Err(FrontendError {
+                pos: 0,
+                message: "wildcard/or/range match pattern lowering is not yet implemented in the IR backend".to_string(),
+            })
+        }
     }
 }
 
@@ -5053,7 +5070,7 @@ fn resolve_sum_match_pattern_for_lowering(
     for (index, (item, declared_ty)) in adt_pat.items.iter().zip(variant.payload.iter()).enumerate()
     {
         let payload_ty = canonicalize_declared_type(declared_ty, record_table, adt_table, arena)?;
-        if let AdtPatternItem::Bind(name) = item {
+        if let AdtPatternItem::Bind { name, .. } = item {
             bindings.push(LoweredAdtMatchBinding {
                 name: *name,
                 ty: payload_ty,

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -128,6 +128,7 @@
   - completed subtracks:
     - M9.1: `docs/roadmap/language_maturity/generics_full_scope.md`
     - M9.2: `docs/roadmap/language_maturity/traits_full_scope.md`
+    - M9.4: richer pattern surface (Wildcard, Or, IntRange, nested tuple, if-let)
   - planning rule:
     - keep one active stream at a time
     - keep UI/platform expansion separate from language-maturity work

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -37,6 +37,8 @@ pub type ImplTable = Vec<ImplDecl>;
 pub struct ScopeBinding {
 pub ty: Type,
 pub is_const: bool,
+pub consumed: bool,
+pub path_state: Vec<(crate::types::PatternPath, crate::types::PathAvailability)>,
 #[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeEnv {
@@ -46,6 +48,11 @@ pub fn push_scope(&mut self) {
 pub fn pop_scope(&mut self) {
 pub fn insert(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
+pub fn mark_consumed(&mut self, name: SymbolId) {
+pub fn is_consumed(&self, name: SymbolId) -> bool {
+pub fn mark_path_state(
+pub fn check_path_available(
+pub fn check_capture_allowed(
 pub fn get(&self, name: SymbolId) -> Option<Type> {
 pub fn is_const(&self, name: SymbolId) -> bool {
 #[cfg(any(feature = "alloc", feature = "std"))]


### PR DESCRIPTION
## Summary

### M9.4 (Waves 1–4) — Richer Pattern Surface
- `Wildcard`, `Or`, `IntRange`, nested tuple destructuring, `if let`
- `TokenKind::Pipe` lexed; exhaustiveness extended for Wildcard/Or
- 304 → 309 tests

### M9.5 (Waves A–D) — Pattern Ownership Semantics
- **Wave A**: `CaptureMode { Move, Borrow }` in all binding nodes
- **Wave B**: `ref x` parser syntax → `CaptureMode::Borrow`
- **Wave C**: `PatternPath`, `BindingPlan`, `validate_binding_plan_conflicts`, `if let` migrated
- **Wave D**: `match` (stmt + expr) migrated to BindingPlan pipeline; `mark_consumed` at stmt level
- 309 → 329 tests

### M9.6 — Prefix-Overlap Conflict Detection
- `path_is_prefix` + `paths_overlap`: catches `root` vs `root.0` conflicts
- `captures_conflict`: borrow+borrow ok, move+overlapping = error
- Replaces exact-path check in `validate_binding_plan_conflicts`
- 329 → 333 tests

### M9.7 (Commits 1–2) — Path-Based Partial-Move Tracking
- `PathAvailability { Available, Borrowed, Moved }` + `ValuePathState` in `types.rs`
- `ScopeEnv::mark_path_state` / `check_path_available`: per-variable path-state table
- `apply_plans_to_scrutinee`: unions arm plans into scrutinee path-state after match
- Both `Stmt::Match` sites and `Expr::IfLet` wired to path-state
- 333 → 340 tests

### M9.8 — Borrow Enforcement Against Prior Path-State
- `ScopeEnv::check_capture_allowed`: rejects borrow+move, move+borrow, move+move on overlapping paths; allows borrow+borrow and sibling paths
- `validate_plan_against_scrutinee_state`: gates each `BindingPlanItem` against scrutinee's current `ValuePathState` before binding
- 340 → 344 tests

### M9.9 (Commits 1–2) — Path-Aware Read Semantics + Path-State Normalization
- `expr_access_path(expr_id, arena)`: extracts `(SymbolId, PatternPath)` for `Var`, `RecordField`, `SequenceIndex` with literal index
- `infer_expr_type` checks most-specific path at call site; `infer_expr_type_no_check` used for base expressions to avoid false root-overlap rejection on sibling paths
- `mark_path_state` normalises on write: shorter path drops longer redundant children; redundant longer entry suppressed when parent already present
- Improved `check_path_available` diagnostics: distinguishes direct-move from whole-var-after-partial-move
- 344 → 353 tests

## Test plan

- [x] `cargo test -p sm-front` — **353 passed, 0 failed**
- [x] Wildcard / Or / IntRange / nested-tuple / if-let pattern tests
- [x] `ref x` parser tests (tuple + ADT)
- [x] BindingPlan conflict + ScrutineeUse + consumed-state tests
- [x] Match ownership pipeline (borrow preserves scrutinee, move consumes)
- [x] Prefix-overlap: parent/child conflict, sibling-path pass (M9.6)
- [x] Path-state: sibling-available, whole-var-blocked, partial-move tracking (M9.7)
- [x] Capture-allowed enforcement: borrow+move / move+borrow / move+move rejected; sibling ok (M9.8)
- [x] `expr_access_path` variants; path-state normalization rules; sibling read ok (M9.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)