### PR TITLE
docs: sync runtime ownership contract layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,23 @@
 </p>
 
 # Semantic
-Rust-like deterministic language toolchain with SemCode emission, verifier admission, and VM execution.
+Deterministic, contract-driven compiler/runtime system with SemCode emission, verifier admission, and VM execution.
 
 Semantic is built for reasoning rules, semantic state transitions, declarative Logos surfaces, and executable logic inside the broader PROMETHEUS system model.
 
 The public contract is centered in `docs/spec/*`. Historical roadmap notes and legacy compatibility shims remain in the repository, but they are not the primary source of truth for the current toolchain surface.
 
-## Current State
-- Active draft toolchain on `main`; this repository is not frozen on `release/v0`.
-- Standard execution route: `source -> AST -> sema -> IR -> SemCode -> verify -> execute`.
-- SemCode is versioned and verifier-gated before standard VM execution.
-- Tuple + direct record-field runtime ownership is implemented end-to-end for borrowed-path write rejection:
-  - frontend preserves borrow capture
-  - lowering emits canonical ownership path events
-  - SemCode transports ownership metadata
-  - verifier admits ownership payload structurally
-  - VM rejects overlapping tuple and direct record-field writes at runtime
+## Current Status
+- Semantic is in a post-v1 stabilization phase on `main`.
+- Canonical staged pipeline: `frontend -> semantics -> lowering -> IR passes -> emit -> VM`.
+- All pipeline stages are deterministic, explicitly staged, and contract-bound; verifier admission remains mandatory before standard VM execution.
+- Runtime Ownership (v1 slice) is DONE:
+  - tuple paths
+  - direct record-field paths
+  - borrow/write path tracking
+  - deterministic overlap enforcement
+  - verifier-admitted execution contract
+- This is a scoped ownership model, not a full borrow system.
 - CLI ownership is centered in `crates/smc-cli`; root `smc` and `svm` binaries remain process entrypoints.
 
 ## Primary References

--- a/docs/architecture/blueprint.md
+++ b/docs/architecture/blueprint.md
@@ -1,5 +1,7 @@
 # Semantic Architecture Blueprint
 
+Semantic is a deterministic, contract-driven compiler/runtime system.
+
 Semantic is split into two architectural products:
 
 - `Semantic Core`: source, frontend, semantic analysis, IR, optimization, SemCode, verifier, VM.
@@ -7,7 +9,7 @@ Semantic is split into two architectural products:
 
 The core execution rule is:
 
-`source -> AST -> sema -> IR -> opt -> SemCode -> verify -> execute`
+`frontend -> semantics -> lowering -> IR passes -> emit -> VM`
 
 Current repository state:
 
@@ -52,8 +54,66 @@ Planned post-stable UI application boundary:
 Non-negotiable architecture rules:
 
 - compiler semantics and runtime semantics must stay separate;
+- no frontend/AST structures may leak into runtime;
+- runtime operates only on lowered execution contracts;
+- verifier enforces structure before execution and is a public admission layer,
+  not an internal VM detail;
+- no silent contract mutation is allowed across source, IR, SemCode, or VM
+  layers;
+- determinism is mandatory across all stages;
 - VM mechanics and semantic state/rule logic must stay separate;
 - all host effects must cross a formal ABI boundary;
-- verifier is a public admission layer, not an internal VM detail;
 - desktop UI, if admitted, must stay behind an explicit host/runtime boundary
   and must not leak backend ownership into compiler or VM crates.
+
+## Runtime Ownership (Execution Contract)
+
+Status: DONE (v1 slice)
+
+Runtime ownership is implemented as a lowered execution contract, not as a full
+ownership system.
+
+### Representation
+
+Ownership is expressed via canonical `AccessPath`:
+
+- `root: SymbolId`
+- `components`:
+  - `TupleIndex`
+  - `Field(SymbolId)` for direct record-field access only
+
+### Semantics
+
+- borrow events register paths in frame-local state
+- write operations check overlap against active borrows
+
+Overlap rules:
+
+- exact -> reject
+- parent-child -> reject
+- child-parent -> reject
+- siblings -> allowed
+
+### Lifetime Model
+
+- borrow lifetime is frame-local until frame exit
+
+### Guarantees
+
+- deterministic enforcement
+- no frontend structure leakage into runtime
+- explicit runtime trap on violation through `BorrowWriteConflict`
+
+### Supported Scope
+
+- tuple paths
+- direct record-field paths
+
+### Out Of Scope
+
+- ADT payload paths
+- nested generalized path systems
+- non-frame-local lifetimes
+- partial release
+- alias/reborrow models
+- indirect field projections beyond direct record-field access

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -23,6 +23,8 @@ Current remaining `v1` wave:
 
 Current post-`v1` wave:
 
+- `Runtime Ownership (tuple + direct record-field paths)` is completed and now
+  lives as frozen baseline history in `docs/spec/runtime_ownership.md`
 - `M7 UI Application Boundary` is now completed as first-wave baseline history
   and is scoped in
   `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
@@ -67,6 +69,12 @@ Current post-`v1` wave:
 - the first-wave `fx` arithmetic expansion track is completed and now lives as
   frozen baseline history in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+
+Current next-focus wave:
+
+- IR v1 contract freeze
+- SemCode version discipline
+- runtime boundary hardening without expanding supported runtime ownership scope
 
 Foundational work already in place:
 


### PR DESCRIPTION
## Summary
- align README, architecture blueprint, and roadmap backlog with one canonical runtime ownership contract layer
- mark runtime ownership as a completed tuple + direct record-field v1 slice with explicit supported and unsupported scope
- tighten architecture wording around staged deterministic contracts and runtime/lowering boundaries

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts