### PR TITLE
cli: resolve bare local helper imports for executables

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -28,26 +28,23 @@ fn iterable_for_impl_out_of_scope_message() -> &'static str {
     "iterable 'for x in collection' executable explicit `Iterable` dispatch currently supports direct record impls only; ADT/schema dispatch stays out of scope"
 }
 
-fn executable_import_resolution_gap_message() -> &'static str {
-    "top-level executable Import is parsed on current main, but executable module resolution is not implemented yet; only single-file entry programs remain admitted until the executable module entry track lands"
-}
-
-fn executable_import_wave1_out_of_scope_message() -> &'static str {
-    "top-level executable Import currently admits only direct local-path namespace imports in wave1; re-export, wildcard, and selected import forms remain out of scope"
+fn executable_import_wave2_out_of_scope_message() -> &'static str {
+    "top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope"
 }
 
 fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
     for import in &program.imports {
-        if import.reexport || import.wildcard || !import.select_items.is_empty() {
+        if import.reexport
+            || import.wildcard
+            || import.alias.is_some()
+            || !import.select_items.is_empty()
+            || import.spec.contains("::")
+        {
             return Err(FrontendError {
                 pos: 0,
-                message: executable_import_wave1_out_of_scope_message().to_string(),
+                message: executable_import_wave2_out_of_scope_message().to_string(),
             });
         }
-        return Err(FrontendError {
-            pos: 0,
-            message: executable_import_resolution_gap_message().to_string(),
-        });
     }
     Ok(())
 }
@@ -2457,7 +2454,7 @@ mod tests {
     }
 
     #[test]
-    fn executable_namespace_import_rejects_with_wave1_gap_message() {
+    fn executable_bare_local_path_import_typechecks_in_wave2() {
         let src = r#"
             Import "helper.sm"
 
@@ -2466,13 +2463,11 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src)
-            .expect_err("top-level executable Import must stay blocked until module resolution lands");
-        assert!(err.message.contains(executable_import_resolution_gap_message()));
+        typecheck_source(src).expect("bare local-path executable import should typecheck in wave2");
     }
 
     #[test]
-    fn executable_selected_import_rejects_as_wave1_out_of_scope() {
+    fn executable_selected_import_rejects_as_wave2_out_of_scope() {
         let src = r#"
             Import "helper.sm" { Foo }
 
@@ -2482,14 +2477,14 @@ mod tests {
         "#;
 
         let err = typecheck_source(src)
-            .expect_err("selected executable import must stay out of scope in wave1");
+            .expect_err("selected executable import must stay out of scope in wave2");
         assert!(err
             .message
-            .contains(executable_import_wave1_out_of_scope_message()));
+            .contains(executable_import_wave2_out_of_scope_message()));
     }
 
     #[test]
-    fn executable_reexport_import_rejects_as_wave1_out_of_scope() {
+    fn executable_reexport_import_rejects_as_wave2_out_of_scope() {
         let src = r#"
             Import pub "helper.sm" { Foo }
 
@@ -2499,10 +2494,27 @@ mod tests {
         "#;
 
         let err = typecheck_source(src)
-            .expect_err("re-export executable import must stay out of scope in wave1");
+            .expect_err("re-export executable import must stay out of scope in wave2");
         assert!(err
             .message
-            .contains(executable_import_wave1_out_of_scope_message()));
+            .contains(executable_import_wave2_out_of_scope_message()));
+    }
+
+    #[test]
+    fn executable_package_qualified_import_rejects_as_wave2_out_of_scope() {
+        let src = r#"
+            Import "math::core.sm"
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("package-qualified executable import must stay out of scope in wave2");
+        assert!(err
+            .message
+            .contains(executable_import_wave2_out_of_scope_message()));
     }
 
     #[test]

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -46,10 +46,112 @@ fn ensure_package_module_admission(path: &Path) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+fn executable_import_wave2_out_of_scope_message() -> &'static str {
+    "top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope"
+}
+
 fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
     ensure_package_module_admission(path)?;
-    std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read '{}': {}", path.display(), e))
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let parser_profile = cli_profile();
+    let program = match parse_program_with_profile(&source, &parser_profile) {
+        Ok(program) => program,
+        Err(_) => return Ok(source),
+    };
+    if program.imports.is_empty() {
+        return Ok(source);
+    }
+    let mut visiting = Vec::new();
+    let mut loaded = HashSet::new();
+    let mut modules = Vec::new();
+    collect_executable_bundle(
+        &canonical,
+        &parser_profile,
+        &mut visiting,
+        &mut loaded,
+        &mut modules,
+    )?;
+    let mut bundle = String::new();
+    for (idx, (_path, module_source)) in modules.into_iter().enumerate() {
+        if idx > 0 {
+            bundle.push_str("\n\n");
+        }
+        bundle.push_str(&module_source);
+        if !module_source.ends_with('\n') {
+            bundle.push('\n');
+        }
+    }
+    Ok(bundle)
+}
+
+fn collect_executable_bundle(
+    path: &Path,
+    parser_profile: &ParserProfile,
+    visiting: &mut Vec<PathBuf>,
+    loaded: &mut HashSet<PathBuf>,
+    modules: &mut Vec<(PathBuf, String)>,
+) -> Result<(), String> {
+    ensure_package_module_admission(path)?;
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    if loaded.contains(&canonical) {
+        return Ok(());
+    }
+    if let Some(pos) = visiting.iter().position(|entry| entry == &canonical) {
+        let mut chain = visiting[pos..]
+            .iter()
+            .map(|entry| entry.to_string_lossy().replace('\\', "/"))
+            .collect::<Vec<_>>();
+        chain.push(canonical.to_string_lossy().replace('\\', "/"));
+        return Err(format!(
+            "cyclic executable helper import detected: {}",
+            chain.join(" -> ")
+        ));
+    }
+    visiting.push(canonical.clone());
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let program = parse_program_with_profile(&source, parser_profile).map_err(|e| {
+        format!(
+            "executable helper module '{}' must parse on the Rust-like source path: {}",
+            canonical.display(),
+            e
+        )
+    })?;
+    for import in &program.imports {
+        validate_executable_bundle_import(&canonical, import)?;
+        let child = resolve_package_import_path(&canonical, &import.spec)
+            .map_err(|e| format!("{}: {}", canonical.display(), e))?;
+        collect_executable_bundle(&child, parser_profile, visiting, loaded, modules)?;
+    }
+    let _ = visiting.pop();
+    loaded.insert(canonical.clone());
+    modules.push((canonical, source));
+    Ok(())
+}
+
+fn validate_executable_bundle_import(
+    importer: &Path,
+    import: &sm_front::types::ExecutableImport,
+) -> Result<(), String> {
+    if import.reexport
+        || import.wildcard
+        || import.alias.is_some()
+        || !import.select_items.is_empty()
+        || import.spec.contains("::")
+    {
+        return Err(format!(
+            "{} in '{}'",
+            executable_import_wave2_out_of_scope_message(),
+            importer.display()
+        ));
+    }
+    Ok(())
 }
 
 fn cli_profile() -> ParserProfile {
@@ -469,10 +571,10 @@ fn cmd_watch(args: &[String]) -> Result<(), String> {
                 if last_fp != Some(fp) {
                     let t0 = Instant::now();
                     last_fp = Some(fp);
-                    let src = match std::fs::read_to_string(&root) {
+                    let src = match read_source_with_package_admission(&root) {
                         Ok(s) => s,
                         Err(e) => {
-                            let snap = format!("error: failed to read '{}': {}", root.display(), e);
+                            let snap = format!("error: {}", e);
                             let changed = last_snapshot
                                 .as_ref()
                                 .map(|prev| prev != &snap)
@@ -1778,6 +1880,76 @@ Import "c.sm" as Core
 "#;
         let specs = parse_import_specs(src);
         assert_eq!(specs, vec!["a.sm", "b.sm", "c.sm"]);
+    }
+
+    #[test]
+    fn executable_bundle_includes_direct_local_helper_modules() {
+        let dir = mk_temp_dir("smc_exec_bundle_local_helper");
+        let root = dir.join("main.sm");
+        let helper = dir.join("helper.sm");
+        std::fs::write(
+            &root,
+            r#"
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}
+"#,
+        )
+        .expect("write root");
+        std::fs::write(
+            &helper,
+            r#"
+fn score(value: i32) -> i32 {
+    return value;
+}
+"#,
+        )
+        .expect("write helper");
+
+        let bundled = read_source_with_package_admission(&root).expect("bundle");
+        assert!(bundled.contains("Import \"helper.sm\""));
+        assert!(bundled.contains("fn score(value: i32) -> i32"));
+        assert!(bundled.contains("fn main()"));
+        assert!(bundled.find("fn score").unwrap() < bundled.find("fn main").unwrap());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn executable_bundle_rejects_selected_imports_in_wave2() {
+        let dir = mk_temp_dir("smc_exec_bundle_selected_blocked");
+        let root = dir.join("main.sm");
+        let helper = dir.join("helper.sm");
+        std::fs::write(
+            &root,
+            r#"
+Import "helper.sm" { score }
+
+fn main() {
+    return;
+}
+"#,
+        )
+        .expect("write root");
+        std::fs::write(
+            &helper,
+            r#"
+fn score(value: i32) -> i32 {
+    return value;
+}
+"#,
+        )
+        .expect("write helper");
+
+        let err = read_source_with_package_admission(&root)
+            .expect_err("selected executable import must stay out of scope in wave2");
+        assert!(err.contains(executable_import_wave2_out_of_scope_message()));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/docs/roadmap/language_maturity/executable_module_entry_scope.md
+++ b/docs/roadmap/language_maturity/executable_module_entry_scope.md
@@ -46,7 +46,7 @@ Those reports showed:
 
 The first wave will target only:
 
-- direct local-path executable module imports
+- direct local-path executable helper-module imports
 - one root executable entry module containing `fn main()`
 - imported executable declarations needed for ordinary helper-module programs
 
@@ -56,7 +56,7 @@ silently widening into a general package or registry system.
 ## Included In First Wave
 
 - top-level `Import` admission on the executable source path
-- direct local-path import resolution for executable module graphs
+- direct local-path helper-module loading for executable module graphs
 - imported executable declarations for current source items such as:
   - `fn`
   - `record`
@@ -79,6 +79,8 @@ silently widening into a general package or registry system.
 - module-level executable statements
 - wildcard or public re-export promises for the executable path unless they are
   explicitly admitted in a later scope decision
+- namespace-qualified executable access unless it is explicitly admitted in a
+  later scope decision
 
 ## Honest First-Wave Rules
 
@@ -104,8 +106,11 @@ silently widening into a general package or registry system.
 
 ### Wave 2 — Executable Module Resolution
 
-- build the executable module graph before semantic checking
-- make imported declarations available to the executable semantic path
+- build the executable helper-module graph before semantic checking
+- make direct local-path helper-module declarations available to the executable
+  semantic path through deterministic bundling
+- keep alias, selected, wildcard, re-export, and package-qualified executable
+  import forms explicitly out of scope
 
 ### Wave 3 — Lowering / CLI / End-To-End
 

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -57,6 +57,27 @@ Import "a/b/c" *
 Import pub "a/b/c" { Foo }
 ```
 
+## Current Executable-Path Narrowing
+
+The broader module/import source contract above is not yet fully admitted on
+the current executable Rust-like path.
+
+Current executable-path admission is narrower:
+
+- direct local-path bare imports such as `Import "helper.sm"` are admitted for
+  deterministic helper-module loading
+- imported helper-module declarations are bundled into the executable semantic
+  path before checking/lowering
+
+The following executable import forms remain out of scope on current `main`:
+
+- explicit alias imports
+- selected imports
+- wildcard imports
+- public re-exports
+- package-qualified executable imports
+- namespace-qualified executable access such as `X.Foo`
+
 ## Name Resolution Order
 
 Current effective resolution order:

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -30,10 +30,17 @@ Current rules:
 - `record` declarations contribute nominal type identity but are not themselves executable entrypoints
 - `schema` declarations contribute compile-time contract metadata only and are
   not executable entrypoints or value families
-- top-level executable `Import` directives are parsed and preserved on current
-  `main`, but ordinary executable module resolution remains a narrower
-  follow-up track rather than part of the already-qualified single-file
-  contour
+- top-level executable `Import` directives now admit one narrow module-entry
+  slice on current `main`:
+  - direct local-path bare imports such as `Import "helper.sm"`
+  - deterministic helper-module bundling before executable semantic checking
+- the current executable path still does **not** admit:
+  - alias imports
+  - selected imports
+  - wildcard imports
+  - public re-exports
+  - package-qualified executable imports
+  - namespace-qualified executable access
 - execution begins at `fn main()`
 - `main` must currently have signature `fn main()`
 - there is no dynamic entrypoint discovery or module-level executable code

--- a/examples/qualification/executable_module_entry/wave2_local_helper_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/wave2_local_helper_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -98,7 +98,7 @@ Fixture:
 
 Observed diagnostic:
 
-- contains `top-level executable Import currently admits only direct local-path namespace imports in wave1`
+- contains `top-level executable Import currently admits only direct local-path helper-module imports in wave2`
 
 Assessment:
 
@@ -199,7 +199,7 @@ Trusted zones on current `main`:
 Still trust-reducing zones:
 
 - ordinary module/import executable entry remains blocked by the current wave1
-  executable import contract
+  executable import contract for alias/selected/wildcard/re-export forms
 - this is deterministic, but it means source-level modular authoring is not yet
   trustworthy as a practical executable path
 

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -136,7 +136,7 @@ Observed behavior:
 Observed blocking surface:
 
 ```text
-top-level executable Import currently admits only direct local-path namespace imports in wave1; re-export, wildcard, and selected import forms remain out of scope
+top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope
 ```
 
 Verdict:

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(command: &str, rel: &str) {
+    let path = repo_path(rel);
+    smc_cli::run(vec![command.to_string(), path.clone()])
+        .unwrap_or_else(|err| panic!("smc {command} failed for {path}: {err}"));
+}
+
+#[test]
+fn executable_module_entry_wave2_local_helper_import_checks_and_runs() {
+    let rel = "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -35,7 +35,7 @@ fn g1_frontend_negative_suite_reports_expected_diagnostics() {
     let cases = [
         (
             "examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm",
-            "top-level executable Import currently admits only direct local-path namespace imports in wave1",
+            "top-level executable Import currently admits only direct local-path helper-module imports in wave2",
         ),
         (
             "examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm",

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -47,13 +47,13 @@ fn g1_module_helpers_program_is_blocked() {
     let check_err = cli_err("check", rel);
     assert!(
         check_err.contains(
-            "top-level executable Import currently admits only direct local-path namespace imports in wave1"
+            "top-level executable Import currently admits only direct local-path helper-module imports in wave2"
         )
     );
     let run_err = cli_err("run", rel);
     assert!(
         run_err.contains(
-            "top-level executable Import currently admits only direct local-path namespace imports in wave1"
+            "top-level executable Import currently admits only direct local-path helper-module imports in wave2"
         )
     );
 }


### PR DESCRIPTION
## Summary
- admit only direct local-path bare executable imports as wave2 helper-module loading
- bundle imported helper modules deterministically before executable semantic checking
- keep alias, selected, wildcard, re-export, package-qualified, and namespace-qualified forms out of scope

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts