### PR TITLE
emit: enable record field write ownership transport

### DIFF
--- a/crates/sm-emit/src/lib.rs
+++ b/crates/sm-emit/src/lib.rs
@@ -163,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn sm_emit_does_not_claim_record_field_write_transport() {
+    fn sm_emit_promotes_record_field_write_transport_to_v12() {
         let src = r#"
             record DecisionContext {
                 camera: quad,
@@ -178,10 +178,29 @@ mod tests {
             }
         "#;
         let bytes = compile_program_to_semcode(src).expect("emit");
-        assert_ne!(&bytes[0..8], &MAGIC12);
+        let bytes_again = compile_program_to_semcode(src).expect("emit");
+
+        assert_eq!(bytes, bytes_again);
+        assert_eq!(&bytes[0..8], &MAGIC12);
+        let mut magic = [0u8; 8];
+        magic.copy_from_slice(&bytes[0..8]);
+        let spec = header_spec_from_magic(&magic).expect("known header");
+        assert_eq!(spec.rev, 13);
+        assert_ne!(spec.capabilities & CAP_OWNERSHIP_PATHS, 0);
+        assert_ne!(spec.capabilities & CAP_OWNERSHIP_FIELD_PATHS, 0);
 
         let code = function_code(&bytes, "main");
-        let cursor = skip_string_table(code);
-        assert_ne!(&code[cursor..cursor + 4], &OWNERSHIP_SECTION_TAG);
+        let mut cursor = skip_string_table(code);
+        assert_eq!(&code[cursor..cursor + 4], &OWNERSHIP_SECTION_TAG);
+        cursor += 4;
+        assert_eq!(read_u16_le(code, &mut cursor).expect("event count"), 1);
+        assert_eq!(read_u8(code, &mut cursor).expect("event kind"), OWNERSHIP_EVENT_KIND_WRITE);
+        let _root = read_u32_le(code, &mut cursor).expect("root");
+        assert_eq!(read_u16_le(code, &mut cursor).expect("component count"), 1);
+        assert_eq!(
+            read_u8(code, &mut cursor).expect("component kind"),
+            OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL
+        );
+        let _field = read_u32_le(code, &mut cursor).expect("field symbol");
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1525,19 +1525,6 @@ fn emit_ownership_events(
         })?,
     );
     for event in ownership_events {
-        if matches!(event.kind, OwnershipPathEventKind::Write)
-            && event
-                .path
-                .components
-                .iter()
-                .any(|component| matches!(component, PathComponent::Field(_)))
-        {
-            return Err(FrontendError {
-                pos: 0,
-                message: "record field write ownership transport is not enabled in this slice"
-                    .to_string(),
-            });
-        }
         out.push(match event.kind {
             OwnershipPathEventKind::Borrow => OWNERSHIP_EVENT_KIND_BORROW,
             OwnershipPathEventKind::Write => OWNERSHIP_EVENT_KIND_WRITE,
@@ -3823,6 +3810,7 @@ fn lower_stmt(
     let stmt = arena.stmt(stmt_id);
     match stmt {
         Stmt::Const { name, ty, value } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let (reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -3846,6 +3834,7 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::Let { name, ty, value } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let (reg, vty) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -3869,6 +3858,7 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::LetTuple { items, ty, value } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let tuple_path = tuple_access_path_from_expr(*value, arena);
             let (tuple_reg, vty) = lower_expr_with_expected(
                 *value,
@@ -3902,6 +3892,7 @@ fn lower_stmt(
             items,
             value,
         } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let record_path = direct_record_access_path_from_expr(*value, arena);
             let (record_reg, record_ty) = lower_expr_with_expected(
                 *value,
@@ -3938,6 +3929,7 @@ fn lower_stmt(
             value,
             else_return,
         } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let record_path = direct_record_access_path_from_expr(*value, arena);
             let (record_reg, record_ty) = lower_expr_with_expected(
                 *value,
@@ -3983,6 +3975,7 @@ fn lower_stmt(
             value,
             else_return,
         } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let tuple_path = tuple_access_path_from_expr(*value, arena);
             let (tuple_reg, vty) = lower_expr_with_expected(
                 *value,
@@ -4023,6 +4016,7 @@ fn lower_stmt(
             )
         }
         Stmt::Discard { ty, value } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let _ = lower_expr_with_expected(
                 *value,
                 arena,
@@ -4056,6 +4050,7 @@ fn lower_stmt(
                     ),
                 });
             }
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let (reg, _) = lower_expr_with_expected(
                 *value,
                 arena,
@@ -4081,6 +4076,7 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::AssignTuple { items, value } => {
+            append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let (tuple_reg, tuple_ty) = lower_expr(
                 *value,
                 arena,
@@ -4173,6 +4169,11 @@ fn lower_stmt(
             condition,
             else_return,
         } => {
+            append_record_update_write_events_from_expr(
+                *condition,
+                arena,
+                &mut ctx.ownership_events,
+            );
             let (cond_reg, cond_ty) = lower_expr(
                 *condition,
                 arena,
@@ -4222,6 +4223,7 @@ fn lower_stmt(
             Ok(())
         }
         Stmt::Expr(expr) => {
+            append_record_update_write_events_from_expr(*expr, arena, &mut ctx.ownership_events);
             lower_expr_stmt(
                 *expr,
                 arena,
@@ -4234,28 +4236,42 @@ fn lower_stmt(
             )?;
             Ok(())
         }
-        Stmt::Return(v) => lower_return_payload(
-            *v,
-            &ctx.ensures,
-            ctx.ensures_result_symbol,
-            &ctx.invariants,
-            ctx.invariants_result_symbol,
-            arena,
-            &mut ctx.next_reg,
-            &mut ctx.instrs,
-            env,
-            &mut ctx.loop_stack,
-            fn_table,
-            record_table,
-            adt_table,
-            ret_ty.clone(),
-            &mut ctx.closure_state,
-        ),
+        Stmt::Return(v) => {
+            if let Some(value) = *v {
+                append_record_update_write_events_from_expr(
+                    value,
+                    arena,
+                    &mut ctx.ownership_events,
+                );
+            }
+            lower_return_payload(
+                *v,
+                &ctx.ensures,
+                ctx.ensures_result_symbol,
+                &ctx.invariants,
+                ctx.invariants_result_symbol,
+                arena,
+                &mut ctx.next_reg,
+                &mut ctx.instrs,
+                env,
+                &mut ctx.loop_stack,
+                fn_table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                &mut ctx.closure_state,
+            )
+        }
         Stmt::If {
             condition,
             then_block,
             else_block,
         } => {
+            append_record_update_write_events_from_expr(
+                *condition,
+                arena,
+                &mut ctx.ownership_events,
+            );
             let (cond_reg, cond_ty) = lower_expr(
                 *condition,
                 arena,
@@ -4337,6 +4353,11 @@ fn lower_stmt(
             arms,
             default,
         } => {
+            append_record_update_write_events_from_expr(
+                *scrutinee,
+                arena,
+                &mut ctx.ownership_events,
+            );
             let (scr_reg, scr_ty) = lower_expr(
                 *scrutinee,
                 arena,
@@ -6877,6 +6898,120 @@ fn direct_record_access_path_from_expr(expr_id: ExprId, arena: &AstArena) -> Opt
     }
 }
 
+fn append_record_update_write_events_from_expr(
+    expr_id: ExprId,
+    arena: &AstArena,
+    ownership_events: &mut Vec<OwnershipPathEvent>,
+) {
+    match arena.expr(expr_id) {
+        Expr::Tuple(items) => {
+            for item in items {
+                append_record_update_write_events_from_expr(*item, arena, ownership_events);
+            }
+        }
+        Expr::RecordLiteral(record_literal) => {
+            for field in &record_literal.fields {
+                append_record_update_write_events_from_expr(field.value, arena, ownership_events);
+            }
+        }
+        Expr::RecordField(field_expr) => {
+            append_record_update_write_events_from_expr(field_expr.base, arena, ownership_events);
+        }
+        Expr::SequenceLiteral(sequence) => {
+            for item in &sequence.items {
+                append_record_update_write_events_from_expr(*item, arena, ownership_events);
+            }
+        }
+        Expr::SequenceIndex(index_expr) => {
+            append_record_update_write_events_from_expr(index_expr.base, arena, ownership_events);
+            append_record_update_write_events_from_expr(index_expr.index, arena, ownership_events);
+        }
+        Expr::RecordUpdate(update_expr) => {
+            append_record_update_write_events_from_expr(update_expr.base, arena, ownership_events);
+            for field in &update_expr.fields {
+                append_record_update_write_events_from_expr(field.value, arena, ownership_events);
+            }
+            if let Some(record_path) = direct_record_access_path_from_expr(update_expr.base, arena) {
+                for field in &update_expr.fields {
+                    ownership_events.push(OwnershipPathEvent {
+                        kind: OwnershipPathEventKind::Write,
+                        path: record_path.field(field.name),
+                    });
+                }
+            }
+        }
+        Expr::Call(_, args) => {
+            for arg in args {
+                append_record_update_write_events_from_expr(arg.value, arena, ownership_events);
+            }
+        }
+        Expr::Unary(_, inner) => {
+            append_record_update_write_events_from_expr(*inner, arena, ownership_events);
+        }
+        Expr::Binary(lhs, _, rhs) => {
+            append_record_update_write_events_from_expr(*lhs, arena, ownership_events);
+            append_record_update_write_events_from_expr(*rhs, arena, ownership_events);
+        }
+        Expr::Range(range) => {
+            append_record_update_write_events_from_expr(range.start, arena, ownership_events);
+            append_record_update_write_events_from_expr(range.end, arena, ownership_events);
+        }
+        Expr::If(if_expr) => {
+            append_record_update_write_events_from_expr(if_expr.condition, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                if_expr.then_block.tail,
+                arena,
+                ownership_events,
+            );
+            append_record_update_write_events_from_expr(
+                if_expr.else_block.tail,
+                arena,
+                ownership_events,
+            );
+        }
+        Expr::IfLet(if_let_expr) => {
+            append_record_update_write_events_from_expr(if_let_expr.value, arena, ownership_events);
+            append_record_update_write_events_from_expr(
+                if_let_expr.then_block.tail,
+                arena,
+                ownership_events,
+            );
+            append_record_update_write_events_from_expr(
+                if_let_expr.else_block.tail,
+                arena,
+                ownership_events,
+            );
+        }
+        Expr::Block(block) => {
+            append_record_update_write_events_from_expr(block.tail, arena, ownership_events);
+        }
+        Expr::Match(match_expr) => {
+            append_record_update_write_events_from_expr(
+                match_expr.scrutinee,
+                arena,
+                ownership_events,
+            );
+            for arm in &match_expr.arms {
+                if let Some(guard) = arm.guard {
+                    append_record_update_write_events_from_expr(guard, arena, ownership_events);
+                }
+                append_record_update_write_events_from_expr(arm.block.tail, arena, ownership_events);
+            }
+            if let Some(default) = &match_expr.default {
+                append_record_update_write_events_from_expr(default.tail, arena, ownership_events);
+            }
+        }
+        Expr::QuadLiteral(_)
+        | Expr::BoolLiteral(_)
+        | Expr::TextLiteral(_)
+        | Expr::NumericLiteral(_)
+        | Expr::Closure(_)
+        | Expr::AdtCtor(_)
+        | Expr::Var(_)
+        | Expr::Loop(_) => {}
+    }
+}
+
 #[inline]
 fn alloc(next: &mut u16) -> u16 {
     let out = *next;
@@ -8454,7 +8589,7 @@ mod opt_tests {
     }
 
     #[test]
-    fn lower_record_copy_with_emits_no_field_write_events() {
+    fn lower_record_copy_with_emits_field_write_events() {
         let src = r#"
             record DecisionContext {
                 camera: quad,
@@ -8469,8 +8604,23 @@ mod opt_tests {
             }
         "#;
 
-        let (_program, main) = lower_single_function_with_program(src, "main");
-        assert!(main.ownership_events.is_empty());
+        let (program, main) = lower_single_function_with_program(src, "main");
+        let main_fn = program
+            .functions
+            .iter()
+            .find(|func| program.arena.symbol_name(func.name) == "main")
+            .expect("main fn");
+        let Stmt::Let { name: ctx_name, .. } = program.arena.stmt(main_fn.body[0]) else {
+            panic!("expected ctx binding");
+        };
+        let quality_field = program.records[0].fields[1].name;
+        assert_eq!(
+            main.ownership_events,
+            vec![OwnershipPathEvent {
+                kind: OwnershipPathEventKind::Write,
+                path: AccessPath::new(*ctx_name).field(quality_field),
+            }]
+        );
     }
 
     #[test]

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -1054,15 +1054,6 @@ fn verify_ownership_section(
             }
         }
 
-        if kind == OWNERSHIP_EVENT_KIND_WRITE && event_has_field_component {
-            return Err(reject_one(
-                function,
-                VerificationCode::InvalidOwnershipSection,
-                event_offset,
-                "record field write ownership transport is not admitted in this slice",
-            ));
-        }
-
         usage.has_record_field_ownership |= event_has_field_component;
     }
 
@@ -1123,8 +1114,7 @@ mod tests {
     use super::*;
     use sm_emit::{
         compile_program_to_semcode, compile_program_to_semcode_with_options_debug, read_u16_le,
-        read_u32_le, CompileProfile, OptLevel, MAGIC11, MAGIC12, OWNERSHIP_EVENT_KIND_WRITE,
-        OWNERSHIP_SECTION_TAG,
+        read_u32_le, CompileProfile, OptLevel, MAGIC11, MAGIC12, OWNERSHIP_SECTION_TAG,
     };
     use sm_ir::{emit_ir_to_semcode, IrFunction, IrInstr};
 
@@ -1557,6 +1547,15 @@ mod tests {
     }
 
     #[test]
+    fn verifier_accepts_record_field_write_ownership_semcode() {
+        let bytes = record_field_write_semcode_bytes();
+        assert_eq!(&bytes[..MAGIC12.len()], &MAGIC12);
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.header.rev, 13);
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
     fn verifier_rejects_short_header() {
         let report = verify_semcode(b"SEMC").expect_err("must reject");
         assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);
@@ -1762,21 +1761,6 @@ mod tests {
     }
 
     #[test]
-    fn verifier_rejects_record_field_write_transport_claim() {
-        let mut bytes = record_field_borrow_semcode_bytes();
-        let (_, code_start, code_end) = function_code_span(&bytes, "main");
-        let code = &mut bytes[code_start..code_end];
-        let section_offset = ownership_section_offset(code);
-        let kind_offset = section_offset + 4 + 2;
-        code[kind_offset] = OWNERSHIP_EVENT_KIND_WRITE;
-        let report = verify_semcode(&bytes).expect_err("must reject");
-        assert_eq!(
-            report.diagnostics[0].code,
-            VerificationCode::InvalidOwnershipSection
-        );
-    }
-
-    #[test]
     fn verifier_rejects_record_field_payload_under_v11_capabilities() {
         let mut bytes = record_field_borrow_semcode_bytes();
         bytes[..MAGIC11.len()].copy_from_slice(&MAGIC11);
@@ -1936,6 +1920,23 @@ mod tests {
             fn main() {
                 let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
                 let DecisionContext { camera: ref seen_camera, quality: _ } = ctx;
+                return;
+            }
+        "#;
+        compile_program_to_semcode(src).expect("compile")
+    }
+
+    fn record_field_write_semcode_bytes() -> Vec<u8> {
+        let src = r#"
+            record DecisionContext {
+                camera: quad,
+                quality: f64,
+            }
+
+            fn main() {
+                let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+                let patched: DecisionContext = ctx with { quality: 1.0 };
+                let _ = patched;
                 return;
             }
         "#;

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -145,9 +145,9 @@ The repository does not yet claim final compatibility guarantees for:
   tuple-only `AccessPath` transport, `Borrow`/`Write` event encoding, and
   `SEMCODE11` contract on `main`
 - direct record-field ownership semantics beyond the current staged
-  producer-side `Borrow(Field)` transport and `SEMCOD12` format extension on
-  `main` (verifier admission, VM tracking, and runtime overlap enforcement are
-  not yet claimed)
+  producer-side `Borrow(Field)`/`Write(Field)` transport and `SEMCOD12`
+  format extension on `main` (verifier admission is claimed; VM tracking and
+  runtime overlap enforcement are not yet claimed)
 - generics semantics beyond the current admitted first-wave type-parameter
   family, call-site substitution, and monomorphisation contract on `main`
   (trait/protocol bounds, higher-kinded types, variance, and specialisation are

--- a/docs/spec/runtime_ownership.md
+++ b/docs/spec/runtime_ownership.md
@@ -137,7 +137,7 @@ Current lowering contract:
 Current binary contract:
 
 - tuple-only ownership metadata is transported through `SEMCOD11`
-- direct record-field borrow transport is emitted through `SEMCOD12`
+- direct record-field `Borrow`/`Write` transport is emitted through `SEMCOD12`
 - the ownership section tag is `OWN0`
 - each event carries:
   - event kind (`Borrow` or `Write`)
@@ -147,7 +147,7 @@ Current binary contract:
 Current transport scope:
 
 - tuple-only path components admitted end-to-end
-- direct record-field `Borrow` transport only, encoded as `Field(SymbolId)`
+- direct record-field `Borrow`/`Write` transport, encoded as `Field(SymbolId)`
 - deterministic event order
 
 Approved next transport scope:
@@ -161,7 +161,7 @@ Current verifier responsibility:
 
 - validate `OWN0` section structure
 - validate admitted ownership event kinds
-- validate tuple-only path payload shape
+- validate tuple and direct record-field path payload shape
 - validate header/capability consistency for ownership transport
 
 Approved next verifier scope:

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -241,11 +241,13 @@ Current ownership-specific structural admission for `SEMCOD11` validates:
 - deterministic root/component payload shape
 - capability/header consistency for ownership transport
 
-Current `SEMCOD12` format extension is transport-only in this slice:
+Current `SEMCOD12` format extension in this slice:
 
-- producer transport may encode direct record-field `Borrow` paths in `OWN0`
-- verifier and VM support for direct record-field ownership payload is staged
-  separately and must not be implied by header support alone
+- producer transport may encode direct record-field `Borrow` and `Write` paths
+  in `OWN0`
+- verifier admits direct record-field ownership payload structurally
+- VM tracking/enforcement for direct record-field ownership payload remains
+  staged separately and must not be implied by header support alone
 
 Execution semantics for admitted ownership payload are specified separately in
 `runtime_ownership.md`.


### PR DESCRIPTION
## Summary
- emit Write(Field) ownership events for direct record update paths during lowering
- allow Write(Field) transport through SEMCOD12 and admit it structurally in the verifier
- update SemCode/runtime ownership docs for the expanded record-field transport slice

## Validation
- cargo test -q -p sm-ir
- cargo test -q -p sm-emit
- cargo test -q -p sm-verify
- cargo test -q --test public_api_contracts
- cargo test -q