### PR TITLE
docs: freeze IR v1 contract

### DIFF
--- a/docs/architecture/blueprint.md
+++ b/docs/architecture/blueprint.md
@@ -54,6 +54,8 @@ Planned post-stable UI application boundary:
 Non-negotiable architecture rules:
 
 - compiler semantics and runtime semantics must stay separate;
+- IR is the lowered execution-contract boundary between source semantics and
+  emitted binary contract;
 - no frontend/AST structures may leak into runtime;
 - runtime operates only on lowered execution contracts;
 - verifier enforces structure before execution and is a public admission layer,

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -72,7 +72,8 @@ Current post-`v1` wave:
 
 Current next-focus wave:
 
-- IR v1 contract freeze
+- IR v1 contract freeze in
+  `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
 - SemCode version discipline
 - runtime boundary hardening without expanding supported runtime ownership scope
 

--- a/docs/roadmap/language_maturity/ir_v1_contract_freeze.md
+++ b/docs/roadmap/language_maturity/ir_v1_contract_freeze.md
@@ -1,0 +1,96 @@
+# IR v1 Contract Freeze
+
+Status: proposed checkpoint
+
+## Goal
+
+Freeze the current IR v1 slice as the canonical lowered execution contract for
+Semantic `main`.
+
+This checkpoint exists to stop IR from drifting implicitly between:
+
+- source/frontend semantics
+- optimizer ownership
+- SemCode transport
+- VM/runtime execution
+
+The point of this track is contract freeze, not new execution behavior.
+
+## Canonical Reading
+
+IR is the explicit execution-contract boundary in the staged pipeline:
+
+`frontend -> semantics -> lowering -> IR passes -> emit -> VM`
+
+In that reading:
+
+- frontend owns source syntax and source typing rules
+- lowering owns translation into execution-shaped IR
+- `sm-ir` owns IR structure and optimizer pass ownership
+- SemCode remains a later binary contract, not the IR itself
+- VM executes admitted SemCode, not raw IR
+
+## Current Landed State
+
+The current `main` already includes:
+
+- canonical IR ownership in `sm-ir`
+- canonical top-level IR units:
+  - `IrFunction`
+  - `IrInstr`
+  - `ImmutableIrProgram`
+- explicit lowering into execution-shaped control flow
+- explicit optimizer ownership in `sm-ir::passes`
+- deterministic default pass ordering:
+  - `StructuralCleanup v1`
+  - `CrystalFold v1`
+- admitted ownership-path IR metadata used for runtime ownership transport
+
+That is enough to freeze the owner boundary and the narrow v1 slice.
+
+## Included In This Freeze
+
+- IR as the canonical lowered execution contract
+- `sm-ir` as the sole owner of:
+  - IR structure
+  - lowering-facing IR construction
+  - optimizer pass ownership
+- explicit boundary between IR and SemCode
+- explicit boundary between IR and VM/runtime semantics
+- deterministic pass ordering as part of the contract
+- honest out-of-scope list for what is not frozen yet
+
+## Explicit Non-Goals
+
+This checkpoint does not include:
+
+- new IR instruction families
+- new optimizer behavior
+- SemCode version changes
+- verifier widening
+- VM/runtime widening
+- a separate `sm-opt` owner crate
+- canonical serialized textual IR format
+- CFG notation freeze beyond the current narrow execution-oriented reading
+
+## Freeze Rules
+
+- no frontend or AST structures leak across the IR boundary
+- IR remains execution-oriented, not syntax-oriented
+- optimizer ownership remains in `sm-ir`
+- pass ordering stays explicit and deterministic
+- SemCode binary ownership is downstream from IR and must not be folded back
+  into the IR contract
+- changes to IR structure or admitted pass behavior require explicit contract
+  review, not silent drift
+
+## Acceptance Criteria
+
+This checkpoint is complete only when:
+
+- `docs/spec/ir.md` reflects the same staged-contract reading
+- architecture docs treat IR as the lowered execution-contract boundary
+- roadmap docs point to this file as the active IR freeze checkpoint
+- supported scope and out-of-scope items are explicit
+- no document implies a separate `sm-opt` owner or a broader frozen IR surface
+

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -39,7 +39,8 @@
   - `docs/spec/vm.md`
   - `docs/spec/quotas.md`
   - `docs/spec/cli.md`
-  - `docs/spec/versioning.md`
+  - current active IR hardening checkpoint:
+    `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
 - `M4 PROMETHEUS Boundary`
   - ABI
   - capabilities

--- a/docs/spec/ir.md
+++ b/docs/spec/ir.md
@@ -5,13 +5,16 @@ Owner crate: `sm-ir`
 
 ## Purpose
 
-This document defines the current intermediate-representation contract between semantic analysis and SemCode production.
+This document defines the current intermediate-representation contract between
+lowering and SemCode production.
 
 IR exists to make execution-relevant structure explicit before bytecode emission.
 
 Current pipeline role:
 
-`source -> AST -> sema -> IR -> opt -> SemCode`
+`frontend -> semantics -> lowering -> IR passes -> emit`
+
+IR is the explicit lowered execution-contract boundary in that staged pipeline.
 
 ## Current Ownership
 
@@ -35,6 +38,12 @@ Current owner decision:
 - `sm-opt` is not a canonical owner crate in the repository baseline
 - any future `sm-opt` split requires an explicit architecture decision and code movement, not just naming changes in docs
 
+Contract freeze rule:
+
+- IR remains execution-oriented rather than syntax-oriented
+- frontend or AST structures must not leak across the IR boundary
+- SemCode remains downstream binary contract ownership, not IR ownership
+
 ## Current IR Shapes
 
 Current top-level IR units:
@@ -42,6 +51,8 @@ Current top-level IR units:
 - `IrFunction`
 - `IrInstr`
 - `ImmutableIrProgram`
+- admitted ownership-path metadata attached to IR functions for the current
+  runtime ownership slice
 
 Current `IrInstr` family includes explicit forms for:
 
@@ -119,3 +130,5 @@ This draft does not yet fully formalize:
 - richer optimizer passes beyond `StructuralCleanup v1` and `CrystalFold v1`
 - a separate `sm-opt` owner model
 - canonical serialized textual IR form
+- broader CFG or generalized graph notation beyond the current narrow
+  execution-oriented reading


### PR DESCRIPTION
## Summary
- freeze the current IR v1 slice as the lowered execution-contract boundary
- align IR spec, architecture, and roadmap docs on the same staged pipeline reading
- add an explicit IR freeze checkpoint document and point roadmap docs at it

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts