### PR TITLE
traits: admit impl-anchored Self method contract

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -35,6 +35,7 @@ pub fn parse_rustlike_with_profile(
         arena: AstArena::default(),
         policy: CompilePolicyView::new(profile),
         type_param_scope: Vec::new(),
+        self_type_scope: None,
     };
     p.parse_program()
 }
@@ -51,6 +52,7 @@ pub fn parse_logos_with_profile(
         arena: AstArena::default(),
         policy: CompilePolicyView::new(profile),
         type_param_scope: Vec::new(),
+        self_type_scope: None,
     };
     p.parse_logos_program()
 }
@@ -67,9 +69,23 @@ struct Parser<'a> {
     /// function/record/adt declaration finishes parsing. Drives `parse_type`
     /// to emit `Type::TypeVar` rather than `Type::Record` for matching names.
     type_param_scope: Vec<SymbolId>,
+    /// Narrow owner-layer `Self` marker available only while parsing trait
+    /// method signatures or impl methods.
+    self_type_scope: Option<Type>,
 }
 
 impl<'a> Parser<'a> {
+    fn with_self_type_scope<T, F>(&mut self, self_ty: Type, f: F) -> Result<T, FrontendError>
+    where
+        F: FnOnce(&mut Self) -> Result<T, FrontendError>,
+    {
+        let previous = self.self_type_scope.clone();
+        self.self_type_scope = Some(self_ty);
+        let result = f(self);
+        self.self_type_scope = previous;
+        result
+    }
+
     fn parse_program(&mut self) -> Result<Program, FrontendError> {
         let mut adts = Vec::new();
         let mut records = Vec::new();
@@ -273,19 +289,23 @@ impl<'a> Parser<'a> {
         let name = self.expect_symbol()?;
         let type_params = self.parse_type_params()?;
         self.expect(TokenKind::LBrace, "expected '{' after trait name")?;
-        let mut methods = Vec::new();
-        loop {
-            let i = self.next_non_layout_idx();
-            if i >= self.tokens.len() {
-                break;
+        let self_placeholder = Type::TypeVar(self.arena.intern_symbol("Self"));
+        let methods = self.with_self_type_scope(self_placeholder, |parser| {
+            let mut methods = Vec::new();
+            loop {
+                let i = parser.next_non_layout_idx();
+                if i >= parser.tokens.len() {
+                    break;
+                }
+                if parser.tokens[i].kind == TokenKind::RBrace {
+                    parser.idx = i;
+                    break;
+                }
+                parser.idx = i;
+                methods.push(parser.parse_trait_method_sig()?);
             }
-            if self.tokens[i].kind == TokenKind::RBrace {
-                self.idx = i;
-                break;
-            }
-            self.idx = i;
-            methods.push(self.parse_trait_method_sig()?);
-        }
+            Ok(methods)
+        })?;
         self.expect(TokenKind::RBrace, "expected '}' to close trait body")?;
         self.pop_type_param_scope(type_params.len());
         Ok(TraitDecl { name, type_params, methods })
@@ -328,19 +348,22 @@ impl<'a> Parser<'a> {
         self.expect(TokenKind::KwFor, "expected 'for' after trait name in impl")?;
         let for_type = self.expect_symbol()?;
         self.expect(TokenKind::LBrace, "expected '{' after impl target type")?;
-        let mut methods = Vec::new();
-        loop {
-            let i = self.next_non_layout_idx();
-            if i >= self.tokens.len() {
-                break;
+        let methods = self.with_self_type_scope(Type::Record(for_type), |parser| {
+            let mut methods = Vec::new();
+            loop {
+                let i = parser.next_non_layout_idx();
+                if i >= parser.tokens.len() {
+                    break;
+                }
+                if parser.tokens[i].kind == TokenKind::RBrace {
+                    parser.idx = i;
+                    break;
+                }
+                parser.idx = i;
+                methods.push(parser.parse_function()?);
             }
-            if self.tokens[i].kind == TokenKind::RBrace {
-                self.idx = i;
-                break;
-            }
-            self.idx = i;
-            methods.push(self.parse_function()?);
-        }
+            Ok(methods)
+        })?;
         self.expect(TokenKind::RBrace, "expected '}' to close impl body")?;
         self.pop_type_param_scope(type_params.len());
         Ok(ImplDecl { trait_name, for_type, type_params, methods })
@@ -2475,7 +2498,14 @@ impl<'a> Parser<'a> {
             self.parse_paren_type_or_tuple()?
         } else if self.check(TokenKind::Ident) {
             let t = self.tokens[self.next_non_layout_idx()].text.clone();
-            if t == "qvec" {
+            if t == "Self" {
+                let _ = self.advance();
+                if let Some(self_ty) = &self.self_type_scope {
+                    self_ty.clone()
+                } else {
+                    Type::Record(self.arena.intern_symbol("Self"))
+                }
+            } else if t == "qvec" {
                 let _ = self.advance();
                 if self.eat(TokenKind::LBracket) || self.eat(TokenKind::LParen) {
                     let n = if self.check(TokenKind::Num) {
@@ -6002,6 +6032,52 @@ fn main() {
         assert_eq!(program.impls.len(), 1);
         assert_eq!(program.arena.symbol_name(program.traits[0].name), "Iterable");
         assert_eq!(program.arena.symbol_name(program.impls[0].trait_name), "Iterable");
+    }
+
+    #[test]
+    fn trait_method_self_type_parses_as_owner_layer_marker() {
+        let src = r#"
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("trait method Self type should parse");
+        let self_symbol = program
+            .arena
+            .symbol_to_id
+            .get("Self")
+            .copied()
+            .expect("Self symbol must be interned");
+        let method = &program.traits[0].methods[0];
+        assert_eq!(method.params[0].1, Type::TypeVar(self_symbol));
+        assert_eq!(method.params[1].1, Type::I32);
+    }
+
+    #[test]
+    fn impl_method_self_type_is_anchored_to_impl_target() {
+        let src = r#"
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Numbers {
+    current: i32,
+}
+
+impl Iterable for Numbers {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        let _ = index;
+        return Option::None;
+    }
+}
+"#;
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("impl method Self type should parse");
+        let numbers = program.impls[0].for_type;
+        let method = &program.impls[0].methods[0];
+        assert_eq!(method.params[0].1, Type::Record(numbers));
+        assert_eq!(method.params[1].1, Type::I32);
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -5366,6 +5366,93 @@ mod tests {
     }
 
     #[test]
+    fn trait_self_contract_allows_multiple_impl_targets() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Self, index: i32) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            record Others {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = self.current;
+                    let _ = index;
+                    return Option::None;
+                }
+            }
+
+            impl Iterable for Others {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = self.current;
+                    let _ = index;
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("trait-side Self should anchor independently per impl target");
+    }
+
+    #[test]
+    fn trait_self_contract_still_rejects_wrong_concrete_impl_parameter() {
+        let src = r#"
+            trait Counter {
+                fn count(self: Self) -> i32;
+            }
+
+            record Cnt { n: i32 }
+
+            impl Counter for Cnt {
+                fn count(self: i32) -> i32 {
+                    return 0;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("trait-side Self must still anchor to the impl target");
+        assert!(
+            err.message.contains("parameter type") || err.message.contains("expected"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn self_type_outside_trait_or_impl_positions_is_not_admitted() {
+        let src = r#"
+            fn id(value: Self) -> Self {
+                return value;
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("Self outside trait/impl method type positions must stay unsupported");
+        assert!(
+            err.message.contains("unknown nominal type 'Self'"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn impl_method_body_is_typechecked_even_without_dispatch() {
         let src = r#"
             trait Iterable {
@@ -6876,6 +6963,7 @@ fn validate_impl_conformance(
     trait_table: &TraitTable,
     arena: &AstArena,
 ) -> Result<(), FrontendError> {
+    let self_type_var = arena.symbol_to_id.get("Self").copied();
     for imp in impls {
         let mut seen_methods = BTreeSet::new();
         for method in &imp.methods {
@@ -6932,7 +7020,9 @@ fn validate_impl_conformance(
                     for ((_, actual_ty), (_, expected_ty)) in
                         m.params.iter().zip(trait_method.params.iter())
                     {
-                        if actual_ty != expected_ty {
+                        let expected_ty =
+                            substitute_trait_self_type(expected_ty, self_type_var, imp.for_type);
+                        if actual_ty != &expected_ty {
                             return Err(FrontendError {
                                 pos: 0,
                                 message: format!(
@@ -6945,14 +7035,16 @@ fn validate_impl_conformance(
                             });
                         }
                     }
-                    if m.ret != trait_method.ret {
+                    let expected_ret =
+                        substitute_trait_self_type(&trait_method.ret, self_type_var, imp.for_type);
+                    if m.ret != expected_ret {
                         return Err(FrontendError {
                             pos: 0,
                             message: format!(
                                 "impl method '{}' has return type {:?}, expected {:?} from trait '{}'",
                                 resolve_symbol_name(arena, trait_method.name)?,
                                 m.ret,
-                                trait_method.ret,
+                                expected_ret,
                                 resolve_symbol_name(arena, imp.trait_name)?,
                             ),
                         });
@@ -6962,6 +7054,70 @@ fn validate_impl_conformance(
         }
     }
     Ok(())
+}
+
+fn substitute_trait_self_type(
+    ty: &Type,
+    self_type_var: Option<SymbolId>,
+    concrete_self: SymbolId,
+) -> Type {
+    match ty {
+        Type::TypeVar(name) if Some(*name) == self_type_var => Type::Record(concrete_self),
+        Type::Tuple(items) => Type::Tuple(
+            items
+                .iter()
+                .map(|item| substitute_trait_self_type(item, self_type_var, concrete_self))
+                .collect(),
+        ),
+        Type::Sequence(sequence) => Type::Sequence(SequenceType {
+            family: sequence.family,
+            item: Box::new(substitute_trait_self_type(
+                sequence.item.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+        }),
+        Type::Closure(closure) => Type::Closure(crate::types::ClosureType {
+            family: closure.family,
+            capture: closure.capture,
+            param: Box::new(substitute_trait_self_type(
+                closure.param.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+            ret: Box::new(substitute_trait_self_type(
+                closure.ret.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+        }),
+        Type::Measured(base, unit) => Type::Measured(
+            Box::new(substitute_trait_self_type(
+                base.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+            *unit,
+        ),
+        Type::Option(item) => Type::Option(Box::new(substitute_trait_self_type(
+            item.as_ref(),
+            self_type_var,
+            concrete_self,
+        ))),
+        Type::Result(ok_ty, err_ty) => Type::Result(
+            Box::new(substitute_trait_self_type(
+                ok_ty.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+            Box::new(substitute_trait_self_type(
+                err_ty.as_ref(),
+                self_type_var,
+                concrete_self,
+            )),
+        ),
+        _ => ty.clone(),
+    }
 }
 
 fn validate_top_level_name_collisions(

--- a/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
+++ b/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
@@ -122,7 +122,7 @@ that iterable abstraction is admitted yet on current `main`.
   dispatch before code changes
 - require one deterministic trait method shape for the first executable
   user-defined slice:
-  `fn next(self: Collection, index: i32) -> Option(Item)`
+  `fn next(self: Self, index: i32) -> Option(Item)`
 - treat `index` as the zero-based loop-driver cursor supplied by the lowered
   `for x in collection` execution path
 - continue the loop on `Option::Some(item)` and terminate on `Option::None`
@@ -135,6 +135,8 @@ that iterable abstraction is admitted yet on current `main`.
 
 - impl method bodies typecheck on current `main`
 - impl methods lower into executable internal functions on current `main`
+- trait-side `Self` now survives parser/typecheck as the narrow impl-anchored
+  receiver contract on current `main`
 - this prerequisite is now complete and removes the earlier dead owner-layer
   gap for trait/impl method bodies
 - this does not by itself claim user-visible iterable loop execution over
@@ -179,7 +181,7 @@ Approved direction for the next step:
   host-managed mutable iteration state
 - the loop driver owns the cursor and passes it explicitly as `index: i32`
 - the executable trait hook is:
-  `fn next(self: Collection, index: i32) -> Option(Item)`
+  `fn next(self: Self, index: i32) -> Option(Item)`
 - `Option::Some(item)` yields one loop item and increments the cursor
 - `Option::None` terminates the loop
 - the built-in `Sequence(T)` / range path remains the already-landed separate

--- a/docs/roadmap/language_maturity/traits_full_scope.md
+++ b/docs/roadmap/language_maturity/traits_full_scope.md
@@ -42,6 +42,8 @@ a claim that trait-based polymorphism was part of the published `v1.1.1` line.
 ### Wave 3 — Typecheck
 - `validate_trait_coherence`: rejects duplicate `(trait, for_type)` impl pairs
 - `validate_impl_conformance`: rejects impls missing required methods or with wrong return types
+- trait-side `Self` in method signatures now anchors to the concrete impl target
+  during conformance checking
 - Bound satisfaction check at generic call sites: after type-var substitution,
   verifies `impl TraitName for ConcreteType` exists in the program's impl list
 - All checks run centrally in `type_check_program`
@@ -63,6 +65,7 @@ a claim that trait-based polymorphism was part of the published `v1.1.1` line.
 - coherence: duplicate `(trait, for_type)` pair is rejected
 - conformance: impl missing a required method is rejected
 - conformance: impl method with wrong return type is rejected
+- conformance: trait-side `Self` may be reused across multiple impl targets
 - bound satisfaction: generic call with satisfying impl typechecks
 - bound satisfaction: generic call with no impl is rejected
 

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -341,6 +341,10 @@ Current v0 limit:
   iterable loop path on `main`
 - explicit user-defined `Iterable` impl dispatch is still deferred beyond the
   current built-in Sequence/range slice
+- trait-side `Self` now denotes the impl-anchored receiver contract only inside
+  trait method signatures and impl method type positions
+- `Self` does not widen the general executable type surface beyond that narrow
+  trait/impl contract
 - descending ranges, custom step values, `continue`, and a general iterable
   subsystem are not yet part of the stable contract
 - `for ... in range` does not widen the public operator surface to general

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -402,6 +402,10 @@ Current v0 range-literal limits:
   first-wave iterable loop path on `main`
 - explicit user-defined `Iterable` impl dispatch is still not executable in the
   current slice
+- `Self` is admitted only in trait method signatures and impl method type
+  positions on current `main`
+- `Self` outside trait/impl method type positions is not part of the stable
+  syntax contract
 - descending/custom-step/general iterable range forms are not yet part of the
   stable syntax contract
 


### PR DESCRIPTION
## Summary
- admit narrow trait-side Self only in trait method signatures and impl method type positions
- anchor trait-side Self to the concrete impl for target during conformance checking
- freeze the iterable dispatch contract on self: Self rather than a nominal placeholder type

## Testing
- cargo test -q -p sm-front
- cargo test -q --test public_api_contracts
- cargo test -q