### PR TITLE
qualification: add gate1 frontend trust pack

### DIFF
--- a/examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_adt_iterable_scope
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/src/main.sm
@@ -1,0 +1,23 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+enum Numbers {
+    Wrap(i32),
+}
+
+impl Iterable for Numbers {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        let _ = self;
+        let _ = index;
+        return Option::None;
+    }
+}
+
+fn main() {
+    let numbers: Numbers = Numbers::Wrap(0);
+    for value in numbers {
+        let _ = value;
+    }
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/negative_iterable_contract/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/negative_iterable_contract/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_iterable_contract
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm
@@ -1,0 +1,21 @@
+trait Iterable {
+    fn next(self: Self) -> Option(i32);
+}
+
+record Numbers {
+    current: i32,
+}
+
+impl Iterable for Numbers {
+    fn next(self: Self) -> Option(i32) {
+        return Option::None;
+    }
+}
+
+fn main() {
+    let numbers: Numbers = Numbers { current: 0 };
+    for value in numbers {
+        let _ = value;
+    }
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_option_match_exhaustiveness
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/src/main.sm
@@ -1,0 +1,10 @@
+fn unwrap(opt: Option(bool)) -> bool {
+    let out: bool = match opt {
+        Option::Some(value) => { value }
+    };
+    return out;
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/negative_result_context/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/negative_result_context/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_result_context
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/negative_result_context/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_result_context/src/main.sm
@@ -1,0 +1,5 @@
+fn main() {
+    let value = Result::Ok(true);
+    let _ = value;
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/negative_top_level_import/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/negative_top_level_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_top_level_import
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/negative_top_level_import/src/helper.sm
+++ b/examples/qualification/g1_frontend_trust/negative_top_level_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm" { score }
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/positive_record_iterable/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/positive_record_iterable/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_record_iterable
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm
@@ -1,0 +1,28 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Numbers {
+    first: i32,
+    second: i32,
+}
+
+impl Iterable for Numbers {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        if index == 0 {
+            return Option::Some(self.first);
+        }
+        if index == 1 {
+            return Option::Some(self.second);
+        }
+        return Option::None;
+    }
+}
+
+fn main() {
+    let numbers: Numbers = Numbers { first: 1, second: 2 };
+    for value in numbers {
+        let _: i32 = value;
+    }
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/positive_sequence_and_match/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/positive_sequence_and_match/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_sequence_and_match
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm
@@ -1,0 +1,25 @@
+fn unwrap(opt: Option(bool)) -> bool {
+    let out: bool = match opt {
+        Option::Some(value) => { value }
+        Option::None => { false }
+    };
+    return out;
+}
+
+fn classify(values: Sequence(i32)) -> bool {
+    let saw_retry: bool = false;
+    for value in values {
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return saw_retry;
+}
+
+fn main() {
+    let left: bool = unwrap(Option::Some(true));
+    let right: bool = classify([0, 2, 4]);
+    assert(left == true);
+    assert(right == true);
+    return;
+}

--- a/examples/qualification/g1_frontend_trust/positive_where_clause/Semantic.package
+++ b/examples/qualification/g1_frontend_trust/positive_where_clause/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_where_clause
+manifest_dir .
+module_root src

--- a/examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm
@@ -1,0 +1,11 @@
+fn magnitude_sq(x: f64, y: f64) -> f64 =
+    total where
+        xx = x * x,
+        yy = y * y,
+        total = xx + yy;
+
+fn main() {
+    let value: f64 = magnitude_sq(3.0, 4.0);
+    assert(value == 25.0);
+    return;
+}

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -1,0 +1,214 @@
+# G1 Frontend Trust
+
+Status: completed evidence report for `Q2`
+
+## Goal
+
+Test whether the current source entry surface can be trusted across:
+
+- admitted positive programs
+- representative negative programs
+- diagnostics for known scope boundaries
+
+This report follows:
+
+- `docs/roadmap/release_qualification/gate1_protocol.md`
+
+## Reproducible Evidence Pack
+
+Canonical positive fixtures:
+
+- `examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm`
+- `examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm`
+- `examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm`
+
+Canonical negative fixtures:
+
+- `examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm`
+- `examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm`
+- `examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/src/main.sm`
+- `examples/qualification/g1_frontend_trust/negative_result_context/src/main.sm`
+- `examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/src/main.sm`
+
+Canonical harness:
+
+```text
+cargo test -q --test g1_frontend_trust
+```
+
+The harness uses the public `smc check` path through `smc_cli::run(...)`.
+
+## Positive Coverage
+
+### Sequence + Option/Result match
+
+Fixture:
+
+- `positive_sequence_and_match`
+
+What it proves:
+
+- `Sequence(i32)` loop admission is stable
+- exhaustive `Option::Some/None` match admission is stable
+- standard executable assertions are accepted on this path
+
+Verdict:
+
+- `trusted`
+
+### Direct record `Iterable` loop
+
+Fixture:
+
+- `positive_record_iterable`
+
+What it proves:
+
+- trait parsing
+- `impl` parsing
+- `self: Self` contract admission
+- direct-record iterable loop admission
+
+Verdict:
+
+- `trusted`
+
+### Where-clause expression sugar
+
+Fixture:
+
+- `positive_where_clause`
+
+What it proves:
+
+- the current where-clause frontend path is admitted and stable on a normal
+  numeric example
+
+Verdict:
+
+- `trusted`
+
+## Negative Coverage
+
+### Module/import executable entry
+
+Fixture:
+
+- `negative_top_level_import`
+
+Observed diagnostic:
+
+- contains `expected top-level`
+
+Assessment:
+
+- this is deterministic
+- this is also a real trust problem, because ordinary module-based executable
+  authoring is still blocked at the parser boundary on current `main`
+
+Verdict:
+
+- `deterministic but trust-reducing`
+
+### Wrong explicit `Iterable` contract
+
+Fixture:
+
+- `negative_iterable_contract`
+
+Observed diagnostic:
+
+- contains `fn next(self: Self, index: i32) -> Option(Item)`
+
+Assessment:
+
+- the frontend rejects the wrong contract for the right reason
+- the message points to the admitted executable shape rather than failing
+  generically
+
+Verdict:
+
+- `trusted`
+
+### ADT iterable dispatch out of scope
+
+Fixture:
+
+- `negative_adt_iterable_scope`
+
+Observed diagnostic:
+
+- contains `direct record impls only`
+
+Assessment:
+
+- the frontend does not silently widen iterable dispatch beyond the admitted
+  slice
+
+Verdict:
+
+- `trusted`
+
+### Contextless `Result::Ok`
+
+Fixture:
+
+- `negative_result_context`
+
+Observed diagnostic:
+
+- contains `Result::Ok currently requires contextual Result(T, E) type in v0`
+
+Assessment:
+
+- this is a clear, intentional rejection rather than a random type failure
+
+Verdict:
+
+- `trusted`
+
+### Non-exhaustive `Option` match
+
+Fixture:
+
+- `negative_option_match_exhaustiveness`
+
+Observed diagnostic:
+
+- contains `non-exhaustive match expression for Option(T); missing variants: None`
+
+Assessment:
+
+- exhaustiveness diagnostics are explicit and understandable on current `main`
+
+Verdict:
+
+- `trusted`
+
+## Frontend Trust Summary
+
+Trusted zones on current `main`:
+
+- sequence-loop admission
+- direct-record iterable trait/impl admission
+- where-clause source sugar
+- contextual `Option` / `Result` match admission
+- negative diagnostics for iterable contract shape and standard-form scope
+
+Still trust-reducing zones:
+
+- ordinary module/import executable entry remains blocked by the current parser
+  top-level contract
+- this is deterministic, but it means source-level modular authoring is not yet
+  trustworthy as a practical executable path
+
+## Q2 Verdict
+
+`G1-B Frontend Trust` is partially evidenced, not fully green.
+
+Operational verdict:
+
+- parser/typechecker behavior is stable on the admitted current slices
+- diagnostics for several narrow boundaries are explicit and reproducible
+- frontend trust for broader practical programming remains limited while
+  module-based executable authoring is still blocked on current `main`

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn check_ok(rel: &str) {
+    let path = repo_path(rel);
+    smc_cli::run(vec!["check".to_string(), path.clone()])
+        .unwrap_or_else(|err| panic!("smc check unexpectedly failed for {path}: {err}"));
+}
+
+fn check_err(rel: &str) -> String {
+    let path = repo_path(rel);
+    smc_cli::run(vec!["check".to_string(), path.clone()])
+        .expect_err(&format!("smc check unexpectedly passed for {path}"))
+}
+
+#[test]
+fn g1_frontend_positive_suite_passes() {
+    for rel in [
+        "examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm",
+        "examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm",
+        "examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm",
+    ] {
+        check_ok(rel);
+    }
+}
+
+#[test]
+fn g1_frontend_negative_suite_reports_expected_diagnostics() {
+    let cases = [
+        (
+            "examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm",
+            "expected top-level",
+        ),
+        (
+            "examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm",
+            "fn next(self: Self, index: i32) -> Option(Item)",
+        ),
+        (
+            "examples/qualification/g1_frontend_trust/negative_adt_iterable_scope/src/main.sm",
+            "direct record impls only",
+        ),
+        (
+            "examples/qualification/g1_frontend_trust/negative_result_context/src/main.sm",
+            "Result::Ok currently requires contextual Result(T, E) type in v0",
+        ),
+        (
+            "examples/qualification/g1_frontend_trust/negative_option_match_exhaustiveness/src/main.sm",
+            "non-exhaustive match expression for Option(T); missing variants: None",
+        ),
+    ];
+    for (rel, needle) in cases {
+        let err = check_err(rel);
+        assert!(
+            err.contains(needle),
+            "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add positive and negative Gate 1 frontend-trust fixtures for the current admitted source surface
- add a reproducible smc check integration harness covering diagnostics and boundary behavior
- add eports/g1_frontend_trust.md with an explicit mixed trust verdict

## Validation
- cargo test -q --test g1_frontend_trust
- cargo test -q
- cargo test -q --test public_api_contracts