### PR TITLE
Frontend: preserve record field ownership paths

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -1011,15 +1011,30 @@ impl<'a> Parser<'a> {
                     RecordPatternTarget::QuadLiteral(QuadVal::T)
                 } else if self.eat(TokenKind::QuadS) {
                     RecordPatternTarget::QuadLiteral(QuadVal::S)
+                } else if self.eat(TokenKind::KwRef) {
+                    RecordPatternTarget::Bind {
+                        name: self.expect_symbol()?,
+                        capture: CaptureMode::Borrow,
+                    }
                 } else {
-                    RecordPatternTarget::Bind(self.expect_symbol()?)
+                    RecordPatternTarget::Bind {
+                        name: self.expect_symbol()?,
+                        capture: CaptureMode::Move,
+                    }
                 }
             } else {
-                RecordPatternTarget::Bind(field)
+                RecordPatternTarget::Bind {
+                    name: field,
+                    capture: CaptureMode::Move,
+                }
             };
-            if let RecordPatternTarget::Bind(target_name) = target {
+            if let RecordPatternTarget::Bind { name: target_name, .. } = target {
                 if items.iter().any(|existing| {
-                    matches!(existing.target, RecordPatternTarget::Bind(existing_name) if existing_name == target_name)
+                    matches!(
+                        existing.target,
+                        RecordPatternTarget::Bind { name: existing_name, .. }
+                            if existing_name == target_name
+                    )
                 }) {
                     return Err(FrontendError {
                         pos: self.pos(),
@@ -5182,7 +5197,13 @@ fn main() {
         assert_eq!(items.len(), 2);
         assert_eq!(program.arena.symbol_name(items[0].field), "camera");
         assert!(
-            matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "seen_camera")
+            matches!(
+                items[0].target,
+                RecordPatternTarget::Bind {
+                    name,
+                    capture: CaptureMode::Move
+                } if program.arena.symbol_name(name) == "seen_camera"
+            )
         );
         assert_eq!(program.arena.symbol_name(items[1].field), "quality");
         assert!(matches!(items[1].target, RecordPatternTarget::Discard));
@@ -5258,7 +5279,13 @@ fn main() {
             panic!("expected record destructuring bind");
         };
         assert!(
-            matches!(items[0].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "camera")
+            matches!(
+                items[0].target,
+                RecordPatternTarget::Bind {
+                    name,
+                    capture: CaptureMode::Move
+                } if program.arena.symbol_name(name) == "camera"
+            )
         );
         assert!(matches!(items[1].target, RecordPatternTarget::Discard));
 
@@ -5270,8 +5297,51 @@ fn main() {
             RecordPatternTarget::QuadLiteral(QuadVal::T)
         ));
         assert!(
-            matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "quality")
+            matches!(
+                items[1].target,
+                RecordPatternTarget::Bind {
+                    name,
+                    capture: CaptureMode::Move
+                } if program.arena.symbol_name(name) == "quality"
+            )
         );
+    }
+
+    #[test]
+    fn rustlike_parser_preserves_borrow_capture_in_record_bind() {
+        let src = r#"
+record DecisionContext {
+    camera: quad,
+    quality: f64,
+}
+
+fn main() {
+    let DecisionContext { camera: ref seen_camera, quality } =
+        DecisionContext { camera: T, quality: 0.75 };
+    return;
+}
+        "#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("record ref bind should parse");
+        let main = &program.functions[0];
+        let Stmt::LetRecord { items, .. } = program.arena.stmt(main.body[0]) else {
+            panic!("expected record destructuring bind");
+        };
+        assert!(matches!(
+            items[0].target,
+            RecordPatternTarget::Bind {
+                name,
+                capture: CaptureMode::Borrow
+            } if program.arena.symbol_name(name) == "seen_camera"
+        ));
+        assert!(matches!(
+            items[1].target,
+            RecordPatternTarget::Bind {
+                name,
+                capture: CaptureMode::Move
+            } if program.arena.symbol_name(name) == "quality"
+        ));
     }
 
     #[test]
@@ -5373,7 +5443,13 @@ fn main() {
             RecordPatternTarget::QuadLiteral(QuadVal::T)
         ));
         assert!(
-            matches!(items[1].target, RecordPatternTarget::Bind(name) if program.arena.symbol_name(name) == "score")
+            matches!(
+                items[1].target,
+                RecordPatternTarget::Bind {
+                    name,
+                    capture: CaptureMode::Move
+                } if program.arena.symbol_name(name) == "score"
+            )
         );
         assert!(matches!(program.arena.expr(*value), Expr::RecordLiteral(_)));
         assert!(else_return.is_none());

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -746,13 +746,6 @@ fn check_stmt(
             items,
             value,
         } => {
-            let record = record_table.get(record_name).ok_or(FrontendError {
-                pos: 0,
-                message: format!(
-                    "unknown record type '{}' in record destructuring bind",
-                    resolve_symbol_name(arena, *record_name)?
-                ),
-            })?;
             let value_ty = infer_expr_type(
                 *value,
                 arena,
@@ -775,36 +768,29 @@ fn check_stmt(
                 });
             }
             for item in items {
-                let field = record
-                    .fields
-                    .iter()
-                    .find(|field| field.name == item.field)
-                    .ok_or(FrontendError {
+                if matches!(item.target, RecordPatternTarget::QuadLiteral(_)) {
+                    return Err(FrontendError {
                         pos: 0,
-                        message: format!(
-                            "record type '{}' has no field named '{}' in destructuring bind",
-                            resolve_symbol_name(arena, *record_name)?,
-                            resolve_symbol_name(arena, item.field)?
-                        ),
-                    })?;
-                match item.target {
-                    RecordPatternTarget::Bind(target) => {
-                        env.insert(
-                            target,
-                            canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?,
-                        );
-                    }
-                    RecordPatternTarget::Discard => {}
-                    RecordPatternTarget::QuadLiteral(_) => {
-                        return Err(FrontendError {
-                            pos: 0,
-                            message:
-                                "quad literal record field patterns currently require let-else; plain record destructuring bind supports only name/_ items"
-                                    .to_string(),
-                        });
-                    }
+                        message:
+                            "quad literal record field patterns currently require let-else; plain record destructuring bind supports only name/_ items"
+                                .to_string(),
+                    });
                 }
             }
+            let mut plan = BindingPlan::default();
+            build_record_pattern_plan(
+                items,
+                &value_ty,
+                &PatternPath::root(),
+                &mut plan,
+                arena,
+                record_table,
+                adt_table,
+            )?;
+            validate_binding_plan_conflicts(&plan)?;
+            validate_plan_against_scrutinee_state(env, *value, arena, &plan)?;
+            apply_binding_plan(env, &plan);
+            apply_plans_to_scrutinee(*value, &[plan], arena, env);
             Ok(())
         }
         Stmt::LetElseRecord {
@@ -813,13 +799,6 @@ fn check_stmt(
             value,
             else_return,
         } => {
-            let record = record_table.get(record_name).ok_or(FrontendError {
-                pos: 0,
-                message: format!(
-                    "unknown record type '{}' in record let-else",
-                    resolve_symbol_name(arena, *record_name)?
-                ),
-            })?;
             let value_ty = infer_expr_type(
                 *value,
                 arena,
@@ -854,6 +833,13 @@ fn check_stmt(
             )?;
             let mut saw_refutable_item = false;
             for item in items {
+                let record = record_table.get(record_name).ok_or(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "unknown record type '{}' in record let-else",
+                        resolve_symbol_name(arena, *record_name)?
+                    ),
+                })?;
                 let field = record
                     .fields
                     .iter()
@@ -867,12 +853,7 @@ fn check_stmt(
                         ),
                     })?;
                 match item.target {
-                    RecordPatternTarget::Bind(target) => {
-                        env.insert(
-                            target,
-                            canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?,
-                        );
-                    }
+                    RecordPatternTarget::Bind { .. } => {}
                     RecordPatternTarget::Discard => {}
                     RecordPatternTarget::QuadLiteral(_) => {
                         saw_refutable_item = true;
@@ -903,6 +884,20 @@ fn check_stmt(
                             .to_string(),
                 });
             }
+            let mut plan = BindingPlan::default();
+            build_record_pattern_plan(
+                items,
+                &value_ty,
+                &PatternPath::root(),
+                &mut plan,
+                arena,
+                record_table,
+                adt_table,
+            )?;
+            validate_binding_plan_conflicts(&plan)?;
+            validate_plan_against_scrutinee_state(env, *value, arena, &plan)?;
+            apply_binding_plan(env, &plan);
+            apply_plans_to_scrutinee(*value, &[plan], arena, env);
             Ok(())
         }
         Stmt::LetElseTuple {
@@ -4599,9 +4594,9 @@ mod tests {
         "#;
 
         let err = typecheck_source(src).expect_err("unknown record field must reject");
-        assert!(err.message.contains(
-            "record type 'DecisionContext' has no field named 'badge' in destructuring bind"
-        ));
+        assert!(err
+            .message
+            .contains("record type 'DecisionContext' has no field named 'badge'"));
     }
 
     #[test]
@@ -5430,6 +5425,99 @@ mod tests {
         assert!(binding.path_state.iter().any(|(path, state)| {
             *state == PathAvailability::Moved
                 && *path == PatternPath::root().tuple_index(1)
+        }));
+    }
+
+    #[test]
+    fn ref_binding_in_record_pattern_parses() {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let DecisionContext { camera: ref seen_camera, quality: score } = ctx;
+                let _ = seen_camera;
+                let _ = score;
+                return;
+            }
+        "#;
+        typecheck_source(src).expect("ref binding in record pattern should parse and typecheck");
+    }
+
+    #[test]
+    fn plain_record_ref_binding_preserves_record_field_path_state() {
+        use crate::types::{PathAvailability, PatternPath, RecordDecl, RecordField, RecordPatternItem};
+
+        let mut arena = AstArena::default();
+        let source = arena.intern_symbol("source");
+        let record_name = arena.intern_symbol("DecisionContext");
+        let camera = arena.intern_symbol("camera");
+        let quality = arena.intern_symbol("quality");
+        let borrowed = arena.intern_symbol("borrowed");
+        let moved = arena.intern_symbol("moved");
+        let value = arena.alloc_expr(Expr::Var(source));
+        let stmt = arena.alloc_stmt(Stmt::LetRecord {
+            record_name,
+            items: vec![
+                RecordPatternItem {
+                    field: camera,
+                    target: RecordPatternTarget::Bind {
+                        name: borrowed,
+                        capture: CaptureMode::Borrow,
+                    },
+                },
+                RecordPatternItem {
+                    field: quality,
+                    target: RecordPatternTarget::Bind {
+                        name: moved,
+                        capture: CaptureMode::Move,
+                    },
+                },
+            ],
+            value,
+        });
+
+        let mut env = ScopeEnv::new();
+        env.insert(source, Type::Record(record_name));
+
+        let table = FnTable::new();
+        let mut record_table = RecordTable::new();
+        record_table.insert(
+            record_name,
+            RecordDecl {
+                name: record_name,
+                type_params: Vec::new(),
+                fields: vec![
+                    RecordField { name: camera, ty: Type::Quad },
+                    RecordField { name: quality, ty: Type::F64 },
+                ],
+            },
+        );
+        let adt_table = AdtTable::new();
+        let mut loop_stack = Vec::new();
+        check_stmt(
+            stmt,
+            &arena,
+            &mut env,
+            Type::Unit,
+            &table,
+            &record_table,
+            &adt_table,
+            &mut loop_stack,
+            &[],
+        )
+        .expect("record ref bind should typecheck");
+
+        let binding = env.binding(source).expect("source binding must exist");
+        assert!(binding.path_state.iter().any(|(path, state)| {
+            *state == PathAvailability::Borrowed
+                && *path == PatternPath::root().record_field(camera)
+        }));
+        assert!(binding.path_state.iter().any(|(path, state)| {
+            *state == PathAvailability::Moved
+                && *path == PatternPath::root().record_field(quality)
         }));
     }
 
