### PR TITLE
roadmap: close units of measure track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -83,10 +83,10 @@ Current post-`v1` wave:
 
 Current next-focus wave:
 
-- `Units Of Measure Scope` in
-  `docs/roadmap/language_maturity/units_of_measure_scope.md`
-- keep one active language-maturity stream at a time while the first-wave
-  compile-time units contract is in flight
+- `Option and Result Standard Forms Scope` in
+  `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
+- keep one active language-maturity stream at a time while the narrow
+  `Option(T)` / `Result(T, E)` decision checkpoint is being resolved
 - do not widen the frozen source-language bundle without a new track or an
   explicit source-contract amendment
 

--- a/docs/roadmap/language_maturity/units_of_measure_scope.md
+++ b/docs/roadmap/language_maturity/units_of_measure_scope.md
@@ -1,6 +1,6 @@
 # Units Of Measure Scope
 
-Status: active first-wave checkpoint
+Status: completed first-wave baseline history
 Related issue: `#118`
 
 ## Goal
@@ -9,8 +9,8 @@ Define a narrow, executable first-wave units-of-measure contract for `v0.2`
 without opening a general dimensional-analysis system or widening runtime and
 host boundaries.
 
-This is the current active language-maturity stream on `main` after the
-completed source-language contract freeze.
+This track is now completed on `main` as a narrow compile-time-only source
+contract over the existing core numeric families.
 
 ## Decision Check
 
@@ -73,11 +73,11 @@ where the bracket payload is a single unit symbol.
 
 ## Done Boundary
 
-`#118` can close when:
+`#118` is complete on `main` because:
 
 1. parser accepts first-wave unit annotations in declared type positions,
 2. sema reports compile-time mismatches on incompatible unit-annotated numeric
    values,
 3. lowering remains unit-erased and reuses the existing numeric execution path,
 4. docs define supported operations and honest non-conversion rules,
-5. verified tests cover assignment/call/return/operator mismatch cases.
+5. verified tests cover assignment, call, return, and operator mismatch cases.

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -22,7 +22,7 @@
   - current stable-note checkpoint: `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
   - current completed post-stable expansion checkpoint:
     `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
-  - current active post-stable units checkpoint:
+  - current completed post-stable units checkpoint:
     `docs/roadmap/language_maturity/units_of_measure_scope.md`
 - `M3 Platform Formalization`
   - spec bundle


### PR DESCRIPTION
## Summary
- mark units of measure as completed first-wave baseline history
- move roadmap next-focus from units to Option and Result standard forms
- align milestones with the already-landed units implementation

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts