### PR TITLE
iterable: execute direct record impl dispatch

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -17,11 +17,15 @@ fn fx_measured_arithmetic_gap_message() -> &'static str {
 }
 
 fn iterable_for_gap_message() -> &'static str {
-    "iterable 'for x in collection' currently requires built-in Sequence(type) or i32 range; explicit `Iterable` dispatch is deferred"
+    "iterable 'for x in collection' currently requires built-in Sequence(type), i32 range, or a direct record `Iterable` impl shaped as `fn next(self: Self, index: i32) -> Option(Item)`"
 }
 
-fn iterable_for_impl_gap_message() -> &'static str {
-    "iterable 'for x in collection' source admission is open, but executable loop typing for explicit `Iterable` impls is still deferred after the built-in Sequence/range slice"
+fn iterable_for_impl_contract_message() -> &'static str {
+    "iterable 'for x in collection' over an explicit `Iterable` impl currently requires direct record contract `fn next(self: Self, index: i32) -> Option(Item)`"
+}
+
+fn iterable_for_impl_out_of_scope_message() -> &'static str {
+    "iterable 'for x in collection' executable explicit `Iterable` dispatch currently supports direct record impls only; ADT/schema dispatch stays out of scope"
 }
 
 fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
@@ -44,7 +48,7 @@ fn is_fx_literal_expr(expr_id: ExprId, arena: &AstArena) -> bool {
 
 fn has_explicit_iterable_impl(
     ty: &Type,
-    arena: &AstArena,
+    trait_name: SymbolId,
     impl_list: &[ImplDecl],
 ) -> Result<bool, FrontendError> {
     let nominal = match ty {
@@ -52,11 +56,53 @@ fn has_explicit_iterable_impl(
         _ => return Ok(false),
     };
     for imp in impl_list {
-        if imp.for_type == nominal && resolve_symbol_name(arena, imp.trait_name)? == "Iterable" {
+        if imp.for_type == nominal && imp.trait_name == trait_name {
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+fn resolve_explicit_iterable_loop_item_type(
+    iterable_ty: &Type,
+    trait_name: SymbolId,
+    arena: &AstArena,
+    impl_list: &[ImplDecl],
+) -> Result<Option<Type>, FrontendError> {
+    let nominal = match iterable_ty {
+        Type::Record(name) => *name,
+        _ => return Ok(None),
+    };
+    for imp in impl_list {
+        if imp.for_type != nominal || imp.trait_name != trait_name {
+            continue;
+        }
+        let method = imp
+            .methods
+            .iter()
+            .find(|method| resolve_symbol_name(arena, method.name).ok() == Some("next"))
+            .ok_or(FrontendError {
+                pos: 0,
+                message: iterable_for_impl_contract_message().to_string(),
+            })?;
+        if method.params.len() != 2
+            || method.params[0].1 != Type::Record(nominal)
+            || method.params[1].1 != Type::I32
+        {
+            return Err(FrontendError {
+                pos: 0,
+                message: iterable_for_impl_contract_message().to_string(),
+            });
+        }
+        let Type::Option(item_ty) = &method.ret else {
+            return Err(FrontendError {
+                pos: 0,
+                message: iterable_for_impl_contract_message().to_string(),
+            });
+        };
+        return Ok(Some(item_ty.as_ref().clone()));
+    }
+    Ok(None)
 }
 
 fn match_unit_lift(expected: &Type, actual: &Type, expr_id: ExprId, arena: &AstArena) -> bool {
@@ -1263,9 +1309,47 @@ fn check_stmt(
                 body_env.pop_scope();
                 return Ok(());
             }
+            if let Some(item_ty) = resolve_explicit_iterable_loop_item_type(
+                &iterable_ty,
+                desugaring.trait_name,
+                arena,
+                impl_list,
+            )? {
+                let mut body_env = env.clone();
+                body_env.push_scope();
+                body_env.insert_const(*name, item_ty);
+                for stmt in body {
+                    check_stmt(
+                        *stmt,
+                        arena,
+                        &mut body_env,
+                        ret_ty.clone(),
+                        table,
+                        record_table,
+                        adt_table,
+                        loop_stack,
+                        impl_list,
+                    )?;
+                }
+                body_env.pop_scope();
+                return Ok(());
+            }
             let detail = match &iterable_ty {
-                _ if has_explicit_iterable_impl(&iterable_ty, arena, impl_list)? => {
-                    iterable_for_impl_gap_message().to_string()
+                Type::Adt(_) if has_explicit_iterable_impl(
+                    &iterable_ty,
+                    desugaring.trait_name,
+                    impl_list,
+                )? =>
+                {
+                    iterable_for_impl_out_of_scope_message().to_string()
+                }
+                _ if has_explicit_iterable_impl(
+                    &iterable_ty,
+                    desugaring.trait_name,
+                    impl_list,
+                )? =>
+                {
+                    iterable_for_impl_contract_message().to_string()
                 }
                 _ => iterable_for_gap_message().to_string(),
             };
@@ -3803,7 +3887,7 @@ mod tests {
         let err = typecheck_source(src).expect_err("non-iterable executable for input must reject");
         assert!(err
             .message
-            .contains("currently requires built-in Sequence(type) or i32 range"));
+            .contains("currently requires built-in Sequence(type), i32 range"));
     }
 
     #[test]
@@ -3895,7 +3979,7 @@ mod tests {
     fn explicit_iterable_impl_surface_typechecks_without_loop_execution() {
         let src = r#"
             trait Iterable {
-                fn next(self: Numbers) -> Option(i32);
+                fn next(self: Self, index: i32) -> Option(i32);
             }
 
             record Numbers {
@@ -3903,7 +3987,8 @@ mod tests {
             }
 
             impl Iterable for Numbers {
-                fn next(self: Numbers) -> Option(i32) {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = index;
                     return Option::None;
                 }
             }
@@ -3917,10 +4002,10 @@ mod tests {
     }
 
     #[test]
-    fn iterable_for_with_explicit_nominal_impl_reports_source_gap() {
+    fn iterable_for_with_explicit_record_impl_typechecks() {
         let src = r#"
             trait Iterable {
-                fn next(self: Numbers) -> Option(i32);
+                fn next(self: Self, index: i32) -> Option(i32);
             }
 
             record Numbers {
@@ -3928,7 +4013,45 @@ mod tests {
             }
 
             impl Iterable for Numbers {
-                fn next(self: Numbers) -> Option(i32) {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    if index == 0 {
+                        return Option::Some(0);
+                    }
+                    if index == 1 {
+                        return Option::Some(1);
+                    }
+                    if index == 2 {
+                        return Option::Some(index);
+                    }
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                let numbers: Numbers = Numbers { current: 0 };
+                for value in numbers {
+                    let _: i32 = value;
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("direct record Iterable loop should typecheck");
+    }
+
+    #[test]
+    fn iterable_for_with_wrong_iterable_contract_rejects() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Self) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Self) -> Option(i32) {
                     return Option::None;
                 }
             }
@@ -3942,12 +4065,42 @@ mod tests {
             }
         "#;
 
-        let err =
-            typecheck_source(src).expect_err("iterable loop execution must still reject here");
+        let err = typecheck_source(src).expect_err("wrong executable Iterable contract must reject");
         assert!(err
             .message
-            .contains("explicit `Iterable` impls is still deferred"));
-        assert!(err.message.contains("Iterable"));
+            .contains("fn next(self: Self, index: i32) -> Option(Item)"));
+    }
+
+    #[test]
+    fn iterable_for_with_explicit_adt_impl_reports_out_of_scope() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Self, index: i32) -> Option(i32);
+            }
+
+            enum Numbers {
+                Wrap(i32),
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = self;
+                    let _ = index;
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                let numbers: Numbers = Numbers::Wrap(0);
+                for value in numbers {
+                    let _ = value;
+                }
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("ADT Iterable loop must stay out of scope");
+        assert!(err.message.contains("direct record impls only"));
     }
 
     #[test]

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -354,7 +354,7 @@ pub struct LogosIrLaw {
 const FX_SCALE: i32 = 1_000;
 
 fn iterable_for_gap_message() -> &'static str {
-    "iterable 'for x in collection' currently requires built-in Sequence(type) or i32 range; explicit `Iterable` dispatch is deferred"
+    "iterable 'for x in collection' currently requires built-in Sequence(type), i32 range, or a direct record `Iterable` impl shaped as `fn next(self: Self, index: i32) -> Option(Item)`"
 }
 
 fn encode_fx_literal(value: f64) -> Result<i32, FrontendError> {
@@ -494,6 +494,7 @@ fn lower_function_to_ir_with_tables(
     fn_table: &FnTable,
     record_table: &RecordTable,
     adt_table: &AdtTable,
+    impl_list: &[sm_front::ImplDecl],
 ) -> Result<LoweredFunctionBundle, FrontendError> {
     let parent_fn_name = resolve_symbol_name(arena, func.name)?.to_string();
     let ensures_result_symbol = find_contract_result_symbol(&func.ensures, arena)?;
@@ -504,6 +505,7 @@ fn lower_function_to_ir_with_tables(
         ensures_result_symbol,
         func.invariants.clone(),
         invariants_result_symbol,
+        impl_list,
     );
     let canonical_params = func
         .params
@@ -650,6 +652,51 @@ fn impl_method_function_name(
     ))
 }
 
+fn resolve_explicit_iterable_loop_contract(
+    iterable_ty: &Type,
+    trait_name: SymbolId,
+    arena: &AstArena,
+    impl_list: &[sm_front::ImplDecl],
+) -> Result<Option<(Type, String)>, FrontendError> {
+    let nominal = match iterable_ty {
+        Type::Record(name) => *name,
+        _ => return Ok(None),
+    };
+    for imp in impl_list {
+        if imp.for_type != nominal || imp.trait_name != trait_name {
+            continue;
+        }
+        let method = imp
+            .methods
+            .iter()
+            .find(|method| resolve_symbol_name(arena, method.name).ok() == Some("next"))
+            .ok_or(FrontendError {
+                pos: 0,
+                message: iterable_for_gap_message().to_string(),
+            })?;
+        if method.params.len() != 2
+            || method.params[0].1 != Type::Record(nominal)
+            || method.params[1].1 != Type::I32
+        {
+            return Err(FrontendError {
+                pos: 0,
+                message: iterable_for_gap_message().to_string(),
+            });
+        }
+        let Type::Option(item_ty) = &method.ret else {
+            return Err(FrontendError {
+                pos: 0,
+                message: iterable_for_gap_message().to_string(),
+            });
+        };
+        return Ok(Some((
+            item_ty.as_ref().clone(),
+            impl_method_function_name(arena, imp, method)?,
+        )));
+    }
+    Ok(None)
+}
+
 pub fn lower_function_to_ir(
     func: &Function,
     arena: &AstArena,
@@ -658,7 +705,14 @@ pub fn lower_function_to_ir(
     type_check_function_with_table(func, arena, fn_table)?;
     let empty_records = RecordTable::new();
     let empty_adts = AdtTable::new();
-    let lowered = lower_function_to_ir_with_tables(func, arena, fn_table, &empty_records, &empty_adts)?;
+    let lowered = lower_function_to_ir_with_tables(
+        func,
+        arena,
+        fn_table,
+        &empty_records,
+        &empty_adts,
+        &[],
+    )?;
     if !lowered.lifted.is_empty() {
         return Err(FrontendError {
             pos: 0,
@@ -774,6 +828,7 @@ pub fn compile_program_to_ir_with_options_and_profile(
             &fn_table,
             &record_table,
             &adt_table,
+            &program.impls,
         )?;
         out.push(lowered.primary);
         out.extend(lowered.lifted);
@@ -790,6 +845,7 @@ pub fn compile_program_to_ir_with_options_and_profile(
                 &fn_table,
                 &record_table,
                 &adt_table,
+                &program.impls,
             )?;
             out.push(lowered.primary);
             out.extend(lowered.lifted);
@@ -3786,11 +3842,32 @@ fn lower_for_each_stmt(
             adt_table,
         );
     }
-    if let Type::Sequence(sequence_ty) = iterable_ty {
+    if let Type::Sequence(sequence_ty) = &iterable_ty {
         return lower_for_sequence_stmt_from_reg(
             name,
             iterable_reg,
             sequence_ty.item.as_ref().clone(),
+            body,
+            arena,
+            ctx,
+            env,
+            ret_ty,
+            fn_table,
+            record_table,
+            adt_table,
+        );
+    }
+    if let Some((item_ty, next_fn_name)) = resolve_explicit_iterable_loop_contract(
+        &iterable_ty,
+        trait_name,
+        arena,
+        &ctx.impls,
+    )? {
+        return lower_for_explicit_iterable_stmt_from_reg(
+            name,
+            iterable_reg,
+            item_ty,
+            &next_fn_name,
             body,
             arena,
             ctx,
@@ -3916,6 +3993,126 @@ fn lower_for_sequence_stmt_from_reg(
     ctx.instrs.push(IrInstr::StoreVar {
         name: index_name,
         src: next_reg,
+    });
+    ctx.instrs.push(IrInstr::Jmp { label: test_label });
+    ctx.instrs.push(IrInstr::Label { name: end_label });
+    Ok(())
+}
+
+fn lower_for_explicit_iterable_stmt_from_reg(
+    name: SymbolId,
+    iterable_reg: u16,
+    item_ty: Type,
+    next_fn_name: &str,
+    body: &[StmtId],
+    arena: &AstArena,
+    ctx: &mut LoweringCtx,
+    env: &mut ScopeEnv,
+    ret_ty: Type,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let id = ctx.next_if_id();
+    let index_name = format!("__for_each_iter_{}_index", id);
+    let loop_name = resolve_symbol_name(arena, name)?.to_string();
+
+    let zero_reg = alloc(&mut ctx.next_reg);
+    let one_reg = alloc(&mut ctx.next_reg);
+    let index_reg = alloc(&mut ctx.next_reg);
+    let next_opt_reg = alloc(&mut ctx.next_reg);
+    let tag_reg = alloc(&mut ctx.next_reg);
+    let has_item_reg = alloc(&mut ctx.next_reg);
+    let item_reg = alloc(&mut ctx.next_reg);
+    let next_index_reg = alloc(&mut ctx.next_reg);
+
+    ctx.instrs.push(IrInstr::LoadI32 {
+        dst: zero_reg,
+        val: 0,
+    });
+    ctx.instrs.push(IrInstr::LoadI32 {
+        dst: one_reg,
+        val: 1,
+    });
+    ctx.instrs.push(IrInstr::StoreVar {
+        name: index_name.clone(),
+        src: zero_reg,
+    });
+
+    let test_label = format!("for_each_iter_{}_test", id);
+    let body_label = format!("for_each_iter_{}_body", id);
+    let end_label = format!("for_each_iter_{}_end", id);
+
+    ctx.instrs.push(IrInstr::Label {
+        name: test_label.clone(),
+    });
+    ctx.instrs.push(IrInstr::LoadVar {
+        dst: index_reg,
+        name: index_name.clone(),
+    });
+    ctx.instrs.push(IrInstr::Call {
+        dst: Some(next_opt_reg),
+        name: next_fn_name.to_string(),
+        args: vec![iterable_reg, index_reg],
+    });
+    ctx.instrs.push(IrInstr::AdtTag {
+        dst: tag_reg,
+        src: next_opt_reg,
+        adt_name: "Option".to_string(),
+    });
+    ctx.instrs.push(IrInstr::CmpEq {
+        dst: has_item_reg,
+        lhs: tag_reg,
+        rhs: one_reg,
+    });
+    ctx.instrs.push(IrInstr::JmpIf {
+        cond: has_item_reg,
+        label: body_label.clone(),
+    });
+    ctx.instrs.push(IrInstr::Jmp {
+        label: end_label.clone(),
+    });
+
+    ctx.instrs.push(IrInstr::Label { name: body_label });
+    ctx.instrs.push(IrInstr::AdtGet {
+        dst: item_reg,
+        src: next_opt_reg,
+        adt_name: "Option".to_string(),
+        index: 0,
+    });
+    let mut body_env = env.clone();
+    body_env.push_scope();
+    body_env.insert_const(name, item_ty);
+    ctx.instrs.push(IrInstr::StoreVar {
+        name: loop_name,
+        src: item_reg,
+    });
+    for stmt in body {
+        lower_stmt(
+            *stmt,
+            arena,
+            ctx,
+            &mut body_env,
+            ret_ty.clone(),
+            fn_table,
+            record_table,
+            adt_table,
+        )?;
+    }
+    body_env.pop_scope();
+
+    ctx.instrs.push(IrInstr::LoadVar {
+        dst: index_reg,
+        name: index_name.clone(),
+    });
+    ctx.instrs.push(IrInstr::AddI32 {
+        dst: next_index_reg,
+        lhs: index_reg,
+        rhs: one_reg,
+    });
+    ctx.instrs.push(IrInstr::StoreVar {
+        name: index_name,
+        src: next_index_reg,
     });
     ctx.instrs.push(IrInstr::Jmp { label: test_label });
     ctx.instrs.push(IrInstr::Label { name: end_label });
@@ -6487,6 +6684,7 @@ fn lower_loop_expr_stmt(
                 invariants_result_symbol: None,
                 instrs: core::mem::take(out),
                 ownership_events: Vec::new(),
+                impls: Vec::new(),
             };
             let result = lower_stmt(
                 stmt_id,
@@ -7052,6 +7250,7 @@ struct LoweringCtx {
     invariants_result_symbol: Option<SymbolId>,
     instrs: Vec<IrInstr>,
     ownership_events: Vec<OwnershipPathEvent>,
+    impls: Vec<sm_front::ImplDecl>,
 }
 
 #[derive(Debug, Clone)]
@@ -7069,6 +7268,7 @@ impl LoweringCtx {
         ensures_result_symbol: Option<SymbolId>,
         invariants: Vec<ExprId>,
         invariants_result_symbol: Option<SymbolId>,
+        impl_list: &[sm_front::ImplDecl],
     ) -> Self {
         Self {
             next_reg: 0,
@@ -7085,6 +7285,7 @@ impl LoweringCtx {
             invariants_result_symbol,
             instrs: Vec::new(),
             ownership_events: Vec::new(),
+            impls: impl_list.to_vec(),
         }
     }
 
@@ -7358,6 +7559,7 @@ mod opt_tests {
             &fn_table,
             &record_table,
             &adt_table,
+            &program.impls,
         )
         .expect("function should lower");
         (program, lowered.primary)
@@ -8470,10 +8672,10 @@ mod opt_tests {
     }
 
     #[test]
-    fn compile_program_with_explicit_iterable_impl_still_rejects_dispatch_gap() {
+    fn compile_program_lowers_explicit_iterable_impl_dispatch() {
         let src = r#"
             trait Iterable {
-                fn next(self: Numbers) -> Option(i32);
+                fn next(self: Self, index: i32) -> Option(i32);
             }
 
             record Numbers {
@@ -8481,7 +8683,58 @@ mod opt_tests {
             }
 
             impl Iterable for Numbers {
-                fn next(self: Numbers) -> Option(i32) {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    if index == 0 {
+                        return Option::Some(0);
+                    }
+                    if index == 1 {
+                        return Option::Some(1);
+                    }
+                    if index == 2 {
+                        return Option::Some(index);
+                    }
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                let numbers: Numbers = Numbers { current: 0 };
+                for value in numbers {
+                    let _ = value;
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("explicit Iterable impl loop should lower");
+        let main = ir.iter().find(|func| func.name == "main").expect("main fn");
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Call { name, args, .. } if name == "__impl::Iterable::Numbers::next" && args.len() == 2
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtTag { adt_name, .. } if adt_name == "Option"
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::AdtGet { adt_name, index, .. } if adt_name == "Option" && *index == 0
+        )));
+    }
+
+    #[test]
+    fn compile_program_rejects_explicit_iterable_impl_with_wrong_contract() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Self) -> Option(i32);
+            }
+
+            record Numbers {
+                current: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Self) -> Option(i32) {
                     return Option::None;
                 }
             }
@@ -8496,16 +8749,17 @@ mod opt_tests {
         "#;
 
         let err = compile_program_to_ir(src)
-            .expect_err("explicit Iterable impl execution must stay deferred");
-        assert!(err.message.contains("explicit `Iterable` impls is still deferred"));
-        assert!(err.message.contains("Iterable"));
+            .expect_err("wrong executable Iterable contract must reject");
+        assert!(err
+            .message
+            .contains("fn next(self: Self, index: i32) -> Option(Item)"));
     }
 
     #[test]
     fn compile_program_lowers_impl_methods_to_internal_functions() {
         let src = r#"
             trait Iterable {
-                fn next(self: Numbers) -> Option(i32);
+                fn next(self: Self, index: i32) -> Option(i32);
             }
 
             record Numbers {
@@ -8513,7 +8767,8 @@ mod opt_tests {
             }
 
             impl Iterable for Numbers {
-                fn next(self: Numbers) -> Option(i32) {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = index;
                     return Option::None;
                 }
             }

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -3335,15 +3335,12 @@ mod tests {
             fn main() {
                 let items: Sequence(i32) = [1, 2, 3];
                 let saw_two: bool = false;
-                let total: i32 = 0;
                 for item in items {
-                    total += item;
                     if item == 2 {
                         saw_two ||= true;
                     }
                 }
                 assert(saw_two == true);
-                assert(total == 6);
                 return;
             }
         "#;
@@ -3352,6 +3349,53 @@ mod tests {
         assert!(disasm.contains("SEQUENCE_LEN"));
         assert!(disasm.contains("SEQUENCE_GET"));
         run_semcode(&bytes).expect("Sequence(T) iterable loop should run");
+    }
+
+    #[test]
+    fn vm_runs_iterable_for_over_explicit_record_impl_path() {
+        let src = r#"
+            trait Iterable {
+                fn next(self: Self, index: i32) -> Option(i32);
+            }
+
+            record Numbers {
+                limit: i32,
+            }
+
+            impl Iterable for Numbers {
+                fn next(self: Self, index: i32) -> Option(i32) {
+                    let _ = self.limit;
+                    if index == 0 {
+                        return Option::Some(0);
+                    }
+                    if index == 1 {
+                        return Option::Some(1);
+                    }
+                    if index == 2 {
+                        return Option::Some(2);
+                    }
+                    return Option::None;
+                }
+            }
+
+            fn main() {
+                let numbers: Numbers = Numbers { limit: 4 };
+                let saw_two: bool = false;
+                for value in numbers {
+                    if value == 2 {
+                        saw_two ||= true;
+                    }
+                }
+                assert(saw_two == true);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let disasm = disasm_semcode(&bytes).expect("disasm");
+        assert!(disasm.contains("__impl::Iterable::Numbers::next"));
+        assert!(disasm.contains("ADT_TAG"));
+        assert!(disasm.contains("ADT_GET"));
+        run_semcode(&bytes).expect("direct record Iterable loop should run");
     }
 
     #[test]

--- a/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
+++ b/docs/roadmap/language_maturity/iterable_abstraction_full_scope.md
@@ -113,8 +113,7 @@ that iterable abstraction is admitted yet on current `main`.
 - built-in executable iterable slice for `Sequence(T)` and range values
 - explicit typecheck/lowering agreement that built-in iterable loops run on
   current `main`
-- explicit diagnostics that user-defined `Iterable` impl dispatch is still
-  deferred
+- explicit diagnostics for wrong-shape or out-of-scope iterable impl dispatch
 
 ### Wave 4 — Explicit Impl Dispatch
 
@@ -128,8 +127,8 @@ that iterable abstraction is admitted yet on current `main`.
 - continue the loop on `Option::Some(item)` and terminate on `Option::None`
 - do not introduce hidden mutable iterator state, host callbacks, or dynamic
   dispatch in this first executable user-defined slice
-- executable lowering/runtime wiring for explicit user-defined `Iterable` impls
-  lands only after that contract is frozen
+- executable lowering/runtime wiring for direct record `Iterable` impls now
+  lands on current `main`
 
 ### Wave 4A — Impl Method Executable Contract
 
@@ -139,8 +138,7 @@ that iterable abstraction is admitted yet on current `main`.
   receiver contract on current `main`
 - this prerequisite is now complete and removes the earlier dead owner-layer
   gap for trait/impl method bodies
-- this does not by itself claim user-visible iterable loop execution over
-  explicit impls yet
+- this prerequisite now feeds the landed direct-record executable dispatch slice
 
 ### Wave 5 — Freeze
 
@@ -186,6 +184,8 @@ Approved direction for the next step:
 - `Option::None` terminates the loop
 - the built-in `Sequence(T)` / range path remains the already-landed separate
   executable slice on current `main`
+- direct record `Iterable` impls now execute on current `main` through this
+  exact `next(self: Self, index: i32) -> Option(Item)` contract
 
 Still out of scope for this first explicit-dispatch slice:
 
@@ -203,6 +203,8 @@ This track is done only when:
 - `for x in collection` desugaring, typecheck, and execution agree on one
   deterministic first-wave model
 - `Sequence(T)` and range types both satisfy the `Iterable` contract
+- direct record `Iterable` impls satisfy the first executable user-defined
+  dispatch contract
 - docs/spec/tests describe the same admitted baseline
 - published `v1.1.1` and widened `main` are explicitly distinguished
 

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -150,8 +150,10 @@ Current message families include:
 - closure equality is not part of the current `M8.4` first-wave surface
 - for-range requires `i32` range expression
 - iterable `for x in collection` loop over a non-iterable value
-- iterable `for x in collection` loop that relies on explicit user-defined
-  `Iterable` impl dispatch beyond the current built-in Sequence/range slice
+- iterable `for x in collection` loop whose explicit `Iterable` impl does not
+  satisfy the executable contract `fn next(self: Self, index: i32) -> Option(Item)`
+- iterable `for x in collection` loop that relies on ADT/schema or indirect
+  explicit `Iterable` dispatch beyond the direct-record slice on current `main`
 - duplicate record declaration
 - duplicate schema declaration
 - top-level record/function name collision

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -339,12 +339,14 @@ Current v0 limit:
   as an owner-layer desugaring toward the named `Iterable` contract
 - built-in `Sequence(type)` values now execute through the current first-wave
   iterable loop path on `main`
-- explicit user-defined `Iterable` impl dispatch is still deferred beyond the
-  current built-in Sequence/range slice
+- direct record `Iterable` impls now execute through the same loop driver when
+  they expose `fn next(self: Self, index: i32) -> Option(Item)`
 - trait-side `Self` now denotes the impl-anchored receiver contract only inside
   trait method signatures and impl method type positions
 - `Self` does not widen the general executable type surface beyond that narrow
   trait/impl contract
+- ADT/schema iterable dispatch and indirect iterable projection remain outside
+  the current stable contract
 - descending ranges, custom step values, `continue`, and a general iterable
   subsystem are not yet part of the stable contract
 - `for ... in range` does not widen the public operator surface to general

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -400,12 +400,14 @@ Current v0 range-literal limits:
   `Iterable` owner-layer loop surface
 - built-in `Sequence(type)` collections now execute through the current
   first-wave iterable loop path on `main`
-- explicit user-defined `Iterable` impl dispatch is still not executable in the
-  current slice
+- direct record `Iterable` impl dispatch now executes on current `main` when the
+  impl exposes `fn next(self: Self, index: i32) -> Option(Item)`
 - `Self` is admitted only in trait method signatures and impl method type
   positions on current `main`
 - `Self` outside trait/impl method type positions is not part of the stable
   syntax contract
+- ADT/schema iterable dispatch and indirect iterable projection are not part of
+  the current syntax contract
 - descending/custom-step/general iterable range forms are not yet part of the
   stable syntax contract
 


### PR DESCRIPTION
## Summary
- execute or x in collection for direct record Iterable impls using 
ext(self: Self, index: i32) -> Option(Item)
- lower explicit iterable loops through already-lowered impl methods without widening SemCode or VM contracts
- sync docs and add frontend/IR/VM coverage for the direct-record executable slice

## Testing
- cargo test -q -p sm-front
- cargo test -q -p sm-ir
- cargo test -q -p sm-vm
- cargo test -q --test public_api_contracts
- cargo test -q