### PR TITLE
docs: freeze tuple and record runtime ownership contract

### DIFF
--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -106,9 +106,10 @@ Current `v1` scope commitment:
 - the same forward-only reading also applies to the first-wave tuple-only
   runtime ownership metadata transport on current `main`, including lowered
   borrow/write path events, canonical `AccessPath`, and `SEMCODE11`
-- the same forward-only reading also applies to the staged direct record-field
-  borrow transport extension on current `main`, including `Field(SymbolId)` in
-  `AccessPath`, `OWN0` field-path payloads, and `SEMCOD12`
+- the same forward-only reading also applies to the direct record-field
+  runtime ownership extension on current `main`, including `Field(SymbolId)` in
+  `AccessPath`, `OWN0` field-path payloads, `SEMCOD12`, verifier admission, VM
+  frame-local borrow tracking, and `BorrowWriteConflict` overlap rejection
 - the same forward-only reading also applies to the first-wave generics surface
   on current `main`, including type-parameter syntax for functions, records, and
   ADTs, deterministic call-site monomorphisation, and the narrow
@@ -141,13 +142,12 @@ The repository does not yet claim final compatibility guarantees for:
   carrier/index/equality contract on `main`
 - closure semantics beyond the current admitted first-wave `Closure(T -> U)`
   family, immutable capture, and direct invocation contract on `main`
-- runtime ownership metadata semantics beyond the current admitted first-wave
-  tuple-only `AccessPath` transport, `Borrow`/`Write` event encoding, and
-  `SEMCODE11` contract on `main`
-- direct record-field ownership semantics beyond the current staged
-  producer-side `Borrow(Field)`/`Write(Field)` transport and `SEMCOD12`
-  format extension on `main` (verifier admission is claimed; VM tracking and
-  runtime overlap enforcement are not yet claimed)
+- runtime ownership metadata semantics beyond the current admitted tuple +
+  direct record-field `AccessPath` transport on `main`, including `Borrow` /
+  `Write` event encoding, `SEMCOD11` / `SEMCOD12`, verifier admission,
+  frame-local borrow lifetime, and `BorrowWriteConflict` overlap rejection
+  (ADT payload paths, schema paths, partial release, advanced aliasing,
+  inter-frame persistence, and indirect field projection are not claimed)
 - generics semantics beyond the current admitted first-wave type-parameter
   family, call-site substitution, and monomorphisation contract on `main`
   (trait/protocol bounds, higher-kinded types, variance, and specialisation are

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -17,7 +17,7 @@ Current documents in this PR:
 - `profile.md` - `ParserProfile` policy contract
 - `verifier.md` - SemCode admission verification contract
 - `vm.md` - Semantic VM public execution contract
-- `runtime_ownership.md` - current tuple-only runtime ownership contract plus the approved direct record-field extension scope
+- `runtime_ownership.md` - frozen tuple + direct record-field runtime ownership contract
 - `quotas.md` - runtime quota taxonomy and enforcement contract
 - `abi.md` - PROMETHEUS host ABI boundary contract
 - `capabilities.md` - capability manifest and denial contract

--- a/docs/spec/runtime_ownership.md
+++ b/docs/spec/runtime_ownership.md
@@ -1,6 +1,6 @@
 # Runtime Ownership Specification
 
-Status: draft v0
+Status: frozen tuple+record v0
 Source ownership owner: `sm-front`
 IR ownership owner: `sm-ir`
 SemCode transport owner: `sm-ir`
@@ -10,21 +10,18 @@ Shared runtime vocabulary owner: `sm-runtime-core`
 
 ## Purpose
 
-This document freezes the current runtime ownership contract and the next
-approved extension boundary for direct record field paths.
+This document freezes the current runtime ownership contract for tuple paths
+and direct record field paths.
 
 Current supported slice:
 
-- tuple-only `AccessPath`
+- tuple `AccessPath`
+- direct record field `AccessPath`
+- `Borrow` and `Write` ownership events for both supported path families
 - frame-local borrow lifetime
 - structural `OWN0` admission before execution
-- runtime write rejection for overlapping borrowed tuple paths
-
-Approved next slice for this track:
-
-- direct record field `AccessPath`
-- borrow and write ownership over direct record field paths
-- the same overlap rule family used by the tuple-only slice
+- runtime write rejection for overlapping borrowed tuple and direct record
+  field paths
 
 This document does not claim a general runtime borrow checker.
 
@@ -36,7 +33,8 @@ The current ownership pipeline is intentionally split:
 - IR/lowering preserves only the canonical execution-path contract
 - SemCode transports that lowered ownership metadata in `OWN0`
 - verifier admits or rejects the `OWN0` payload structurally
-- VM enforces the runtime write-path guard over admitted tuple paths
+- VM enforces the runtime write-path guard over admitted tuple and direct
+  record field paths
 
 Important rule:
 
@@ -52,9 +50,6 @@ Current runtime path form:
 Current supported component kinds:
 
 - `TupleIndex(u16)`
-
-Approved next component kind for this track:
-
 - `Field(SymbolId)` for direct named record field projection only
 
 Current ordering rule:
@@ -70,11 +65,13 @@ Important boundary:
 
 ## Supported Behavior
 
-Current supported runtime ownership behavior is limited to tuple paths.
+Current supported runtime ownership behavior covers tuple paths and direct
+record field paths.
 
 Borrow lifetime v0:
 
-- a borrowed tuple path becomes active for the current frame
+- a borrowed tuple or direct record field path becomes active for the current
+  frame
 - the active borrowed-path set is cleared when that frame exits
 
 Current runtime write rule:
@@ -90,42 +87,19 @@ Current overlap cases that must reject:
 Current allowed case:
 
 - sibling tuple paths
-
-## Approved Record Field Extension Scope
-
-The next runtime ownership slice approved by this document extends the current
-tuple-only contract to direct record field access paths.
-
-Approved target behavior for that track:
-
-- borrow direct record fields
-- write direct record fields
-- reject exact overlap
-- reject borrowed parent, written child
-- reject borrowed child, written parent
-- allow sibling record fields
-
-Approved identity rule for that track:
-
-- record field path identity is represented as `Field(SymbolId)` inside
-  `AccessPath`
-- the first slice is limited to direct named field projection
+- sibling direct record fields
 
 ## Frontend And Lowering Contract
 
 Current source/frontend contract:
 
-- tuple borrow capture must not be erased before lowering
+- tuple and direct record field borrow/write intent must not be erased before
+  lowering
 - lowering must preserve enough ownership metadata to recover:
   - borrow event kind
   - write event kind
-  - canonical tuple-only `AccessPath`
-
-Approved next frontend/lowering target:
-
-- preserve borrow and write intent for direct record field access paths
-- lower direct record field paths into canonical `AccessPath` using
-  `Field(SymbolId)`
+  - canonical `AccessPath`
+  - direct record field projection as `Field(SymbolId)` when present
 
 Current lowering contract:
 
@@ -146,14 +120,12 @@ Current binary contract:
 
 Current transport scope:
 
-- tuple-only path components admitted end-to-end
-- direct record-field `Borrow`/`Write` transport, encoded as `Field(SymbolId)`
+- tuple-only path components admitted end-to-end through `SEMCOD11`
+- direct record-field `Borrow`/`Write` transport, encoded as `Field(SymbolId)`,
+  admitted end-to-end through `SEMCOD12`
 - deterministic event order
-
-Approved next transport scope:
-
-- deterministic transport of direct record field path components through the
-  same ownership event contract
+- `CAP_OWNERSHIP_PATHS` remains the tuple ownership capability family
+- `CAP_OWNERSHIP_FIELD_PATHS` marks direct record-field ownership path transport
 
 ## Verifier Admission Contract
 
@@ -163,11 +135,8 @@ Current verifier responsibility:
 - validate admitted ownership event kinds
 - validate tuple and direct record-field path payload shape
 - validate header/capability consistency for ownership transport
-
-Approved next verifier scope:
-
-- admit or reject direct record field ownership payload structurally
-- do not imply ADT payload or schema ownership support
+- admit valid `Borrow(Field)` and `Write(Field)` payloads structurally
+- reject malformed or unsupported record ownership payload before execution
 
 Current verifier non-goal:
 
@@ -178,15 +147,11 @@ Current verifier non-goal:
 
 Current VM responsibility:
 
-- keep a frame-local set of active borrowed tuple paths
+- keep a frame-local set of active borrowed tuple and direct record field paths
 - consume admitted ownership metadata only
-- reject overlapping writes at runtime for the supported tuple slice
-
-Approved next VM target:
-
-- track borrowed direct record field paths in the same frame-local ownership
-  model
-- reject overlapping writes for admitted direct record field paths
+- reject overlapping writes at runtime for the supported tuple and direct
+  record field slice
+- surface ownership conflicts through `BorrowWriteConflict`
 
 Current VM non-goals:
 
@@ -198,19 +163,9 @@ Current VM non-goals:
 
 The current implemented runtime ownership contract does not claim support for:
 
-- record field paths until the direct-field track is landed
 - ADT payload paths
 - schema paths
 - partial borrow release before frame exit
-- advanced aliasing or region reasoning
-- inter-frame borrow persistence
-- non-tuple ownership transport
-
-The approved record-field track still remains explicitly out of scope for:
-
-- ADT payload paths
-- schema paths
-- partial release before frame exit
 - advanced aliasing or region reasoning
 - inter-frame borrow persistence
 - indirect field selection or broader smart path normalization

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -170,15 +170,18 @@ Compatibility rules:
 
 `SEMCOD12`
 
-- promoted contract used when emitted program usage requires direct record-field
-  borrow ownership path transport
+- promoted contract used when emitted program usage requires direct
+  record-field ownership path transport
 - keeps `SEMCOD11` fixed for tuple-only ownership-path artifacts
 - uses the fixed-width 8-byte header magic form `SEMCOD12`
 - keeps the tagged function-local ownership section `OWN0`
 - extends the ownership-path component vocabulary with:
   - `Field(SymbolId)` encoded as component kind + little-endian `u32`
-- does not claim direct record-field `Write` transport, verifier admission, or
-  VM enforcement beyond the currently landed tuple-only slice
+- transports direct record-field `Borrow` and `Write` paths deterministically
+- requires `CAP_OWNERSHIP_FIELD_PATHS` when direct record-field components are
+  present
+- does not claim ADT payload, schema, or release/lifetime transport beyond the
+  current frame-local tuple+record slice
 
 Important rule:
 
@@ -237,7 +240,7 @@ Current ownership-specific structural admission for `SEMCOD11` validates:
 
 - `OWN0` section layout
 - admitted ownership event kinds
-- tuple-only path component kinds
+- tuple-only path component kinds under `SEMCOD11`
 - deterministic root/component payload shape
 - capability/header consistency for ownership transport
 
@@ -246,8 +249,10 @@ Current `SEMCOD12` format extension in this slice:
 - producer transport may encode direct record-field `Borrow` and `Write` paths
   in `OWN0`
 - verifier admits direct record-field ownership payload structurally
-- VM tracking/enforcement for direct record-field ownership payload remains
-  staged separately and must not be implied by header support alone
+- VM consumes admitted direct record-field ownership payload for frame-local
+  borrow tracking and overlap enforcement
+- ownership execution semantics remain specified separately in
+  `runtime_ownership.md`
 
 Execution semantics for admitted ownership payload are specified separately in
 `runtime_ownership.md`.

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -35,11 +35,13 @@ Current SemCode verification checks include:
 - call-target validity
 - capability consistency with actual opcode usage
 
-Current ownership-specific structural checks for `SEMCOD11` include:
+Current ownership-specific structural checks for ownership transport include:
 
 - `OWN0` section presence and layout validity when ownership transport is used
 - admitted ownership event kind validity
-- tuple-only `AccessPath` payload validity
+- tuple `AccessPath` payload validity under `SEMCOD11`
+- direct record-field `AccessPath` payload validity under `SEMCOD12`
+- structural admission for valid `Borrow(Field)` and `Write(Field)` payloads
 - header/capability consistency for ownership transport
 
 ## Contract Rule

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -141,17 +141,19 @@ Current function-bytecode model includes:
 - string table
 - runtime symbol ids
 - optional debug symbols
-- tuple-only ownership path metadata admitted from `OWN0`
+- tuple and direct record-field ownership path metadata admitted from `OWN0`
 - instruction stream
 - instruction start offset
 
 ## Runtime Ownership Slice
 
-Current supported runtime ownership slice is narrow:
+Current supported runtime ownership slice is:
 
-- tuple-only `AccessPath`
+- tuple `AccessPath`
+- direct record field `AccessPath`
 - frame-local borrow lifetime
-- runtime write rejection on overlapping borrowed tuple paths
+- runtime write rejection on overlapping borrowed tuple and direct record field
+  paths
 
 Current overlap cases that reject:
 
@@ -162,6 +164,11 @@ Current overlap cases that reject:
 Current allowed case:
 
 - sibling tuple paths
+- sibling direct record fields
+
+Current ownership conflict surface:
+
+- runtime overlap rejection uses `BorrowWriteConflict`
 
 Unsupported ownership behavior remains outside the VM contract here and is
 specified explicitly in `runtime_ownership.md`.


### PR DESCRIPTION
## Summary
- freeze the runtime ownership spec around the landed tuple + direct record-field slice
- align SemCode, verifier, VM, and compatibility docs with SEMCOD11 / SEMCOD12 and the current BorrowWriteConflict surface
- remove stale staged/approved-next wording now that record field ownership is implemented end-to-end

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts