### PR TITLE
docs/tests: close executable module entry track

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -87,13 +87,14 @@ Current post-`v1` wave:
 
 Current next-focus wave:
 
-- `Executable Module Entry Scope` is now the active blocker-removal stream in
+- no new blocker-removal stream is currently active on `main`
+- `Executable Module Entry Scope` is completed and now lives as frozen
+  baseline history in
   `docs/roadmap/language_maturity/executable_module_entry_scope.md`
-- this stream exists because `Gate 1` ended in `limited release` rather than a
-  broader practical-programming claim
-- do not widen the frozen source-language bundle beyond this narrow executable
-  module entry track without a new track or an explicit source-contract
-  amendment
+- any broader practical-programming widening now requires:
+  - a new explicit scope decision
+  - a new qualification amendment or cycle under
+    `docs/roadmap/release_qualification/gate1_protocol.md`
 
 Current qualification wave:
 
@@ -106,8 +107,8 @@ Current qualification wave:
   - `reports/g1_benchmark_baseline.md`
   - `reports/g1_surface_expressiveness.md`
   - `reports/g1_release_scope_statement.md`
-- the current Gate 1 decision state is `limited release` for the admitted
-  narrow practical-programming contour
+- the current Gate 1 decision state remains `limited release` for the amended
+  admitted practical-programming contour
 - keep UI out of the first qualification contour unless UI is explicitly
   admitted into a future release scope
 - do not treat landed-on-`main` behavior as automatically release-promised

--- a/docs/roadmap/language_maturity/executable_module_entry_scope.md
+++ b/docs/roadmap/language_maturity/executable_module_entry_scope.md
@@ -1,17 +1,17 @@
 # Executable Module Entry Scope
 
-Status: active post-qualification blocker-removal checkpoint
+Status: completed post-qualification blocker-removal checkpoint
 
 ## Goal
 
-Open a narrow follow-up track after the first `Gate 1` cycle to remove the
-largest remaining practical-programming blocker on current `main`:
+This narrow follow-up track removed the largest practical-programming blocker
+identified after the first `Gate 1` cycle:
 
-- ordinary module-based executable authoring is still blocked because top-level
-  `Import` is not admitted on the executable source path
+- ordinary helper-module executable authoring was blocked because top-level
+  executable `Import` was not admitted on the executable source path
 
-This track is intentionally narrow. It is not a reboot of the whole package or
-module ecosystem story.
+The landed result remains intentionally narrow. It is not a reboot of the whole
+package or module ecosystem story.
 
 ## Why This Track Exists
 
@@ -28,12 +28,12 @@ Evidence is frozen in:
 - `reports/g1_frontend_trust.md`
 - `reports/g1_release_scope_statement.md`
 
-Those reports showed:
+Those reports originally showed:
 
 - single-file executable programs are admitted and runnable
 - the frontend and execution path are trusted on the admitted contour
-- module-based executable entry with top-level `Import` is still blocked at the
-  parser/source-contract boundary
+- module-based executable entry with top-level `Import` was still blocked at
+  the parser/source-contract boundary
 
 ## Decision Check
 
@@ -42,18 +42,18 @@ Those reports showed:
 - [x] This remains one stream, not a mixture of package, registry, and stdlib expansion
 - [x] This can close with a clear done-boundary
 
-## Narrow First-Wave Decision
+## Landed First-Wave Reading
 
-The first wave will target only:
+The landed first wave now admits only:
 
 - direct local-path executable helper-module imports
 - one root executable entry module containing `fn main()`
 - imported executable declarations needed for ordinary helper-module programs
 
-The goal is to admit ordinary module-based executable authoring without
+The goal was to admit ordinary module-based executable authoring without
 silently widening into a general package or registry system.
 
-## Included In First Wave
+## Landed In First Wave
 
 - top-level `Import` admission on the executable source path
 - direct local-path helper-module loading for executable module graphs
@@ -91,7 +91,7 @@ silently widening into a general package or registry system.
 - landed package/dependency work on `main` does not automatically mean broader
   executable-module promises are qualified
 
-## Suggested Wave Order
+## Executed Wave Order
 
 ### Wave 0 — Governance
 
@@ -127,9 +127,24 @@ silently widening into a general package or registry system.
 - docs/spec/tests agree on the admitted executable module contour
 - rerun qualification evidence if the practical-programming contour widens
 
+## Qualification Sync Result
+
+The widened admitted contour is now frozen as:
+
+- single-file executable programs
+- narrow helper-module executable programs using direct local-path bare imports
+
+The updated Gate 1 evidence keeps the overall decision state at:
+
+- `limited release`
+
+The blocker was removed, but the release contour remains intentionally narrow
+because broader executable import forms and full CLI-style authoring are still
+outside the admitted contour.
+
 ## Acceptance Reading
 
-This track is done only when:
+This track is now done because:
 
 1. ordinary helper-module executable programs are admitted on current `main`,
 2. the executable import path is deterministic and tested end to end,

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -45,7 +45,7 @@
   - `docs/spec/cli.md`
   - current completed post-stable source-contract freeze checkpoint:
     `docs/roadmap/language_maturity/source_language_contract.md`
-  - current active post-qualification executable module entry checkpoint:
+  - current completed post-qualification executable module entry checkpoint:
     `docs/roadmap/language_maturity/executable_module_entry_scope.md`
   - current active IR hardening checkpoint:
     `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -116,10 +116,11 @@ The following limits remain explicit and should be treated as release-facing hon
   ecosystem baseline, even though current `main` now admits `Semantic.package`
   parsing, package entry-module admission, and deterministic local-path
   dependency loading for package-qualified imports
-- current `main` still does not claim ordinary module-based executable entry
-  with top-level `Import`; the first `Gate 1` cycle keeps broader executable
-  module authoring outside the current release-promised contour until the
-  dedicated executable-module-entry track lands and is re-qualified
+- current `main` now admits one narrow executable-module-entry slice through
+  direct local-path bare imports such as `Import "helper.sm"`, but broader
+  alias/selected/wildcard/public re-export/package-qualified/namespace-qualified
+  executable module authoring remains outside the current release-promised
+  contour
 - the published `v1.1.1` line intentionally excludes the first-wave ordered
   sequence collection surface, even though current `main` now admits
   `Sequence(type)`, bracketed literals, same-family equality, `expr[index]`,
@@ -185,8 +186,8 @@ Current highest-signal remaining work after the first stable `v1.1.1` tag:
    `docs/roadmap/release_qualification/gate1_protocol.md`; use
    `reports/g1_release_scope_statement.md` as the current authority and rerun
    Gate 1 before widening any broader release-readiness claim
-5. treat executable module entry as the current highest-signal practical
-   blocker before any broader release-readiness claim
+5. treat any broader practical-programming widening as a new explicit scope
+   decision plus a Gate 1 amendment or new qualification cycle
 6. treat any future widening as a forward versioned release, not silent drift
 
 ## Contract Rule

--- a/reports/g1_benchmark_baseline.md
+++ b/reports/g1_benchmark_baseline.md
@@ -19,6 +19,7 @@ representative executable programs already used in `Q1` and `Q3`:
 - small single-file CLI-style core
 - medium rule/state program
 - data-heavy direct-record iterable program
+- narrow helper-module executable program using direct local-path bare import
 
 Measured stages:
 
@@ -35,8 +36,8 @@ This baseline does **not** include:
 - UI, which remains outside the current qualification contour
 - cache cold/warm behavior, because this first pass is intended to isolate the
   compiler/runtime pipeline rather than the filesystem cache path
-- blocked module-based executable entry, because it is already known not to
-  reach the admitted pipeline on current `main`
+- out-of-scope executable module forms such as selected or alias imports,
+  because they are still intentionally outside the admitted contour
 
 ## Reproducible Harness
 
@@ -55,6 +56,10 @@ The harness measures the public in-process APIs directly:
 - `compile_program_to_semcode(...)`
 - `verify_semcode(...)`
 - `run_verified_semcode(...)`
+
+For the admitted helper-module executable slice, the harness first applies the
+same deterministic direct local-path bare-import bundling rule that current
+`smc` uses before semantic checking/lowering.
 
 Method:
 
@@ -86,35 +91,46 @@ measured_runs=7
 scenario=small_cli_core
 path=examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm
 snapshot=tokens:156 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:90 semcode_bytes:601 semcode_hash:416f22cbb9708ff7
-lex_us=min:32 median:55 max:183
-parse_us=min:79 median:168 max:577
-sema_us=min:226 median:357 max:1965
-ir_us=min:277 median:348 max:1323
-emit_us=min:331 median:452 max:820
-verify_us=min:25 median:30 max:68
-runtime_us=min:252 median:421 max:669
+lex_us=min:28 median:38 max:84
+parse_us=min:61 median:92 max:208
+sema_us=min:221 median:327 max:579
+ir_us=min:254 median:377 max:719
+emit_us=min:321 median:400 max:741
+verify_us=min:24 median:26 max:37
+runtime_us=min:252 median:254 max:486
 
 scenario=medium_rule_state
 path=examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm
 snapshot=tokens:226 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:100 semcode_bytes:654 semcode_hash:cb30d87c1081677e
-lex_us=min:43 median:92 max:122
-parse_us=min:111 median:220 max:255
-sema_us=min:506 median:1055 max:2314
-ir_us=min:497 median:1226 max:1571
-emit_us=min:559 median:1757 max:3318
-verify_us=min:30 median:68 max:82
-runtime_us=min:166 median:380 max:685
+lex_us=min:39 median:45 max:143
+parse_us=min:106 median:143 max:282
+sema_us=min:364 median:485 max:995
+ir_us=min:441 median:618 max:1244
+emit_us=min:497 median:539 max:1273
+verify_us=min:27 median:28 max:57
+runtime_us=min:150 median:155 max:386
 
 scenario=record_iterable_data
 path=examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm
 snapshot=tokens:359 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:3 ir_instructions:131 semcode_bytes:1030 semcode_hash:5ca7f7eee779e16f
-lex_us=min:130 median:137 max:246
-parse_us=min:265 median:374 max:635
-sema_us=min:822 median:1178 max:1791
-ir_us=min:839 median:1673 max:2266
-emit_us=min:839 median:1869 max:2989
-verify_us=min:78 median:89 max:164
-runtime_us=min:438 median:792 max:1536
+lex_us=min:63 median:110 max:219
+parse_us=min:179 median:208 max:427
+sema_us=min:604 median:669 max:1256
+ir_us=min:694 median:857 max:1194
+emit_us=min:783 median:825 max:1344
+verify_us=min:38 median:40 max:51
+runtime_us=min:425 median:432 max:620
+
+scenario=module_helper_entry
+path=examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm
+snapshot=tokens:57 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:11 semcode_bytes:114 semcode_hash:6a3934431b5d325b
+lex_us=min:9 median:10 max:24
+parse_us=min:20 median:21 max:54
+sema_us=min:70 median:72 max:209
+ir_us=min:77 median:78 max:217
+emit_us=min:87 median:88 max:242
+verify_us=min:6 median:6 max:15
+runtime_us=min:27 median:27 max:69
 ```
 
 ## Interpretation
@@ -127,6 +143,9 @@ What the baseline currently shows:
   set
 - the data-heavy record iterable program is the heaviest admitted scenario in
   the current first-cycle pack, as expected
+- the admitted helper-module executable path sits close to the small single-file
+  core and does not introduce a disproportionate pipeline cost on current
+  `main`
 
 What it does **not** show:
 

--- a/reports/g1_execution_integrity.md
+++ b/reports/g1_execution_integrity.md
@@ -24,6 +24,7 @@ Representative source fixtures reused from `Q1`:
 - `examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm`
 - `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
 - `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
+- `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
 
 Canonical harness:
 
@@ -39,6 +40,10 @@ The harness goes through the public compiler/runtime surface:
 - `verify_semcode(...)`
 - `run_verified_semcode(...)`
 - `disasm_semcode(...)`
+
+For the admitted helper-module executable slice, the harness first applies the
+same deterministic direct local-path bare-import bundling rule that current
+`smc` uses before semantic checking/lowering.
 
 ## Representative Stage Snapshots
 
@@ -68,6 +73,14 @@ semcode:magic=SEMCOD12 rev=13
 verify:names=__impl::Iterable::Samples::next,main,summarize
 disasm:names=__impl::Iterable::Samples::next,main,summarize
 run=ok
+
+program=wave2_local_helper_import
+sema:warnings=0 laws=0
+ir:names=main,score
+semcode:magic=SEMCODE0 rev=1
+verify:names=main,score
+disasm:names=main,score
+run=ok
 ```
 
 What this proves:
@@ -76,6 +89,8 @@ What this proves:
   through verifier and disasm
 - the current executable iterable slice reaches SemCode and VM without semantic
   disappearance
+- the admitted helper-module executable slice also reaches SemCode and VM
+  without semantic disappearance
 - the public `run_verified_semcode(...)` path stays successful after verifier
   admission
 
@@ -119,12 +134,10 @@ Both fixes were narrow and directly tied to Q3 evidence integrity.
 
 ## Boundary Notes
 
-The blocked module-based executable program from `Q1` is not counted here as an
-execution-integrity failure, because it does not reach the full
-`source -> sema -> IR -> SemCode -> verifier -> VM` path on current `main`.
-
-That remains a source/frontend practical-readiness limitation, not evidence of a
-semantic-preservation break inside the admitted execution contour.
+The selected-import executable helper program from `Q1` still remains outside
+the admitted contour, so it is not counted here as an execution-integrity
+failure. The current admitted executable module-entry slice is only the direct
+local-path bare-import form.
 
 ## Q3 Verdict
 

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -21,6 +21,7 @@ Canonical positive fixtures:
 - `examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm`
 - `examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm`
 - `examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm`
+- `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
 
 Canonical negative fixtures:
 
@@ -90,7 +91,7 @@ Verdict:
 
 ## Negative Coverage
 
-### Module/import executable entry
+### Out-of-scope executable import form
 
 Fixture:
 
@@ -103,13 +104,13 @@ Observed diagnostic:
 Assessment:
 
 - this is deterministic
-- this is also a real trust problem, because ordinary module-based executable
-  authoring is still blocked at the executable module-entry boundary on current
-  `main`
+- this now reads as an honest boundary diagnostic rather than a parser/source
+  failure, because the admitted bare-import helper-module path is already
+  working on current `main`
 
 Verdict:
 
-- `deterministic but trust-reducing`
+- `trusted`
 
 ### Wrong explicit `Iterable` contract
 
@@ -193,23 +194,26 @@ Trusted zones on current `main`:
 - sequence-loop admission
 - direct-record iterable trait/impl admission
 - where-clause source sugar
+- direct local-path bare executable helper-module imports
 - contextual `Option` / `Result` match admission
-- negative diagnostics for iterable contract shape and standard-form scope
+- negative diagnostics for iterable contract shape, standard-form scope, and
+  out-of-scope executable import forms
 
 Still trust-reducing zones:
 
-- ordinary module/import executable entry remains blocked by the current wave1
-  executable import contract for alias/selected/wildcard/re-export forms
-- this is deterministic, but it means source-level modular authoring is not yet
-  trustworthy as a practical executable path
+- broader executable-module authoring remains intentionally narrow because
+  alias/selected/wildcard/re-export/package-qualified forms are still out of
+  scope on the executable path
+- this is no longer a parser trust failure, but it still limits the broader
+  practical-programming contour
 
 ## Q2 Verdict
 
-`G1-B Frontend Trust` is partially evidenced, not fully green.
+`G1-B Frontend Trust` is green for the admitted current contour.
 
 Operational verdict:
 
 - parser/typechecker behavior is stable on the admitted current slices
 - diagnostics for several narrow boundaries are explicit and reproducible
-- frontend trust for broader practical programming remains limited while
-  module-based executable authoring is still blocked on current `main`
+- frontend trust for broader practical programming remains limited only because
+  the admitted contour itself is still intentionally narrow

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -20,7 +20,7 @@ Canonical committed trial programs:
 - `examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm`
 - `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
 - `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
-- `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+- `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
 
 Canonical reproducible harness:
 
@@ -120,7 +120,7 @@ Reason:
 
 Path:
 
-- `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+- `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
 
 Intent:
 
@@ -128,40 +128,43 @@ Intent:
 
 Observed behavior:
 
-- `smc check` rejects the entry module
-- `smc run` rejects the entry module
-- current wave1 executable import surface rejects selected import form in this
-  executable program path
+- `smc check` passes
+- `smc run` passes
+- direct local-path helper-module imports now execute through the full
+  `source -> sema -> IR -> SemCode -> verifier -> VM` path on current `main`
 
-Observed blocking surface:
+Verdict:
+
+- `tolerable`
+
+Reason:
+
+- ordinary helper-module authoring now works without hidden compiler shortcuts
+- the admitted slice is still narrow because selected, alias, wildcard,
+  re-export, and package-qualified executable imports remain out of scope
+
+## Additional Friction Found During Authoring
+
+Two extra limitations showed up while drafting the trial programs:
+
+- direct `i32` accumulation through `+=` produced
+  `f64 arithmetic requires f64 operands, got I32 and I32`
+- the selected-import helper-module variant in
+  `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+  still rejects with:
 
 ```text
 top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope
 ```
 
-Verdict:
-
-- `blocked`
-
-Reason:
-
-- a normal module-based executable helper split is not admitted as a working
-  current-`main` program path
-- this is a real qualification blocker for broader practical programming claims
-
-## Additional Friction Found During Authoring
-
-One extra limitation showed up while drafting the trial programs:
-
-- direct `i32` accumulation through `+=` produced
-  `f64 arithmetic requires f64 operands, got I32 and I32`
-
-That probe is not counted as a formal trial-family program, but it is relevant
-evidence:
+Those probes are not counted as separate formal trial-family programs, but they
+are relevant evidence:
 
 - integer control/data handling is usable
 - integer arithmetic ergonomics still require more trust work before a broader
   practical-readiness claim
+- executable module authoring is now admitted only for the narrow direct
+  local-path bare-import slice
 
 ## Q1 Summary
 
@@ -170,26 +173,31 @@ Current `main` can already support:
 - small single-file utility cores
 - rule/state-oriented executable programs
 - narrow data programs over `Sequence(T)` and direct-record `Iterable` impls
+- narrow helper-module executable programs using direct local-path bare imports
 
 Current `main` does **not** yet prove:
 
-- ordinary module-based executable program authoring
+- broader executable module authoring beyond the direct local-path bare-import
+  slice
 - full CLI-style practical usability with admitted IO/process interaction
 
-## Q1 Verdict
-
-Gate `G1-D` is now evidenced, but the outcome is mixed rather than fully green.
-
-Per-program verdicts:
+Per-program verdicts for the admitted trial families:
 
 - CLI utility core: `tolerable`
 - rule/state-oriented program: `natural`
 - data-heavy small program: `tolerable`
-- module-based program: `blocked`
+- module-based program: `tolerable`
+
+## Q1 Verdict
+
+`G1-D Real Program Trial` is green for the widened admitted contour, but the
+contour remains narrow.
 
 Operational conclusion:
 
 - Semantic is already capable of writing some real small programs
+- Semantic is now also capable of ordinary helper-module executable authoring
+  through direct local-path bare imports
 - Semantic is not yet qualified to claim broad practical-programming readiness
-  while ordinary module-based executable authoring remains blocked on current
-  `main`
+  because executable-module authoring remains narrow and full CLI-style
+  practicality is still outside the admitted contour

--- a/reports/g1_release_scope_statement.md
+++ b/reports/g1_release_scope_statement.md
@@ -37,9 +37,9 @@ This is enough to support a narrow release promise.
 
 The evidence does **not** support a broader practical-programming claim because:
 
-- ordinary module-based executable authoring is still blocked at the current
-  executable module-entry boundary
 - practical CLI-style authoring remains incomplete
+- executable-module authoring is now admitted only for the narrow direct
+  local-path bare-import helper-module slice
 - the admitted contour is still narrow enough that broader ecosystem/program
   authoring would be overstated
 
@@ -48,6 +48,7 @@ The evidence does **not** support a broader practical-programming claim because:
 The currently qualified release contour is:
 
 - single-file executable programs on the admitted current source surface
+- narrow helper-module executable programs using direct local-path bare imports
 - rule/state-oriented programs using records, `quad`, and explicit
   `Option` / `Result` handling
 - built-in `Sequence(T)` iteration
@@ -62,8 +63,10 @@ The currently qualified release contour is:
 The following are **not** qualified by this Gate 1 cycle and must remain
 outside the release promise:
 
-- module-based executable entry with top-level `Import`
-- broader practical-programming claims beyond the admitted single-file contour
+- alias, selected, wildcard, public re-export, package-qualified, and
+  namespace-qualified executable import forms
+- broader practical-programming claims beyond the admitted single-file plus
+  bare helper-module contour
 - full CLI application authoring with admitted argv/stdout/file IO
 - UI, which remains outside the current qualification contour
 - ADT iterable dispatch

