### PR TITLE
docs: align qualification status skeleton

### DIFF
--- a/docs/roadmap/language_maturity/executable_module_entry_scope.md
+++ b/docs/roadmap/language_maturity/executable_module_entry_scope.md
@@ -13,11 +13,24 @@ identified after the first `Gate 1` cycle:
 The landed result remains intentionally narrow. It is not a reboot of the whole
 package or module ecosystem story.
 
+## Status Reading For This Scope Doc
+
+This document records a completed blocker-removal checkpoint on current `main`.
+
+Per `docs/roadmap/public_status_model.md`, it should be read as a track record
+for landed behavior and track scope, not as the authority for the current
+release-facing verdict.
+
+Current release-facing posture still lives in:
+
+- `docs/roadmap/v1_readiness.md`
+- `reports/g1_release_scope_statement.md`
+
 ## Why This Track Exists
 
 The first `Gate 1` qualification cycle ended in:
 
-- `limited release`
+- `qualified limited release`
 
 The main blocker preventing a broader practical-programming claim was not VM
 integrity or verifier trust. It was ordinary module-based executable authoring.
@@ -136,7 +149,7 @@ The widened admitted contour is now frozen as:
 
 The updated Gate 1 evidence keeps the overall decision state at:
 
-- `limited release`
+- `qualified limited release`
 
 The blocker was removed, but the release contour remains intentionally narrow
 because broader executable import forms and full CLI-style authoring are still

--- a/docs/roadmap/language_maturity/import_reexport_full_scope.md
+++ b/docs/roadmap/language_maturity/import_reexport_full_scope.md
@@ -12,6 +12,18 @@ This was a post-stable closure pass on current `main`. It did not reinterpret
 the published `v1.1.1` line as if every post-stable import-path widening had
 already shipped there.
 
+## Status Reading For This Scope Doc
+
+This document records a completed closure track on current `main`.
+
+Per `docs/roadmap/public_status_model.md`, it should be read as a track record
+for landed behavior and non-goals, not as the authority for the current
+release-facing posture.
+
+Unless a later qualification or stable publication step explicitly promotes a
+surface described here, it should be read as landed on current `main`, not yet
+promised.
+
 ## Stable Baseline Before This Track
 
 The published stable line already froze these facts:

--- a/reports/g1_benchmark_baseline.md
+++ b/reports/g1_benchmark_baseline.md
@@ -11,6 +11,20 @@ This report follows:
 
 - `docs/roadmap/release_qualification/gate1_protocol.md`
 
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Its role is benchmark evidence for the currently admitted qualification contour.
+
+It does not by itself:
+
+- promote landed current-`main` behavior into `published stable`
+- widen the current practical-programming claim
+- override the release-facing posture in `docs/roadmap/v1_readiness.md`
+
 ## Scope
 
 This first baseline measures in-process public pipeline stages for the same

--- a/reports/g1_execution_integrity.md
+++ b/reports/g1_execution_integrity.md
@@ -17,6 +17,20 @@ This report follows:
 
 - `docs/roadmap/release_qualification/gate1_protocol.md`
 
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Its role is evidence for the admitted execution contour on current `main`.
+
+It does not by itself:
+
+- promote landed current-`main` behavior into `published stable`
+- widen the current practical-programming release promise
+- override the current release-facing posture in `docs/roadmap/v1_readiness.md`
+
 ## Reproducible Evidence Pack
 
 Representative source fixtures reused from `Q1`:

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -14,6 +14,20 @@ This report follows:
 
 - `docs/roadmap/release_qualification/gate1_protocol.md`
 
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Its role is evidence for the currently admitted frontend contour.
+
+It does not by itself:
+
+- promote landed current-`main` behavior into `published stable`
+- define the current release-facing posture
+- broaden the current practical-programming claim beyond the evidence pack
+
 ## Reproducible Evidence Pack
 
 Canonical positive fixtures:

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -13,6 +13,21 @@ This report follows the canonical Gate 1 protocol in:
 
 UI is not part of this qualification contour.
 
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Its role is evidence for the current practical-programming contour.
+
+It does not by itself:
+
+- promote landed current-`main` behavior into `published stable`
+- override the current release-facing posture in `docs/roadmap/v1_readiness.md`
+- replace the current qualification verdict in
+  `reports/g1_release_scope_statement.md`
+
 ## Reproducible Evidence Pack
 
 Canonical committed trial programs:

--- a/reports/g1_release_scope_statement.md
+++ b/reports/g1_release_scope_statement.md
@@ -4,7 +4,22 @@ Status: completed synthesis report for `Q5`
 
 ## Decision State
 
-`limited release`
+`qualified limited release`
+
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Per the authority order defined there, this report is the current
+practical-programming qualification verdict authority.
+
+It does not by itself:
+
+- promote behavior into the `published stable` line
+- override stable publication rules in `docs/roadmap/stable_release_policy.md`
+- reinterpret all landed current-`main` behavior as release-promised
 
 ## Decision Basis
 

--- a/reports/g1_surface_expressiveness.md
+++ b/reports/g1_surface_expressiveness.md
@@ -18,6 +18,20 @@ This report follows:
 
 UI remains outside this qualification contour.
 
+## Status Reading
+
+This report uses the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Its role is synthesis for the current practical-programming qualification.
+
+It does not by itself:
+
+- promote landed current-`main` behavior into `published stable`
+- replace `docs/roadmap/v1_readiness.md` as the release-facing posture authority
+- widen the release claim beyond the evidence set summarized here
+
 ## Evidence Summary
 
 ### Natural zone
@@ -95,7 +109,8 @@ still matters for practical readiness:
 
 ## G1-A Verdict
 
-`G1-A Surface Expressiveness` is green only for a **limited** admitted contour.
+`G1-A Surface Expressiveness` is green only for a `qualified limited release`
+contour.
 
 Operational meaning:
 
@@ -106,6 +121,6 @@ Operational meaning:
   programming claim while executable-module authoring remains intentionally
   narrow and CLI-style authoring remains incomplete
 
-This is sufficient for a `limited release` decision.
+This is sufficient for a `qualified limited release` decision.
 
 It is not sufficient for a `public release` decision.


### PR DESCRIPTION
## Summary
- align the g1_* qualification reports to the canonical public status vocabulary
- make the import/module scope docs read as landed-track records rather than release-facing authorities
- keep the step structural only, without factual release-claim widening

## Scope
- docs-only PR-A1.3
- no technical behavior changes
- no new release promises
- no qualification verdict changes

## Why now
- PR-A1.1 established docs/roadmap/public_status_model.md as the vocabulary authority
- PR-A1.2 aligned the core release-facing roadmap docs
- the remaining A1 tail is the qualification-report layer plus stale scope docs that still shape public reading

## Out of scope
- factual readiness sync after a future re-synthesis
- any module widening
- any benchmark rerun
- any release-claim broadening

## Verification
- git diff --check
- docs-only change; no cargo tests run
