### PR TITLE
Close anti-drift roadmap checkpoint drift

### DIFF
--- a/docs/roadmap/language_maturity/ir_v1_contract_freeze.md
+++ b/docs/roadmap/language_maturity/ir_v1_contract_freeze.md
@@ -1,6 +1,9 @@
 # IR v1 Contract Freeze
 
-Status: proposed checkpoint
+Status: completed post-stable anti-drift checkpoint
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
 
 ## Goal
 
@@ -84,13 +87,13 @@ This checkpoint does not include:
 - changes to IR structure or admitted pass behavior require explicit contract
   review, not silent drift
 
-## Acceptance Criteria
+## Completed Reading
 
-This checkpoint is complete only when:
+This checkpoint is now complete because:
 
 - `docs/spec/ir.md` reflects the same staged-contract reading
 - architecture docs treat IR as the lowered execution-contract boundary
-- roadmap docs point to this file as the active IR freeze checkpoint
+- roadmap docs point to this file as the completed IR freeze checkpoint
 - supported scope and out-of-scope items are explicit
 - no document implies a separate `sm-opt` owner or a broader frozen IR surface
 

--- a/docs/roadmap/language_maturity/runtime_boundary_hardening.md
+++ b/docs/roadmap/language_maturity/runtime_boundary_hardening.md
@@ -1,6 +1,9 @@
 # Runtime Boundary Hardening
 
-Status: proposed checkpoint
+Status: completed post-stable anti-drift checkpoint
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
 
 ## Goal
 
@@ -75,13 +78,13 @@ This checkpoint does not include:
 - execution-boundary changes require explicit spec and compatibility review, not
   silent drift
 
-## Acceptance Criteria
+## Completed Reading
 
-This checkpoint is complete only when:
+This checkpoint is now complete because:
 
 - `docs/spec/verifier.md`, `docs/spec/vm.md`, and `docs/spec/runtime.md`
   reflect the same verified-only execution route
 - architecture docs describe `prom-runtime` as orchestration only
-- roadmap docs point to this file as the active runtime hardening checkpoint
+- roadmap docs point to this file as the completed runtime hardening checkpoint
 - public VM/runtime docs list the current admitted ownership trap surface
 - no document implies a second execution authority outside verified VM entrypoints

--- a/docs/roadmap/language_maturity/semcode_version_discipline.md
+++ b/docs/roadmap/language_maturity/semcode_version_discipline.md
@@ -1,6 +1,9 @@
 # SemCode Version Discipline
 
-Status: proposed checkpoint
+Status: completed post-stable anti-drift checkpoint
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
 
 ## Goal
 
@@ -88,12 +91,12 @@ Any future header or capability widening must update all of:
 - VM compatibility tests
 - golden or compatibility fixtures if public behavior changed
 
-## Acceptance Criteria
+## Completed Reading
 
-This checkpoint is complete only when:
+This checkpoint is now complete because:
 
 - `docs/spec/semcode.md` reflects the same staged-contract reading
 - architecture docs treat SemCode widening as explicit and additive
-- roadmap docs point to this file as the active SemCode discipline checkpoint
+- roadmap docs point to this file as the completed SemCode discipline checkpoint
 - release-facing compatibility docs use the real admitted header names
 - no document implies silent retroactive widening of the published stable line

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -47,9 +47,9 @@
     `docs/roadmap/language_maturity/source_language_contract.md`
   - current completed post-qualification executable module entry checkpoint:
     `docs/roadmap/language_maturity/executable_module_entry_scope.md`
-  - current active IR hardening checkpoint:
+  - current completed post-stable IR hardening checkpoint:
     `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
-  - current active SemCode version-discipline checkpoint:
+  - current completed post-stable SemCode version-discipline checkpoint:
     `docs/roadmap/language_maturity/semcode_version_discipline.md`
 - `M4 PROMETHEUS Boundary`
   - ABI
@@ -83,7 +83,7 @@
     `docs/roadmap/language_maturity/multi_session_replay_archive_scope.md`
   - current completed post-stable rollback checkpoint:
     `docs/roadmap/language_maturity/rollback_persistence_semantics_scope.md`
-  - current active runtime-boundary hardening checkpoint:
+  - current completed post-stable runtime-boundary hardening checkpoint:
     `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
 - `M6 v1 Lockdown`
   - freezes


### PR DESCRIPTION
## Summary
- mark the IR, SemCode, and runtime anti-drift checkpoint docs as completed post-stable baseline history
- align milestones wording with the completed anti-drift package already recorded in backlog
- keep current main honest without opening a new feature or widening scope

## Why this is the next honest step
- current main does not justify a new widening track without a new explicit scope decision and Gate 1 follow-up
- backlog already says the anti-drift package is completed and frozen
- milestones and the three checkpoint docs still described that completed slice as active/proposed

## Verification
- cargo test -q --test legacy_guards
- git diff --check
- LF normalization confirmed for touched files

## Scope
- document-only release-maintenance truth sync
