### PR TITLE
docs: harden runtime execution boundaries

### DIFF
--- a/docs/architecture/blueprint.md
+++ b/docs/architecture/blueprint.md
@@ -62,6 +62,8 @@ Non-negotiable architecture rules:
 - runtime operates only on lowered execution contracts;
 - verifier enforces structure before execution and is a public admission layer,
   not an internal VM detail;
+- orchestration layers must call verified VM entrypoints only and must not
+  become alternate execution authorities;
 - no silent contract mutation is allowed across source, IR, SemCode, or VM
   layers;
 - determinism is mandatory across all stages;

--- a/docs/architecture/dependency_boundary_rules.md
+++ b/docs/architecture/dependency_boundary_rules.md
@@ -27,7 +27,10 @@ Boundary rules:
 
 - construction crates must not depend on VM/runtime state or PROMETHEUS internals;
 - execution crates must not reach back into parser/sema internals;
+- shared runtime vocabulary stays in `sm-runtime-core`; it must not become a
+  second execution authority;
 - integration crates must not rewrite compiler or VM semantics;
+- integration crates must reach execution only through verified VM entrypoints;
 - all host effects must cross ABI and capability checks;
 - public contracts require versioning, tests, and spec updates.
 

--- a/docs/architecture/module_ownership_map.md
+++ b/docs/architecture/module_ownership_map.md
@@ -34,8 +34,11 @@ Ownership rules:
 - `sm-emit` is a producer-facing facade in the current `v1` baseline; the SemCode header/opcode/capability contract is owned by `sm-ir`;
 - `smc-cli` is the canonical owner of the public CLI contract in the current `v1` baseline; root `smc` and `svm` binaries are process entrypoints and not second CLI owners;
 - the retained non-owning TON618 compatibility perimeter (`ton618_core`, `ton618-core`, `ton618_legacy/`) is not a canonical public owner and must not become a second owner for `sm-*` public contracts;
+- `sm-runtime-core` owns shared runtime vocabulary only; it does not own
+  verifier admission, VM execution mechanics, or orchestration semantics;
 - `sm-vm` consumes SemCode but does not own its format contract;
 - `sm-verify` owns admission, `sm-vm` executes only admitted code;
 - `prom-state` owns semantic state, not `sm-vm`;
 - `prom-rules` owns agenda/conflict logic, not `sm-vm`;
