### PR TITLE
docs: align core roadmap vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ Semantic is built for reasoning rules, semantic state transitions, declarative L
 The public contract is centered in `docs/spec/*`. Historical roadmap notes and legacy compatibility shims remain in the repository, but they are not the primary source of truth for the current toolchain surface.
 
 ## Current Status
+- Semantic currently spans four release-facing status layers:
+  - `published stable`
+  - `qualified limited release`
+  - `landed on main, not yet promised`
+  - `out of scope`
+- The canonical vocabulary for those layers is defined in
+  `docs/roadmap/public_status_model.md`.
 - Semantic is in a post-v1 stabilization phase on `main`.
+- The current published stable line is `v1.1.1`.
+- The current practical-programming qualification posture remains
+  `qualified limited release`, not `public release`.
 - Canonical staged pipeline: `frontend -> semantics -> lowering -> IR passes -> emit -> VM`.
 - All pipeline stages are deterministic, explicitly staged, and contract-bound; verifier admission remains mandatory before standard VM execution.
 - Runtime Ownership (v1 slice) is DONE:
@@ -21,6 +31,9 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
   - verifier-admitted execution contract
 - This is a scoped ownership model, not a full borrow system.
 - CLI ownership is centered in `crates/smc-cli`; root `smc` and `svm` binaries remain process entrypoints.
+- Landed post-stable surfaces on current `main` should not be read as
+  release-promised unless a later readiness or release decision explicitly
+  promotes them.
 
 ## Primary References
 - `docs/spec/index.md` - canonical spec bundle entrypoint

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -7,10 +7,13 @@ Current release-control wave:
 - keep active engineering work anchored to the canonical `main` source of truth
   in
   `docs/roadmap/language_maturity/mainline_source_of_truth_policy.md`
+- keep release-facing wording anchored to
+  `docs/roadmap/public_status_model.md`
 
 Current release-maintenance wave:
 
-- keep `blueprint`, `milestones`, `backlog`, and `v1_readiness` aligned with the published stable line
+- keep `blueprint`, `milestones`, `backlog`, and `v1_readiness` aligned with
+  the published stable line
 - keep published release assets validated against representative source programs
 - keep release notes and compatibility statements honest about current narrow `v1` limits
 
@@ -23,6 +26,10 @@ Current remaining `v1` wave:
   `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`
 
 Current post-`v1` wave:
+
+- the items listed below are landed on current `main` as frozen baseline
+  history; they are not automatically part of the published stable or
+  qualified-limited-release contour unless a later decision promotes them
 
 - `Runtime Ownership (tuple + direct record-field paths)` is completed and now
   lives as frozen baseline history in `docs/spec/runtime_ownership.md`

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -5,6 +5,15 @@ Status: active stable release baseline
 This document summarizes the current compatibility commitments for the
 repository state published on the active Semantic stable line.
 
+Read this document using the canonical status vocabulary in
+`docs/roadmap/public_status_model.md`.
+
+In this document:
+
+- `published stable` refers to the active stable line and its commitments
+- `landed on main, not yet promised` refers to forward-only widenings that
+  exist on current `main` but are not part of the stable promise
+
 ## SemCode Compatibility
 
 Current published-stable compatible SemCode families:
@@ -14,7 +23,7 @@ Current published-stable compatible SemCode families:
 - `SEMCODE2`
 - `SEMCODE3`
 
-Current post-stable admitted families on `main`:
+Current landed-on-`main`, not-yet-promised families:
 
 - `SEMCODE4`
 - `SEMCODE5`

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -1,5 +1,20 @@
 # Semantic v1 Milestones
 
+This document is a milestone/checkpoint map, not the authority for the current
+release-facing verdict.
+
+Read milestone statuses through the canonical status vocabulary in
+`docs/roadmap/public_status_model.md`.
+
+Use:
+
+- `docs/roadmap/v1_readiness.md` for the current published-stable posture
+- `reports/g1_release_scope_statement.md` for the current qualified-limited
+  practical-programming verdict
+
+Do not treat a milestone or subtrack marked as completed on current `main` as
+automatically published stable or release-promised.
+
 - `M0 Repository Discipline`
   - architecture docs
   - crate map

--- a/docs/roadmap/stable_release_policy.md
+++ b/docs/roadmap/stable_release_policy.md
@@ -6,6 +6,13 @@ This document defines the release discipline that governed the `v1.1.1` stable
 cut and should continue to govern forward stable releases without reopening
 scope.
 
+Read this policy using the canonical status vocabulary in
+`docs/roadmap/public_status_model.md`.
+
+This document governs the `published stable` line.
+It does not automatically promote behavior that is merely landed on current
+`main`.
+
 ## Scope Freeze
 
 While the repository is preparing or validating a stable release:
@@ -21,6 +28,11 @@ Allowed changes during the release-validation window:
 - release asset validation
 - packaging fixes
 - emergency correctness fixes that are rerun through the full validation contour
+
+Disallowed interpretation:
+
+- landed-on-`main`, not-yet-promised behavior must not be treated as part of
+  the stable line unless an explicit later release decision promotes it
 
 ## Stable Tag Preconditions
 

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -4,6 +4,12 @@ Status: published stable release line
 
 This document summarizes the current release-facing readiness state for Semantic v1.
 
+Read this document using the canonical status vocabulary in
+`docs/roadmap/public_status_model.md`.
+
+Within that model, this document is the authority for the current
+release-facing posture.
+
 ## Current Readiness Position
 
 Current repository state has working coverage for:
@@ -34,6 +40,16 @@ Current `v1` boundary decision:
 - the first `Gate 1` qualification cycle is completed and currently supports
   only a `limited release` decision for the admitted practical-programming
   contour documented in `reports/g1_release_scope_statement.md`
+
+Status reading:
+
+- `published stable`: the `v1.1.1` line and its stable assets
+- `qualified limited release`: the admitted practical-programming contour
+  documented by the completed first `Gate 1` cycle
+- `landed on main, not yet promised`: widened current-`main` surfaces listed
+  under `Current Known Limits` as excluded from the published stable line
+- `out of scope`: behavior explicitly excluded from both the current stable
+  line and the current qualified contour
 
 ## Current Artifact List
 


### PR DESCRIPTION
## Summary
- align core release-facing docs to the canonical public status vocabulary
- make README, backlog, milestones, readiness, compatibility, and stable release policy use the same published stable / qualified limited release / landed on main, not yet promised / out of scope reading
- keep this step structural/vocabulary-only, without factual release-claim widening

## Scope
- docs-only PR-A1.2
- no technical behavior changes
- no new release promises
- no qualification verdict changes

## Why now
- PR-A1.1 added docs/roadmap/public_status_model.md as the vocabulary authority
- core release-facing docs should now read through that vocabulary before any later factual sync work
- this keeps Phase A1 structural and avoids mixing vocabulary sync with later A2 factual claim updates

## Out of scope
- stale scope-doc factual sync
- report-level wording sync
- any module widening
- any release claim broadening

## Verification
- git diff --check
- docs-only change; no cargo tests run