--- a/reports/g1_surface_expressiveness.md
+++ b/reports/g1_surface_expressiveness.md
@@ -28,13 +28,16 @@ The current language surface reads naturally for:
 - explicit `Option` / `Result` handling through contextual constructors and
   exhaustive `match`
 - narrow direct-record iterable dispatch with `for x in collection`
+- narrow helper-module executable authoring through direct local-path bare
+  imports
 
 Evidence:
 
 - `reports/g1_real_program_trial.md` marked the rule/state program as
   `natural`
 - `reports/g1_frontend_trust.md` marked sequence loops, direct-record iterable
-  admission, and where-clause source sugar as `trusted`
+  admission, where-clause source sugar, and direct local-path bare helper-module
+  imports as `trusted`
 - `reports/g1_execution_integrity.md` confirmed end-to-end semantic
   preservation on the representative admitted programs
 
@@ -43,46 +46,49 @@ Evidence:
 The current surface is usable, but still narrow, for:
 
 - small single-file executable cores
+- narrow module-based helper-module executable programs
 - data-heavy programs over `Sequence(T)` and direct-record iterable impls
 
 Evidence:
 
 - `reports/g1_real_program_trial.md` marked both the CLI-style core and the
   data-heavy iterable program as `tolerable`
+- `reports/g1_real_program_trial.md` also marked the admitted helper-module
+  executable program as `tolerable`
 - `reports/g1_benchmark_baseline.md` showed these programs stay reproducible
   and fast on the admitted current pipeline
 
 Why this is only `tolerable`:
 
-- admitted practical programs still skew toward single-file shapes
+- admitted practical programs still skew toward single-file or bare helper-module
+  shapes
 - full CLI-style authoring is not yet qualified because argv/stdout/file IO is
   not part of the admitted contour
 - iterable reuse remains narrow rather than general-purpose
 
 ### Blocked zone
 
-The current surface is still blocked for ordinary module-based executable
-authoring.
+The current surface is still blocked for broader executable-module authoring
+beyond the admitted bare local-path helper-module slice.
 
 Evidence:
 
-- `reports/g1_real_program_trial.md` marked the module-based helper split as
-  `blocked`
-- `reports/g1_frontend_trust.md` confirmed the current wave1 executable import
-  contract still rejects the selected-import module helper path with
-  deterministic but trust-reducing diagnostics
+- `reports/g1_real_program_trial.md` preserved the selected-import helper-module
+  probe as an explicit blocked boundary
+- `reports/g1_frontend_trust.md` confirms that selected/alias/wildcard/re-export
+  executable import forms remain out of scope with deterministic diagnostics
 
 This matters because a language can be technically executable while still
-failing a practical-authoring gate. That is exactly the current situation for
-multi-file executable programs on `main`.
+impose a much narrower practical-authoring contour than a broader public-release
+claim would imply.
 
 ## Friction Inventory
 
 Current trust-reducing friction that does not break the admitted contour, but
 still matters for practical readiness:
 
-- module-based executable entry is blocked at the current executable module-entry
-  boundary
+- broader executable-module entry remains outside the admitted contour beyond
+  the direct local-path bare-import slice
 - CLI-style programs remain core-only rather than fully user-facing
 - integer arithmetic ergonomics still show rough edges, as seen in the `i32`
   `+=` probe noted in `Q1`
@@ -94,11 +100,11 @@ still matters for practical readiness:
 Operational meaning:
 
 - the language is expressive enough for a narrow release contour centered on
-  single-file executable programs, rule/state logic, sequence loops, and
-  direct-record iterable dispatch
+  single-file executable programs, narrow helper-module executable programs,
+  rule/state logic, sequence loops, and direct-record iterable dispatch
 - the language is **not** yet expressive enough to justify a broader practical
-  programming claim while ordinary module-based executable authoring remains
-  blocked
+  programming claim while executable-module authoring remains intentionally
+  narrow and CLI-style authoring remains incomplete
 
 This is sufficient for a `limited release` decision.
 

--- a/tests/g1_benchmark_baseline.rs
+++ b/tests/g1_benchmark_baseline.rs
@@ -68,9 +68,56 @@ fn repo_path(rel: &str) -> String {
         .replace('\\', "/")
 }
 
-fn source_text(rel: &str) -> String {
-    let path = repo_path(rel);
-    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read failed for {path}: {err}"))
+fn bundle_source(rel: &str) -> String {
+    let root = PathBuf::from(repo_path(rel));
+    let parser_profile = ParserProfile::foundation_default();
+    let mut loaded = Vec::new();
+    let mut visiting = Vec::new();
+    let mut modules = Vec::new();
+    collect_bundle_modules(&root, &parser_profile, &mut loaded, &mut visiting, &mut modules);
+    modules.join("\n\n")
+}
+
+fn collect_bundle_modules(
+    path: &PathBuf,
+    parser_profile: &ParserProfile,
+    loaded: &mut Vec<PathBuf>,
+    visiting: &mut Vec<PathBuf>,
+    modules: &mut Vec<String>,
+) {
+    let canonical = path
+        .canonicalize()
+        .unwrap_or_else(|err| panic!("resolve failed for {}: {err}", path.display()));
+    if loaded.iter().any(|entry| entry == &canonical) {
+        return;
+    }
+    if visiting.iter().any(|entry| entry == &canonical) {
+        panic!("cyclic executable helper import detected at {}", canonical.display());
+    }
+    visiting.push(canonical.clone());
+    let source = fs::read_to_string(&canonical)
+        .unwrap_or_else(|err| panic!("read failed for {}: {err}", canonical.display()));
+    let program = parse_program_with_profile(&source, parser_profile)
+        .unwrap_or_else(|err| panic!("parse failed for {}: {err}", canonical.display()));
+    for import in &program.imports {
+        assert!(
+            !import.reexport
+                && !import.wildcard
+                && import.alias.is_none()
+                && import.select_items.is_empty()
+                && !import.spec.contains("::"),
+            "out-of-scope executable import leaked into bundled contour for {}",
+            canonical.display()
+        );
+        let child = canonical
+            .parent()
+            .expect("module parent")
+            .join(&import.spec);
+        collect_bundle_modules(&child, parser_profile, loaded, visiting, modules);
+    }
+    let _ = visiting.pop();
+    loaded.push(canonical);
+    modules.push(source);
 }
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
@@ -135,7 +182,7 @@ fn summarize(mut values: Vec<u128>) -> StageStats {
 }
 
 fn measure_scenario(label: &'static str, rel: &'static str) -> ScenarioBaseline {
-    let src = source_text(rel);
+    let src = bundle_source(rel);
     let profile = ParserProfile::foundation_default();
 
     for _ in 0..WARMUP_RUNS {
@@ -233,6 +280,10 @@ fn g1_benchmark_baseline_collects_reproducible_pipeline_metrics() {
         measure_scenario(
             "record_iterable_data",
             "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+        ),
+        measure_scenario(
+            "module_helper_entry",
+            "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
         ),
     ];
 

--- a/tests/g1_execution_integrity.rs
+++ b/tests/g1_execution_integrity.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use semantic_language::{
-    frontend::{compile_program_to_ir, compile_program_to_semcode},
+    frontend::{compile_program_to_ir, compile_program_to_semcode, parse_program_with_profile, ParserProfile},
     semantics::check_source,
     semcode_format::header_spec_from_magic,
     semcode_verify::{verify_semcode, VerificationCode},
@@ -19,6 +19,58 @@ fn repo_path(rel: &str) -> String {
 fn source_text(rel: &str) -> String {
     let path = repo_path(rel);
     fs::read_to_string(&path).unwrap_or_else(|err| panic!("read failed for {path}: {err}"))
+}
+
+fn bundle_source(rel: &str) -> String {
+    let root = PathBuf::from(repo_path(rel));
+    let parser_profile = ParserProfile::foundation_default();
+    let mut loaded = Vec::new();
+    let mut visiting = Vec::new();
+    let mut modules = Vec::new();
+    collect_bundle_modules(&root, &parser_profile, &mut loaded, &mut visiting, &mut modules);
+    modules.join("\n\n")
+}
+
+fn collect_bundle_modules(
+    path: &PathBuf,
+    parser_profile: &ParserProfile,
+    loaded: &mut Vec<PathBuf>,
+    visiting: &mut Vec<PathBuf>,
+    modules: &mut Vec<String>,
+) {
+    let canonical = path
+        .canonicalize()
+        .unwrap_or_else(|err| panic!("resolve failed for {}: {err}", path.display()));
+    if loaded.iter().any(|entry| entry == &canonical) {
+        return;
+    }
+    if visiting.iter().any(|entry| entry == &canonical) {
+        panic!("cyclic executable helper import detected at {}", canonical.display());
+    }
+    visiting.push(canonical.clone());
+    let source = fs::read_to_string(&canonical)
+        .unwrap_or_else(|err| panic!("read failed for {}: {err}", canonical.display()));
+    let program = parse_program_with_profile(&source, parser_profile)
+        .unwrap_or_else(|err| panic!("parse failed for {}: {err}", canonical.display()));
+    for import in &program.imports {
+        assert!(
+            !import.reexport
+                && !import.wildcard
+                && import.alias.is_none()
+                && import.select_items.is_empty()
+                && !import.spec.contains("::"),
+            "out-of-scope executable import leaked into bundled contour for {}",
+            canonical.display()
+        );
+        let child = canonical
+            .parent()
+            .expect("module parent")
+            .join(&import.spec);
+        collect_bundle_modules(&child, parser_profile, loaded, visiting, modules);
+    }
+    let _ = visiting.pop();
+    loaded.push(canonical);
+    modules.push(source);
 }
 
 fn label_for(rel: &str) -> &str {
@@ -41,7 +93,7 @@ fn disasm_function_names(disasm: &str) -> Vec<String> {
 }
 
 fn execution_summary(rel: &str) -> String {
-    let src = source_text(rel);
+    let src = bundle_source(rel);
     let sema = check_source(&src).expect("semantic check");
     let ir = compile_program_to_ir(&src).expect("compile ir");
     let bytes = compile_program_to_semcode(&src).expect("compile semcode");
@@ -93,6 +145,7 @@ fn g1_execution_integrity_stage_summaries_match_current_baseline() {
         "examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm",
         "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
         "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+        "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
     ] {
         observed.push_str(&execution_summary(rel));
         observed.push('\n');
@@ -123,6 +176,14 @@ verify:names=__impl::Iterable::Samples::next,main,summarize
 disasm:names=__impl::Iterable::Samples::next,main,summarize
 run=ok
 
+program=wave2_local_helper_import
+sema:warnings=0 laws=0
+ir:names=main,score
+semcode:magic=SEMCODE0 rev=1
+verify:names=main,score
+disasm:names=main,score
+run=ok
+
 ";
     assert_eq!(observed, expected);
 }
@@ -133,8 +194,9 @@ fn g1_execution_integrity_repeated_compiles_are_byte_stable() {
         "examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm",
         "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
         "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+        "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
     ] {
-        let src = source_text(rel);
+        let src = bundle_source(rel);
 
         let first = compile_program_to_semcode(&src).expect("first compile");
         let second = compile_program_to_semcode(&src).expect("second compile");

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -25,6 +25,7 @@ fn g1_frontend_positive_suite_passes() {
         "examples/qualification/g1_frontend_trust/positive_sequence_and_match/src/main.sm",
         "examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm",
         "examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm",
+        "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
     ] {
         check_ok(rel);
     }

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -42,7 +42,15 @@ fn g1_data_audit_record_iterable_checks_and_runs() {
 }
 
 #[test]
-fn g1_module_helpers_program_is_blocked() {
+fn g1_module_helpers_program_checks_and_runs() {
+    let rel =
+        "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn g1_selected_import_module_program_remains_out_of_scope() {
     let rel = "examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm";
     let check_err = cli_err("check", rel);
     assert!(


### PR DESCRIPTION
## Summary\n- close the executable-module-entry blocker-removal track as a completed narrow slice\n- amend Gate 1 reports/tests for the admitted bare local-path helper-module contour\n- keep the overall release decision at limited release and leave broader executable import forms out of scope\n\n## Validation\n- cargo test -q --test g1_real_program_trial\n- cargo test -q --test g1_frontend_trust\n- cargo test -q --test g1_execution_integrity\n- cargo test -q --test g1_benchmark_baseline -- --nocapture\n- cargo test -q\n- cargo test -q --test public_api_contracts