### PR TITLE
qualification: close G1-C execution integrity

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -219,19 +219,6 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
         ));
     }
 
-    if header.capabilities & CAP_OWNERSHIP_FIELD_PATHS != 0
-        && !pending_functions
-            .iter()
-            .any(|function| function.has_record_field_ownership)
-    {
-        diagnostics.push(diag(
-            VerificationCode::InvalidOwnershipSection,
-            None,
-            None,
-            "header advertises record-field ownership transport but no Field(SymbolId) path is present",
-        ));
-    }
-
     let known_functions = pending_functions
         .iter()
         .map(|function| function.verified.name.as_str())
@@ -521,7 +508,6 @@ fn verify_function_code(
         },
         call_targets,
         has_ownership_section,
-        has_record_field_ownership: ownership_usage.has_record_field_ownership,
     })
 }
 
@@ -1085,7 +1071,6 @@ struct PendingVerifiedFunction {
     verified: VerifiedFunction,
     call_targets: Vec<(usize, String)>,
     has_ownership_section: bool,
-    has_record_field_ownership: bool,
 }
 
 #[cfg(feature = "std")]
@@ -1564,6 +1549,33 @@ mod tests {
         let verified = verify_semcode(&bytes).expect("verify");
         assert_eq!(verified.header.rev, 13);
         assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
+    fn verifier_accepts_v13_program_without_record_field_ownership_payload() {
+        let src = r#"
+            fn saw_retry(values: Sequence(i32)) -> bool {
+                let found: bool = false;
+                for value in values {
+                    if value == 2 {
+                        found ||= true;
+                    }
+                }
+                return found;
+            }
+
+            fn main() {
+                let values: Sequence(i32) = [2, 9, 4];
+                let found: bool = saw_retry(values);
+                assert(found == true);
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        assert_eq!(&bytes[..MAGIC12.len()], b"SEMCOD13");
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.header.rev, 14);
+        assert_eq!(verified.functions.len(), 2);
     }
 
     #[test]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -295,7 +295,9 @@ pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {
         spec.rev,
         spec.capabilities
     ));
-    for f in functions.values() {
+    let mut ordered = functions.values().collect::<Vec<_>>();
+    ordered.sort_by(|left, right| left.name.cmp(&right.name));
+    for f in ordered {
         out.push_str(&format!(
             "fn {}: code={} bytes, strings={}, debug={}\n",
             f.name,

--- a/reports/g1_execution_integrity.md
+++ b/reports/g1_execution_integrity.md
@@ -1,0 +1,142 @@
+# G1 Execution Integrity
+
+Status: completed evidence report for `Q3`
+
+## Goal
+
+Test whether the admitted current-`main` execution path preserves meaning across:
+
+- source
+- semantics
+- IR lowering
+- SemCode emission
+- verifier admission
+- VM execution
+
+This report follows:
+
+- `docs/roadmap/release_qualification/gate1_protocol.md`
+
+## Reproducible Evidence Pack
+
+Representative source fixtures reused from `Q1`:
+
+- `examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm`
+- `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
+- `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
+
+Canonical harness:
+
+```text
+cargo test -q --test g1_execution_integrity
+```
+
+The harness goes through the public compiler/runtime surface:
+
+- `check_source(...)`
+- `compile_program_to_ir(...)`
+- `compile_program_to_semcode(...)`
+- `verify_semcode(...)`
+- `run_verified_semcode(...)`
+- `disasm_semcode(...)`
+
+## Representative Stage Snapshots
+
+Observed stable baseline on current `main`:
+
+```text
+program=cli_batch_core
+sema:warnings=0 laws=0
+ir:names=classify_exit,main
+semcode:magic=SEMCOD13 rev=14
+verify:names=classify_exit,main
+disasm:names=classify_exit,main
+run=ok
+
+program=rule_state_decision
+sema:warnings=0 laws=0
+ir:names=decide,main
+semcode:magic=SEMCODE0 rev=1
+verify:names=decide,main
+disasm:names=decide,main
+run=ok
+
+program=data_audit_record_iterable
+sema:warnings=0 laws=0
+ir:names=__impl::Iterable::Samples::next,main,summarize
+semcode:magic=SEMCOD12 rev=13
+verify:names=__impl::Iterable::Samples::next,main,summarize
+disasm:names=__impl::Iterable::Samples::next,main,summarize
+run=ok
+```
+
+What this proves:
+
+- the admitted representative programs preserve the same function surface from IR
+  through verifier and disasm
+- the current executable iterable slice reaches SemCode and VM without semantic
+  disappearance
+- the public `run_verified_semcode(...)` path stays successful after verifier
+  admission
+
+## Negative Execution Evidence
+
+The canonical negative case mutates valid SemCode into malformed function data.
+
+Observed behavior:
+
+- `verify_semcode(...)` rejects before execution
+- the rejection contains `InvalidStringTable`
+- raw `run_semcode(...)` also rejects the malformed payload
+
+Operational meaning:
+
+- malformed SemCode is not silently admitted into verified execution
+- verifier/runtime rejection remains aligned on the malformed-binary path
+
+## Determinism Evidence
+
+For each representative source program, the harness repeats:
+
+- SemCode compilation three times
+- disassembly twice
+- verified execution three times
+
+Observed behavior:
+
+- SemCode bytes are identical across repeated compiles
+- disassembly is stable across repeated reads of identical bytes
+- verified execution remains stable across repeated runs
+
+Two real defects were found and fixed while running this qualification step:
+
+1. verifier incorrectly treated `CAP_OWNERSHIP_FIELD_PATHS` as requiring every
+   `SEMCOD12/13` program to contain a `Field(SymbolId)` payload
+2. `disasm_semcode(...)` emitted functions through unordered `HashMap` iteration,
+   which made the snapshot surface nondeterministic even for identical SemCode
+
+Both fixes were narrow and directly tied to Q3 evidence integrity.
+
+## Boundary Notes
+
+The blocked module-based executable program from `Q1` is not counted here as an
+execution-integrity failure, because it does not reach the full
+`source -> sema -> IR -> SemCode -> verifier -> VM` path on current `main`.
+
+That remains a source/frontend practical-readiness limitation, not evidence of a
+semantic-preservation break inside the admitted execution contour.
+
+## Q3 Verdict
+
+`G1-C Execution Integrity` is green for the admitted current execution contour.
+
+Operational verdict:
+
+- source-to-runtime semantic preservation is trusted on the representative
+  admitted programs
+- malformed SemCode rejection is explicit before verified execution
+- pipeline determinism is evidenced on the current representative pack
+
+This does **not** yet upgrade the overall release decision by itself, because
+broader practical readiness is still constrained by evidence already found in
+`Q1` and `Q2`.

--- a/tests/g1_execution_integrity.rs
+++ b/tests/g1_execution_integrity.rs
@@ -1,0 +1,179 @@
+use std::{fs, path::PathBuf};
+
+use semantic_language::{
+    frontend::{compile_program_to_ir, compile_program_to_semcode},
+    semantics::check_source,
+    semcode_format::header_spec_from_magic,
+    semcode_verify::{verify_semcode, VerificationCode},
+    semcode_vm::{disasm_semcode, run_semcode},
+};
+use sm_vm::run_verified_semcode;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn source_text(rel: &str) -> String {
+    let path = repo_path(rel);
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read failed for {path}: {err}"))
+}
+
+fn label_for(rel: &str) -> &str {
+    rel.split('/').rev().nth(2).expect("fixture folder name")
+}
+
+fn csv(values: &[String]) -> String {
+    values.join(",")
+}
+
+fn disasm_function_names(disasm: &str) -> Vec<String> {
+    disasm
+        .lines()
+        .filter_map(|line| {
+            line.strip_prefix("fn ")
+                .and_then(|rest| rest.split(": code=").next())
+                .map(|name| name.to_string())
+        })
+        .collect()
+}
+
+fn execution_summary(rel: &str) -> String {
+    let src = source_text(rel);
+    let sema = check_source(&src).expect("semantic check");
+    let ir = compile_program_to_ir(&src).expect("compile ir");
+    let bytes = compile_program_to_semcode(&src).expect("compile semcode");
+    let verified = verify_semcode(&bytes).expect("verify");
+    let disasm = disasm_semcode(&bytes).expect("disasm");
+    run_verified_semcode(&bytes).expect("verified run");
+
+    let mut magic = [0u8; 8];
+    magic.copy_from_slice(&bytes[..8]);
+    let header = header_spec_from_magic(&magic).expect("known header");
+
+    let mut ir_names: Vec<String> = ir.iter().map(|func| func.name.clone()).collect();
+    let mut verified_names: Vec<String> = verified
+        .functions
+        .iter()
+        .map(|func| func.name.clone())
+        .collect();
+    let mut disasm_names = disasm_function_names(&disasm);
+
+    ir_names.sort();
+    verified_names.sort();
+    disasm_names.sort();
+
+    assert_eq!(ir_names, verified_names, "IR and verifier surface drifted for {rel}");
+    assert_eq!(verified_names, disasm_names, "verifier and disasm surface drifted for {rel}");
+
+    format!(
+        "program={}\nsema:warnings={} laws={}\nir:names={}\nsemcode:magic={} rev={}\nverify:names={}\ndisasm:names={}\nrun=ok\n",
+        label_for(rel),
+        sema.warnings.len(),
+        sema.scheduled_laws.len(),
+        csv(&ir_names),
+        String::from_utf8_lossy(&magic),
+        header.rev,
+        csv(&verified_names),
+        csv(&disasm_names),
+    )
+}
+
+fn first_function_code_offset(bytes: &[u8]) -> usize {
+    let name_len = u16::from_le_bytes([bytes[8], bytes[9]]) as usize;
+    8 + 2 + name_len + 4
+}
+
+#[test]
+fn g1_execution_integrity_stage_summaries_match_current_baseline() {
+    let mut observed = String::new();
+    for rel in [
+        "examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm",
+        "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
+        "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+    ] {
+        observed.push_str(&execution_summary(rel));
+        observed.push('\n');
+    }
+
+    let expected = "\
+program=cli_batch_core
+sema:warnings=0 laws=0
+ir:names=classify_exit,main
+semcode:magic=SEMCOD13 rev=14
+verify:names=classify_exit,main
+disasm:names=classify_exit,main
+run=ok
+
+program=rule_state_decision
+sema:warnings=0 laws=0
+ir:names=decide,main
+semcode:magic=SEMCODE0 rev=1
+verify:names=decide,main
+disasm:names=decide,main
+run=ok
+
+program=data_audit_record_iterable
+sema:warnings=0 laws=0
+ir:names=__impl::Iterable::Samples::next,main,summarize
+semcode:magic=SEMCOD12 rev=13
+verify:names=__impl::Iterable::Samples::next,main,summarize
+disasm:names=__impl::Iterable::Samples::next,main,summarize
+run=ok
+
+";
+    assert_eq!(observed, expected);
+}
+
+#[test]
+fn g1_execution_integrity_repeated_compiles_are_byte_stable() {
+    for rel in [
+        "examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm",
+        "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
+        "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+    ] {
+        let src = source_text(rel);
+
+        let first = compile_program_to_semcode(&src).expect("first compile");
+        let second = compile_program_to_semcode(&src).expect("second compile");
+        let third = compile_program_to_semcode(&src).expect("third compile");
+        assert_eq!(first, second, "second compile drifted for {rel}");
+        assert_eq!(second, third, "third compile drifted for {rel}");
+
+        let disasm_first = disasm_semcode(&first).expect("first disasm");
+        let disasm_second = disasm_semcode(&second).expect("second disasm");
+        assert_eq!(disasm_first, disasm_second, "disasm drifted for {rel}");
+
+        verify_semcode(&first).expect("verify");
+        for _ in 0..3 {
+            run_verified_semcode(&first).expect("verified run must stay successful");
+        }
+    }
+}
+
+#[test]
+fn g1_execution_integrity_malformed_semcode_rejects_before_execution() {
+    let src = source_text("examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm");
+    let mut bytes = compile_program_to_semcode(&src).expect("compile");
+
+    let code_offset = first_function_code_offset(&bytes);
+    bytes[code_offset] = 0xff;
+
+    let reject = verify_semcode(&bytes).expect_err("malformed semcode must reject");
+    assert!(
+        reject
+            .diagnostics
+            .iter()
+            .any(|diag| diag.code == VerificationCode::InvalidStringTable),
+        "expected InvalidStringTable in verifier rejection, got: {reject:?}"
+    );
+
+    let runtime_err = run_semcode(&bytes).expect_err("raw runtime path must reject malformed semcode");
+    let rendered = format!("{runtime_err}");
+    assert!(
+        rendered.contains("bad SemCode format") || rendered.contains("string"),
+        "unexpected runtime rejection: {rendered}"
+    );
+}


### PR DESCRIPTION
## Summary
- add the Q3 execution-integrity harness and evidence report
- fix verifier admission so SEMCOD12/13 capability bits do not falsely require a Field(SymbolId) payload
- make SemCode disassembly deterministic by sorting functions by name

## Validation
- cargo test -q --test g1_execution_integrity
- cargo test -q --test public_api_contracts
- cargo test -q
