### PR TITLE
docs: freeze SemCode version discipline

### DIFF
--- a/docs/architecture/blueprint.md
+++ b/docs/architecture/blueprint.md
@@ -22,6 +22,8 @@ Current repository limits that remain within the published stable `v1` line:
 - richer `fx` arithmetic remains intentionally narrower than the `f64` surface in the canonical Rust-like execution path
 - optimizer surface is fixed to `sm-ir` for the current `v1`; no separate `sm-opt` owner is planned inside the current baseline
 - SemCode format surface is fixed to `sm-ir` for the current `v1`; `sm-emit` remains a producer facade over that contract
+- SemCode version and capability widening must stay explicit and additive; older
+  admitted header families remain fixed once published on `main`
 - public CLI surface is fixed to `smc-cli` for the current `v1`; root `smc` remains a thin process entrypoint over the canonical CLI owner
 - PROMETHEUS `v1` scope is fixed to the current narrow ABI/capability/gate boundary; wider planned calls remain post-`v1`
 - stable release packaging policy remains narrower than the long-term planned distribution story

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -74,7 +74,8 @@ Current next-focus wave:
 
 - IR v1 contract freeze in
   `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
-- SemCode version discipline
+- SemCode version discipline in
+  `docs/roadmap/language_maturity/semcode_version_discipline.md`
 - runtime boundary hardening without expanding supported runtime ownership scope
 
 Foundational work already in place:

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -22,14 +22,17 @@ Current post-stable admitted families on `main`:
 - `SEMCODE7`
 - `SEMCODE8`
 - `SEMCODE9`
-- `SEMCODE10`
-- `SEMCODE11`
+- `SEMCOD10`
+- `SEMCOD11`
+- `SEMCOD12`
 
 Current compatibility rule:
 
 - standard execution accepts only verified SemCode
 - verifier rejects unknown or unsupported SemCode headers
 - VM must not silently reinterpret unsupported headers
+- widening on current `main` is forward-only and additive, not a retroactive
+  widening of the published stable line
 
 ## ParserProfile Compatibility
 
@@ -102,10 +105,10 @@ Current `v1` scope commitment:
   bracketed literals, same-family equality, `expr[index]`, and `SEMCODE9`
 - the same forward-only reading also applies to the first-wave first-class
   closure surface on current `main`, including `Closure(T -> U)`, standalone
-  closure literals, immutable capture, direct invocation, and `SEMCODE10`
+  closure literals, immutable capture, direct invocation, and `SEMCOD10`
 - the same forward-only reading also applies to the first-wave tuple-only
   runtime ownership metadata transport on current `main`, including lowered
-  borrow/write path events, canonical `AccessPath`, and `SEMCODE11`
+  borrow/write path events, canonical `AccessPath`, and `SEMCOD11`
 - the same forward-only reading also applies to the direct record-field
   runtime ownership extension on current `main`, including `Field(SymbolId)` in
   `AccessPath`, `OWN0` field-path payloads, `SEMCOD12`, verifier admission, VM

--- a/docs/roadmap/language_maturity/semcode_version_discipline.md
+++ b/docs/roadmap/language_maturity/semcode_version_discipline.md
@@ -1,0 +1,99 @@
+# SemCode Version Discipline
+
+Status: proposed checkpoint
+
+## Goal
+
+Freeze the SemCode version-discipline rules for the current `main` baseline.
+
+This checkpoint exists to stop SemCode drift between:
+
+- IR/emit ownership
+- verifier admission
+- VM execution support
+- release-facing compatibility statements
+
+The point of this track is version discipline, not new binary behavior.
+
+## Canonical Reading
+
+SemCode is the versioned binary contract between the lowered execution pipeline
+and verified VM execution:
+
+`frontend -> semantics -> lowering -> IR passes -> emit -> verify -> VM`
+
+In that reading:
+
+- `sm-ir` owns SemCode header, opcode, section, and capability semantics
+- `sm-emit` remains a producer-facing facade over that owned contract
+- `sm-verify` admits or rejects produced artifacts structurally before execution
+- `sm-vm` executes only admitted SemCode and must not redefine the format
+
+## Current Landed State
+
+The current `main` already includes:
+
+- a supported header family from `SEMCODE0` through `SEMCOD12`
+- canonical header specs and capability masks in `sm-ir`
+- verifier admission aligned to the same supported header family
+- VM rejection of unsupported headers without silent reinterpretation
+- additive capability widening across the admitted header line
+- explicit release-facing distinction between the published stable line and the
+  wider admitted line on current `main`
+
+That is enough to freeze the narrow version-discipline contract.
+
+## Included In This Freeze
+
+- SemCode as a versioned binary contract owned by `sm-ir`
+- the current supported family from `SEMCODE0` through `SEMCOD12`
+- additive capability widening as the only admitted widening model in the
+  current baseline
+- explicit version review for binary layout or meaning changes
+- release-facing honesty about published stable versus forward-only admitted
+  `main` behavior
+- explicit required follow-up items for any future SemCode family bump
+
+## Explicit Non-Goals
+
+This checkpoint does not include:
+
+- a new SemCode header family
+- opcode widening
+- section-layout widening
+- verifier semantic widening
+- VM execution widening
+- stable-tag promotion of post-stable admitted families
+- textual IR or package-level versioning work
+
+## Freeze Rules
+
+- existing admitted header families remain fixed once they ship on `main`
+- capability bits widen additively and must not be repurposed in place
+- header selection remains derived from actual emitted usage, not from profile
+  permission alone
+- verifier and VM support must stay aligned to the same supported header family
+- release docs must distinguish the published stable line from the wider
+  forward-only admitted line on `main`
+- SemCode format changes require explicit version review, not silent mutation
+
+## Required Follow-Up For A Future SemCode Bump
+
+Any future header or capability widening must update all of:
+
+- `docs/spec/semcode.md`
+- `docs/roadmap/compatibility_statement.md`
+- `docs/roadmap/v1_readiness.md`
+- verifier compatibility tests
+- VM compatibility tests
+- golden or compatibility fixtures if public behavior changed
+
+## Acceptance Criteria
+
+This checkpoint is complete only when:
+
+- `docs/spec/semcode.md` reflects the same staged-contract reading
+- architecture docs treat SemCode widening as explicit and additive
+- roadmap docs point to this file as the active SemCode discipline checkpoint
+- release-facing compatibility docs use the real admitted header names
+- no document implies silent retroactive widening of the published stable line

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -41,6 +41,8 @@
   - `docs/spec/cli.md`
   - current active IR hardening checkpoint:
     `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
