### PR TITLE
Add project discipline process baseline

### DIFF
--- a/docs/process/change_traceability.md
+++ b/docs/process/change_traceability.md
@@ -1,0 +1,54 @@
+# Semantic Change Traceability
+
+Status: active and mandatory
+
+This document defines the minimum documentation trail required for project work.
+
+## Required Trail For Every Logical Step
+
+Each logical step must leave a written record containing:
+
+- `Request`
+- `Why now`
+- `In scope`
+- `Out of scope`
+- `Files or areas touched`
+- `Tests added or updated`
+- `Docs updated`
+- `Release or milestone claim impact`
+- `Status`
+
+The trail may live in one or more repository artifacts, but it must exist by the time the step is ready for review.
+
+## Request Discipline
+
+- every request that changes code, contracts, release posture, or roadmap must be recorded
+- the request record must describe the narrow intent of the step, not a vague future ambition
+- if the request is document-only, mark it explicitly as document-only
+- if the request is behavioral, identify the expected verification contour
+
+## Milestone Discipline
+
+- every milestone must have a scope document
+- every milestone must state what is admitted, what remains outside scope, and what counts as done
+- every milestone close-out must record whether the result is frozen, qualified, limited, or still experimental
+- after a milestone is closed, do not continue widening the same surface without opening a new scope decision
+
+## PR Discipline
+
+- every PR must state the exact logical step it implements
+- every PR must identify test evidence or state why the change is document-only
+- every PR must identify which docs were updated
+- every PR must state whether release claims or readiness claims changed
+
+## Checkpoint Discipline
+
+- after a meaningful project phase, create a dated checkpoint that records current canonical branch truth
+- each checkpoint should include:
+  - canonical commit
+  - current admitted surfaces
+  - current non-admitted surfaces
+  - qualification status
+  - active or completed milestone state
+  - workspace warnings if local trees are dirty or unsuitable as clean bases
+- checkpoints are continuity artifacts for future sessions and new work windows

--- a/docs/process/change_traceability.md
+++ b/docs/process/change_traceability.md
@@ -12,6 +12,7 @@ Each logical step must leave a written record containing:
 - `Why now`
 - `In scope`
 - `Out of scope`
+- `Backups created`
 - `Files or areas touched`
 - `Tests added or updated`
 - `Docs updated`
@@ -37,9 +38,11 @@ The trail may live in one or more repository artifacts, but it must exist by the
 ## PR Discipline
 
 - every PR must state the exact logical step it implements
+- every PR must state that two reserve backups were created before edits began
 - every PR must identify test evidence or state why the change is document-only
 - every PR must identify which docs were updated
 - every PR must state whether release claims or readiness claims changed
+- every PR must state whether the first backup was deleted and why the second backup is being kept or removed
 
 ## Checkpoint Discipline
 

--- a/docs/process/index.md
+++ b/docs/process/index.md
@@ -1,0 +1,16 @@
+# Semantic Process Index
+
+Status: active project-governance baseline
+
+This directory defines the operating discipline for repository changes.
+
+Use these documents as the canonical process layer for new work:
+
+- `project_discipline.md` - non-negotiable project rules
+- `change_traceability.md` - required documentation trail for requests, milestones, and PRs
+- `pr_and_merge_policy.md` - PR readiness, test expectations, and merge gate
+
+Process rule:
+
+- if code, behavior, release claims, or milestone status changes, update the relevant process trail in the same step
+- if a change is truly document-only, keep the scope narrow and do not claim behavioral impact

--- a/docs/process/pr_and_merge_policy.md
+++ b/docs/process/pr_and_merge_policy.md
@@ -22,6 +22,7 @@ A PR is ready for review only if all of the following are true:
 - partial green is not enough if the affected layer requires a wider validation contour
 - if a test fails, stop and fix the cause before asking for merge
 - do not normalize red tests as acceptable backlog
+- if a change cannot be brought back to green, roll it back before merge
 
 ## Merge Rule
 
@@ -29,6 +30,7 @@ A PR is ready for review only if all of the following are true:
 - merge only when CI is green
 - merge only when documentation is synchronized with the actual change
 - merge only when the PR does not exceed its declared scope
+- merge only when the backup record is explicit: two backups before edits, first backup removed after green, second backup retained or removed with justification
 - if any required gate is red, merge is blocked
 
 ## Recovery Rule
@@ -36,6 +38,7 @@ A PR is ready for review only if all of the following are true:
 - if desired behavior is correct but tests are red, the task is still incomplete
 - if tests are red because expectations are outdated, update the tests and the associated docs explicitly
 - if a fix reveals broader drift, narrow the change or open a new scope rather than hiding the drift inside the same PR
+- if the step cannot be stabilized to green in the current PR, revert the change to the last green state and regroup from there
 
 ## Reviewer Rule
 

--- a/docs/process/pr_and_merge_policy.md
+++ b/docs/process/pr_and_merge_policy.md
@@ -1,0 +1,45 @@
+# Semantic PR And Merge Policy
+
+Status: active and mandatory
+
+This document defines the repository gate for PR readiness and merge eligibility.
+
+## PR Ready Checklist
+
+A PR is ready for review only if all of the following are true:
+
+- the PR is one logical step with a narrow scope
+- the scope and rationale are documented
+- behavior-changing work includes tests or updated verification evidence
+- relevant docs are updated in the same step
+- release, readiness, and milestone claims remain honest
+- the author can state exactly what is in scope and what is intentionally left out
+
+## Test Gate
+
+- document-only PRs may skip tests if they do not change behavior, contracts, generated artifacts, or release outputs
+- every non-document-only PR must run the relevant test and verification contour for the affected layer
+- partial green is not enough if the affected layer requires a wider validation contour
+- if a test fails, stop and fix the cause before asking for merge
+- do not normalize red tests as acceptable backlog
+
+## Merge Rule
+
+- merge only when all relevant tests are green
+- merge only when CI is green
+- merge only when documentation is synchronized with the actual change
+- merge only when the PR does not exceed its declared scope
+- if any required gate is red, merge is blocked
+
+## Recovery Rule
+
+- if desired behavior is correct but tests are red, the task is still incomplete
+- if tests are red because expectations are outdated, update the tests and the associated docs explicitly
+- if a fix reveals broader drift, narrow the change or open a new scope rather than hiding the drift inside the same PR
+
+## Reviewer Rule
+
+- reject PRs with undocumented scope movement
+- reject PRs with missing tests for behavioral changes
+- reject PRs whose docs and claims overstate actual behavior
+- reject PRs that depend on follow-up fixes to become safe to merge

--- a/docs/process/project_discipline.md
+++ b/docs/process/project_discipline.md
@@ -6,6 +6,12 @@ Project motto:
 
 - discipline in maximum form
 
+Priority statement:
+
+- project tempo must be driven by discipline, not by chaotic acceleration
+- when speed and discipline conflict, discipline wins
+- repeat this rule in scope setting, PR review, checkpointing, and merge decisions
+
 This document defines the repository operating contract.
 It applies to every request, every milestone, every PR, and every merge decision.
 

--- a/docs/process/project_discipline.md
+++ b/docs/process/project_discipline.md
@@ -40,6 +40,15 @@ It applies to every request, every milestone, every PR, and every merge decision
 - do not merge with failing relevant tests
 - if tests fail, the work is not complete until the cause is understood and the state is returned to green
 
+## Backup And Recovery Discipline
+
+- before making changes, create two reserve backups of the relevant working state
+- the backups may be filesystem snapshots, worktree snapshots, or another explicit recovery form, but both copies must be real and restorable
+- if the change cannot be brought back to a green state before merge readiness, roll the step back rather than carrying broken state forward
+- after the change reaches a verified green state, delete the first backup
+- keep the second backup until it is genuinely no longer needed for recovery, audit, or comparison
+- do not remove the final backup copy just because the branch is green; remove it only when the recovery value is truly exhausted
+
 ## Claim Discipline
 
 - documentation claims must match actual repository behavior

--- a/docs/process/project_discipline.md
+++ b/docs/process/project_discipline.md
@@ -1,0 +1,56 @@
+# Semantic Project Discipline
+
+Status: active and mandatory
+
+Project motto:
+
+- discipline in maximum form
+
+This document defines the repository operating contract.
+It applies to every request, every milestone, every PR, and every merge decision.
+
+## Canonical Source Of Truth
+
+- treat `origin/main` as the canonical source of truth for merge-ready work
+- do not treat a dirty local worktree as a clean basis for new PRs
+- if a local workspace contains unrelated WIP, create a fresh worktree from the canonical branch before starting merge-ready work
+- do not make release or readiness claims from local-only state
+
+## Scope Discipline
+
+- every logical step must have an explicit scope before implementation begins
+- every scope must state `in-scope`, `out-of-scope`, and done criteria
+- do not silently widen language semantics, runtime behavior, verifier behavior, import behavior, or release claims
+- if a surface needs to widen beyond current admitted behavior, open a new explicit scope first
+- one PR equals one logical step
+
+## Documentation Discipline
+
+- every step must leave a durable documentation trail
+- every request that changes code, behavior, contracts, release posture, or roadmap must be reflected in repository documentation
+- every milestone must record scope, status, admitted contour, and close-out state
+- every PR must leave an explicit note of what changed and why
+- do not rely on chat history as the sole record of project decisions
+
+## Test Discipline
+
+- every behavioral change must be covered by tests or updated verification evidence
+- document-only changes are the only class of change allowed to skip tests
+- if a change touches behavior and the existing tests are insufficient, add or extend tests before considering the step complete
+- do not merge with failing relevant tests
+- if tests fail, the work is not complete until the cause is understood and the state is returned to green
+
+## Claim Discipline
+
+- documentation claims must match actual repository behavior
+- milestone and release claims must match qualified evidence, not intent
+- do not call a surface stable, complete, qualified, or released unless the repository evidence supports that claim
+- if behavior is narrower than desired, state the narrow truth explicitly
+
+## Execution Rule
+
+- scope first
+- implementation second
+- tests and verification third
+- documentation sync before completion
+- merge only after the full relevant validation contour is green


### PR DESCRIPTION
## Summary\n- add a dedicated process layer for project discipline\n- define mandatory change traceability rules for requests, milestones, and PRs\n- define PR and merge policy with explicit green-test and green-CI gates\n\n## Testing\n- not run (document-only change)