@@ -8649,6 +8737,57 @@ pub(crate) fn build_tuple_pattern_plan(
                     ty: item_ty.clone(),
                 });
             }
+        }
+    }
+    Ok(())
+}
+
+/// Build a `BindingPlan` from record pattern items against a known record type.
+pub(crate) fn build_record_pattern_plan(
+    items: &[crate::types::RecordPatternItem],
+    expected_ty: &Type,
+    base: &PatternPath,
+    out: &mut BindingPlan,
+    arena: &AstArena,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let Type::Record(record_name) = expected_ty else {
+        return Err(FrontendError {
+            pos: 0,
+            message: format!(
+                "record pattern requires record scrutinee, got {:?}",
+                expected_ty
+            ),
+        });
+    };
+    let record = record_table.get(record_name).ok_or(FrontendError {
+        pos: 0,
+        message: format!(
+            "unknown record type '{}' in record pattern",
+            resolve_symbol_name(arena, *record_name)?
+        ),
+    })?;
+    for item in items {
+        let field = record
+            .fields
+            .iter()
+            .find(|field| field.name == item.field)
+            .ok_or(FrontendError {
+                pos: 0,
+                message: format!(
+                    "record type '{}' has no field named '{}' in record pattern",
+                    resolve_symbol_name(arena, *record_name)?,
+                    resolve_symbol_name(arena, item.field)?
+                ),
+            })?;
+        if let RecordPatternTarget::Bind { name, capture } = &item.target {
+            out.push(BindingPlanItem {
+                name: *name,
+                capture: *capture,
+                path: base.record_field(item.field),
+                ty: canonicalize_declared_type(&field.ty, record_table, adt_table, arena)?,
+            });
         }
     }
     Ok(())

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -350,7 +350,7 @@ pub struct RecordPatternItem {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RecordPatternTarget {
-    Bind(SymbolId),
+    Bind { name: SymbolId, capture: CaptureMode },
     Discard,
     QuadLiteral(QuadVal),
 }
@@ -1366,6 +1366,36 @@ mod tests {
         assert_eq!(capture, CaptureMode::Move, "default ADT binding capture must be Move");
     }
 
+    #[test]
+    fn record_pattern_bind_carries_capture_mode() {
+        let item_move =
+            RecordPatternTarget::Bind { name: SymbolId(5), capture: CaptureMode::Move };
+        let item_borrow =
+            RecordPatternTarget::Bind { name: SymbolId(5), capture: CaptureMode::Borrow };
+        assert!(matches!(
+            item_move,
+            RecordPatternTarget::Bind {
+                capture: CaptureMode::Move,
+                ..
+            }
+        ));
+        assert!(matches!(
+            item_borrow,
+            RecordPatternTarget::Bind {
+                capture: CaptureMode::Borrow,
+                ..
+            }
+        ));
+        assert_ne!(item_move, item_borrow);
+    }
+
+    #[test]
+    fn record_pattern_default_is_move() {
+        let item = RecordPatternTarget::Bind { name: SymbolId(6), capture: CaptureMode::Move };
+        let RecordPatternTarget::Bind { capture, .. } = item else { panic!("expected Bind") };
+        assert_eq!(capture, CaptureMode::Move, "default record binding capture must be Move");
+    }
+
     // M9.5 Wave B — KwRef token owner layer
 
     #[test]
@@ -1396,6 +1426,13 @@ mod tests {
         assert_eq!(p.elems.len(), 2);
         assert!(matches!(p.elems[0], PatternPathElem::TupleIndex(1)));
         assert!(matches!(p.elems[1], PatternPathElem::VariantField(0)));
+    }
+
+    #[test]
+    fn pattern_path_record_field_appends() {
+        let field = SymbolId(7);
+        let p = PatternPath::root().record_field(field);
+        assert_eq!(p.elems, vec![PatternPathElem::RecordField(field)]);
     }
 
     #[test]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3196,7 +3196,7 @@ fn bind_record_items(
             index,
         });
         match item.target {
-            RecordPatternTarget::Bind(target) => {
+            RecordPatternTarget::Bind { name: target, .. } => {
                 env.insert(target, field.ty.clone());
                 out.push(IrInstr::StoreVar {
                     name: resolve_symbol_name(arena, target)?.to_string(),
@@ -3284,7 +3284,7 @@ fn bind_let_else_record_items(
             index,
         });
         match item.target {
-            RecordPatternTarget::Bind(target) => {
+            RecordPatternTarget::Bind { name: target, .. } => {
                 deferred_binds.push((target, reg, field.ty.clone()));
             }
             RecordPatternTarget::Discard => {}


### PR DESCRIPTION
## Summary
- preserve record field borrow vs move capture in frontend pattern structures
- carry direct record field paths through the existing binding-plan path-state layer
- keep lowering behavior unchanged apart from the mechanical AST shape follow-through

## Validation
- cargo test -q -p sm-front
- cargo test -q --test public_api_contracts
- cargo test -q