### PR TITLE
frontend: admit executable import source surface

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -4,8 +4,8 @@ use crate::types::{
     BlockExpr, CallArg, CaptureMode, ClosureCapturePolicy, ClosureLiteral, ClosureValueFamily,
     Expr, ExprId, FrontendError, Function, IfExpr, IfLetExpr, ImplDecl, IntRangePattern, IterableLoopDesugaring, LogosEntity,
     LogosEntityField, LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen,
-    LoopExpr, MatchArm, MatchExpr, MatchExprArm, MatchPattern, NumericLiteral, Program, QuadVal,
-    RangeExpr, RecordDecl, RecordField,
+    ExecutableImport, ExecutableImportSelectItem, LoopExpr, MatchArm, MatchExpr, MatchExprArm,
+    MatchPattern, NumericLiteral, Program, QuadVal, RangeExpr, RecordDecl, RecordField,
     RecordFieldExpr, RecordInitField, RecordLiteralExpr, RecordPatternItem, RecordPatternTarget,
     RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole, SchemaShape, SchemaVariant,
     SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr, SequenceLiteral, SequenceType,
@@ -87,6 +87,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_program(&mut self) -> Result<Program, FrontendError> {
+        let mut imports = Vec::new();
         let mut adts = Vec::new();
         let mut records = Vec::new();
         let mut schemas = Vec::new();
@@ -104,6 +105,7 @@ impl<'a> Parser<'a> {
                 continue;
             }
             match self.tokens[i].kind {
+                TokenKind::KwImport => imports.push(self.parse_import_decl()?),
                 TokenKind::KwEnum => adts.push(self.parse_adt_decl()?),
                 TokenKind::KwFn => functions.push(self.parse_function()?),
                 TokenKind::KwRecord => records.push(self.parse_record_decl()?),
@@ -114,7 +116,7 @@ impl<'a> Parser<'a> {
                     return Err(FrontendError {
                         pos: self.tokens[i].pos,
                         message:
-                            "expected top-level 'enum', 'fn', 'impl', 'record', 'schema', 'trait', or role-marked schema declaration"
+                            "expected top-level 'Import', 'enum', 'fn', 'impl', 'record', 'schema', 'trait', or role-marked schema declaration"
                                 .to_string(),
                     });
                 }
@@ -122,12 +124,51 @@ impl<'a> Parser<'a> {
         }
         Ok(Program {
             arena: ::core::mem::take(&mut self.arena),
+            imports,
             adts,
             records,
             schemas,
             functions,
             traits,
             impls,
+        })
+    }
+
+    fn parse_import_decl(&mut self) -> Result<ExecutableImport, FrontendError> {
+        self.expect(TokenKind::KwImport, "expected 'Import'")?;
+        let reexport = self.eat_ident_text("pub");
+        let spec = self.expect_string_literal_text("expected import path string")?;
+        let alias = if self.eat_ident_text("as") {
+            Some(self.expect_symbol()?)
+        } else {
+            None
+        };
+        let wildcard = self.eat(TokenKind::Star);
+        let mut select_items = Vec::new();
+        if self.eat(TokenKind::LBrace) {
+            if !self.check(TokenKind::RBrace) {
+                loop {
+                    let name = self.expect_symbol()?;
+                    let alias = if self.eat_ident_text("as") {
+                        Some(self.expect_symbol()?)
+                    } else {
+                        None
+                    };
+                    select_items.push(ExecutableImportSelectItem { name, alias });
+                    if self.eat(TokenKind::Comma) {
+                        continue;
+                    }
+                    break;
+                }
+            }
+            self.expect(TokenKind::RBrace, "expected '}' after import select list")?;
+        }
+        Ok(ExecutableImport {
+            spec,
+            alias,
+            reexport,
+            select_items,
+            wildcard,
         })
     }
 
@@ -3178,6 +3219,21 @@ impl<'a> Parser<'a> {
         self.tokens.get(i).map(|t| t.kind == kind).unwrap_or(false)
     }
 
+    fn eat_ident_text(&mut self, text: &str) -> bool {
+        let i = self.next_non_layout_idx();
+        if self
+            .tokens
+            .get(i)
+            .map(|t| t.kind == TokenKind::Ident && t.text == text)
+            .unwrap_or(false)
+        {
+            self.idx = i + 1;
+            true
+        } else {
+            false
+        }
+    }
+
     fn eat(&mut self, kind: TokenKind) -> bool {
         let i = self.next_non_layout_idx();
         if self.tokens.get(i).map(|t| t.kind == kind).unwrap_or(false) {
@@ -3233,6 +3289,18 @@ impl<'a> Parser<'a> {
             Err(FrontendError {
                 pos: self.pos(),
                 message: "expected identifier".to_string(),
+            })
+        }
+    }
+
+    fn expect_string_literal_text(&mut self, msg: &str) -> Result<String, FrontendError> {
+        if self.check(TokenKind::String) {
+            let token = self.advance().text;
+            Ok(token.trim_matches('"').to_string())
+        } else {
+            Err(FrontendError {
+                pos: self.pos(),
+                message: msg.to_string(),
             })
         }
     }
@@ -3403,6 +3471,60 @@ fn main() { return; }
             panic!("expected desugared return statement");
         };
         assert!(matches!(program.arena.expr(*value), Expr::Var(_)));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_top_level_namespace_import() {
+        let src = r#"
+Import "helper.sm"
+
+fn main() { return; }
+        "#;
+
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
+        assert_eq!(program.imports.len(), 1);
+        let import = &program.imports[0];
+        assert_eq!(import.spec, "helper.sm");
+        assert_eq!(import.alias, None);
+        assert!(!import.reexport);
+        assert!(!import.wildcard);
+        assert!(import.select_items.is_empty());
+    }
+
+    #[test]
+    fn rustlike_parser_preserves_import_alias_and_select_items() {
+        let src = r#"
+Import "helper.sm" as Helpers { Foo, Bar as Baz }
+
+fn main() { return; }
+        "#;
+
+        let program =
+            parse_rustlike_with_profile(src, &ParserProfile::foundation_default()).expect("parse");
+        assert_eq!(program.imports.len(), 1);
+        let import = &program.imports[0];
+        assert_eq!(import.spec, "helper.sm");
+        assert_eq!(
+            import.alias.map(|sym| program.arena.symbol_name(sym).to_string()),
+            Some("Helpers".to_string())
+        );
+        assert_eq!(import.select_items.len(), 2);
+        assert_eq!(
+            program.arena.symbol_name(import.select_items[0].name),
+            "Foo"
+        );
+        assert_eq!(import.select_items[0].alias, None);
+        assert_eq!(
+            program.arena.symbol_name(import.select_items[1].name),
+            "Bar"
+        );
+        assert_eq!(
+            import.select_items[1]
+                .alias
+                .map(|sym| program.arena.symbol_name(sym).to_string()),
+            Some("Baz".to_string())
+        );
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -28,6 +28,30 @@ fn iterable_for_impl_out_of_scope_message() -> &'static str {
     "iterable 'for x in collection' executable explicit `Iterable` dispatch currently supports direct record impls only; ADT/schema dispatch stays out of scope"
 }
 
+fn executable_import_resolution_gap_message() -> &'static str {
+    "top-level executable Import is parsed on current main, but executable module resolution is not implemented yet; only single-file entry programs remain admitted until the executable module entry track lands"
+}
+
+fn executable_import_wave1_out_of_scope_message() -> &'static str {
+    "top-level executable Import currently admits only direct local-path namespace imports in wave1; re-export, wildcard, and selected import forms remain out of scope"
+}
+
+fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
+    for import in &program.imports {
+        if import.reexport || import.wildcard || !import.select_items.is_empty() {
+            return Err(FrontendError {
+                pos: 0,
+                message: executable_import_wave1_out_of_scope_message().to_string(),
+            });
+        }
+        return Err(FrontendError {
+            pos: 0,
+            message: executable_import_resolution_gap_message().to_string(),
+        });
+    }
+    Ok(())
+}
+
 fn is_numeric_literal_like_expr(expr_id: ExprId, arena: &AstArena) -> bool {
     match arena.expr(expr_id) {
         Expr::NumericLiteral(_) => true,
@@ -131,6 +155,7 @@ fn lift_literal_to_expected_type(
 }
 
 pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
+    validate_executable_imports(program)?;
     if program.functions.len() != 1 {
         return Err(FrontendError {
             pos: 0,
@@ -167,6 +192,7 @@ pub fn type_check_function(program: &Program) -> Result<(), FrontendError> {
 }
 
 pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
+    validate_executable_imports(p)?;
     let table = build_fn_table(p)?;
     let record_table = build_record_table(p)?;
     let adt_table = build_adt_table(p)?;
@@ -219,6 +245,7 @@ pub fn type_check_program(p: &Program) -> Result<(), FrontendError> {
 pub fn derive_validation_plan_table(
     program: &Program,
 ) -> Result<ValidationPlanTable, FrontendError> {
+    validate_executable_imports(program)?;
     let record_table = build_record_table(program)?;
     let adt_table = build_adt_table(program)?;
     let schema_table = build_schema_table(program)?;
@@ -2427,6 +2454,55 @@ mod tests {
         "#;
 
         typecheck_source(src).expect("fx passthrough surface should typecheck");
+    }
+
+    #[test]
+    fn executable_namespace_import_rejects_with_wave1_gap_message() {
+        let src = r#"
+            Import "helper.sm"
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("top-level executable Import must stay blocked until module resolution lands");
+        assert!(err.message.contains(executable_import_resolution_gap_message()));
+    }
+
+    #[test]
+    fn executable_selected_import_rejects_as_wave1_out_of_scope() {
+        let src = r#"
+            Import "helper.sm" { Foo }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("selected executable import must stay out of scope in wave1");
+        assert!(err
+            .message
+            .contains(executable_import_wave1_out_of_scope_message()));
+    }
+
+    #[test]
+    fn executable_reexport_import_rejects_as_wave1_out_of_scope() {
+        let src = r#"
+            Import pub "helper.sm" { Foo }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("re-export executable import must stay out of scope in wave1");
+        assert!(err
+            .message
+            .contains(executable_import_wave1_out_of_scope_message()));
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -756,9 +756,25 @@ pub struct ValidationPlan {
     pub checks: Vec<ValidationCheck>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutableImportSelectItem {
+    pub name: SymbolId,
+    pub alias: Option<SymbolId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutableImport {
+    pub spec: String,
+    pub alias: Option<SymbolId>,
+    pub reexport: bool,
+    pub select_items: Vec<ExecutableImportSelectItem>,
+    pub wildcard: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
     pub arena: AstArena,
+    pub imports: Vec<ExecutableImport>,
     pub adts: Vec<AdtDecl>,
     pub records: Vec<RecordDecl>,
     pub schemas: Vec<SchemaDecl>,

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -24,11 +24,16 @@ The current Rust-like executable surface is a deterministic function program.
 
 Current rules:
 
-- top-level source items currently include nominal `record`, compile-time-only
-  `schema`, and executable function declarations
+- top-level source items currently include executable `Import` directives,
+  nominal `record`, compile-time-only `schema`, and executable function
+  declarations
 - `record` declarations contribute nominal type identity but are not themselves executable entrypoints
 - `schema` declarations contribute compile-time contract metadata only and are
   not executable entrypoints or value families
+- top-level executable `Import` directives are parsed and preserved on current
+  `main`, but ordinary executable module resolution remains a narrower
+  follow-up track rather than part of the already-qualified single-file
+  contour
 - execution begins at `fn main()`
 - `main` must currently have signature `fn main()`
 - there is no dynamic entrypoint discovery or module-level executable code

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -98,13 +98,14 @@ Fixture:
 
 Observed diagnostic:
 
-- contains `expected top-level`
+- contains `top-level executable Import currently admits only direct local-path namespace imports in wave1`
 
 Assessment:
 
 - this is deterministic
 - this is also a real trust problem, because ordinary module-based executable
-  authoring is still blocked at the parser boundary on current `main`
+  authoring is still blocked at the executable module-entry boundary on current
+  `main`
 
 Verdict:
 
@@ -197,8 +198,8 @@ Trusted zones on current `main`:
 
 Still trust-reducing zones:
 
-- ordinary module/import executable entry remains blocked by the current parser
-  top-level contract
+- ordinary module/import executable entry remains blocked by the current wave1
+  executable import contract
 - this is deterministic, but it means source-level modular authoring is not yet
   trustworthy as a practical executable path
 

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -130,13 +130,13 @@ Observed behavior:
 
 - `smc check` rejects the entry module
 - `smc run` rejects the entry module
-- current parser surface reports top-level `Import` as invalid in this
+- current wave1 executable import surface rejects selected import form in this
   executable program path
 
 Observed blocking surface:
 
 ```text
-expected top-level 'enum', 'fn', 'impl', 'record', 'schema', 'trait', or role-marked schema declaration
+top-level executable Import currently admits only direct local-path namespace imports in wave1; re-export, wildcard, and selected import forms remain out of scope
 ```
 
 Verdict:

--- a/reports/g1_release_scope_statement.md
+++ b/reports/g1_release_scope_statement.md
@@ -37,8 +37,8 @@ This is enough to support a narrow release promise.
 
 The evidence does **not** support a broader practical-programming claim because:
 
-- ordinary module-based executable authoring is still blocked at the parser
-  boundary
+- ordinary module-based executable authoring is still blocked at the current
+  executable module-entry boundary
 - practical CLI-style authoring remains incomplete
 - the admitted contour is still narrow enough that broader ecosystem/program
   authoring would be overstated

--- a/reports/g1_surface_expressiveness.md
+++ b/reports/g1_surface_expressiveness.md
@@ -68,9 +68,9 @@ Evidence:
 
 - `reports/g1_real_program_trial.md` marked the module-based helper split as
   `blocked`
-- `reports/g1_frontend_trust.md` confirmed the parser still rejects top-level
-  `Import` on this executable path with deterministic but trust-reducing
-  diagnostics
+- `reports/g1_frontend_trust.md` confirmed the current wave1 executable import
+  contract still rejects the selected-import module helper path with
+  deterministic but trust-reducing diagnostics
 
 This matters because a language can be technically executable while still
 failing a practical-authoring gate. That is exactly the current situation for
@@ -81,7 +81,8 @@ multi-file executable programs on `main`.
 Current trust-reducing friction that does not break the admitted contour, but
 still matters for practical readiness:
 
-- module-based executable entry is blocked at the parser boundary
+- module-based executable entry is blocked at the current executable module-entry
+  boundary
 - CLI-style programs remain core-only rather than fully user-facing
 - integer arithmetic ergonomics still show rough edges, as seen in the `i32`
   `+=` probe noted in `Q1`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ pub mod frontend {
         }
         Ok(Program {
             arena: ::core::mem::take(&mut p.arena),
+            imports: p.imports,
             adts: p.adts,
             records: p.records,
             schemas: p.schemas,

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -35,7 +35,7 @@ fn g1_frontend_negative_suite_reports_expected_diagnostics() {
     let cases = [
         (
             "examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm",
-            "expected top-level",
+            "top-level executable Import currently admits only direct local-path namespace imports in wave1",
         ),
         (
             "examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm",

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -45,7 +45,15 @@ fn g1_data_audit_record_iterable_checks_and_runs() {
 fn g1_module_helpers_program_is_blocked() {
     let rel = "examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm";
     let check_err = cli_err("check", rel);
-    assert!(check_err.contains("expected top-level"));
+    assert!(
+        check_err.contains(
+            "top-level executable Import currently admits only direct local-path namespace imports in wave1"
+        )
+    );
     let run_err = cli_err("run", rel);
-    assert!(run_err.contains("expected top-level"));
+    assert!(
+        run_err.contains(
+            "top-level executable Import currently admits only direct local-path namespace imports in wave1"
+        )
+    );
 }


### PR DESCRIPTION
## Summary
- parse and preserve top-level executable Import directives in Program
- return explicit wave1 executable-import diagnostics instead of generic parser rejection
- sync Gate 1 qualification tests and reports to the new executable module-entry boundary wording

## Testing
- cargo test -q
- cargo test -q --test public_api_contracts