### PR TITLE
Reconcile schema roadmap baseline history

### DIFF
--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -84,6 +84,14 @@ Current post-`v1` wave:
   - `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
   - `docs/roadmap/language_maturity/semcode_version_discipline.md`
   - `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
+- the `v0.3` schema and boundary core package is completed and now lives as
+  frozen baseline history in:
+  - `docs/roadmap/language_maturity/schema_first_declarations_scope.md`
+  - `docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md`
+  - `docs/roadmap/language_maturity/config_schema_contract_scope.md`
+  - `docs/roadmap/language_maturity/generated_api_contract_surface_scope.md`
+  - `docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md`
+  - `docs/roadmap/language_maturity/tagged_wire_unions_and_patch_types_scope.md`
 
 Current next-focus wave:
 

--- a/docs/roadmap/language_maturity/config_schema_contract_scope.md
+++ b/docs/roadmap/language_maturity/config_schema_contract_scope.md
@@ -1,6 +1,14 @@
 # Config Schema Contract Scope
 
-Status: proposed
+Status: first-wave implemented baseline history
+
+Implementation note:
+
+- this scope is already implemented on current `main`
+- `smc-cli` already owns the canonical config-document parse and validation
+  path for `config schema`
+- the planning language below is retained as the historical acceptance contract
+  for the landed first wave
 
 ## Goal
 

--- a/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
+++ b/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
@@ -1,6 +1,13 @@
 # Release Freeze Post-V03 Checkpoint
 
-Status: proposed
+Status: completed baseline history
+
+Implementation note:
+
+- this freeze reading is already reflected in the published `v1.1.1` release
+  notes and the current repository governance posture
+- the planning language below is retained as the historical freeze contract for
+  the landed post-`v0.3` state
 
 ## Goal
 

--- a/docs/roadmap/language_maturity/schema_first_declarations_scope.md
+++ b/docs/roadmap/language_maturity/schema_first_declarations_scope.md
@@ -1,7 +1,13 @@
 # Schema-First Declarations Scope
 
-Status: proposed first-wave checkpoint
+Status: first-wave implemented baseline history
 Related issue: `#121`
+
+Implementation note:
+
+- this scope is already implemented on current `main`
+- the planning language below is retained as the historical acceptance contract
+  for the landed first wave
 
 ## Goal
 

--- a/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
+++ b/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
@@ -1,6 +1,15 @@
 # Schema Versioning And Migration Scope
 
-Status: proposed
+Status: first-wave implemented baseline history
+
+Implementation note:
+
+- this scope is already implemented on current `main`
+- explicit schema version markers, deterministic compatibility classification,
+  and compile-time migration metadata artifacts are already part of the current
+  tooling surface
+- the planning language below is retained as the historical acceptance contract
+  for the landed first wave
 
 ## Goal
 

--- a/docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md
+++ b/docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md
@@ -1,7 +1,15 @@
 # Validation Derived From Schemas Scope
 
-Status: proposed first-wave checkpoint
+Status: first-wave implemented baseline history
 Related issue: `#122`
+
+Implementation note:
+
+- this scope is already implemented on current `main`
+- canonical schema validation-plan ownership and generated validation checks are
+  already part of the current tooling surface
+- the planning language below is retained as the historical acceptance contract
+  for the landed first wave
 
 ## Goal
 

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -45,6 +45,13 @@
   - `docs/spec/cli.md`
   - current completed post-stable source-contract freeze checkpoint:
     `docs/roadmap/language_maturity/source_language_contract.md`
+  - current completed post-stable schema/boundary checkpoint bundle:
+    - `docs/roadmap/language_maturity/schema_first_declarations_scope.md`
+    - `docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md`
+    - `docs/roadmap/language_maturity/config_schema_contract_scope.md`
+    - `docs/roadmap/language_maturity/generated_api_contract_surface_scope.md`
+    - `docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md`
+    - `docs/roadmap/language_maturity/tagged_wire_unions_and_patch_types_scope.md`
   - current completed post-qualification executable module entry checkpoint:
     `docs/roadmap/language_maturity/executable_module_entry_scope.md`
   - current active IR hardening checkpoint:


### PR DESCRIPTION
## Summary\n- mark the landed schema roadmap scopes as implemented baseline history\n- align backlog and milestones with the already-landed v0.3 schema and boundary core package\n- record the post-v0.3 freeze note as completed baseline history instead of a still-proposed checkpoint\n\n## Backups\n- created 2 reserve backups before edits\n- backup 1 retained for now until this PR reaches verified green state\n- backup 2 retained until its recovery value is genuinely exhausted\n\n## Testing\n- not run (document-only reconciliation)