### PR TITLE
Sync schema docs with landed main state

### DIFF
--- a/docs/roadmap/language_maturity/config_schema_contract_scope.md
+++ b/docs/roadmap/language_maturity/config_schema_contract_scope.md
@@ -1,6 +1,11 @@
 # Config Schema Contract Scope
 
-Status: proposed
+Status: completed first-wave baseline history
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
+The scope text below is preserved as the historical scope decision for that
+landed wave.
 
 ## Goal
 
@@ -64,9 +69,9 @@ Canonical tagged-union config document choice for the next slice:
 - creating an alternate config truth layer separate from canonical schemas and
   validation plans
 
-## Acceptance Reading
+## Completed Reading
 
-This issue is done only when:
+This issue is now complete because:
 
 - one canonical config document surface exists
 - config parsing and validation reuse canonical schema and validation-plan

--- a/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
+++ b/docs/roadmap/language_maturity/release_freeze_post_v03_checkpoint.md
@@ -1,6 +1,11 @@
 # Release Freeze Post-V03 Checkpoint
 
-Status: proposed
+Status: completed post-v0.3 release-freeze checkpoint
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
+The checkpoint text below is preserved as the historical freeze reading for
+that landed state.
 
 ## Goal
 
@@ -50,9 +55,9 @@ milestone state.
 - widening `prom-*`, host capability, or runtime boundaries
 - mixing release-note work with another schema/language implementation wave
 
-## Acceptance Reading
+## Completed Reading
 
-This checkpoint is useful only if:
+This checkpoint is now complete because:
 
 - closed roadmap waves are no longer presented as active work
 - the repository has one explicit post-`v0.3` freeze note

--- a/docs/roadmap/language_maturity/schema_first_declarations_scope.md
+++ b/docs/roadmap/language_maturity/schema_first_declarations_scope.md
@@ -1,7 +1,12 @@
 # Schema-First Declarations Scope
 
-Status: proposed first-wave checkpoint
+Status: completed first-wave baseline history
 Related issue: `#121`
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
+The scope text below is preserved as the historical scope decision for that
+landed wave.
 
 ## Goal
 
@@ -72,9 +77,9 @@ while remaining separate from:
 3. schema role markers for `config`, `api`, and `wire`
 4. docs/spec freeze for declaration-only schema surface
 
-## Done Boundary
+## Completed Reading
 
-`#121` can close when:
+`#121` is now complete because:
 
 1. canonical schema declaration syntax exists for record and tagged-union
    shapes,

--- a/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
+++ b/docs/roadmap/language_maturity/schema_versioning_and_migration_scope.md
@@ -1,6 +1,11 @@
 # Schema Versioning And Migration Scope
 
-Status: proposed
+Status: completed first-wave baseline history
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
+The scope text below is preserved as the historical scope decision for that
+landed wave.
 
 ## Goal
 
@@ -94,9 +99,9 @@ stable formatter owned by tooling.
 - widening `prom-*`, host capability, or VM/runtime boundaries
 - introducing a second hand-maintained migration truth layer
 
-## Acceptance Reading
+## Completed Reading
 
-This issue is done only when:
+This issue is now complete because:
 
 - schema versions are explicit and inspectable
 - compatibility reading is deterministic and diffable

--- a/docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md
+++ b/docs/roadmap/language_maturity/validation_derived_from_schemas_scope.md
@@ -1,7 +1,12 @@
 # Validation Derived From Schemas Scope
 
-Status: proposed first-wave checkpoint
+Status: completed first-wave baseline history
 Related issue: `#122`
+
+This checkpoint is completed and now serves as frozen baseline history on
+current `main`.
+The scope text below is preserved as the historical scope decision for that
+landed wave.
 
 ## Goal
 
@@ -71,9 +76,9 @@ while remaining separate from:
 3. deterministic derivation for tagged-union schemas
 4. inspectable output and diagnostics freeze for generated validation failures
 
-## Done Boundary
+## Completed Reading
 
-`#122` can close when:
+`#122` is now complete because:
 
 1. canonical schema declarations derive deterministic validation plans,
 2. derived validation stays inspectable and attributable to source schemas,

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -116,6 +116,12 @@ The following limits remain explicit and should be treated as release-facing hon
   ecosystem baseline, even though current `main` now admits `Semantic.package`
   parsing, package entry-module admission, and deterministic local-path
   dependency loading for package-qualified imports
+- the published `v1.1.1` line intentionally excludes the landed `v0.3`
+  schema/boundary-core wave, even though current `main` now admits canonical
+  schema declarations with record/tagged-union forms, role markers, version
+  metadata, deterministic validation-plan derivation, canonical config-contract
+  parsing/validation, generated API/wire artifacts, and deterministic schema
+  compatibility/migration metadata
 - current `main` now admits one narrow executable-module-entry slice through
   direct local-path bare imports such as `Import "helper.sm"`, but broader
   alias/selected/wildcard/public re-export/package-qualified/namespace-qualified


### PR DESCRIPTION
## Summary
- mark landed schema roadmap checkpoints as completed baseline history instead of proposed work
- mark the post-v0.3 release-freeze checkpoint as completed baseline history
- add one release-facing readiness note that the published v1.1.1 line excludes the landed post-stable schema/boundary-core wave on current main

## Why
- current main and CHANGELOG already treat the v0.3 schema/boundary-core wave as landed
- these schema docs were still framed as future/proposed work, which understates current main and blurs stable-vs-main truth
- the spec bundle already reflects the wider schema surface, so this PR stays in roadmap/readiness only

## Verification
- document-only change
- git diff --check
- LF normalization confirmed for touched files

## Scope
- no code changes
- no behavior changes
- no new scope activation
