### PR TITLE
qualification: add gate1 real program trial

### DIFF
--- a/examples/qualification/g1_real_program_trial/cli_batch_core/Semantic.package
+++ b/examples/qualification/g1_real_program_trial/cli_batch_core/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package cli_batch_core
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm
+++ b/examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm
@@ -1,0 +1,26 @@
+fn classify_exit(codes: Sequence(i32)) -> text {
+    let saw_error: bool = false;
+    let saw_retry: bool = false;
+    for code in codes {
+        if code == 9 {
+            saw_error ||= true;
+        }
+        if code == 2 {
+            saw_retry ||= true;
+        }
+    }
+    if saw_error == true {
+        return "error";
+    }
+    if saw_retry == true {
+        return "retry";
+    }
+    return "ok";
+}
+
+fn main() {
+    let argv_like: Sequence(i32) = [2, 1, 0];
+    let mode: text = classify_exit(argv_like);
+    assert(mode == "retry");
+    return;
+}

--- a/examples/qualification/g1_real_program_trial/data_audit_record_iterable/Semantic.package
+++ b/examples/qualification/g1_real_program_trial/data_audit_record_iterable/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package data_audit_record_iterable
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm
+++ b/examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm
@@ -1,0 +1,60 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Samples {
+    first: i32,
+    second: i32,
+    third: i32,
+}
+
+record AuditSummary {
+    saw_alert: bool,
+    saw_retry: bool,
+}
+
+impl Iterable for Samples {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        if index == 0 {
+            return Option::Some(self.first);
+        }
+        if index == 1 {
+            return Option::Some(self.second);
+        }
+        if index == 2 {
+            return Option::Some(self.third);
+        }
+        return Option::None;
+    }
+}
+
+fn summarize(samples: Samples) -> AuditSummary {
+    let saw_alert: bool = false;
+    let saw_retry: bool = false;
+    for value in samples {
+        if value == 9 {
+            saw_alert ||= true;
+        }
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return AuditSummary {
+        saw_alert: saw_alert,
+        saw_retry: saw_retry,
+    };
+}
+
+fn main() {
+    let samples: Samples = Samples {
+        first: 2,
+        second: 9,
+        third: 4,
+    };
+    let summary: AuditSummary = summarize(samples);
+    let patched: AuditSummary = summary with { saw_retry: false };
+    assert(summary.saw_alert == true);
+    assert(summary.saw_retry == true);
+    assert(patched.saw_retry == false);
+    return;
+}

--- a/examples/qualification/g1_real_program_trial/module_helpers_blocked/Semantic.package
+++ b/examples/qualification/g1_real_program_trial/module_helpers_blocked/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package module_helpers_blocked
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_real_program_trial/module_helpers_blocked/src/helper.sm
+++ b/examples/qualification/g1_real_program_trial/module_helpers_blocked/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm
+++ b/examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm" { score }
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/examples/qualification/g1_real_program_trial/rule_state_decision/Semantic.package
+++ b/examples/qualification/g1_real_program_trial/rule_state_decision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package rule_state_decision
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm
+++ b/examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm
@@ -1,0 +1,35 @@
+record DecisionContext {
+    camera: quad,
+    override_state: quad,
+    ready: bool,
+}
+
+fn decide(ctx: DecisionContext) -> Result(quad, quad) {
+    if ctx.override_state == T {
+        return Result::Ok(T);
+    }
+    if ctx.override_state == F {
+        return Result::Ok(F);
+    }
+    if ctx.camera == N {
+        return Result::Err(N);
+    }
+    if ctx.ready == true {
+        return Result::Ok(T);
+    }
+    return Result::Err(S);
+}
+
+fn main() {
+    let ctx: DecisionContext = DecisionContext {
+        camera: T,
+        override_state: S,
+        ready: true,
+    };
+    let verdict: quad = match decide(ctx) {
+        Result::Ok(value) => { value }
+        Result::Err(code) => { code }
+    };
+    assert(verdict == T);
+    return;
+}

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -1,0 +1,195 @@
+# G1 Real Program Trial
+
+Status: completed evidence report for `Q1`
+
+## Goal
+
+Test whether current `main` can express actual small programs through the
+public executable surface, rather than only isolated feature demos.
+
+This report follows the canonical Gate 1 protocol in:
+
+- `docs/roadmap/release_qualification/gate1_protocol.md`
+
+UI is not part of this qualification contour.
+
+## Reproducible Evidence Pack
+
+Canonical committed trial programs:
+
+- `examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm`
+- `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
+- `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
+- `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+
+Canonical reproducible harness:
+
+```text
+cargo test -q --test g1_real_program_trial
+```
+
+The harness runs the public `smc` command surface through `smc_cli::run(...)`
+for `check` and `run`, rather than using private compiler shortcuts.
+
+## Trial Matrix
+
+### 1. CLI utility core
+
+Path:
+
+- `examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm`
+
+Intent:
+
+- emulate a batch/CLI classification core over argv-like numeric inputs
+- consume a `Sequence(i32)`
+- produce a `text` status
+
+Observed behavior:
+
+- `smc check` passes
+- `smc run` passes
+- the program shape is viable as a small single-file utility core
+
+Verdict:
+
+- `tolerable`
+
+Reason:
+
+- the logic itself is straightforward
+- the lack of admitted argv/stdout/file IO means this is only the core of a CLI
+  tool, not a full user-facing CLI application
+
+### 2. Rule/state-oriented program
+
+Path:
+
+- `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
+
+Intent:
+
+- model a small decision engine over a nominal record snapshot
+- use `quad`, `Result(T, E)`, and explicit match-based settlement
+
+Observed behavior:
+
+- `smc check` passes
+- `smc run` passes
+- the source reads naturally for the intended domain
+
+Verdict:
+
+- `natural`
+
+Reason:
+
+- this is close to the problem shape Semantic already favors
+- record + quad + explicit result handling compose without visible friction
+
+### 3. Data-heavy small program
+
+Path:
+
+- `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
+
+Intent:
+
+- scan a direct-record dataset through the current executable `Iterable` slice
+- produce an immutable record summary
+- patch that summary with record `with { ... }`
+
+Observed behavior:
+
+- `smc check` passes
+- `smc run` passes
+- direct-record `Iterable` impl dispatch works end to end on current `main`
+
+Verdict:
+
+- `tolerable`
+
+Reason:
+
+- the admitted slice is real and executable
+- the program is writable without hacks
+- the surface still feels narrow because only the direct-record iterable form is
+  available; broader collection/generic reuse is not there yet
+
+### 4. Module-based program
+
+Path:
+
+- `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+
+Intent:
+
+- write a small multi-file executable program with a helper module
+
+Observed behavior:
+
+- `smc check` rejects the entry module
+- `smc run` rejects the entry module
+- current parser surface reports top-level `Import` as invalid in this
+  executable program path
+
+Observed blocking surface:
+
+```text
+expected top-level 'enum', 'fn', 'impl', 'record', 'schema', 'trait', or role-marked schema declaration
+```
+
+Verdict:
+
+- `blocked`
+
+Reason:
+
+- a normal module-based executable helper split is not admitted as a working
+  current-`main` program path
+- this is a real qualification blocker for broader practical programming claims
+
+## Additional Friction Found During Authoring
+
+One extra limitation showed up while drafting the trial programs:
+
+- direct `i32` accumulation through `+=` produced
+  `f64 arithmetic requires f64 operands, got I32 and I32`
+
+That probe is not counted as a formal trial-family program, but it is relevant
+evidence:
+
+- integer control/data handling is usable
+- integer arithmetic ergonomics still require more trust work before a broader
+  practical-readiness claim
+
+## Q1 Summary
+
+Current `main` can already support:
+
+- small single-file utility cores
+- rule/state-oriented executable programs
+- narrow data programs over `Sequence(T)` and direct-record `Iterable` impls
+
+Current `main` does **not** yet prove:
+
+- ordinary module-based executable program authoring
+- full CLI-style practical usability with admitted IO/process interaction
+
+## Q1 Verdict
+
+Gate `G1-D` is now evidenced, but the outcome is mixed rather than fully green.
+
+Per-program verdicts:
+
+- CLI utility core: `tolerable`
+- rule/state-oriented program: `natural`
+- data-heavy small program: `tolerable`
+- module-based program: `blocked`
+
+Operational conclusion:
+
+- Semantic is already capable of writing some real small programs
+- Semantic is not yet qualified to claim broad practical-programming readiness
+  while ordinary module-based executable authoring remains blocked on current
+  `main`

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(command: &str, rel: &str) {
+    let path = repo_path(rel);
+    smc_cli::run(vec![command.to_string(), path.clone()])
+        .unwrap_or_else(|err| panic!("smc {command} failed for {path}: {err}"));
+}
+
+fn cli_err(command: &str, rel: &str) -> String {
+    let path = repo_path(rel);
+    smc_cli::run(vec![command.to_string(), path.clone()])
+        .expect_err(&format!("smc {command} unexpectedly passed for {path}"))
+}
+
+#[test]
+fn g1_cli_batch_core_checks_and_runs() {
+    let rel = "examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn g1_rule_state_decision_checks_and_runs() {
+    let rel = "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn g1_data_audit_record_iterable_checks_and_runs() {
+    let rel =
+        "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn g1_module_helpers_program_is_blocked() {
+    let rel = "examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm";
+    let check_err = cli_err("check", rel);
+    assert!(check_err.contains("expected top-level"));
+    let run_err = cli_err("run", rel);
+    assert!(run_err.contains("expected top-level"));
+}


### PR DESCRIPTION
## Summary
- add four committed Gate 1 real-program trial packages for the current Semantic surface
- add a reproducible integration harness that exercises the public smc check/run path
- add eports/g1_real_program_trial.md with honest mixed verdicts, including the blocked module-based executable case

## Validation
- cargo test -q --test g1_real_program_trial
- cargo test -q
- cargo test -q --test public_api_contracts