### PR TITLE
Docs: freeze tuple-only runtime ownership contract

### DIFF
--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -17,6 +17,7 @@ Current documents in this PR:
 - `profile.md` - `ParserProfile` policy contract
 - `verifier.md` - SemCode admission verification contract
 - `vm.md` - Semantic VM public execution contract
+- `runtime_ownership.md` - tuple-only runtime ownership transport and enforcement contract
 - `quotas.md` - runtime quota taxonomy and enforcement contract
 - `abi.md` - PROMETHEUS host ABI boundary contract
 - `capabilities.md` - capability manifest and denial contract

--- a/docs/spec/runtime_ownership.md
+++ b/docs/spec/runtime_ownership.md
@@ -1,0 +1,158 @@
+# Runtime Ownership Specification
+
+Status: draft v0
+Source ownership owner: `sm-front`
+IR ownership owner: `sm-ir`
+SemCode transport owner: `sm-ir`
+Admission owner: `sm-verify`
+Execution consumer: `sm-vm`
+Shared runtime vocabulary owner: `sm-runtime-core`
+
+## Purpose
+
+This document freezes the current first-wave runtime ownership contract.
+
+Current supported slice:
+
+- tuple-only `AccessPath`
+- frame-local borrow lifetime
+- structural `OWN0` admission before execution
+- runtime write rejection for overlapping borrowed tuple paths
+
+This document does not claim a general runtime borrow checker.
+
+## Layer Separation
+
+The current ownership pipeline is intentionally split:
+
+- source/frontend semantics decide where borrow capture exists in source
+- IR/lowering preserves only the canonical execution-path contract
+- SemCode transports that lowered ownership metadata in `OWN0`
+- verifier admits or rejects the `OWN0` payload structurally
+- VM enforces the runtime write-path guard over admitted tuple paths
+
+Important rule:
+
+- runtime ownership must not depend on frontend AST or parser-only pattern
+  structures
+
+## Canonical Runtime Path
+
+Current runtime path form:
+
+- `AccessPath { root: SymbolId, components: Vec<PathComponent> }`
+
+Current supported component kinds:
+
+- `TupleIndex(u16)`
+
+Current ordering rule:
+
+- path components are ordered from root to leaf
+- the same path must serialize, admit, and execute in the same deterministic
+  order
+
+## Supported Behavior
+
+Current supported runtime ownership behavior is limited to tuple paths.
+
+Borrow lifetime v0:
+
+- a borrowed tuple path becomes active for the current frame
+- the active borrowed-path set is cleared when that frame exits
+
+Current runtime write rule:
+
+- a write must be rejected if its target path overlaps an active borrowed path
+
+Current overlap cases that must reject:
+
+- exact path equality
+- borrowed parent, written child
+- borrowed child, written parent
+
+Current allowed case:
+
+- sibling tuple paths
+
+## Frontend And Lowering Contract
+
+Current source/frontend contract:
+
+- tuple borrow capture must not be erased before lowering
+- lowering must preserve enough ownership metadata to recover:
+  - borrow event kind
+  - write event kind
+  - canonical tuple-only `AccessPath`
+
+Current lowering contract:
+
+- runtime ownership transport is path-based, not AST-pattern-based
+- the lowered contract uses canonical `AccessPath` rooted in `SymbolId`
+
+## SemCode Transport Contract
+
+Current binary contract:
+
+- ownership metadata is transported only through `SEMCOD11`
+- the ownership section tag is `OWN0`
+- each event carries:
+  - event kind (`Borrow` or `Write`)
+  - root `SymbolId`
+  - ordered tuple-only path components
+
+Current transport scope:
+
+- tuple-only path components
+- deterministic event order
+
+## Verifier Admission Contract
+
+Current verifier responsibility:
+
+- validate `OWN0` section structure
+- validate admitted ownership event kinds
+- validate tuple-only path payload shape
+- validate header/capability consistency for ownership transport
+
+Current verifier non-goal:
+
+- do not evaluate borrow overlap policy
+- do not execute runtime ownership semantics
+
+## VM Enforcement Contract
+
+Current VM responsibility:
+
+- keep a frame-local set of active borrowed tuple paths
+- consume admitted ownership metadata only
+- reject overlapping writes at runtime for the supported tuple slice
+
+Current VM non-goals:
+
+- no partial borrow release
+- no inter-frame borrow persistence
+- no advanced alias inference
+
+## Explicitly Unsupported
+
+The current runtime ownership contract does not claim support for:
+
+- record field paths
+- ADT payload paths
+- schema paths
+- partial borrow release before frame exit
+- advanced aliasing or region reasoning
+- inter-frame borrow persistence
+- non-tuple ownership transport
+
+## Honesty Rule
+
+If a behavior is not implemented across:
+
+- lowering
+- SemCode transport
+- verifier admission
+- VM enforcement
+
+then it must remain unsupported here rather than being implied by analogy.

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -163,6 +163,8 @@ Compatibility rules:
   - event kind (`Borrow` or `Write`)
   - root `SymbolId` as little-endian `u32`
   - ordered tuple-only path components as `TupleIndex(u16)`
