### PR TITLE
docs: close gate1 synthesis

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -97,10 +97,20 @@ Current qualification wave:
 
 - `Gate 1 Release Qualification Protocol` in
   `docs/roadmap/release_qualification/gate1_protocol.md`
-- run `Q1` through `Q5` only after this protocol is frozen
+- the first `Gate 1` cycle is now completed through:
+  - `reports/g1_real_program_trial.md`
+  - `reports/g1_frontend_trust.md`
+  - `reports/g1_execution_integrity.md`
+  - `reports/g1_benchmark_baseline.md`
+  - `reports/g1_surface_expressiveness.md`
+  - `reports/g1_release_scope_statement.md`
+- the current Gate 1 decision state is `limited release` for the admitted
+  narrow practical-programming contour
 - keep UI out of the first qualification contour unless UI is explicitly
-  admitted into the release scope
+  admitted into a future release scope
 - do not treat landed-on-`main` behavior as automatically release-promised
+- rerun or amend Gate 1 only through a new explicit qualification cycle if the
+  admitted release contour is widened
 
 Foundational work already in place:
 

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -31,6 +31,9 @@ Current `v1` boundary decision:
 - wider planned host calls are not part of the current `v1` commitment
 - ownership alignment for optimizer, SemCode, and CLI is already implemented in code
 - the active stable `v1.1.1` line is published from `main`
+- the first `Gate 1` qualification cycle is completed and currently supports
+  only a `limited release` decision for the admitted practical-programming
+  contour documented in `reports/g1_release_scope_statement.md`
 
 ## Current Artifact List
 
@@ -118,8 +121,10 @@ The following limits remain explicit and should be treated as release-facing hon
 - the published `v1.1.1` line intentionally excludes the built-in executable
   iterable loop slice, even though current `main` now admits `for x in
   collection` over `Sequence(type)` through canonical `SEQUENCE_LEN` lowering
-  and verified execution under `SEMCOD13`; explicit user-defined `Iterable`
-  impl dispatch remains out of scope for the current slice
+  and verified execution under `SEMCOD13`, plus direct-record user-defined
+  `Iterable` impl dispatch through the admitted
+  `fn next(self: Self, index: i32) -> Option(Item)` contract; broader
+  ADT/schema/generalized iterable dispatch remains out of scope
 - the published `v1.1.1` line intentionally excludes the first-wave first-class
   closure surface, even though current `main` now admits `Closure(T -> U)`,
   standalone closure literals, immutable capture, direct invocation, and
@@ -170,8 +175,9 @@ Current highest-signal remaining work after the first stable `v1.1.1` tag:
 2. rerun representative asset smoke for every forward release tag
 3. keep narrow `v1` limits explicit unless a separate scope decision promotes them
 4. run the internal Gate 1 qualification program in
-   `docs/roadmap/release_qualification/gate1_protocol.md` before making any
-   broader release-readiness claim
+   `docs/roadmap/release_qualification/gate1_protocol.md`; use
+   `reports/g1_release_scope_statement.md` as the current authority and rerun
+   Gate 1 before widening any broader release-readiness claim
 5. treat any future widening as a forward versioned release, not silent drift
 
 ## Contract Rule

--- a/reports/g1_release_scope_statement.md
+++ b/reports/g1_release_scope_statement.md
@@ -1,0 +1,89 @@
+# G1 Release Scope Statement
+
+Status: completed synthesis report for `Q5`
+
+## Decision State
+
+`limited release`
+
+## Decision Basis
+
+This decision is based on the evidence collected in:
+
+- `reports/g1_real_program_trial.md`
+- `reports/g1_frontend_trust.md`
+- `reports/g1_execution_integrity.md`
+- `reports/g1_benchmark_baseline.md`
+- `reports/g1_surface_expressiveness.md`
+
+and follows:
+
+- `docs/roadmap/release_qualification/gate1_protocol.md`
+
+## Why The Decision Is Not `not ready`
+
+The first Gate 1 cycle did prove a coherent admitted contour:
+
+- real small programs can be written and run on current `main`
+- the admitted frontend slices are stable and diagnostically understandable
+- the execution path
+  `source -> sema -> IR -> SemCode -> verifier -> VM`
+  is trusted on representative programs
+- a reproducible benchmark baseline now exists
+
+This is enough to support a narrow release promise.
+
+## Why The Decision Is Not `public release`
+
+The evidence does **not** support a broader practical-programming claim because:
+
+- ordinary module-based executable authoring is still blocked at the parser
+  boundary
+- practical CLI-style authoring remains incomplete
+- the admitted contour is still narrow enough that broader ecosystem/program
+  authoring would be overstated
+
+## Release-Promised Contour
+
+The currently qualified release contour is:
+
+- single-file executable programs on the admitted current source surface
+- rule/state-oriented programs using records, `quad`, and explicit
+  `Option` / `Result` handling
+- built-in `Sequence(T)` iteration
+- direct-record user-defined `Iterable` impl dispatch
+- verified execution through the admitted IR, SemCode, verifier, and VM
+  pipeline
+- deterministic behavior and reproducible benchmark baselines for the
+  representative current program pack
+
+## Explicitly Not Release-Promised
+
+The following are **not** qualified by this Gate 1 cycle and must remain
+outside the release promise:
+
+- module-based executable entry with top-level `Import`
+- broader practical-programming claims beyond the admitted single-file contour
+- full CLI application authoring with admitted argv/stdout/file IO
+- UI, which remains outside the current qualification contour
+- ADT iterable dispatch
+- schema-owned iterable dispatch
+- indirect or generalized iterable dispatch beyond the admitted direct-record
+  slice
+
+## Landed Is Not Automatically Release-Promised
+
+This report does not widen the release promise merely because behavior exists on
+`main`.
+
+Any landed surface outside the admitted contour must stay unpromoted until a
+later qualification cycle explicitly qualifies it.
+
+## Operational Release Statement
+
+Semantic is currently qualified for a **limited release** as a deterministic,
+verified language/runtime system with a narrow admitted practical-programming
+contour.
+
+Semantic is **not yet qualified** for a broader public-release claim as a
+general practical programming language.

--- a/reports/g1_surface_expressiveness.md
+++ b/reports/g1_surface_expressiveness.md
@@ -1,0 +1,104 @@
+# G1 Surface Expressiveness
+
+Status: completed synthesis report for `Q5`
+
+## Goal
+
+Decide whether the currently admitted Semantic surface is expressive enough for
+real programming, based on the evidence collected in:
+
+- `reports/g1_real_program_trial.md`
+- `reports/g1_frontend_trust.md`
+- `reports/g1_execution_integrity.md`
+- `reports/g1_benchmark_baseline.md`
+
+This report follows:
+
+- `docs/roadmap/release_qualification/gate1_protocol.md`
+
+UI remains outside this qualification contour.
+
+## Evidence Summary
+
+### Natural zone
+
+The current language surface reads naturally for:
+
+- rule/state-oriented programs over records and nominal data
+- explicit `Option` / `Result` handling through contextual constructors and
+  exhaustive `match`
+- narrow direct-record iterable dispatch with `for x in collection`
+
+Evidence:
+
+- `reports/g1_real_program_trial.md` marked the rule/state program as
+  `natural`
+- `reports/g1_frontend_trust.md` marked sequence loops, direct-record iterable
+  admission, and where-clause source sugar as `trusted`
+- `reports/g1_execution_integrity.md` confirmed end-to-end semantic
+  preservation on the representative admitted programs
+
+### Tolerable but narrow zone
+
+The current surface is usable, but still narrow, for:
+
+- small single-file executable cores
+- data-heavy programs over `Sequence(T)` and direct-record iterable impls
+
+Evidence:
+
+- `reports/g1_real_program_trial.md` marked both the CLI-style core and the
+  data-heavy iterable program as `tolerable`
+- `reports/g1_benchmark_baseline.md` showed these programs stay reproducible
+  and fast on the admitted current pipeline
+
+Why this is only `tolerable`:
+
+- admitted practical programs still skew toward single-file shapes
+- full CLI-style authoring is not yet qualified because argv/stdout/file IO is
+  not part of the admitted contour
+- iterable reuse remains narrow rather than general-purpose
+
+### Blocked zone
+
+The current surface is still blocked for ordinary module-based executable
+authoring.
+
+Evidence:
+
+- `reports/g1_real_program_trial.md` marked the module-based helper split as
+  `blocked`
+- `reports/g1_frontend_trust.md` confirmed the parser still rejects top-level
+  `Import` on this executable path with deterministic but trust-reducing
+  diagnostics
+
+This matters because a language can be technically executable while still
+failing a practical-authoring gate. That is exactly the current situation for
+multi-file executable programs on `main`.
+
+## Friction Inventory
+
+Current trust-reducing friction that does not break the admitted contour, but
+still matters for practical readiness:
+
+- module-based executable entry is blocked at the parser boundary
+- CLI-style programs remain core-only rather than fully user-facing
+- integer arithmetic ergonomics still show rough edges, as seen in the `i32`
+  `+=` probe noted in `Q1`
+
+## G1-A Verdict
+
+`G1-A Surface Expressiveness` is green only for a **limited** admitted contour.
+
+Operational meaning:
+
+- the language is expressive enough for a narrow release contour centered on
+  single-file executable programs, rule/state logic, sequence loops, and
+  direct-record iterable dispatch
+- the language is **not** yet expressive enough to justify a broader practical
+  programming claim while ordinary module-based executable authoring remains
+  blocked
+
+This is sufficient for a `limited release` decision.
+
+It is not sufficient for a `public release` decision.


### PR DESCRIPTION
## Summary
- add the Q5 synthesis reports for G1-A surface expressiveness and G1-F release scope
- close the first Gate 1 qualification cycle in backlog/readiness docs
- keep the release verdict explicit as limited release for the admitted narrow contour

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts