### PR TITLE
Mark legacy package design docs as non-baseline

### DIFF
--- a/docs/roadmap/language_maturity/dependency_resolution.md
+++ b/docs/roadmap/language_maturity/dependency_resolution.md
@@ -1,18 +1,24 @@
 # Dependency Resolution
 
-Status: proposed v0
+Status: historical design note, not current baseline
 
 ## Purpose
 
-This document defines the first intended dependency-resolution and lockfile
-contract for Semantic packages.
+This document records one future design candidate for dependency resolution and
+lockfile behavior above the landed first-wave package baseline.
 
-It describes how package metadata should feed the module/import surface without
-pretending that packages and modules are the same concept.
+Current-main truth:
+
+- current `main` already admits deterministic local-path dependency loading
+  through `Semantic.package`
+- this document does not describe that landed baseline; it sketches a broader
+  future layer that would require a new explicit scope decision
+- packages and modules are still distinct concepts in both the landed baseline
+  and any future expansion
 
 ## Resolution Layers
 
-The intended package model has three distinct layers:
+This future package-manager sketch has three distinct layers:
 
 1. package manifest declares dependency roots
 2. resolver maps those dependency roots to concrete package sources
@@ -23,7 +29,7 @@ context.
 
 ## Lockfile
 
-The first canonical lockfile should be:
+One future canonical lockfile candidate would be:
 
 - `Semantic.lock`
 
@@ -35,7 +41,7 @@ Purpose:
 
 ## Resolution Rules
 
-The first package resolver should be deterministic.
+Any future package-manager resolver should be deterministic.
 
 Expected rules:
 
@@ -67,7 +73,8 @@ claim about runtime semantics.
 
 ## Path Dependencies
 
-The first supported dependency source should be local paths.
+The first supported dependency source in this future sketch should be local
+paths.
 
 Reason:
 
@@ -77,8 +84,8 @@ Reason:
 
 ## Versioned Dependencies
 
-Versioned dependencies should be part of the package contract even before a
-public registry is fully implemented.
+Versioned dependencies would belong to the broader package contract even before
+a public registry is fully implemented, if this design is ever reopened.
 
 Expected rules:
 
@@ -88,7 +95,7 @@ Expected rules:
 
 ## Conflict Policy
 
-The first dependency story should prefer clarity over cleverness.
+Any future dependency story should prefer clarity over cleverness.
 
 Expected rules:
 
@@ -108,7 +115,7 @@ ecosystem workstream.
 
 ## Non-Goals
 
-This first resolution contract does not yet define:
+This future resolution contract does not yet define:
 
 - remote registry wire protocol
 - mirrors

--- a/docs/roadmap/language_maturity/package_ecosystem.md
+++ b/docs/roadmap/language_maturity/package_ecosystem.md
@@ -1,30 +1,43 @@
 # Package And Dependency Ecosystem
 
-Status: proposed v0
+Status: historical design note, not current baseline
+
+Current-main truth:
+
+- the first-wave package baseline is already completed on current `main` in
+  `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
+- the admitted current-main package contract is the landed `Semantic.package`
+  baseline with deterministic local-path dependency loading
+- this document is retained only as a broader future design note; it does not
+  describe the current admitted package baseline or the published stable line
 
 ## Goal
 
-Move Semantic from file- and module-level imports toward an intentional package
-and dependency story.
+Sketch one possible broader package-manager direction beyond the landed
+`Semantic.package` baseline.
 
-This workstream is about reproducible project structure, dependency
-declaration, and publishing discipline. It is not about replacing the current
-module/import contract.
+This document is about a future manifest/lockfile/versioning/publishing layer.
+It is not about replacing the current module/import contract, and it is not a
+claim that this broader package-manager layer is active today.
 
 ## Current Baseline
 
-Today Semantic has:
+Today current `main` has:
 
 - source-level file/module imports
 - deterministic module resolution and validation
 - import/export/re-export policy
-- no package manifest
+- canonical `Semantic.package` parsing and validation
+- package entry-module admission
+- deterministic local-path dependency loading for package-qualified imports
 - no lockfile
-- no dependency resolver as a public user-facing contract
+- no public registry/publishing contract
+- no lockfile-backed package-manager contract
 
 Current honest constraint:
 
-- file imports are useful, but they are not yet a package ecosystem
+- current `main` has a first-wave package baseline, but it is not yet a full
+  package-manager ecosystem
 
 ## Why This Matters
 
@@ -120,24 +133,18 @@ This workstream is not intended to:
 
 ## Acceptance Criteria
 
-This workstream should be considered materially started only when:
+Any future reopening of this broader package-manager design should be
+considered materially started only when:
 
 - one canonical package model exists in docs
 - import/module behavior is clearly separated from package/dependency behavior
 - project metadata and lockfile expectations are documented
 - publishing and version-compatibility policy are stated explicitly
 
-## Immediate Next Slice
+## Current Decision
 
-This PR now defines:
-
-- the package manifest
-- dependency-resolution rules
-- lockfile expectations
-- one end-to-end worked example
-
-The next slice after this PR should define:
-
-- workspace/package layout expectations
-- update flows that are allowed to rewrite `Semantic.lock`
-- the first stable package-aware CLI entrypoints
+- no active implementation slice is currently open from this document
+- any reopening of manifest/lockfile/versioning/registry work requires a new
+  explicit scope decision from fresh `main`
+- until that happens, the current admitted package truth remains the completed
+  `Semantic.package` baseline and its close-out docs

--- a/docs/roadmap/language_maturity/package_lockfile.md
+++ b/docs/roadmap/language_maturity/package_lockfile.md
@@ -1,18 +1,24 @@
 # `Semantic.lock`
 
-Status: proposed v0
+Status: historical design note, not current baseline
 
 ## Purpose
 
-This document defines the first intended lockfile contract for Semantic
-packages.
+This document records one future design candidate for a package-manager
+lockfile above the landed first-wave package baseline.
+
+Current-main truth:
+
+- the admitted current-main package baseline has no public lockfile contract
+- this document does not describe current `main`; it describes a broader future
+  design that would require a new explicit scope decision
 
 It is the reproducibility companion to `Semantic.toml`. The manifest declares
 intent; the lockfile records the concrete resolved graph used for one build.
 
 ## Canonical Name
 
-The first canonical lockfile name should be:
+One future canonical lockfile candidate would be:
 
 - `Semantic.lock`
 
@@ -67,7 +73,7 @@ feature, or registry wire protocol yet.
 
 ## Required Fields
 
-The first lockfile wave should include:
+One future lockfile wave could include:
 
 - top-level `version`
 - top-level `root`
@@ -87,7 +93,7 @@ Optional later fields may include:
 
 ## Source Forms
 
-The first lockfile wave should support these source forms:
+One future lockfile wave could support these source forms:
 
 - `path:.`
 - `path:../relative-path`
@@ -98,7 +104,7 @@ transport too early.
 
 ## Determinism Rules
 
-The first lockfile contract should obey these rules:
+Any future lockfile contract should obey these rules:
 
 - the same manifest plus lockfile resolves to the same package graph
 - the same lockfile may be used on different machines without changing package
@@ -108,7 +114,8 @@ The first lockfile contract should obey these rules:
 
 ## Mutation Rules
 
-The first stable behavior should be conservative:
+If this future lockfile layer is ever admitted, its stable behavior should be
+conservative:
 
 - ordinary compile/check/run commands should not silently rewrite
   `Semantic.lock`
@@ -117,7 +124,7 @@ The first stable behavior should be conservative:
 
 ## Conflict And Validation Rules
 
-The first lockfile layer should reject:
+The first lockfile layer in this design sketch should reject:
 
 - duplicate package entries with the same identity
 - missing root package entry
@@ -126,7 +133,7 @@ The first lockfile layer should reject:
 
 ## Non-Goals
 
-This first lockfile document does not define:
+This future lockfile document does not define:
 
 - a workspace lockfile grammar
 - feature activation state

--- a/docs/roadmap/language_maturity/package_manifest.md
+++ b/docs/roadmap/language_maturity/package_manifest.md
@@ -1,18 +1,23 @@
 # Package Manifest
 
-Status: proposed v0
+Status: historical design note, not current baseline
 
 ## Purpose
 
-This document defines the first intended package manifest contract for
-Semantic projects.
+This document records one future design candidate for a broader package-manager
+manifest layer above the landed first-wave package baseline.
 
-It is a design target for the package ecosystem workstream, not a claim that
-the current CLI already parses this file.
+Current-main truth:
+
+- the admitted current-main package baseline is `Semantic.package`, not
+  `Semantic.toml`
+- this document does not describe the landed `M8.2` package baseline
+- if a broader manifest layer is reopened, it requires a new explicit scope
+  decision from fresh `main`
 
 ## Proposed Manifest Name
 
-The first canonical manifest file should be:
+One future canonical manifest candidate would be:
 
 - `Semantic.toml`
 
@@ -51,7 +56,7 @@ policy_core = { version = "^0.2.0" }
 
 ## `package` Table
 
-The first manifest wave should include:
+One future broader manifest wave could include:
 
 - `name`
 - `version`
@@ -87,7 +92,7 @@ Purpose:
 - edition marks the intended language/library compatibility wave for the
   package surface
 
-The first expected value is:
+The first expected value in this design sketch is:
 
 - `v1`
 
@@ -104,7 +109,7 @@ Current honest limit:
 
 ## `dependencies` Table
 
-The first manifest wave should support explicit dependency entries.
+This future design sketch would support explicit dependency entries.
 
 Proposed dependency forms:
 
@@ -123,8 +128,8 @@ The dependency key is the local package alias exposed to the resolver.
 
 ## Future Tables
 
-These tables may come later, but should not be treated as part of the first
-stabilized manifest wave:
+These tables may come later, but should not be treated as part of the initial
+broader manifest wave if it is ever reopened:
 
 - `[dev-dependencies]`
 - `[features]`
@@ -133,7 +138,7 @@ stabilized manifest wave:
 
 ## Non-Goals
 
-This first manifest design does not yet try to define:
+This future manifest design does not yet try to define:
 
 - a full workspace grammar
 - registry authentication

--- a/docs/roadmap/language_maturity/package_worked_example.md
+++ b/docs/roadmap/language_maturity/package_worked_example.md
@@ -1,11 +1,18 @@
 # Package Worked Example
 
-Status: proposed v0
+Status: historical design note, not current baseline
 
 ## Purpose
 
-This document gives one end-to-end example of the intended Semantic package
-story.
+This document gives one end-to-end example of a future package-manager design
+direction beyond the landed first-wave package baseline.
+
+Current-main truth:
+
+- current `main` already has a narrower admitted package baseline centered on
+  `Semantic.package` and deterministic local-path dependency loading
+- this example does not describe the landed baseline; it is retained only as a
+  future illustrative design note
 
 It connects:
 


### PR DESCRIPTION
## Summary
- mark legacy `Semantic.toml` / `Semantic.lock` package design docs as non-baseline
- point those docs back at the landed `Semantic.package` first-wave baseline on current `main`
- remove the false implication that a new package local-model track is the next honest step

## Request
- document-only truth sync for legacy package design docs after current-main audit showed that first-wave package baseline already landed

## Why now
- `docs/roadmap/backlog.md`, `docs/roadmap/v1_readiness.md`, `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`, and current code in `crates/smc-cli/src/package_manifest.rs` / `crates/smc-cli/src/incremental.rs` already establish the landed `Semantic.package` baseline
- the older package docs still read like active first-wave planning and can mislead future scope decisions

## In scope
- clarify that these five legacy package design docs are not the current admitted baseline
- point them at the completed `Semantic.package` baseline as the current-main truth
- keep them as future design notes rather than deleting them silently

## Out of scope
- no new package feature track
- no package semantics changes
- no CLI/parser/runtime behavior changes
- no lockfile or manifest implementation work

## Backups created
- `C:\Users\said3\Desktop\EXOcode\backup_snapshots\2026-04-22_pr31_package_docs_truth_backup_1`
- `C:\Users\said3\Desktop\EXOcode\backup_snapshots\2026-04-22_pr31_package_docs_truth_backup_2`

## Files touched
- `docs/roadmap/language_maturity/package_ecosystem.md`
- `docs/roadmap/language_maturity/package_manifest.md`
- `docs/roadmap/language_maturity/package_lockfile.md`
- `docs/roadmap/language_maturity/dependency_resolution.md`
- `docs/roadmap/language_maturity/package_worked_example.md`

## Tests / verification
- document-only change; no cargo tests run
- `git diff --cached --check`

## Docs updated
- yes; only roadmap/language_maturity docs listed above

## Release or milestone claim impact
- no behavior or release-surface widening
- clarifies that current-main package truth is the completed first-wave `Semantic.package` baseline, not the older `Semantic.toml` / `Semantic.lock` design bundle

## Status
- ready for review as one docs-only truth-sync step
- backup 1 will be deleted only after green CI + merge; backup 2 will be kept until no longer needed