### PR TITLE
docs: freeze stable vs main fx contract reading

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -16,7 +16,8 @@ Current release-maintenance wave:
 
 Current remaining `v1` wave:
 
-- `fx` numeric contract notes are frozen for the current stable line in
+- `fx` numeric contract notes now freeze the published stable `v1.1.1`
+  reading versus the forward-only current-`main` widening in
   `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
 - forward stable release/tag policy is frozen for the current stable line in
   `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -82,6 +82,8 @@ Current `v1` scope commitment:
 - compatibility commitments for `prom-*` apply only to the narrow ABI/capability/gate surface already implemented in the repository
 - the published `v1.1.1` line keeps `fx` narrower than the widened first-wave
   plain `fx` arithmetic now admitted on current `main`
+- that stable-vs-main `fx` distinction is frozen in
+  `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
 - post-stable admitted calls such as `StateQuery`, `StateUpdate`, `EventPost`,
   and `ClockRead` remain outside the current `v1.1.1` compatibility envelope
 - support for those wider calls on current `main` is a forward-only repo-main
@@ -136,6 +138,8 @@ The repository does not yet claim final compatibility guarantees for:
 
 - `fx` arithmetic semantics beyond the current admitted first-wave plain
   unary/binary contract on `main`
+- implicit coercion from non-literal non-`fx` expressions into `fx`
+- `fx[unit]` arithmetic
 - any wider PROMETHEUS host-call families beyond the currently admitted
   first-wave post-stable pack
 - replay archive semantics beyond the current admitted first-wave

--- a/docs/roadmap/language_maturity/fx_numeric_contract_notes.md
+++ b/docs/roadmap/language_maturity/fx_numeric_contract_notes.md
@@ -8,10 +8,14 @@ Related milestone: `M2 Language Completion`
 Freeze the honest `v1.1.1` reading of the current `fx` contract now that the
 canonical value path is end-to-end.
 
-This checkpoint does not widen `fx` semantics. It narrows the wording around
-what is already stable.
+This checkpoint does not widen the published stable line. It freezes the
+release-facing distinction between:
 
-## Current Stable Reading
+- the published stable `v1.1.1` `fx` contract
+- the forward-only first-wave plain `fx` arithmetic widening now admitted on
+  current `main`
+
+## Published Stable `v1.1.1` Reading
 
 - `fx` has a canonical source -> IR -> VM value path.
 - explicit `fx` literals are supported and lower through the fixed-point
@@ -30,15 +34,45 @@ what is already stable.
   in the canonical Rust-like path; they are not general-purpose `fx` operators.
 - coercion from non-literal non-`fx` numeric expressions into `fx` is not part
   of the stable contract.
-- richer `fx` arithmetic remains post-`v1` work and must not be implied by the
-  current end-to-end value path.
+
+## Current `main` Forward-Only Widening
+
+Current `main` now admits one completed first-wave widening beyond the
+published stable line:
+
+- deterministic plain unary `+` / unary `-` over already-typed `fx`
+  expressions
+- deterministic plain binary `+`, `-`, `*`, `/` between already-typed `fx`
+  operands
+- canonical lowering and verified execution for that admitted arithmetic
+  surface under `SEMCODE3`
+
+That widening is forward-only. It does not retroactively change the published
+`v1.1.1` release promise.
+
+The completed widening checkpoint is:
+
+- `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
+
+## Still Outside The Current Contract
+
+Even after the completed first-wave widening on current `main`, the repository
+still does not claim:
+
+- implicit coercion from non-literal non-`fx` numeric expressions into `fx`
+- `fx[unit]` arithmetic
+- full arithmetic parity between `fx` and `f64`
+- any host/runtime/ABI widening justified only by the presence of `fx`
+  arithmetic on current `main`
 
 ## Release Honesty Rule
 
 Release-facing docs should describe `fx` as:
 
-- stable for explicit fixed-point values and transport through the current
-  canonical execution path
-- intentionally narrower than `f64` for arithmetic semantics
-- not a justification for widening host/runtime/operator boundaries on the
-  stable line
+- stable for explicit fixed-point values and transport through the published
+  `v1.1.1` execution path
+- widened on current `main` only for the admitted first-wave plain arithmetic
+  slice documented above
+- still intentionally narrower than `f64` for arithmetic semantics
+- not a justification for silently widening host/runtime/operator boundaries on
+  either the published stable line or the forward-only first-wave widening

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -91,6 +91,8 @@ The following limits remain explicit and should be treated as release-facing hon
   unary/binary arithmetic, even though current `main` now admits deterministic
   plain `fx` arithmetic with canonical lowering/verified execution under
   `SEMCODE3`
+- the canonical stable-vs-main `fx` reading is frozen in
+  `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
 - the published `v1.1.1` line intentionally excludes post-stable PROMETHEUS
   calls such as `StateQuery`, `StateUpdate`, `EventPost`, and `ClockRead`,
   even though current `main` now admits them as a forward-only widened boundary


### PR DESCRIPTION
## Summary
- make fx numeric contract notes the canonical stable-vs-main reading
- clarify that v1.1.1 stays narrower while current main carries the forward-only SEMCODE3 widening
- sync backlog, readiness, and compatibility docs to the same fx contract statement

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts