### PR TITLE
frontend/docs: admit iterable source surface

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -5975,6 +5975,36 @@ impl Display for MyNum {
     }
 
     #[test]
+    fn iterable_trait_and_impl_surface_parse_on_current_main() {
+        let src = r#"
+trait Iterable {
+    fn next(self: Numbers) -> Option(i32);
+}
+
+record Numbers {
+    current: i32,
+}
+
+impl Iterable for Numbers {
+    fn next(self: Numbers) -> Option(i32) {
+        return Option::None;
+    }
+}
+
+fn main() {
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("Iterable trait and impl surface should parse");
+        assert_eq!(program.traits.len(), 1);
+        assert_eq!(program.impls.len(), 1);
+        assert_eq!(program.arena.symbol_name(program.traits[0].name), "Iterable");
+        assert_eq!(program.arena.symbol_name(program.impls[0].trait_name), "Iterable");
+    }
+
+    #[test]
     fn function_with_trait_bound_is_parsed() {
         let src = r#"
 fn print_all<T: Display>(x: T) -> i32 {

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -20,6 +20,14 @@ fn iterable_for_gap_message() -> &'static str {
     "iterable 'for x in collection' loops are owner-layer only in M9.3 Wave 1; executable admission is deferred"
 }
 
+fn iterable_for_stdlib_gap_message() -> &'static str {
+    "iterable 'for x in collection' source admission is open, but stdlib Iterable implementations are deferred to M9.3 Wave 3"
+}
+
+fn iterable_for_impl_gap_message() -> &'static str {
+    "iterable 'for x in collection' source admission is open, but executable loop typing for explicit `Iterable` impls is deferred to M9.3 Wave 3"
+}
+
 fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
     match arena.expr(expr_id) {
         Expr::NumericLiteral(_) => true,
@@ -36,6 +44,23 @@ fn is_numeric_for_fx_gap(ty: &Type) -> bool {
 
 fn is_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> bool {
     is_numeric_literal_like_expr(expr_id, arena)
+}
+
+fn has_explicit_iterable_impl(
+    ty: &Type,
+    arena: &AstArena,
+    impl_list: &[ImplDecl],
+) -> Result<bool, FrontendError> {
+    let nominal = match ty {
+        Type::Record(name) | Type::Adt(name) => *name,
+        _ => return Ok(false),
+    };
+    for imp in impl_list {
+        if imp.for_type == nominal && resolve_symbol_name(arena, imp.trait_name)? == "Iterable" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn match_unit_lift(expected: &Type, actual: &Type, expr_id: ExprId, arena: &AstArena) -> bool {
@@ -1210,11 +1235,18 @@ fn check_stmt(
                 body_env.pop_scope();
                 return Ok(());
             }
+            let detail = match &iterable_ty {
+                Type::Sequence(_) => iterable_for_stdlib_gap_message().to_string(),
+                _ if has_explicit_iterable_impl(&iterable_ty, arena, impl_list)? => {
+                    iterable_for_impl_gap_message().to_string()
+                }
+                _ => iterable_for_gap_message().to_string(),
+            };
             Err(FrontendError {
                 pos: 0,
                 message: format!(
                     "{} (`{}` contract)",
-                    iterable_for_gap_message(),
+                    detail,
                     resolve_symbol_name(arena, desugaring.trait_name)?
                 ),
             })
@@ -3761,7 +3793,7 @@ mod tests {
 
         let err =
             typecheck_source(src).expect_err("general iterable loop must stay owner-layer only");
-        assert!(err.message.contains("iterable 'for x in collection' loops are owner-layer only"));
+        assert!(err.message.contains("stdlib Iterable implementations are deferred"));
         assert!(err.message.contains("Iterable"));
     }
 
@@ -3833,6 +3865,65 @@ mod tests {
         assert!(err
             .message
             .contains("loop expression body currently does not allow iterable for-each"));
+    }
+
+    #[test]
+    fn explicit_iterable_impl_surface_typechecks_without_loop_execution() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Numbers) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Numbers) -> Option(i32) {
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("Iterable trait/impl surface should typecheck");
+    }
+
+    #[test]
+    fn iterable_for_with_explicit_nominal_impl_reports_source_gap() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Numbers) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Numbers) -> Option(i32) {
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                let numbers: Numbers = Numbers { current: 0 };
+                for value in numbers {
+                    let _ = value;
+                }
+                return;
+            }
+        "#;
+
+        let err =
+            typecheck_source(src).expect_err("iterable loop execution must still reject here");
+        assert!(err
+            .message
+            .contains("explicit `Iterable` impls is deferred to M9.3 Wave 3"));
+        assert!(err.message.contains("Iterable"));
     }
 
     #[test]

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -149,6 +149,8 @@ Current message families include:
   `M8.4` first-wave surface
 - closure equality is not part of the current `M8.4` first-wave surface
 - for-range requires `i32` range expression
+- source-admitted iterable `for x in collection` loop whose executable
+  `Iterable` contract wave has not landed yet
 - duplicate record declaration
 - duplicate schema declaration
 - top-level record/function name collision
@@ -213,8 +215,8 @@ Current message families include:
 - tuple destructuring assignment to const target
 - malformed or empty `where` binding lists
 - `break expr;` outside `loop` expression context
-- loop-expression bodies that currently use unsupported `for-range`, `guard`,
-  or `return`
+- loop-expression bodies that currently use unsupported `for-range`,
+  iterable `for-each`, `guard`, or `return`
 - UFCS method-call sugar written without explicit `(...)`
 - return type mismatch
 - invalid `guard` condition type

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -335,6 +335,10 @@ Current `for ... in range` semantics:
 Current v0 limit:
 
 - `for ... in range` currently accepts only `RangeI32` values
+- general `for x in collection` source syntax is now admitted on current `main`
+  as an owner-layer desugaring toward the named `Iterable` contract
+- non-range iterable loops still reject during source checking until the stdlib
+  `Iterable` contract and loop typing wave lands
 - descending ranges, custom step values, `continue`, and a general iterable
   subsystem are not yet part of the stable contract
 - `for ... in range` does not widen the public operator surface to general

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -209,6 +209,7 @@ Current statement forms:
 - `(a, b) = expr;`
 - `for name in 0..10 { ... }`
 - `for name in 0..=10 { ... }`
+- `for name in collection { ... }`
 - `guard condition else return;`
 - `guard condition else return expr;`
 - `assert(condition);`
@@ -395,6 +396,10 @@ Current v0 range-literal limits:
 - range equality is not yet part of the stable source contract
 - range literals are not yet part of the stable tuple/user-data surface
 - `for ... in range` currently exposes only the narrow `i32` interval surface
+- `for name in collection { ... }` is source-admitted on current `main` as the
+  `Iterable` owner-layer loop surface
+- non-range iterable loops still reject before execution until the stdlib
+  `Iterable` contract and loop typing wave lands
 - descending/custom-step/general iterable range forms are not yet part of the
   stable syntax contract
 


### PR DESCRIPTION
## Summary
- admit the named Iterable trait/impl source surface on current main with explicit parser and typecheck coverage
- differentiate iterable loop diagnostics between owner-layer-only loops, future stdlib Iterable loops, and explicit nominal Iterable impls
- sync syntax, source semantics, and diagnostics docs with the current non-executable iterable source slice

## Testing
- cargo test -q -p sm-front
- cargo test -q --test public_api_contracts
- cargo test -q