### PR TITLE
roadmap: freeze gate 1 release qualification

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -93,6 +93,15 @@ Current next-focus wave:
 - do not widen the frozen source-language bundle without a new track or an
   explicit source-contract amendment
 
+Current qualification wave:
+
+- `Gate 1 Release Qualification Protocol` in
+  `docs/roadmap/release_qualification/gate1_protocol.md`
+- run `Q1` through `Q5` only after this protocol is frozen
+- keep UI out of the first qualification contour unless UI is explicitly
+  admitted into the release scope
+- do not treat landed-on-`main` behavior as automatically release-promised
+
 Foundational work already in place:
 
 - repository discipline and architecture baseline

--- a/docs/roadmap/release_qualification/gate1_protocol.md
+++ b/docs/roadmap/release_qualification/gate1_protocol.md
@@ -1,0 +1,164 @@
+# Gate 1 Release Qualification Protocol
+
+Status: active internal qualification checkpoint
+
+## Goal
+
+Define the evidence-based internal gate that must be passed before Semantic is
+described as ready for a broader release contour beyond the currently published
+stable line.
+
+This is a release qualification program, not a language-maturity feature
+roadmap.
+
+## Current Default Qualification Contour
+
+The first Gate 1 cycle qualifies:
+
+- source/frontend behavior
+- IR, SemCode, verifier, and VM integrity
+- representative real-program coverage
+- benchmark and reproducibility baselines
+- release-scope honesty
+
+The first Gate 1 cycle does **not** treat UI as blocking by default.
+
+UI enters the qualification contour only if it is explicitly admitted into the
+release scope for the cycle being judged.
+
+## Gate 1 Blocks
+
+### G1-A Surface Expressiveness
+
+Question: can real programs be written without the language constantly fighting
+the author?
+
+Required output:
+
+- `reports/g1_surface_expressiveness.md`
+
+### G1-B Frontend Trust
+
+Question: can the source entry surface be trusted across positive, negative,
+and edge-case inputs?
+
+Required output:
+
+- `reports/g1_frontend_trust.md`
+
+### G1-C Execution Integrity
+
+Question: does
+`source -> sema -> IR -> SemCode -> verifier -> VM`
+preserve the promised meaning of representative programs?
+
+Required output:
+
+- `reports/g1_execution_integrity.md`
+
+### G1-D Real Program Trial
+
+Question: is the current language surface sufficient for writing actual small
+programs rather than feature demonstrations?
+
+Required output:
+
+- `reports/g1_real_program_trial.md`
+
+Required first-cycle program families:
+
+1. CLI utility
+2. rule/state-oriented program
+3. module-based program
+4. data-heavy small program
+
+Optional conditional family:
+
+5. minimal UI program, only if UI is explicitly admitted into the release
+   contour for the cycle
+
+### G1-E Benchmark Baseline
+
+Question: is there a reproducible performance and stability baseline rather
+than intuition?
+
+Required output:
+
+- `reports/g1_benchmark_baseline.md`
+
+### G1-F Honest Release Scope
+
+Question: what is actually qualified for release, and what is still merely
+landed on `main`?
+
+Required output:
+
+- `reports/g1_release_scope_statement.md`
+
+## Decision States
+
+Gate 1 may end in exactly one of these states:
+
+- `not ready`
+- `limited release`
+- `public release`
+
+### Decision Rule
+
+- `not ready` if any blocking block remains red, if the release scope cannot be
+  stated honestly, or if evidence from Q1-Q5 contradicts release confidence
+- `limited release` if all blocking blocks are green for a narrow admitted
+  contour and the remaining non-admitted surfaces stay explicit
+- `public release` if all blocking blocks are green, practical program coverage
+  is strong enough for a broader promise, and the release statement remains
+  honest
+
+UI may become blocking only if UI is explicitly admitted into the release
+contour for the cycle.
+
+## Hard Rules
+
+### Rule 1 - No Release By Intuition
+
+Release decisions must be made from evidence collected in Q1-Q5, not from the
+feeling that the platform now looks mature enough.
+
+### Rule 2 - No Scope Inflation During Qualification
+
+The active release contour must not widen during the qualification cycle unless
+the widening is itself treated as a new explicit scope decision.
+
+### Rule 3 - Landed Is Not Release-Promised
+
+Behavior present on `main` is not automatically stable, qualified, or promised
+in the release scope.
+
+## Execution Order
+
+The qualification cycle runs in this order:
+
+1. `Q0` - freeze this Gate 1 protocol
+2. `Q1` - `G1-D Real Program Trial`
+3. `Q2` - `G1-B Frontend Trust`
+4. `Q3` - `G1-C Execution Integrity`
+5. `Q4` - `G1-E Benchmark Baseline`
+6. `Q5` - `G1-A` and `G1-F` synthesis
+
+This order is intentional:
+
+- real programs expose the truth fastest
+- frontend trust and execution integrity should be measured against those real
+  scenarios
+- benchmarks come after representative scenarios exist
+- final release judgment comes only after evidence is collected
+
+## Done Boundary For Q0
+
+`Q0` is complete when:
+
+1. this document is the canonical internal Gate 1 protocol,
+2. the UI conditional rule is explicit,
+3. the `not ready` / `limited release` / `public release` states are defined
+   without ambiguity,
+4. backlog and readiness docs point to this protocol as the release
+   qualification authority.

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -43,6 +43,7 @@ Current v1-facing artifact families in the repository:
   - `docs/roadmap/type_completeness_matrix.md`
   - `docs/roadmap/runtime_validation_policy.md`
   - `docs/roadmap/release_bundle_checklist.md`
+  - `docs/roadmap/release_qualification/gate1_protocol.md`
   - `docs/roadmap/compatibility_statement.md`
   - `docs/roadmap/release_asset_smoke_matrix.md`
   - `docs/roadmap/stable_release_policy.md`
@@ -168,7 +169,10 @@ Current highest-signal remaining work after the first stable `v1.1.1` tag:
 1. keep release-facing docs aligned with the published stable line on `main`
 2. rerun representative asset smoke for every forward release tag
 3. keep narrow `v1` limits explicit unless a separate scope decision promotes them
-4. treat any future widening as a forward versioned release, not silent drift
+4. run the internal Gate 1 qualification program in
+   `docs/roadmap/release_qualification/gate1_protocol.md` before making any
+   broader release-readiness claim
+5. treat any future widening as a forward versioned release, not silent drift
 
 ## Contract Rule
 


### PR DESCRIPTION
## Summary
- add the canonical Gate 1 internal release qualification protocol
- sync backlog to show the active qualification wave and the non-blocking default UI rule
- point v1 readiness at the new qualification authority before any broader release claim

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts