### PR TITLE
frontend/ir: own iterable for-loop surface

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -20,7 +20,7 @@ pub use types::{
     ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,
     FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField,
     LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
-    MatchExpr, MatchExprArm, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
+    MatchExpr, MatchExprArm, IterableLoopDesugaring, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
     RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
     SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
     SequenceLiteral, SequenceType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2,7 +2,7 @@ use crate::lexer::lex_tokens;
 use crate::types::{
     AdtCtorExpr, AdtDecl, AdtMatchPattern, AdtPatternItem, AdtVariant, AstArena, BinaryOp,
     BlockExpr, CallArg, CaptureMode, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily,
-    Expr, ExprId, FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, LogosEntity,
+    Expr, ExprId, FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, IterableLoopDesugaring, LogosEntity,
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
     LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
     RangeExpr, RecordDecl, RecordField,
@@ -784,9 +784,24 @@ impl<'a> Parser<'a> {
         if self.eat(TokenKind::KwFor) {
             let name = self.expect_symbol()?;
             self.expect(TokenKind::KwIn, "expected 'in' after for binding")?;
-            let range = self.parse_expr()?;
+            let iterable = self.parse_expr()?;
             let body = self.parse_block()?;
-            return Ok(self.arena.alloc_stmt(Stmt::ForRange { name, range, body }));
+            let iterable_trait = self.arena.intern_symbol("Iterable");
+            return Ok(match self.arena.expr(iterable) {
+                Expr::Range(_) => self.arena.alloc_stmt(Stmt::ForRange {
+                    name,
+                    range: iterable,
+                    body,
+                }),
+                _ => self.arena.alloc_stmt(Stmt::ForEach {
+                    name,
+                    iterable,
+                    body,
+                    desugaring: IterableLoopDesugaring {
+                        trait_name: iterable_trait,
+                    },
+                }),
+            });
         }
         if self.eat(TokenKind::KwGuard) {
             let condition = self.parse_expr()?;
@@ -4347,6 +4362,36 @@ fn main() {
             panic!("expected range expression");
         };
         assert!(range_expr.inclusive);
+        assert_eq!(body.len(), 1);
+    }
+
+    #[test]
+    fn rustlike_parser_owns_iterable_for_surface_separately_from_range() {
+        let src = r#"
+fn main() {
+    let items: Sequence(i32) = [1, 2, 3];
+    for item in items {
+        let _ = item;
+    }
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("iterable owner-layer for-loop should parse");
+        let func = &program.functions[0];
+        let Stmt::ForEach {
+            name,
+            iterable,
+            body,
+            desugaring,
+        } = program.arena.stmt(func.body[1])
+        else {
+            panic!("expected owner-layer iterable for-loop");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "item");
+        assert!(matches!(program.arena.expr(*iterable), Expr::Var(_)));
+        assert_eq!(program.arena.symbol_name(desugaring.trait_name), "Iterable");
         assert_eq!(body.len(), 1);
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -16,6 +16,10 @@ fn fx_measured_arithmetic_gap_message() -> &'static str {
     "unit-carrying fx arithmetic is not part of the first post-stable fx arithmetic slice yet"
 }
 
+fn iterable_for_gap_message() -> &'static str {
+    "iterable 'for x in collection' loops are owner-layer only in M9.3 Wave 1; executable admission is deferred"
+}
+
 fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
     match arena.expr(expr_id) {
         Expr::NumericLiteral(_) => true,
@@ -1168,6 +1172,52 @@ fn check_stmt(
             }
             body_env.pop_scope();
             Ok(())
+        }
+        Stmt::ForEach {
+            name,
+            iterable,
+            body,
+            desugaring,
+        } => {
+            let iterable_ty = infer_expr_type(
+                *iterable,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+                impl_list,
+            )?;
+            if iterable_ty == Type::RangeI32 {
+                let mut body_env = env.clone();
+                body_env.push_scope();
+                body_env.insert_const(*name, Type::I32);
+                for stmt in body {
+                    check_stmt(
+                        *stmt,
+                        arena,
+                        &mut body_env,
+                        ret_ty.clone(),
+                        table,
+                        record_table,
+                        adt_table,
+                        loop_stack,
+                        impl_list,
+                    )?;
+                }
+                body_env.pop_scope();
+                return Ok(());
+            }
+            Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "{} (`{}` contract)",
+                    iterable_for_gap_message(),
+                    resolve_symbol_name(arena, desugaring.trait_name)?
+                ),
+            })
         }
         Stmt::Break(value) => {
             let break_ty = infer_expr_type(
@@ -3681,7 +3731,7 @@ mod tests {
     }
 
     #[test]
-    fn for_range_rejects_non_range_value() {
+    fn iterable_for_surface_rejects_non_iterable_execution_in_wave_one() {
         let src = r#"
             fn main() {
                 for i in 1 {
@@ -3691,10 +3741,43 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src).expect_err("non-range for input must reject");
+        let err = typecheck_source(src).expect_err("non-iterable executable for input must reject");
         assert!(err
             .message
-            .contains("for-range currently requires i32 range expression"));
+            .contains("iterable 'for x in collection' loops are owner-layer only"));
+    }
+
+    #[test]
+    fn iterable_for_gap_is_explicit_for_sequence_values() {
+        let src = r#"
+            fn main() {
+                let items: Sequence(i32) = [1, 2, 3];
+                for item in items {
+                    let _: i32 = item;
+                }
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("general iterable loop must stay owner-layer only");
+        assert!(err.message.contains("iterable 'for x in collection' loops are owner-layer only"));
+        assert!(err.message.contains("Iterable"));
+    }
+
+    #[test]
+    fn for_range_through_variable_remains_typecheckable() {
+        let src = r#"
+            fn main() {
+                let window = 0..=2;
+                for i in window {
+                    let _: i32 = i;
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("range-valued variable for-loop should keep existing path");
     }
 
     #[test]
@@ -3729,6 +3812,27 @@ mod tests {
         assert!(err
             .message
             .contains("loop expression body currently does not allow for-range"));
+    }
+
+    #[test]
+    fn loop_expression_rejects_iterable_for_each_in_body() {
+        let src = r#"
+            fn main() {
+                let items: Sequence(i32) = [1, 2, 3];
+                let value: i32 = loop {
+                    for item in items {
+                        break item;
+                    }
+                };
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("iterable for-each in loop expression must reject");
+        assert!(err
+            .message
+            .contains("loop expression body currently does not allow iterable for-each"));
     }
 
     #[test]
@@ -6395,6 +6499,11 @@ fn check_loop_expr_stmt(
         Stmt::ForRange { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow for-range".to_string(),
+        }),
+        Stmt::ForEach { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow iterable for-each"
+                .to_string(),
         }),
         Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
             pos: 0,

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -430,6 +430,17 @@ pub enum Stmt {
         items: Vec<Option<SymbolId>>,
         value: ExprId,
     },
+    /// M9.3 Wave 1: owner-layer iterable loop surface.
+    ///
+    /// This records the future `for x in collection` contract without making
+    /// general iterable loops executable yet. Existing `RangeI32` loops remain
+    /// runnable through explicit typecheck/lowering compatibility handling.
+    ForEach {
+        name: SymbolId,
+        iterable: ExprId,
+        body: Vec<StmtId>,
+        desugaring: IterableLoopDesugaring,
+    },
     ForRange {
         name: SymbolId,
         range: ExprId,
@@ -543,6 +554,15 @@ pub struct MatchArm {
     pub pat: MatchPattern,
     pub guard: Option<ExprId>,
     pub block: Vec<StmtId>,
+}
+
+/// M9.3 Wave 1: canonical owner-layer desugaring anchor for iterable loops.
+///
+/// Wave 1 records only the stdlib trait contract name. Type admission and
+/// executable lowering remain deferred to later iterable waves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterableLoopDesugaring {
+    pub trait_name: SymbolId,
 }
 
 /// A named behavior bound on a type parameter.
@@ -1253,6 +1273,41 @@ mod tests {
         assert_eq!(func.trait_bounds.len(), 1);
         assert_eq!(func.trait_bounds[0].bound, display);
         assert!(func.type_params.contains(&t_param));
+    }
+
+    #[test]
+    fn iterable_loop_desugaring_owner_layer_is_stable() {
+        let mut arena = AstArena::default();
+        let iterable_trait = arena.intern_symbol("Iterable");
+        let desugaring = IterableLoopDesugaring {
+            trait_name: iterable_trait,
+        };
+        assert_eq!(desugaring.trait_name, iterable_trait);
+    }
+
+    #[test]
+    fn for_each_statement_owner_layer_is_stable() {
+        let stmt = Stmt::ForEach {
+            name: SymbolId(1),
+            iterable: ExprId(2),
+            body: vec![StmtId(3)],
+            desugaring: IterableLoopDesugaring {
+                trait_name: SymbolId(4),
+            },
+        };
+        let Stmt::ForEach {
+            name,
+            iterable,
+            body,
+            desugaring,
+        } = stmt
+        else {
+            panic!("expected ForEach");
+        };
+        assert_eq!(name, SymbolId(1));
+        assert_eq!(iterable, ExprId(2));
+        assert_eq!(body, vec![StmtId(3)]);
+        assert_eq!(desugaring.trait_name, SymbolId(4));
     }
 
     #[test]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -349,6 +349,10 @@ pub struct LogosIrLaw {
 
 const FX_SCALE: i32 = 1_000;
 
+fn iterable_for_gap_message() -> &'static str {
+    "iterable 'for x in collection' loops are owner-layer only in M9.3 Wave 1; executable admission is deferred"
+}
+
 fn encode_fx_literal(value: f64) -> Result<i32, FrontendError> {
     let scaled = value * FX_SCALE as f64;
     if !scaled.is_finite() {
@@ -3489,9 +3493,9 @@ fn assign_tuple_items(
     Ok(())
 }
 
-fn lower_for_range_stmt(
+fn lower_for_range_stmt_from_reg(
     name: SymbolId,
-    range: ExprId,
+    range_reg: u16,
     body: &[StmtId],
     arena: &AstArena,
     ctx: &mut LoweringCtx,
@@ -3501,27 +3505,6 @@ fn lower_for_range_stmt(
     record_table: &RecordTable,
     adt_table: &AdtTable,
 ) -> Result<(), FrontendError> {
-    let (range_reg, range_ty) = lower_expr_with_expected(
-        range,
-        arena,
-        &mut ctx.next_reg,
-        &mut ctx.instrs,
-        env,
-        &mut ctx.loop_stack,
-        fn_table,
-        record_table,
-        adt_table,
-        Some(Type::RangeI32),
-        ret_ty.clone(),
-        &mut ctx.closure_state,
-    )?;
-    if range_ty != Type::RangeI32 {
-        return Err(FrontendError {
-            pos: 0,
-            message: "for-range currently requires i32 range expression".to_string(),
-        });
-    }
-
     let id = ctx.next_if_id();
     let current_name = format!("__for_range_{}_current", id);
     let start_reg = alloc(&mut ctx.next_reg);
@@ -3665,6 +3648,102 @@ fn lower_for_range_stmt(
     ctx.instrs.push(IrInstr::Jmp { label: test_label });
     ctx.instrs.push(IrInstr::Label { name: end_label });
     Ok(())
+}
+
+fn lower_for_range_stmt(
+    name: SymbolId,
+    range: ExprId,
+    body: &[StmtId],
+    arena: &AstArena,
+    ctx: &mut LoweringCtx,
+    env: &mut ScopeEnv,
+    ret_ty: Type,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let (range_reg, range_ty) = lower_expr_with_expected(
+        range,
+        arena,
+        &mut ctx.next_reg,
+        &mut ctx.instrs,
+        env,
+        &mut ctx.loop_stack,
+        fn_table,
+        record_table,
+        adt_table,
+        Some(Type::RangeI32),
+        ret_ty.clone(),
+        &mut ctx.closure_state,
+    )?;
+    if range_ty != Type::RangeI32 {
+        return Err(FrontendError {
+            pos: 0,
+            message: "for-range currently requires i32 range expression".to_string(),
+        });
+    }
+    lower_for_range_stmt_from_reg(
+        name,
+        range_reg,
+        body,
+        arena,
+        ctx,
+        env,
+        ret_ty,
+        fn_table,
+        record_table,
+        adt_table,
+    )
+}
+
+fn lower_for_each_stmt(
+    name: SymbolId,
+    iterable: ExprId,
+    trait_name: SymbolId,
+    body: &[StmtId],
+    arena: &AstArena,
+    ctx: &mut LoweringCtx,
+    env: &mut ScopeEnv,
+    ret_ty: Type,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let (iterable_reg, iterable_ty) = lower_expr(
+        iterable,
+        arena,
+        &mut ctx.next_reg,
+        &mut ctx.instrs,
+        env,
+        &mut ctx.loop_stack,
+        fn_table,
+        record_table,
+        adt_table,
+        ret_ty.clone(),
+        &mut ctx.closure_state,
+    )?;
+    if iterable_ty == Type::RangeI32 {
+        return lower_for_range_stmt_from_reg(
+            name,
+            iterable_reg,
+            body,
+            arena,
+            ctx,
+            env,
+            ret_ty,
+            fn_table,
+            record_table,
+            adt_table,
+        );
+    }
+    Err(FrontendError {
+        pos: 0,
+        message: format!(
+            "{} (`{}` contract)",
+            iterable_for_gap_message(),
+            resolve_symbol_name(arena, trait_name)?
+        ),
+    })
 }
 
 fn bind_let_else_tuple_items(
@@ -4104,6 +4183,24 @@ fn lower_stmt(
         Stmt::ForRange { name, range, body } => lower_for_range_stmt(
             *name,
             *range,
+            body,
+            arena,
+            ctx,
+            env,
+            ret_ty,
+            fn_table,
+            record_table,
+            adt_table,
+        ),
+        Stmt::ForEach {
+            name,
+            iterable,
+            body,
+            desugaring,
+        } => lower_for_each_stmt(
+            *name,
+            *iterable,
+            desugaring.trait_name,
             body,
             arena,
             ctx,
@@ -5816,6 +5913,11 @@ fn lower_loop_expr_stmt(
         Stmt::ForRange { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow for-range".to_string(),
+        }),
+        Stmt::ForEach { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow iterable for-each"
+                .to_string(),
         }),
         Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
             pos: 0,
@@ -8133,6 +8235,48 @@ mod opt_tests {
             instr,
             IrInstr::StoreVar { name, .. } if name.starts_with("__for_range_")
         )));
+    }
+
+    #[test]
+    fn lower_for_range_through_variable_keeps_existing_execution_path() {
+        let src = r#"
+            fn main() {
+                let window = 0..=2;
+                for i in window {
+                    assert(i == i);
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("range-valued variable loop should still lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::LoadVar { name, .. } if name == "window")));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::CmpI32Le { .. })));
+    }
+
+    #[test]
+    fn compile_program_rejects_general_iterable_loop_before_wave_three() {
+        let src = r#"
+            fn main() {
+                let items: Sequence(i32) = [1, 2, 3];
+                for item in items {
+                    let _: i32 = item;
+                }
+                return;
+            }
+        "#;
+
+        let err = compile_program_to_ir(src)
+            .expect_err("general iterable loop must remain non-executable in owner slice");
+        assert!(err.message.contains("iterable 'for x in collection' loops are owner-layer only"));
+        assert!(err.message.contains("Iterable"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add owner-layer iterable for-loop surface distinct from executable range loops
- keep existing range execution path working, including range-valued variables
- add explicit typecheck/lowering gap markers for general iterable loops in M9.3 Wave 1

## Testing
- cargo test -q -p sm-front
- cargo test -q -p sm-ir
- cargo test -q --test public_api_contracts
- cargo test -q