### PR TITLE
Preserve borrow capture in tuple pattern surface

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -706,7 +706,17 @@ impl<'a> Parser<'a> {
                         else_return: None,
                     }));
                 }
-                let items = self.lower_tuple_pattern_items_to_bind(items)?;
+                if items
+                    .iter()
+                    .any(|item| matches!(item, TuplePatternItem::QuadLiteral(_)))
+                {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message:
+                            "quad literal tuple patterns currently require let-else; plain tuple destructuring bind supports only name/_/ref items"
+                                .to_string(),
+                    });
+                }
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::LetTuple { items, ty, value }));
             }
@@ -955,7 +965,7 @@ impl<'a> Parser<'a> {
                     return Err(FrontendError {
                         pos: self.pos(),
                         message:
-                            "quad literal tuple patterns currently require let-else; plain tuple destructuring bind supports only name/_ items"
+                            "quad literal tuple patterns currently require let-else; tuple assignment targets currently support only name/_ items"
                                 .to_string(),
                     })
                 }
@@ -963,7 +973,7 @@ impl<'a> Parser<'a> {
                     return Err(FrontendError {
                         pos: self.pos(),
                         message:
-                            "nested tuple patterns are not yet supported in plain let bindings; use let-else form"
+                            "nested tuple patterns are not supported in tuple assignment targets"
                                 .to_string(),
                     })
                 }
@@ -1879,7 +1889,10 @@ impl<'a> Parser<'a> {
             Stmt::LetTuple { items, value, .. } => {
                 self.collect_short_lambda_expr_captures(*value, scopes, captures)?;
                 if let Some(scope) = scopes.last_mut() {
-                    scope.extend(items.iter().flatten().copied());
+                    scope.extend(items.iter().filter_map(|item| match item {
+                        TuplePatternItem::Bind { name, .. } => Some(*name),
+                        _ => None,
+                    }));
                 }
                 Ok(())
             }
@@ -2082,7 +2095,10 @@ impl<'a> Parser<'a> {
             Stmt::LetTuple { items, value, .. } => {
                 self.ensure_short_lambda_expr_capture_free(*value, scopes)?;
                 if let Some(scope) = scopes.last_mut() {
-                    scope.extend(items.iter().flatten().copied());
+                    scope.extend(items.iter().filter_map(|item| match item {
+                        TuplePatternItem::Bind { name, .. } => Some(*name),
+                        _ => None,
+                    }));
                 }
                 Ok(())
             }
@@ -4396,17 +4412,53 @@ fn main() {
             panic!("expected tuple destructuring statement");
         };
         assert_eq!(items.len(), 2);
-        assert_eq!(
-            items[0].map(|name| program.arena.symbol_name(name)),
-            Some("count")
-        );
-        assert!(items[1].is_none());
+        assert!(matches!(
+            items[0],
+            TuplePatternItem::Bind {
+                name,
+                capture: CaptureMode::Move
+            } if program.arena.symbol_name(name) == "count"
+        ));
+        assert!(matches!(items[1], TuplePatternItem::Discard));
         assert_eq!(*ty, Some(Type::Tuple(vec![Type::I32, Type::Bool])));
         let Expr::Call(name, args) = program.arena.expr(*value) else {
             panic!("expected call expression");
         };
         assert_eq!(program.arena.symbol_name(*name), "pair");
         assert!(args.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_preserves_borrow_capture_in_plain_tuple_bind() {
+        let src = r#"
+fn pair() -> (i32, bool) = (1, true);
+
+fn main() {
+    let (ref count, ready) = pair();
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("tuple ref bind should parse");
+        let func = &program.functions[1];
+        let Stmt::LetTuple { items, .. } = program.arena.stmt(func.body[0]) else {
+            panic!("expected tuple destructuring statement");
+        };
+        assert!(matches!(
+            items[0],
+            TuplePatternItem::Bind {
+                name,
+                capture: CaptureMode::Borrow
+            } if program.arena.symbol_name(name) == "count"
+        ));
+        assert!(matches!(
+            items[1],
+            TuplePatternItem::Bind {
+                name,
+                capture: CaptureMode::Move
+            } if program.arena.symbol_name(name) == "ready"
+        ));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -732,16 +732,9 @@ fn check_stmt(
                 });
             }
             // M9.10 Wave B: build BindingPlan so path-state is tracked on the source variable.
-            let tuple_items: Vec<TuplePatternItem> = items
-                .iter()
-                .map(|opt| match opt {
-                    Some(name) => TuplePatternItem::Bind { name: *name, capture: CaptureMode::Move },
-                    None => TuplePatternItem::Discard,
-                })
-                .collect();
             let tuple_ty = Type::Tuple(item_tys);
             let mut plan = BindingPlan::default();
-            build_tuple_pattern_plan(&tuple_items, &tuple_ty, &PatternPath::root(), &mut plan)?;
+            build_tuple_pattern_plan(items, &tuple_ty, &PatternPath::root(), &mut plan)?;
             validate_binding_plan_conflicts(&plan)?;
             validate_plan_against_scrutinee_state(env, *value, arena, &plan)?;
             apply_binding_plan(env, &plan);
@@ -5380,9 +5373,64 @@ mod tests {
                 return;
             }
         "#;
-        // Wave B: parser must admit `ref x` without error.
-        // CaptureMode::Borrow is stored but not yet enforced in typecheck (Wave C).
+        // Plain tuple binds must preserve borrow capture instead of rewriting
+        // every bind to Move before the ownership pipeline runs.
         typecheck_source(src).expect("ref binding in tuple pattern should parse and typecheck");
+    }
+
+    #[test]
+    fn plain_tuple_ref_binding_preserves_borrow_path_state() {
+        use crate::types::{PathAvailability, PatternPath};
+
+        let mut arena = AstArena::default();
+        let source = arena.intern_symbol("source");
+        let borrowed = arena.intern_symbol("borrowed");
+        let moved = arena.intern_symbol("moved");
+        let value = arena.alloc_expr(Expr::Var(source));
+        let stmt = arena.alloc_stmt(Stmt::LetTuple {
+            items: vec![
+                TuplePatternItem::Bind {
+                    name: borrowed,
+                    capture: CaptureMode::Borrow,
+                },
+                TuplePatternItem::Bind {
+                    name: moved,
+                    capture: CaptureMode::Move,
+                },
+            ],
+            ty: None,
+            value,
+        });
+
+        let mut env = ScopeEnv::new();
+        env.insert(source, Type::Tuple(vec![Type::I32, Type::I32]));
+
+        let table = FnTable::new();
+        let record_table = RecordTable::new();
+        let adt_table = AdtTable::new();
+        let mut loop_stack = Vec::new();
+        check_stmt(
+            stmt,
+            &arena,
+            &mut env,
+            Type::Unit,
+            &table,
+            &record_table,
+            &adt_table,
+            &mut loop_stack,
+            &[],
+        )
+        .expect("tuple ref bind should typecheck");
+
+        let binding = env.binding(source).expect("source binding must exist");
+        assert!(binding.path_state.iter().any(|(path, state)| {
+            *state == PathAvailability::Borrowed
+                && *path == PatternPath::root().tuple_index(0)
+        }));
+        assert!(binding.path_state.iter().any(|(path, state)| {
+            *state == PathAvailability::Moved
+                && *path == PatternPath::root().tuple_index(1)
+        }));
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -397,7 +397,7 @@ pub enum Stmt {
         value: ExprId,
     },
     LetTuple {
-        items: Vec<Option<SymbolId>>,
+        items: Vec<TuplePatternItem>,
         ty: Option<Type>,
         value: ExprId,
     },

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -2970,7 +2970,7 @@ fn lower_expr_with_expected(
 }
 
 fn bind_tuple_items(
-    items: &[Option<SymbolId>],
+    items: &[TuplePatternItem],
     tuple_reg: u16,
     tuple_ty: &Type,
     arena: &AstArena,
@@ -2995,8 +2995,25 @@ fn bind_tuple_items(
         });
     }
     for (index, (item, item_ty)) in items.iter().zip(item_tys.iter()).enumerate() {
-        let Some(name) = item else {
-            continue;
+        let name = match item {
+            TuplePatternItem::Bind { name, .. } => *name,
+            TuplePatternItem::Discard => continue,
+            TuplePatternItem::QuadLiteral(_) => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "quad literal tuple patterns currently require let-else; plain tuple destructuring bind supports only name/_/ref items"
+                            .to_string(),
+                })
+            }
+            TuplePatternItem::Nested(_) => {
+                return Err(FrontendError {
+                    pos: 0,
+                    message:
+                        "nested tuple patterns are not yet supported in plain let bindings; use let-else form"
+                            .to_string(),
+                })
+            }
         };
         let reg = alloc(next);
         let index = u16::try_from(index).map_err(|_| FrontendError {
@@ -3008,9 +3025,9 @@ fn bind_tuple_items(
             src: tuple_reg,
             index,
         });
-        env.insert(*name, item_ty.clone());
+        env.insert(name, item_ty.clone());
         out.push(IrInstr::StoreVar {
-            name: resolve_symbol_name(arena, *name)?.to_string(),
+            name: resolve_symbol_name(arena, name)?.to_string(),
             src: reg,
         });
     }


### PR DESCRIPTION
## Summary
- preserve `TuplePatternItem` on plain `Stmt::LetTuple` instead of erasing every bind to `Option<SymbolId>`
- keep `Borrow` vs `Move` visible through parser and typecheck so tuple borrow intent survives to the lowering boundary
- update the existing `sm-ir` tuple bind consumer mechanically so the workspace stays green, without adding new lowering/runtime ownership semantics yet

## Scope
- frontend preservation slice only
- no SemCode format changes
- no verifier changes
- no VM enforcement changes

## Verification
- `cargo test -q -p sm-front`
- `cargo test -q -p sm-ir`
- `cargo test -q --test public_api_contracts`