### PR TITLE
docs: activate iterable abstraction track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -69,16 +69,20 @@ Current post-`v1` wave:
 - the first-wave `fx` arithmetic expansion track is completed and now lives as
   frozen baseline history in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+- the IR/runtime anti-drift package is completed and now lives as frozen
+  baseline history in:
+  - `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
+  - `docs/roadmap/language_maturity/semcode_version_discipline.md`
+  - `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
 
 Current next-focus wave:
 
-- IR v1 contract freeze in
-  `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
-- SemCode version discipline in
-  `docs/roadmap/language_maturity/semcode_version_discipline.md`
-- runtime boundary hardening in
-  `docs/roadmap/language_maturity/runtime_boundary_hardening.md` without
-  expanding supported runtime ownership scope
+- `M9.3 Iterable Abstraction` in
+  `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
+- keep one active language-maturity stream at a time while `M9.3` is in flight
+- do not widen iterable scope beyond the first-wave `Iterable` contract,
+  `for x in collection` desugaring, and stdlib/typecheck admission defined in
+  the scope doc
 
 Foundational work already in place:
 

--- a/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
+++ b/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
@@ -1,6 +1,6 @@
 # Iterable Abstraction Full Scope
 
-Status: proposed M9.3 post-stable subtrack
+Status: active M9.3 post-stable subtrack
 Related roadmap package:
 `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
 
@@ -37,10 +37,10 @@ system without mixing in lazy evaluation, async iteration, or combinator chains.
 
 ## Decision Check
 
-- [ ] This is a new explicit post-stable track with its own scope decision
-- [ ] This does not silently widen published `v1.1.1`
-- [ ] This is one stream, not a mixture of multiple tracks
-- [ ] This can be closed with a clear done-boundary
+- [x] This is a new explicit post-stable track with its own scope decision
+- [x] This does not silently widen published `v1.1.1`
+- [x] This is one stream, not a mixture of multiple tracks
+- [x] This can be closed with a clear done-boundary
 
 ## Stable Baseline Before This Track
 
@@ -55,6 +55,18 @@ The current stable line already freezes these facts:
 
 That baseline remains the source of truth until this subtrack explicitly lands
 its widened contract on `main`.
+
+## Activation Reading
+
+`M9.3 Iterable Abstraction` is now the active language-maturity stream after
+the completion of:
+
+- `IR v1 contract freeze`
+- `SemCode version discipline`
+- `runtime boundary hardening`
+
+This activation is a scope/governance checkpoint only. It does not itself claim
+that iterable abstraction is admitted yet on current `main`.
 
 ## Included In This Track
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -130,6 +130,8 @@
   - iterable abstraction
   - richer pattern surface
   - current status: active post-stable language-maturity package
+  - current active subtrack:
+    `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
   - completed subtracks:
     - M9.1: `docs/roadmap/language_maturity/generics_full_scope.md`
     - M9.2: `docs/roadmap/language_maturity/traits_full_scope.md`


### PR DESCRIPTION
## Summary
- activate M9.3 Iterable Abstraction as the next active language-maturity stream
- mark the IR/SemCode/runtime anti-drift package as completed baseline history
- align backlog, milestones, and the iterable scope doc on the same governance reading

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts