### PR TITLE
Add runtime-core ownership path primitives

### DIFF
--- a/crates/sm-runtime-core/src/lib.rs
+++ b/crates/sm-runtime-core/src/lib.rs
@@ -39,6 +39,37 @@ impl SymbolId {
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AccessPath {
+    pub root: SymbolId,
+    pub components: Vec<PathComponent>,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+impl AccessPath {
+    pub fn new(root: SymbolId) -> Self {
+        Self {
+            root,
+            components: Vec::new(),
+        }
+    }
+
+    pub fn tuple_index(&self, index: u16) -> Self {
+        let mut components = self.components.clone();
+        components.push(PathComponent::TupleIndex(index));
+        Self {
+            root: self.root,
+            components,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PathComponent {
+    TupleIndex(u16),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionContext {
     PureCompute,
@@ -255,6 +286,32 @@ impl DebugNameMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn access_path_root_starts_with_empty_component_list() {
+        let path = AccessPath::new(SymbolId(7));
+        assert_eq!(path.root, SymbolId(7));
+        assert!(path.components.is_empty());
+    }
+
+    #[test]
+    fn access_path_tuple_indices_preserve_append_order() {
+        let path = AccessPath::new(SymbolId(3)).tuple_index(1).tuple_index(4);
+        assert_eq!(path.root, SymbolId(3));
+        assert_eq!(
+            path.components,
+            vec![PathComponent::TupleIndex(1), PathComponent::TupleIndex(4)]
+        );
+    }
+
+    #[test]
+    fn access_path_component_order_is_deterministic() {
+        let left = AccessPath::new(SymbolId(9)).tuple_index(0).tuple_index(2);
+        let right = AccessPath::new(SymbolId(9)).tuple_index(0).tuple_index(2);
+        let different = AccessPath::new(SymbolId(9)).tuple_index(2).tuple_index(0);
+        assert_eq!(left, right);
+        assert_ne!(left, different);
+    }
 
     #[test]
     fn runtime_symbol_table_assigns_deterministic_ids() {

--- a/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
@@ -15,6 +15,15 @@ pub payload: Vec<T>,
 pub struct SymbolId(pub u32);
 pub const fn new(raw: u32) -> Self {
 pub const fn raw(self) -> u32 {
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AccessPath {
+pub root: SymbolId,
+pub components: Vec<PathComponent>,
+pub fn new(root: SymbolId) -> Self {
+pub fn tuple_index(&self, index: u16) -> Self {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PathComponent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecutionContext {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add execution-layer AccessPath and PathComponent::TupleIndex(u16) to sm-runtime-core
- keep the surface tuple-only and independent from frontend and IR types
- update the checked-in public API snapshot for the intentional runtime-core contract change

## Verification
- cargo test -q -p sm-runtime-core
- cargo test -q --test public_api_contracts