+- does not claim record, ADT payload, schema, or release/lifetime transport
+  beyond the current frame-local tuple slice
 
 Important rule:
 
@@ -215,6 +217,17 @@ Current SemCode admission validates:
 - register-budget validity against the runtime contract
 - string and debug reference validity
 - capability consistency between actual usage and emitted contract
+
+Current ownership-specific structural admission for `SEMCOD11` validates:
+
+- `OWN0` section layout
+- admitted ownership event kinds
+- tuple-only path component kinds
+- deterministic root/component payload shape
+- capability/header consistency for ownership transport
+
+Execution semantics for admitted ownership payload are specified separately in
+`runtime_ownership.md`.
 
 ## Backward Compatibility Rule
 

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -35,6 +35,13 @@ Current SemCode verification checks include:
 - call-target validity
 - capability consistency with actual opcode usage
 
+Current ownership-specific structural checks for `SEMCOD11` include:
+
+- `OWN0` section presence and layout validity when ownership transport is used
+- admitted ownership event kind validity
+- tuple-only `AccessPath` payload validity
+- header/capability consistency for ownership transport
+
 ## Contract Rule
 
 Standard execution uses the chain:
@@ -56,6 +63,12 @@ Important rule:
 - a general optimizer
 
 It is allowed to reject malformed or contract-inconsistent bytecode only.
+
+Current ownership rule:
+
+- verifier admits ownership payload structurally only
+- verifier does not evaluate borrow overlap, release timing, or runtime alias
+  policy
 
 ## Reject Model
 

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -131,6 +131,7 @@ Current frame model includes:
 - program counter
 - register vector
 - `SymbolId` local map
+- frame-local borrowed tuple paths
 - function identity
 - optional return destination
 
@@ -140,8 +141,30 @@ Current function-bytecode model includes:
 - string table
 - runtime symbol ids
 - optional debug symbols
+- tuple-only ownership path metadata admitted from `OWN0`
 - instruction stream
 - instruction start offset
+
+## Runtime Ownership Slice
+
+Current supported runtime ownership slice is narrow:
+
+- tuple-only `AccessPath`
+- frame-local borrow lifetime
+- runtime write rejection on overlapping borrowed tuple paths
+
+Current overlap cases that reject:
+
+- exact path equality
+- borrowed parent, written child
+- borrowed child, written parent
+
+Current allowed case:
+
+- sibling tuple paths
+
+Unsupported ownership behavior remains outside the VM contract here and is
+specified explicitly in `runtime_ownership.md`.
 
 ## Effect Opcode Boundary
 


### PR DESCRIPTION
## Summary
- add the canonical tuple-only runtime ownership spec document
- tighten SemCode, verifier, and VM docs around the landed OWN0 / tuple-only slice
- make supported and unsupported runtime ownership scope explicit

## Notes
- docs/spec only
- no code changes
- no architecture expansion