### PR TITLE
tests: add tuple and record runtime ownership e2e coverage

### DIFF
--- a/tests/runtime_ownership_e2e.rs
+++ b/tests/runtime_ownership_e2e.rs
@@ -1,17 +1,25 @@
 use sm_emit::compile_program_to_semcode;
 use sm_ir::semcode_format::{
-    read_u16_le, read_u32_le, read_u8, read_utf8, MAGIC11, OWNERSHIP_EVENT_KIND_BORROW,
-    OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
+    read_u16_le, read_u32_le, read_u8, read_utf8, MAGIC11, MAGIC12,
+    OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
+    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
+    OWNERSHIP_SECTION_TAG,
 };
 use sm_runtime_core::RuntimeTrap;
 use sm_verify::verify_semcode;
 use sm_vm::{run_verified_semcode, RuntimeError};
 
 #[derive(Clone, Copy)]
+enum OwnershipPathComponentSpec {
+    TupleIndex(u16),
+    FieldSymbol(u32),
+}
+
+#[derive(Clone, Copy)]
 struct OwnershipEventSpec<'a> {
     kind: u8,
     root: &'a str,
-    components: &'a [u16],
+    components: &'a [OwnershipPathComponentSpec],
 }
 
 struct FunctionLayout {
@@ -34,12 +42,12 @@ fn runtime_ownership_sibling_write_passes_on_verified_path() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[1],
+                components: &[OwnershipPathComponentSpec::TupleIndex(1)],
             },
         ],
     );
@@ -58,12 +66,12 @@ fn runtime_ownership_rejects_same_path_write_deterministically() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
         ],
     );
@@ -86,7 +94,7 @@ fn runtime_ownership_rejects_parent_child_overlap_deterministically() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
         ],
     );
@@ -104,7 +112,7 @@ fn runtime_ownership_rejects_child_parent_overlap_deterministically() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
@@ -139,14 +147,129 @@ fn runtime_ownership_inner_frame_borrow_does_not_leak_after_exit() {
 }
 
 #[test]
-fn runtime_ownership_does_not_silently_claim_record_or_adt_support() {
-    for src in [record_source(), adt_source()] {
+fn runtime_ownership_record_sibling_field_write_passes_on_verified_path() {
+    let bytes = compile_program_to_semcode(record_assignment_source()).expect("compile");
+    assert_eq!(&bytes[..8], &MAGIC12);
+    assert!(function_has_ownership_section(&bytes, "main"));
+    let (camera_field, quality_field) = record_field_component_ids(&bytes, "main");
+
+    let rewritten = rewrite_function_ownership_events(
+        &bytes,
+        "main",
+        &[
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_BORROW,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(camera_field)],
+            },
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_WRITE,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(quality_field)],
+            },
+        ],
+    );
+
+    verify_semcode(&rewritten).expect("verify");
+    run_verified_semcode(&rewritten).expect("sibling record field write should pass");
+}
+
+#[test]
+fn runtime_ownership_record_same_field_conflict_rejects() {
+    let bytes = compile_program_to_semcode(record_assignment_source()).expect("compile");
+    let (camera_field, _) = record_field_component_ids(&bytes, "main");
+    let rewritten = rewrite_function_ownership_events(
+        &bytes,
+        "main",
+        &[
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_BORROW,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(camera_field)],
+            },
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_WRITE,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(camera_field)],
+            },
+        ],
+    );
+
+    assert_write_overlap_rejects_deterministically(&rewritten, "ctx");
+}
+
+#[test]
+fn runtime_ownership_record_parent_child_conflict_rejects() {
+    let bytes = compile_program_to_semcode(record_assignment_source()).expect("compile");
+    let (camera_field, _) = record_field_component_ids(&bytes, "main");
+    let rewritten = rewrite_function_ownership_events(
+        &bytes,
+        "main",
+        &[
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_BORROW,
+                root: "ctx",
+                components: &[],
+            },
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_WRITE,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(camera_field)],
+            },
+        ],
+    );
+
+    assert_write_overlap_rejects_deterministically(&rewritten, "ctx");
+}
+
+#[test]
+fn runtime_ownership_record_child_parent_conflict_rejects() {
+    let bytes = compile_program_to_semcode(record_assignment_source()).expect("compile");
+    let (camera_field, _) = record_field_component_ids(&bytes, "main");
+    let rewritten = rewrite_function_ownership_events(
+        &bytes,
+        "main",
+        &[
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_BORROW,
+                root: "ctx",
+                components: &[OwnershipPathComponentSpec::FieldSymbol(camera_field)],
+            },
+            OwnershipEventSpec {
+                kind: OWNERSHIP_EVENT_KIND_WRITE,
+                root: "ctx",
+                components: &[],
+            },
+        ],
+    );
+
+    assert_write_overlap_rejects_deterministically(&rewritten, "ctx");
+}
+
+#[test]
+fn runtime_ownership_record_inner_frame_borrow_does_not_leak_after_exit() {
+    let bytes = compile_program_to_semcode(record_multi_frame_source()).expect("compile");
+    assert_eq!(&bytes[..8], &MAGIC12);
+    assert!(function_has_ownership_section(&bytes, "helper"));
+    assert!(function_has_ownership_section(&bytes, "main"));
+
+    verify_semcode(&bytes).expect("verify");
+    run_verified_semcode(&bytes).expect("inner-frame record borrow must not leak after return");
+}
+
+#[test]
+fn runtime_ownership_unsupported_paths_do_not_silently_claim_support() {
+    for src in [adt_source(), schema_source()] {
         let bytes = compile_program_to_semcode(src).expect("compile");
         assert_ne!(&bytes[..8], &MAGIC11);
+        assert_ne!(&bytes[..8], &MAGIC12);
         assert!(!any_function_has_ownership_section(&bytes));
         verify_semcode(&bytes).expect("verify");
         run_verified_semcode(&bytes).expect("run");
     }
+
+    let _ = compile_program_to_semcode(indirect_record_projection_source())
+        .expect_err("indirect record-field projection must not silently claim support");
 }
 
 #[test]
@@ -159,12 +282,12 @@ fn runtime_ownership_sibling_write_is_stable_across_runs() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[1],
+                components: &[OwnershipPathComponentSpec::TupleIndex(1)],
             },
         ],
     );
@@ -182,12 +305,12 @@ fn runtime_ownership_same_path_rejects_identically_across_runs() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
         ],
     );
@@ -210,7 +333,7 @@ fn runtime_ownership_parent_child_rejects_identically_across_runs() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
         ],
     );
@@ -228,7 +351,7 @@ fn runtime_ownership_child_parent_rejects_identically_across_runs() {
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_BORROW,
                 root: "pair",
-                components: &[0],
+                components: &[OwnershipPathComponentSpec::TupleIndex(0)],
             },
             OwnershipEventSpec {
                 kind: OWNERSHIP_EVENT_KIND_WRITE,
@@ -268,6 +391,28 @@ fn tuple_assignment_source() -> &'static str {
     "#
 }
 
+fn record_assignment_source() -> &'static str {
+    r#"
+        record DecisionContext {
+            camera: quad,
+            quality: f64,
+        }
+
+        fn main() {
+            let camera: f64 = 0.0;
+            let quality: f64 = 1.0;
+            let ctx: f64 = 1.0;
+            let probe: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+            let DecisionContext { camera: ref seen_camera, quality: _ } = probe;
+            let patched: DecisionContext = probe with { quality: 1.0 };
+            let _ = seen_camera;
+            let _ = patched;
+            ctx += 2.0;
+            return;
+        }
+    "#
+}
+
 fn multi_frame_source() -> &'static str {
     r#"
         fn helper(pair: (i32, bool)) {
@@ -286,17 +431,24 @@ fn multi_frame_source() -> &'static str {
     "#
 }
 
-fn record_source() -> &'static str {
+fn record_multi_frame_source() -> &'static str {
     r#"
         record DecisionContext {
             camera: quad,
             quality: f64,
         }
 
+        fn helper(ctx: DecisionContext) {
+            let DecisionContext { camera: ref seen_camera, quality: _ } = ctx;
+            let _ = seen_camera;
+            return;
+        }
+
         fn main() {
-            let ctx: DecisionContext = DecisionContext { quality: 0.75, camera: T };
-            let shadow: DecisionContext = ctx;
-            let _ = shadow;
+            let ctx: DecisionContext = DecisionContext { camera: T, quality: 0.75 };
+            helper(DecisionContext { camera: N, quality: 0.5 });
+            let patched: DecisionContext = ctx with { quality: 1.0 };
+            let _ = patched;
             return;
         }
     "#
@@ -318,6 +470,42 @@ fn adt_source() -> &'static str {
             let right: Maybe = Maybe::None;
             let _ = left;
             let _ = right;
+            return;
+        }
+    "#
+}
+
+fn schema_source() -> &'static str {
+    r#"
+        api schema Telemetry version(1) {
+            level: i32,
+            active: bool,
+        }
+
+        fn main() {
+            let total: i32 = 1;
+            let _ = total;
+            return;
+        }
+    "#
+}
+
+fn indirect_record_projection_source() -> &'static str {
+    r#"
+        record CameraState {
+            active: quad,
+        }
+
+        record DecisionContext {
+            camera: CameraState,
+            quality: f64,
+        }
+
+        fn main() {
+            let ctx: DecisionContext =
+                DecisionContext { camera: CameraState { active: T }, quality: 0.75 };
+            let DecisionContext { camera: CameraState { active: ref seen_active }, quality: _ } = ctx;
+            let _ = seen_active;
             return;
         }
     "#
@@ -426,14 +614,66 @@ fn ownership_section_bytes(strings: &[String], events: &[OwnershipEventSpec<'_>]
     out
 }
 
-fn append_ownership_event(out: &mut Vec<u8>, kind: u8, root: u32, components: &[u16]) {
+fn append_ownership_event(
+    out: &mut Vec<u8>,
+    kind: u8,
+    root: u32,
+    components: &[OwnershipPathComponentSpec],
+) {
     out.push(kind);
     out.extend_from_slice(&root.to_le_bytes());
     out.extend_from_slice(&(components.len() as u16).to_le_bytes());
-    for index in components {
-        out.push(OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX);
-        out.extend_from_slice(&index.to_le_bytes());
+    for component in components {
+        match component {
+            OwnershipPathComponentSpec::TupleIndex(index) => {
+                out.push(OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX);
+                out.extend_from_slice(&index.to_le_bytes());
+            }
+            OwnershipPathComponentSpec::FieldSymbol(field) => {
+                out.push(OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL);
+                out.extend_from_slice(&field.to_le_bytes());
+            }
+        }
     }
+}
+
+fn record_field_component_ids(bytes: &[u8], target: &str) -> (u32, u32) {
+    let (_, code, _) = find_function(bytes, target);
+    let layout = parse_function_layout(code);
+    let mut cursor = layout.ownership_start.expect("OWN0 section");
+    cursor += OWNERSHIP_SECTION_TAG.len();
+    let count = read_u16_le(code, &mut cursor).expect("ownership count") as usize;
+
+    let mut borrow_field = None;
+    let mut write_field = None;
+    for _ in 0..count {
+        let kind = read_u8(code, &mut cursor).expect("ownership kind");
+        let _ = read_u32_le(code, &mut cursor).expect("ownership root");
+        let component_count = read_u16_le(code, &mut cursor).expect("ownership component count");
+        let mut only_field = None;
+        for _ in 0..component_count {
+            let component_kind = read_u8(code, &mut cursor).expect("ownership component kind");
+            match component_kind {
+                OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
+                    let _ = read_u16_le(code, &mut cursor).expect("tuple component");
+                }
+                OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
+                    only_field = Some(read_u32_le(code, &mut cursor).expect("field component"));
+                }
+                _ => panic!("unexpected ownership component kind 0x{component_kind:02x}"),
+            }
+        }
+        match (kind, only_field) {
+            (OWNERSHIP_EVENT_KIND_BORROW, Some(field)) => borrow_field = Some(field),
+            (OWNERSHIP_EVENT_KIND_WRITE, Some(field)) => write_field = Some(field),
+            _ => {}
+        }
+    }
+
+    (
+        borrow_field.expect("record borrow field"),
+        write_field.expect("record write field"),
+    )
 }
 
 fn parse_function_layout(code: &[u8]) -> FunctionLayout {
@@ -476,8 +716,16 @@ fn parse_function_layout(code: &[u8]) -> FunctionLayout {
                 read_u16_le(code, &mut cursor).expect("ownership component count") as usize;
             for _ in 0..component_count {
                 let kind = read_u8(code, &mut cursor).expect("ownership component kind");
-                assert_eq!(kind, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX);
-                let _ = read_u16_le(code, &mut cursor).expect("ownership component value");
+                match kind {
+                    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
+                        let _ = read_u16_le(code, &mut cursor).expect("ownership component value");
+                    }
+                    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
+                        let _ =
+                            read_u32_le(code, &mut cursor).expect("ownership component value");
+                    }
+                    _ => panic!("unexpected ownership component kind 0x{kind:02x}"),
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend runtime ownership e2e coverage from tuple-only assumptions to tuple + direct record field paths
- add record sibling/conflict cases, record frame-cleanup coverage, and unsupported-source checks for ADT/schema/indirect projection
- update the OWN0 rewrite harness to understand Field(SymbolId) so verified runtime tests can exercise the current contract

## Validation
- cargo test -q --test runtime_ownership_e2e
- cargo test -q
- cargo test -q --test public_api_contracts