### PR TITLE
Tests/runtime: stabilize tuple ownership reject surface

### DIFF
--- a/crates/sm-runtime-core/src/lib.rs
+++ b/crates/sm-runtime-core/src/lib.rs
@@ -101,6 +101,7 @@ pub struct QuotaExceeded {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeTrap {
     AssertionFailed,
+    BorrowWriteConflict,
     StackOverflow,
     StackUnderflow,
     TypeMismatch,

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -134,6 +134,9 @@ impl core::fmt::Display for RuntimeError {
             RuntimeError::CapabilityDenied(err) => write!(f, "{err}"),
             RuntimeError::UiCapabilityDenied(err) => write!(f, "{err}"),
             RuntimeError::Trap(RuntimeTrap::AssertionFailed) => write!(f, "assertion failed"),
+            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict) => {
+                write!(f, "write path overlaps active borrow")
+            }
             RuntimeError::Trap(trap) => write!(f, "runtime trap: {:?}", trap),
         }
     }
@@ -1708,7 +1711,7 @@ fn access_paths_overlap(lhs: &AccessPath, rhs: &AccessPath) -> bool {
 }
 
 fn ensure_write_path_allowed(
-    symbol_name: &str,
+    _symbol_name: &str,
     write_path: &AccessPath,
     borrowed_paths: &[AccessPath],
 ) -> Result<(), RuntimeError> {
@@ -1716,10 +1719,7 @@ fn ensure_write_path_allowed(
         .iter()
         .any(|borrowed_path| access_paths_overlap(write_path, borrowed_path))
     {
-        return Err(RuntimeError::TypeMismatchRuntime(format!(
-            "write path overlaps active borrow for '{}'",
-            symbol_name
-        )));
+        return Err(RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict));
     }
     Ok(())
 }
@@ -2763,9 +2763,9 @@ mod tests {
         let err = run_semcode(&bytes).expect_err("overlapping write must fail");
         assert!(matches!(
             err,
-            RuntimeError::TypeMismatchRuntime(message)
-                if message.contains("write path overlaps active borrow")
+            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
         ));
+        assert_eq!(format!("{err}"), "write path overlaps active borrow");
     }
 
     #[test]
@@ -2774,9 +2774,9 @@ mod tests {
         let err = run_semcode(&bytes).expect_err("parent-child overlap must fail");
         assert!(matches!(
             err,
-            RuntimeError::TypeMismatchRuntime(message)
-                if message.contains("write path overlaps active borrow")
+            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
         ));
+        assert_eq!(format!("{err}"), "write path overlaps active borrow");
     }
 
     #[test]
@@ -2785,9 +2785,9 @@ mod tests {
         let err = run_semcode(&bytes).expect_err("child-parent overlap must fail");
         assert!(matches!(
             err,
-            RuntimeError::TypeMismatchRuntime(message)
-                if message.contains("write path overlaps active borrow")
+            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
         ));
+        assert_eq!(format!("{err}"), "write path overlaps active borrow");
     }
 
     #[test]

--- a/tests/runtime_ownership_e2e.rs
+++ b/tests/runtime_ownership_e2e.rs
@@ -3,6 +3,7 @@ use sm_ir::semcode_format::{
     read_u16_le, read_u32_le, read_u8, read_utf8, MAGIC11, OWNERSHIP_EVENT_KIND_BORROW,
     OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
 };
+use sm_runtime_core::RuntimeTrap;
 use sm_verify::verify_semcode;
 use sm_vm::{run_verified_semcode, RuntimeError};
 
@@ -333,7 +334,7 @@ fn assert_repeated_verified_success(bytes: &[u8], runs: usize) {
     }
 }
 
-fn assert_repeated_write_overlap_rejects(bytes: &[u8], symbol_name: &str, runs: usize) {
+fn assert_repeated_write_overlap_rejects(bytes: &[u8], _symbol_name: &str, runs: usize) {
     verify_semcode(bytes).expect("verify");
 
     let mut observed = Vec::with_capacity(runs);
@@ -342,9 +343,9 @@ fn assert_repeated_write_overlap_rejects(bytes: &[u8], symbol_name: &str, runs: 
         let rendered = format!("{err}");
         assert!(matches!(
             err,
-            RuntimeError::TypeMismatchRuntime(message)
-                if message == format!("write path overlaps active borrow for '{symbol_name}'")
+            RuntimeError::Trap(RuntimeTrap::BorrowWriteConflict)
         ));
+        assert_eq!(rendered, "write path overlaps active borrow");
         observed.push(rendered);
     }
 


### PR DESCRIPTION
## Summary
- make tuple ownership conflicts return an explicit runtime trap instead of a generic type mismatch
- freeze the rendered reject surface for tuple-only ownership conflicts
- extend VM and end-to-end tests to assert the stable trap kind and message

## Testing
- cargo test -q -p sm-vm
- cargo test -q
- cargo test -q --test public_api_contracts