+  - current active SemCode version-discipline checkpoint:
+    `docs/roadmap/language_maturity/semcode_version_discipline.md`
 - `M4 PROMETHEUS Boundary`
   - ABI
   - capabilities

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -19,6 +19,8 @@ Current repository state has working coverage for:
 - tuple + direct record-field runtime ownership, including deterministic
   `BorrowWriteConflict` enforcement and end-to-end regression coverage
 - CI-enforced boundary, public API, runtime, and release-bundle gates
+- explicit SemCode version/capability discipline through the admitted
+  `SEMCODE0`..`SEMCOD12` family on current `main`
 
 This means the repository has crossed from architecture-only planning into a
 published stable release line for the current contract surfaces.
@@ -115,7 +117,7 @@ The following limits remain explicit and should be treated as release-facing hon
 - the published `v1.1.1` line intentionally excludes the first-wave first-class
   closure surface, even though current `main` now admits `Closure(T -> U)`,
   standalone closure literals, immutable capture, direct invocation, and
-  canonical verified execution through `SEMCODE10`
+  canonical verified execution through `SEMCOD10`
 - the published `v1.1.1` line intentionally excludes the first-wave generics
   surface, even though current `main` now admits type-parameter syntax for
   functions, records, and ADTs, and deterministic call-site monomorphisation

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -19,7 +19,10 @@ Ownership rule:
 
 Standard execution rule:
 
-`source -> AST -> sema -> IR -> SemCode -> verify -> execute`
+`frontend -> semantics -> lowering -> IR passes -> emit -> verify -> execute`
+
+SemCode is the downstream binary contract after IR passes and before
+verifier-admitted VM execution.
 
 The VM is not the primary structural admission gate.
 `sm-verify` is the required admission stage for standard SemCode execution.
@@ -72,6 +75,16 @@ Compatibility rules:
 2. A verifier must reject artifacts with unknown or unsupported headers.
 3. A VM must not silently reinterpret an unsupported header as a supported one.
 4. Any incompatible binary layout or meaning change requires a version bump.
+
+Discipline rules:
+
+- existing admitted header families remain fixed once they ship on `main`
+- capability widening stays additive in the current baseline and must not
+  repurpose existing bits
+- release-facing documents must distinguish the published stable line from the
+  wider admitted line on current `main`
+- SemCode header selection remains derived from actual emitted usage, not from
+  policy permission alone
 
 ## Current Header Semantics
 
@@ -271,9 +284,11 @@ The following changes require a SemCode version review:
 Required follow-up:
 
 1. update this specification
-2. update verifier compatibility tests
-3. update VM compatibility tests
-4. update golden or compatibility fixtures if public behavior changed
+2. update `docs/roadmap/compatibility_statement.md`
+3. update `docs/roadmap/v1_readiness.md`
+4. update verifier compatibility tests
+5. update VM compatibility tests
+6. update golden or compatibility fixtures if public behavior changed
 
 ## No Silent Mutation Rule
 


### PR DESCRIPTION
## Summary
- freeze the current SemCode version-discipline rules as a docs checkpoint
- align the SemCode spec, architecture, roadmap, and release-facing docs on additive version widening
- fix release-facing header-name drift and make SEMCOD12 explicit in the forward admitted line

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts