### PR TITLE
docs: close runtime ownership track

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
 - Active draft toolchain on `main`; this repository is not frozen on `release/v0`.
 - Standard execution route: `source -> AST -> sema -> IR -> SemCode -> verify -> execute`.
 - SemCode is versioned and verifier-gated before standard VM execution.
-- Tuple-only runtime ownership is implemented end-to-end for borrowed-path write rejection:
+- Tuple + direct record-field runtime ownership is implemented end-to-end for borrowed-path write rejection:
   - frontend preserves borrow capture
   - lowering emits canonical ownership path events
   - SemCode transports ownership metadata
   - verifier admits ownership payload structurally
-  - VM rejects overlapping tuple writes at runtime
+  - VM rejects overlapping tuple and direct record-field writes at runtime
 - CLI ownership is centered in `crates/smc-cli`; root `smc` and `svm` binaries remain process entrypoints.
 
 ## Primary References
@@ -29,7 +29,7 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
 - `docs/spec/semcode.md` - SemCode contract and version policy
 - `docs/spec/verifier.md` - admission verifier contract
 - `docs/spec/vm.md` - VM execution contract
-- `docs/spec/runtime_ownership.md` - tuple-only runtime ownership contract
+- `docs/spec/runtime_ownership.md` - frozen tuple + direct record-field runtime ownership contract
 - `docs/spec/cli.md` - public CLI surface
 - `docs/LANGUAGE.md` - language overview and design intent
 - `docs/NAMING.md` - naming rules and short forms
@@ -122,12 +122,14 @@ Low-level VM entrypoint:
 - The current spec documents a versioned SemCode family and capability-gated emission.
 - Standard `.smc` execution is verifier-first; verified admission is not optional on the public route.
 - The current runtime ownership slice is intentionally narrow:
-  - tuple-only paths
+  - tuple paths
+  - direct record-field paths
   - frame-local borrow lifetime
   - exact overlap rejection
   - parent-child rejection
   - child-parent rejection
   - sibling writes allowed
+  - unsupported: ADT payload paths, schema paths, partial release, aliasing graphs, inter-frame persistence, and indirect projections
 
 ## Testing
 ```powershell

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -110,6 +110,9 @@ Current `v1` scope commitment:
   runtime ownership extension on current `main`, including `Field(SymbolId)` in
   `AccessPath`, `OWN0` field-path payloads, `SEMCOD12`, verifier admission, VM
   frame-local borrow tracking, and `BorrowWriteConflict` overlap rejection
+- the tuple + direct record-field runtime ownership track is complete on
+  current `main`; no additional runtime ownership scope is implied beyond the
+  admitted contract listed above
 - the same forward-only reading also applies to the first-wave generics surface
   on current `main`, including type-parameter syntax for functions, records, and
   ADTs, deterministic call-site monomorphisation, and the narrow

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -16,6 +16,8 @@ Current repository state has working coverage for:
 - PROMETHEUS ABI, capability, and gate boundaries
 - PROMETHEUS runtime, state, rules, and audit owner crates
 - semantic runtime validation matrix and golden baselines
+- tuple + direct record-field runtime ownership, including deterministic
+  `BorrowWriteConflict` enforcement and end-to-end regression coverage
 - CI-enforced boundary, public API, runtime, and release-bundle gates
 
 This means the repository has crossed from architecture-only planning into a
@@ -64,6 +66,7 @@ Currently ready or substantially stabilized surfaces:
 - `sm-verify`
 - verified-only VM execution path
 - `sm-runtime-core`
+- runtime ownership pipeline for tuple + direct record-field paths
 - `sm-profile`
 - `sm-ir` verification and minimum optimizer contract
 - `prom-abi`
@@ -117,6 +120,13 @@ The following limits remain explicit and should be treated as release-facing hon
   surface, even though current `main` now admits type-parameter syntax for
   functions, records, and ADTs, and deterministic call-site monomorphisation
   under the narrow `TypeVar`-to-concrete substitution model
+- the published `v1.1.1` line intentionally excludes the completed runtime
+  ownership track on current `main`, even though `main` now admits tuple +
+  direct record-field `AccessPath` transport, verifier admission, frame-local
+  borrow tracking, deterministic `BorrowWriteConflict` rejection, and e2e
+  regression coverage; unsupported scope remains explicit for ADT payload
+  paths, schema paths, partial release, aliasing graphs, inter-frame
+  persistence, and indirect projections
 - the published `v1.1.1` line intentionally excludes the first-wave UI
   application boundary, even though current `main` now admits single-window
   session ownership, deterministic event polling, frame-token ownership, and


### PR DESCRIPTION
## Summary
- mark the tuple + direct record-field runtime ownership track as completed in status and roadmap docs
- update the README current-state wording to match the landed tuple + record runtime ownership scope
- keep unsupported ownership scope explicit without changing behavior

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts