### PR TITLE
Docs: define record field runtime ownership scope

### DIFF
--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -17,7 +17,7 @@ Current documents in this PR:
 - `profile.md` - `ParserProfile` policy contract
 - `verifier.md` - SemCode admission verification contract
 - `vm.md` - Semantic VM public execution contract
-- `runtime_ownership.md` - tuple-only runtime ownership transport and enforcement contract
+- `runtime_ownership.md` - current tuple-only runtime ownership contract plus the approved direct record-field extension scope
 - `quotas.md` - runtime quota taxonomy and enforcement contract
 - `abi.md` - PROMETHEUS host ABI boundary contract
 - `capabilities.md` - capability manifest and denial contract

--- a/docs/spec/runtime_ownership.md
+++ b/docs/spec/runtime_ownership.md
@@ -10,7 +10,8 @@ Shared runtime vocabulary owner: `sm-runtime-core`
 
 ## Purpose
 
-This document freezes the current first-wave runtime ownership contract.
+This document freezes the current runtime ownership contract and the next
+approved extension boundary for direct record field paths.
 
 Current supported slice:
 
@@ -18,6 +19,12 @@ Current supported slice:
 - frame-local borrow lifetime
 - structural `OWN0` admission before execution
 - runtime write rejection for overlapping borrowed tuple paths
+
+Approved next slice for this track:
+
+- direct record field `AccessPath`
+- borrow and write ownership over direct record field paths
+- the same overlap rule family used by the tuple-only slice
 
 This document does not claim a general runtime borrow checker.
 
@@ -46,11 +53,20 @@ Current supported component kinds:
 
 - `TupleIndex(u16)`
 
+Approved next component kind for this track:
+
+- `Field(SymbolId)` for direct named record field projection only
+
 Current ordering rule:
 
 - path components are ordered from root to leaf
 - the same path must serialize, admit, and execute in the same deterministic
   order
+
+Important boundary:
+
+- this document does not approve indirect field selection or broader path
+  normalization
 
 ## Supported Behavior
 
@@ -75,6 +91,26 @@ Current allowed case:
 
 - sibling tuple paths
 
+## Approved Record Field Extension Scope
+
+The next runtime ownership slice approved by this document extends the current
+tuple-only contract to direct record field access paths.
+
+Approved target behavior for that track:
+
+- borrow direct record fields
+- write direct record fields
+- reject exact overlap
+- reject borrowed parent, written child
+- reject borrowed child, written parent
+- allow sibling record fields
+
+Approved identity rule for that track:
+
+- record field path identity is represented as `Field(SymbolId)` inside
+  `AccessPath`
+- the first slice is limited to direct named field projection
+
 ## Frontend And Lowering Contract
 
 Current source/frontend contract:
@@ -84,6 +120,12 @@ Current source/frontend contract:
   - borrow event kind
   - write event kind
   - canonical tuple-only `AccessPath`
+
+Approved next frontend/lowering target:
+
+- preserve borrow and write intent for direct record field access paths
+- lower direct record field paths into canonical `AccessPath` using
+  `Field(SymbolId)`
 
 Current lowering contract:
 
@@ -106,6 +148,11 @@ Current transport scope:
 - tuple-only path components
 - deterministic event order
 
+Approved next transport scope:
+
+- deterministic transport of direct record field path components through the
+  same ownership event contract
+
 ## Verifier Admission Contract
 
 Current verifier responsibility:
@@ -114,6 +161,11 @@ Current verifier responsibility:
 - validate admitted ownership event kinds
 - validate tuple-only path payload shape
 - validate header/capability consistency for ownership transport
+
+Approved next verifier scope:
+
+- admit or reject direct record field ownership payload structurally
+- do not imply ADT payload or schema ownership support
 
 Current verifier non-goal:
 
@@ -128,6 +180,12 @@ Current VM responsibility:
 - consume admitted ownership metadata only
 - reject overlapping writes at runtime for the supported tuple slice
 
+Approved next VM target:
+
+- track borrowed direct record field paths in the same frame-local ownership
+  model
+- reject overlapping writes for admitted direct record field paths
+
 Current VM non-goals:
 
 - no partial borrow release
@@ -136,15 +194,24 @@ Current VM non-goals:
 
 ## Explicitly Unsupported
 
-The current runtime ownership contract does not claim support for:
+The current implemented runtime ownership contract does not claim support for:
 
-- record field paths
+- record field paths until the direct-field track is landed
 - ADT payload paths
 - schema paths
 - partial borrow release before frame exit
 - advanced aliasing or region reasoning
 - inter-frame borrow persistence
 - non-tuple ownership transport
+
+The approved record-field track still remains explicitly out of scope for:
+
+- ADT payload paths
+- schema paths
+- partial release before frame exit
+- advanced aliasing or region reasoning
+- inter-frame borrow persistence
+- indirect field selection or broader smart path normalization
 
 ## Honesty Rule
 


### PR DESCRIPTION
## Summary
- freeze the next runtime ownership slice for direct record field paths
- keep the current implemented slice documented as tuple-only
- make the direct-field boundary explicit without implying ADT or schema support

## Scope
- docs/spec only
- no code changes