### PR TITLE
traits/ir: lower impl methods into executable contract

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -155,6 +155,18 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
     for f in &p.functions {
         type_check_function_with_tables(f, &p.arena, &table, &record_table, &adt_table, &p.impls)?;
     }
+    for imp in &p.impls {
+        for method in &imp.methods {
+            type_check_function_with_tables(
+                method,
+                &p.arena,
+                &table,
+                &record_table,
+                &adt_table,
+                &p.impls,
+            )?;
+        }
+    }
     Ok(())
 }
 
@@ -5326,6 +5338,65 @@ mod tests {
     }
 
     #[test]
+    fn impl_method_wrong_parameter_type_is_rejected() {
+        let src = r#"
+            trait Counter {
+                fn count(self: Cnt) -> i32;
+            }
+
+            record Cnt { n: i32 }
+
+            impl Counter for Cnt {
+                fn count(self: i32) -> i32 {
+                    return 0;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("impl method with wrong parameter type must be rejected");
+        assert!(
+            err.message.contains("parameter type") || err.message.contains("expected"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn impl_method_body_is_typechecked_even_without_dispatch() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Numbers) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Numbers) -> Option(i32) {
+                    return 1;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("impl method body must be typechecked before dispatch lands");
+        assert!(
+            err.message.contains("return") || err.message.contains("Option"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn generic_fn_with_bound_and_satisfying_impl_typechecks() {
         let src = r#"
             trait Zeroable {
@@ -6806,6 +6877,20 @@ fn validate_impl_conformance(
     arena: &AstArena,
 ) -> Result<(), FrontendError> {
     for imp in impls {
+        let mut seen_methods = BTreeSet::new();
+        for method in &imp.methods {
+            if !seen_methods.insert(method.name) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: format!(
+                        "impl of '{}' for '{}' defines duplicate method '{}'",
+                        resolve_symbol_name(arena, imp.trait_name)?,
+                        resolve_symbol_name(arena, imp.for_type)?,
+                        resolve_symbol_name(arena, method.name)?,
+                    ),
+                });
+            }
+        }
         let trait_decl = match trait_table.get(&imp.trait_name) {
             Some(t) => t,
             None => {
@@ -6832,6 +6917,34 @@ fn validate_impl_conformance(
                     });
                 }
                 Some(m) => {
+                    if m.params.len() != trait_method.params.len() {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "impl method '{}' has {} parameter(s), expected {} from trait '{}'",
+                                resolve_symbol_name(arena, trait_method.name)?,
+                                m.params.len(),
+                                trait_method.params.len(),
+                                resolve_symbol_name(arena, imp.trait_name)?,
+                            ),
+                        });
+                    }
+                    for ((_, actual_ty), (_, expected_ty)) in
+                        m.params.iter().zip(trait_method.params.iter())
+                    {
+                        if actual_ty != expected_ty {
+                            return Err(FrontendError {
+                                pos: 0,
+                                message: format!(
+                                    "impl method '{}' parameter type {:?} does not match expected {:?} from trait '{}'",
+                                    resolve_symbol_name(arena, trait_method.name)?,
+                                    actual_ty,
+                                    expected_ty,
+                                    resolve_symbol_name(arena, imp.trait_name)?,
+                                ),
+                            });
+                        }
+                    }
                     if m.ret != trait_method.ret {
                         return Err(FrontendError {
                             pos: 0,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -637,6 +637,19 @@ fn lower_function_to_ir_with_tables(
     })
 }
 
+fn impl_method_function_name(
+    arena: &AstArena,
+    imp: &sm_front::ImplDecl,
+    method: &Function,
+) -> Result<String, FrontendError> {
+    Ok(format!(
+        "__impl::{}::{}::{}",
+        resolve_symbol_name(arena, imp.trait_name)?,
+        resolve_symbol_name(arena, imp.for_type)?,
+        resolve_symbol_name(arena, method.name)?,
+    ))
+}
+
 pub fn lower_function_to_ir(
     func: &Function,
     arena: &AstArena,
@@ -748,7 +761,7 @@ pub fn compile_program_to_ir_with_options_and_profile(
             message: "RustLike lowering is disabled at compile time".to_string(),
         });
     }
-    let program = parse_program_with_profile(input, parser_profile)?;
+    let mut program = parse_program_with_profile(input, parser_profile)?;
     let fn_table = build_fn_table(&program)?;
     let record_table = build_record_table(&program)?;
     let adt_table = build_adt_table(&program)?;
@@ -764,6 +777,23 @@ pub fn compile_program_to_ir_with_options_and_profile(
         )?;
         out.push(lowered.primary);
         out.extend(lowered.lifted);
+    }
+    let impls = program.impls.clone();
+    for imp in &impls {
+        for method in &imp.methods {
+            let mut lowered_method = method.clone();
+            let lowered_name = impl_method_function_name(&program.arena, imp, method)?;
+            lowered_method.name = program.arena.intern_symbol(&lowered_name);
+            let lowered = lower_function_to_ir_with_tables(
+                &lowered_method,
+                &program.arena,
+                &fn_table,
+                &record_table,
+                &adt_table,
+            )?;
+            out.push(lowered.primary);
+            out.extend(lowered.lifted);
+        }
     }
     if matches!(opt, OptLevel::O1) {
         let _ = crate::passes::run_default_opt_passes(&mut out);
@@ -8469,6 +8499,34 @@ mod opt_tests {
             .expect_err("explicit Iterable impl execution must stay deferred");
         assert!(err.message.contains("explicit `Iterable` impls is still deferred"));
         assert!(err.message.contains("Iterable"));
+    }
+
+    #[test]
+    fn compile_program_lowers_impl_methods_to_internal_functions() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Numbers) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Numbers) -> Option(i32) {
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("impl methods should now lower to IR");
+        assert!(ir
+            .iter()
+            .any(|func| func.name == "__impl::Iterable::Numbers::next"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- typecheck impl method bodies as part of program checking
- tighten impl conformance for duplicate names and parameter shape
- lower impl methods into IR under deterministic internal function names without enabling iterable dispatch yet

## Testing
- cargo test -q -p sm-front
- cargo test -q -p sm-ir
- cargo test -q --test public_api_contracts
- cargo test -q