-- `prom-runtime` orchestrates but does not own all subdomains.
+- `prom-runtime` orchestrates verified entrypoints but does not own VM
+  execution, runtime traps, or quota semantics.

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -76,7 +76,9 @@ Current next-focus wave:
   `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
 - SemCode version discipline in
   `docs/roadmap/language_maturity/semcode_version_discipline.md`
-- runtime boundary hardening without expanding supported runtime ownership scope
+- runtime boundary hardening in
+  `docs/roadmap/language_maturity/runtime_boundary_hardening.md` without
+  expanding supported runtime ownership scope
 
 Foundational work already in place:
 

--- a/docs/roadmap/language_maturity/runtime_boundary_hardening.md
+++ b/docs/roadmap/language_maturity/runtime_boundary_hardening.md
@@ -1,0 +1,87 @@
+# Runtime Boundary Hardening
+
+Status: proposed checkpoint
+
+## Goal
+
+Freeze the current execution-boundary rules between verifier admission, shared
+runtime vocabulary, VM execution, and PROMETHEUS orchestration on `main`.
+
+This checkpoint exists to stop runtime authority from drifting implicitly
+between:
+
+- `sm-verify`
+- `sm-runtime-core`
+- `sm-vm`
+- `prom-runtime`
+
+The point of this track is boundary hardening, not new runtime behavior.
+
+## Canonical Reading
+
+The standard execution route is:
+
+`emit -> verify -> run_verified_* -> execute`
+
+In that reading:
+
+- `sm-verify` owns SemCode admission before standard execution
+- `sm-runtime-core` owns shared runtime vocabulary used across execution crates
+- `sm-vm` owns execution mechanics, frames, quotas, and runtime trap surfacing
+- `prom-runtime` orchestrates verified execution sessions only and must not
+  become a second execution authority
+
+## Current Landed State
+
+The current `main` already includes:
+
+- verified-only public VM entrypoints
+- explicit `ExecutionConfig` / `ExecutionContext` runtime wiring
+- runtime quota enforcement in `sm-vm`
+- frame-local runtime ownership tracking and `BorrowWriteConflict`
+  enforcement for the admitted tuple + direct record-field slice
+- PROMETHEUS execution-session wiring that composes verified entrypoints
+  rather than redefining VM semantics
+
+That is enough to freeze the current boundary rules.
+
+## Included In This Freeze
+
+- verifier-before-execution as the public route
+- `sm-runtime-core` as shared runtime vocabulary owner only
+- `sm-vm` as the sole owner of execution mechanics and runtime trap surfaces
+- `prom-runtime` as orchestration glue over verified entrypoints only
+- explicit non-goal list for what orchestration does not own
+
+## Explicit Non-Goals
+
+This checkpoint does not include:
+
+- new VM opcodes
+- new execution contexts
+- new host-call families
+- runtime ownership widening beyond the admitted tuple + direct record-field
+  slice
+- retries, rollback, or compensation semantics
+- alternate raw execution authorities outside the verified path
+
+## Freeze Rules
+
+- standard public execution must continue to require verifier admission
+- raw or test-only helpers must not become public orchestration boundaries
+- `prom-runtime` must not redefine VM trap, quota, or ownership semantics
+- `sm-runtime-core` stays a vocabulary crate, not a second VM or verifier owner
+- admitted runtime trap surfaces remain owned by `sm-vm`
+- execution-boundary changes require explicit spec and compatibility review, not
+  silent drift
+
+## Acceptance Criteria
+
+This checkpoint is complete only when:
+
+- `docs/spec/verifier.md`, `docs/spec/vm.md`, and `docs/spec/runtime.md`
+  reflect the same verified-only execution route
+- architecture docs describe `prom-runtime` as orchestration only
+- roadmap docs point to this file as the active runtime hardening checkpoint
+- public VM/runtime docs list the current admitted ownership trap surface
+- no document implies a second execution authority outside verified VM entrypoints

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -75,6 +75,8 @@
     `docs/roadmap/language_maturity/multi_session_replay_archive_scope.md`
   - current completed post-stable rollback checkpoint:
     `docs/roadmap/language_maturity/rollback_persistence_semantics_scope.md`
+  - current active runtime-boundary hardening checkpoint:
+    `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
 - `M6 v1 Lockdown`
   - freezes
   - golden baselines

--- a/docs/spec/runtime.md
+++ b/docs/spec/runtime.md
@@ -30,6 +30,10 @@ Current canonical orchestration types:
 
 - ABI descriptor semantics
 - capability policy semantics
+- verifier admission
+- VM execution mechanics
+- runtime trap taxonomy
+- quota semantics
 - gate registry semantics
 - semantic state, agenda, or rule scheduling
 
@@ -42,6 +46,8 @@ Current `v1` rule:
 Current session invariant:
 
 - every runtime session must execute only through verified SemCode entrypoints
+- raw or testing-only VM helpers are not part of the public orchestration
+  boundary
 - session context is explicit through `ExecutionConfig` / `ExecutionContext`
 - session descriptor must expose:
   - execution context
@@ -55,6 +61,8 @@ Current orchestrator wiring:
 - `ExecutionSession` wires a generic `prom-abi` host and `prom-cap` checker
 - `GateExecutionSession` wires `prom-gates` through `GateHostAdapter`
 - session orchestration may compose owner crates, but it must not redefine their contracts
+- orchestration must surface VM verifier rejection and runtime traps as owned by
+  the execution layer, not reinterpret them as new orchestration semantics
 
 ## Controlled Integration Surface
 

--- a/docs/spec/vm.md
+++ b/docs/spec/vm.md
@@ -101,6 +101,7 @@ Current public runtime error families include:
 - `StackOverflow`
 - `QuotaExceeded`
 - `VerifierRejected`
+- `BorrowWriteConflict`
 - `UnknownVariable`
 - `InvalidStringId`
 
@@ -131,7 +132,7 @@ Current frame model includes:
 - program counter
 - register vector
 - `SymbolId` local map
-- frame-local borrowed tuple paths
+- frame-local borrowed tuple and direct record-field paths
 - function identity
 - optional return destination
 


### PR DESCRIPTION
## Summary
- freeze the current verified-only runtime boundary between verifier, runtime-core, VM, and PROMETHEUS orchestration
- align VM/runtime/architecture docs on ownership of traps, quotas, and execution authority
- add an explicit runtime boundary hardening checkpoint and point roadmap docs at it

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts