### PR TITLE
roadmap: activate units of measure scope

### DIFF
--- a/docs/roadmap/language_maturity/units_of_measure_scope.md
+++ b/docs/roadmap/language_maturity/units_of_measure_scope.md
@@ -1,6 +1,6 @@
 # Units Of Measure Scope
 
-Status: proposed first-wave checkpoint
+Status: active first-wave checkpoint
 Related issue: `#118`
 
 ## Goal
@@ -8,6 +8,16 @@ Related issue: `#118`
 Define a narrow, executable first-wave units-of-measure contract for `v0.2`
 without opening a general dimensional-analysis system or widening runtime and
 host boundaries.
+
+This is the current active language-maturity stream on `main` after the
+completed source-language contract freeze.
+
+## Decision Check
+
+- [x] This is a new explicit post-stable track with its own scope decision
+- [x] This remains compile-time-only and does not widen the VM/runtime contract
+- [x] This is one stream, not a mixture of multiple tracks
+- [x] This can close with a clear done-boundary
 
 ## Decision
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -22,6 +22,8 @@
   - current stable-note checkpoint: `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
   - current completed post-stable expansion checkpoint:
     `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+  - current active post-stable units checkpoint:
+    `docs/roadmap/language_maturity/units_of_measure_scope.md`
 - `M3 Platform Formalization`
   - spec bundle
   - stable CLI


### PR DESCRIPTION
## Summary
- mark the units-of-measure track as the active first-wave checkpoint
- add a narrow decision check for the compile-time-only units slice
- sync milestones with the active units checkpoint

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts