### PR TITLE
roadmap: close option and result track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -75,6 +75,9 @@ Current post-`v1` wave:
 - the first-wave `fx` arithmetic expansion track is completed and now lives as
   frozen baseline history in
   `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+- the first-wave `Option` / `Result` standard-forms track is completed and now
+  lives as frozen baseline history in
+  `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
 - the IR/runtime anti-drift package is completed and now lives as frozen
   baseline history in:
   - `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
@@ -83,10 +86,10 @@ Current post-`v1` wave:
 
 Current next-focus wave:
 
-- `Option and Result Standard Forms Scope` in
-  `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
-- keep one active language-maturity stream at a time while the narrow
-  `Option(T)` / `Result(T, E)` decision checkpoint is being resolved
+- no active language-maturity stream is currently open after the completed
+  units and standard-forms close-outs
+- open the next language-maturity stream only through an explicit scope
+  checkpoint
 - do not widen the frozen source-language bundle without a new track or an
   explicit source-contract amendment
 

--- a/docs/roadmap/language_maturity/option_result_standard_forms_scope.md
+++ b/docs/roadmap/language_maturity/option_result_standard_forms_scope.md
@@ -1,11 +1,11 @@
 # Option and Result Standard Forms Scope
 
-Status: proposed checkpoint
+Status: completed first-wave baseline history
 
 ## Purpose
 
-Freeze the decision boundary for `V02-06` before opening implementation work
-for first-class `Option` and `Result`.
+Freeze the decision boundary for `V02-06` as completed first-wave baseline
+history for first-class `Option` and `Result`.
 
 This document exists because `#117` is not just "more ADT work". The current
 language now has:
@@ -98,17 +98,15 @@ Do not include any of the following in the first implementation wave:
 If any of those become necessary, they should be treated as a later expansion
 issue, not as part of `V02-06`.
 
-## Binary Decision Rule For `#117`
+## Completed Decision
 
-Close `#117` only if one of these becomes true:
+`#117` is complete on `main` as the narrow standard-forms wave:
 
-1. a narrow standard-forms wave lands in `main` with explicit `Option(T)` /
-   `Result(T, E)` typing, canonical constructors, and verified success/none/error
-   execution tests
-2. `#117` is explicitly reshaped so first-class `Option`/`Result` move out of
-   `v0.2` and into a later generics or stdlib expansion wave
-
-Anything in between is roadmap drift.
+1. explicit `Option(T)` / `Result(T, E)` typing is admitted,
+2. canonical constructors and variant patterns are supported,
+3. verified success/none/error execution coverage exists,
+4. the implementation stays inside the existing ADT-style carrier path rather
+   than widening into a general generic runtime.
 
 ## Acceptance Criteria For A Narrow Standard-Forms Wave
 
@@ -120,14 +118,12 @@ Anything in between is roadmap drift.
 - docs and diagnostics describe the exact first-wave boundary
 - verified-path tests cover success, none, and error flows
 
-## Recommended Next Action
+## Freeze Rule
 
-Before opening a code PR for `#117`, decide intentionally whether `Option` and
-`Result` are being implemented as narrow standard forms inside the current
-language surface.
+The completed first wave remains narrow:
 
-If the answer is yes, the next implementation branch should be a first slice
-for type syntax and constructor semantics only.
-
-If the answer is no, reshape `#117` first and move the wider feature to a later
-wave.
+- `Option(T)` and `Result(T, E)` stay standard forms, not a reopening of
+  general user-defined parameterized ADTs,
+- constructor and pattern ergonomics remain canonical and explicit,
+- any widening into broader generic, prelude-injection, or call-boundary
+  semantics requires a new explicit track.

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -24,6 +24,8 @@
     `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
   - current completed post-stable units checkpoint:
     `docs/roadmap/language_maturity/units_of_measure_scope.md`
+  - current completed post-stable standard-forms checkpoint:
+    `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
 - `M3 Platform Formalization`
   - spec bundle
   - stable CLI


### PR DESCRIPTION
## Summary
- mark Option and Result standard forms as completed first-wave baseline history
- reflect the already-landed narrow standard-forms slice in roadmap status docs
- clear active next-focus until the next explicit language-maturity scope decision

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts