### PR TITLE
docs/examples: add draft canonical examples and wave decision

### DIFF
--- a/docs/roadmap/module_authoring_wave_decision.md
+++ b/docs/roadmap/module_authoring_wave_decision.md
@@ -1,0 +1,159 @@
+# Module Authoring Wave Decision
+
+Status: completed `B0` decision note
+Primary owners: language maturity, practical-programming readiness
+
+## Purpose
+
+This note records the evidence-driven choice for the single `B2` widening wave
+in the readiness-completion plan.
+
+It does not widen the executable module contour by itself.
+
+## Evidence Base
+
+Draft canonical examples used for this note:
+
+- `examples/readiness_draft_canonical/cli_batch_core`
+- `examples/readiness_draft_canonical/rule_state_decision`
+- `examples/readiness_draft_canonical/data_audit_record_iterable`
+- `examples/readiness_draft_canonical/wave2_local_helper_import`
+- `examples/readiness_draft_canonical/module_selected_import_settlement`
+- `examples/readiness_draft_canonical/module_selected_import_audit_report`
+
+Current admitted executable module contour:
+
+- direct local-path bare helper-module imports
+- direct helper declarations bundled into the executable semantic path
+- no selected import
+- no alias import
+- no wildcard import
+- no namespace-qualified executable access
+
+## Example Friction Reading
+
+### 1. `cli_batch_core`
+
+Module pressure:
+
+- none
+
+Reading:
+
+- this example validates the single-file executable core but does not influence
+  the next module wave choice
+
+### 2. `rule_state_decision`
+
+Module pressure:
+
+- none
+
+Reading:
+
+- this example validates the natural rule/state shape but does not influence
+  the next module wave choice
+
+### 3. `data_audit_record_iterable`
+
+Module pressure:
+
+- none
+
+Reading:
+
+- this example validates the iterable/data contour but does not influence the
+  next module wave choice
+
+### 4. `wave2_local_helper_import`
+
+Module pressure:
+
+- low, but still narrow
+
+Current benefit:
+
+- proves that one helper module can already be admitted end to end
+
+Current limitation:
+
+- every imported executable declaration arrives as an unqualified root binding
+- there is no way to request only the symbols the root file actually uses
+
+### 5. `module_selected_import_settlement`
+
+Module pressure:
+
+- high
+
+Observed friction:
+
+- two helper modules both export `status_text`
+- the natural source shape wants symbol-level import plus aliasing
+- the current bare-import-only contour would force unnatural helper renaming or
+  helper-file reshaping just to avoid executable root-scope collision
+
+### 6. `module_selected_import_audit_report`
+
+Module pressure:
+
+- high
+
+Observed friction:
+
+- the root file wants only four helper functions
+- the current bare-import-only contour would import every helper declaration
+  into the executable root scope
+- this creates avoidable scope spillover and makes later helper growth more
+  collision-prone than the example logic warrants
+
+## Chosen `B2` Wave
+
+Chosen wave:
+
+- `selected import`
+
+## Why `selected import` Wins
+
+1. It removes the strongest friction shown by the draft examples:
+   - symbol-level curation
+   - aliasing for same-named helper exports
+   - avoiding root-scope spillover from helper-heavy modules
+
+2. It directly addresses the already-preserved blocked probe from the first
+   qualification cycle:
+   - `examples/qualification/g1_real_program_trial/module_helpers_blocked`
+
+3. It is the tighter widening:
+   - the broader module contract already owns selected import syntax
+   - executable-path admission is the missing piece
+
+4. It removes a more structural pain point than namespace-qualified access:
+   - namespace-qualified access would improve provenance, but it would still
+     leave import-all behavior and symbol-selection pain unresolved
+
+## Why `namespace-qualified executable access` Is Not First
+
+`namespace-qualified executable access` remains a valid later candidate, but it
+is not the highest-value first step for readiness completion.
+
+Reason:
+
+- the draft examples do not primarily fail because they need repeated namespace
+  calls
+- they fail because they need symbol-level import control and aliasing
+- selected import therefore removes the higher-value blocker first
+
+## Resulting `B2` Boundary
+
+`B2` should admit exactly one narrow widening wave:
+
+- selected import on the executable path
+
+Still out of scope for `B2`:
+
+- wildcard import admission
+- public re-export admission on the executable path
+- package-qualified executable widening beyond the already landed baseline
+- namespace-qualified executable access
+- any generalized import/package redesign

--- a/examples/readiness_draft_canonical/README.md
+++ b/examples/readiness_draft_canonical/README.md
@@ -1,0 +1,55 @@
+# Readiness Draft Canonical Examples
+
+Status: draft examples pack for `PR-B0.1`
+
+## Purpose
+
+This directory collects the draft canonical example programs used during the
+readiness-completion cycle.
+
+At this stage the pack is intentionally mixed:
+
+- some examples are already inside the current `qualified limited release`
+  contour
+- some examples are draft text artifacts used to decide the next
+  module-authoring widening wave
+
+This pack does not by itself widen the release contour.
+
+## Draft Matrix
+
+1. `cli_batch_core`
+   - current reading: `qualified limited release`
+   - purpose: small CLI-style computation core over `Sequence(i32)` and `text`
+
+2. `rule_state_decision`
+   - current reading: `qualified limited release`
+   - purpose: record-oriented rule/state decision logic with explicit
+     `Result(T, E)` handling
+
+3. `data_audit_record_iterable`
+   - current reading: `qualified limited release`
+   - purpose: data-heavy audit pass over direct-record `Iterable` dispatch
+
+4. `wave2_local_helper_import`
+   - current reading: `qualified limited release`
+   - purpose: admitted narrow helper-module executable program using direct
+     local-path bare import
+
+5. `module_selected_import_settlement`
+   - current reading: `out of scope on current main`
+   - purpose: settlement-style module split that wants symbol-level import and
+     aliasing
+
+6. `module_selected_import_audit_report`
+   - current reading: `out of scope on current main`
+   - purpose: module-based reporting flow that wants selective helper import
+     without root-scope spillover
+
+## Reading Rule
+
+These example directories are draft source-shaped text artifacts for readiness
+planning.
+
+They are not yet the final canonical examples pack promised by later readiness
+phases.

--- a/examples/readiness_draft_canonical/cli_batch_core/Semantic.package
+++ b/examples/readiness_draft_canonical/cli_batch_core/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package cli_batch_core
+manifest_dir .
+module_root src

--- a/examples/readiness_draft_canonical/cli_batch_core/src/main.sm
+++ b/examples/readiness_draft_canonical/cli_batch_core/src/main.sm
@@ -1,0 +1,26 @@
+fn classify_exit(codes: Sequence(i32)) -> text {
+    let saw_error: bool = false;
+    let saw_retry: bool = false;
+    for code in codes {
+        if code == 9 {
+            saw_error ||= true;
+        }
+        if code == 2 {
+            saw_retry ||= true;
+        }
+    }
+    if saw_error == true {
+        return "error";
+    }
+    if saw_retry == true {
+        return "retry";
+    }
+    return "ok";
+}
+
+fn main() {
+    let argv_like: Sequence(i32) = [2, 1, 0];
+    let mode: text = classify_exit(argv_like);
+    assert(mode == "retry");
+    return;
+}

--- a/examples/readiness_draft_canonical/data_audit_record_iterable/Semantic.package
+++ b/examples/readiness_draft_canonical/data_audit_record_iterable/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package data_audit_record_iterable
+manifest_dir .
+module_root src

--- a/examples/readiness_draft_canonical/data_audit_record_iterable/src/main.sm
+++ b/examples/readiness_draft_canonical/data_audit_record_iterable/src/main.sm
@@ -1,0 +1,60 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Samples {
+    first: i32,
+    second: i32,
+    third: i32,
+}
+
+record AuditSummary {
+    saw_alert: bool,
+    saw_retry: bool,
+}
+
+impl Iterable for Samples {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        if index == 0 {
+            return Option::Some(self.first);
+        }
+        if index == 1 {
+            return Option::Some(self.second);
+        }
+        if index == 2 {
+            return Option::Some(self.third);
+        }
+        return Option::None;
+    }
+}
+
+fn summarize(samples: Samples) -> AuditSummary {
+    let saw_alert: bool = false;
+    let saw_retry: bool = false;
+    for value in samples {
+        if value == 9 {
+            saw_alert ||= true;
+        }
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return AuditSummary {
+        saw_alert: saw_alert,
+        saw_retry: saw_retry,
+    };
+}
+
+fn main() {
+    let samples: Samples = Samples {
+        first: 2,
+        second: 9,
+        third: 4,
+    };
+    let summary: AuditSummary = summarize(samples);
+    let patched: AuditSummary = summary with { saw_retry: false };
+    assert(summary.saw_alert == true);
+    assert(summary.saw_retry == true);
+    assert(patched.saw_retry == false);
+    return;
+}

--- a/examples/readiness_draft_canonical/module_selected_import_audit_report/README.md
+++ b/examples/readiness_draft_canonical/module_selected_import_audit_report/README.md
@@ -1,0 +1,15 @@
+# Module Selected-Import Audit Report
+
+Status: draft text artifact for `PR-B0.1`
+
+## Why This Example Exists
+
+This program models a reporting flow that wants:
+
+- narrow import of only the helper functions it actually uses
+- avoidance of root-scope spillover from utility-heavy helper modules
+- a clear path to add more helper functions later without forcing every helper
+  symbol into the executable root namespace
+
+This example is intentionally outside the current admitted executable contour.
+It exists only as decision input for the next module-authoring widening wave.

--- a/examples/readiness_draft_canonical/module_selected_import_audit_report/Semantic.package
+++ b/examples/readiness_draft_canonical/module_selected_import_audit_report/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package module_selected_import_audit_report
+manifest_dir .
+module_root src

--- a/examples/readiness_draft_canonical/module_selected_import_audit_report/src/main.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_audit_report/src/main.sm
@@ -1,0 +1,13 @@
+Import "risk_policy.sm" { classify_risk, normalize_delta }
+Import "text_format.sm" { format_amount, format_delta }
+
+fn main() {
+    let normalized: i32 = normalize_delta(-2);
+    let risk: quad = classify_risk(9, normalized);
+    let amount_text: text = format_amount(9);
+    let delta_text: text = format_delta(normalized);
+    assert(risk == T);
+    assert(amount_text == "9");
+    assert(delta_text == "2");
+    return;
+}

--- a/examples/readiness_draft_canonical/module_selected_import_audit_report/src/risk_policy.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_audit_report/src/risk_policy.sm
@@ -1,0 +1,20 @@
+fn normalize_delta(delta: i32) -> i32 {
+    if delta < 0 {
+        return 0 - delta;
+    }
+    return delta;
+}
+
+fn classify_risk(amount: i32, delta: i32) -> quad {
+    if amount >= 9 && delta >= 2 {
+        return T;
+    }
+    if amount >= 9 {
+        return S;
+    }
+    return F;
+}
+
+fn helper_threshold() -> i32 {
+    return 9;
+}

--- a/examples/readiness_draft_canonical/module_selected_import_audit_report/src/text_format.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_audit_report/src/text_format.sm
@@ -1,0 +1,17 @@
+fn format_amount(amount: i32) -> text {
+    if amount == 9 {
+        return "9";
+    }
+    return "other";
+}
+
+fn format_delta(delta: i32) -> text {
+    if delta == 2 {
+        return "2";
+    }
+    return "other";
+}
+
+fn format_banner() -> text {
+    return "AUDIT";
+}

--- a/examples/readiness_draft_canonical/module_selected_import_settlement/README.md
+++ b/examples/readiness_draft_canonical/module_selected_import_settlement/README.md
@@ -1,0 +1,16 @@
+# Module Selected-Import Settlement
+
+Status: draft text artifact for `PR-B0.1`
+
+## Why This Example Exists
+
+This program models a small settlement helper split where two helper modules
+both export a function called `status_text`.
+
+The natural source shape wants symbol-level import plus aliasing:
+
+- one helper provides policy-facing classification
+- another helper provides presentation-facing rendering
+
+This example is intentionally outside the current admitted executable contour.
+It exists only as decision input for the next module-authoring widening wave.

--- a/examples/readiness_draft_canonical/module_selected_import_settlement/Semantic.package
+++ b/examples/readiness_draft_canonical/module_selected_import_settlement/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package module_selected_import_settlement
+manifest_dir .
+module_root src

--- a/examples/readiness_draft_canonical/module_selected_import_settlement/src/main.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_settlement/src/main.sm
@@ -1,0 +1,13 @@
+Import "rules.sm" { classify_status, status_text as rule_status_text }
+Import "rendering.sm" { status_text as render_status_text, render_notice }
+
+fn main() {
+    let verdict: quad = classify_status(12, false);
+    let short_status: text = rule_status_text(verdict);
+    let banner: text = render_status_text(verdict);
+    let notice: text = render_notice(short_status, banner);
+    assert(short_status == "ok");
+    assert(banner == "OK");
+    assert(notice == "ok:OK");
+    return;
+}

--- a/examples/readiness_draft_canonical/module_selected_import_settlement/src/rendering.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_settlement/src/rendering.sm
@@ -1,0 +1,19 @@
+fn status_text(verdict: quad) -> text {
+    if verdict == T {
+        return "OK";
+    }
+    if verdict == F {
+        return "HOLD";
+    }
+    return "REVIEW";
+}
+
+fn render_notice(short_status: text, banner: text) -> text {
+    if short_status == "ok" && banner == "OK" {
+        return "ok:OK";
+    }
+    if short_status == "hold" && banner == "HOLD" {
+        return "hold:HOLD";
+    }
+    return "review:REVIEW";
+}

--- a/examples/readiness_draft_canonical/module_selected_import_settlement/src/rules.sm
+++ b/examples/readiness_draft_canonical/module_selected_import_settlement/src/rules.sm
@@ -1,0 +1,19 @@
+fn classify_status(amount: i32, flagged: bool) -> quad {
+    if flagged == true {
+        return F;
+    }
+    if amount >= 10 {
+        return T;
+    }
+    return S;
+}
+
+fn status_text(verdict: quad) -> text {
+    if verdict == T {
+        return "ok";
+    }
+    if verdict == F {
+        return "hold";
+    }
+    return "review";
+}

--- a/examples/readiness_draft_canonical/rule_state_decision/Semantic.package
+++ b/examples/readiness_draft_canonical/rule_state_decision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package rule_state_decision
+manifest_dir .
+module_root src

--- a/examples/readiness_draft_canonical/rule_state_decision/src/main.sm
+++ b/examples/readiness_draft_canonical/rule_state_decision/src/main.sm
@@ -1,0 +1,35 @@
+record DecisionContext {
+    camera: quad,
+    override_state: quad,
+    ready: bool,
+}
+
+fn decide(ctx: DecisionContext) -> Result(quad, quad) {
+    if ctx.override_state == T {
+        return Result::Ok(T);
+    }
+    if ctx.override_state == F {
+        return Result::Ok(F);
+    }
+    if ctx.camera == N {
+        return Result::Err(N);
+    }
+    if ctx.ready == true {
+        return Result::Ok(T);
+    }
+    return Result::Err(S);
+}
+
+fn main() {
+    let ctx: DecisionContext = DecisionContext {
+        camera: T,
+        override_state: S,
+        ready: true,
+    };
+    let verdict: quad = match decide(ctx) {
+        Result::Ok(value) => { value }
+        Result::Err(code) => { code }
+    };
+    assert(verdict == T);
+    return;
+}

--- a/examples/readiness_draft_canonical/wave2_local_helper_import/src/helper.sm
+++ b/examples/readiness_draft_canonical/wave2_local_helper_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/readiness_draft_canonical/wave2_local_helper_import/src/main.sm
+++ b/examples/readiness_draft_canonical/wave2_local_helper_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}


### PR DESCRIPTION
## Summary
- add a draft canonical examples pack under xamples/readiness_draft_canonical
- record the concrete module-authoring friction observed in those examples
- choose exactly one B2 widening wave from evidence instead of intuition

## Scope
- docs/examples-only PR-B0.1
- no technical behavior changes
- no release-claim widening
- examples are draft text artifacts for readiness planning, not a new runnable promise

## What was added
- six draft canonical example programs under xamples/readiness_draft_canonical
- docs/roadmap/module_authoring_wave_decision.md

## B2 choice
- chosen wave: selected import
- reason: the draft module-based examples need symbol-level import control and aliasing more urgently than namespace-qualified access

## Out of scope
- implementing the chosen wave
- widening executable module admission
- updating qualification verdicts
- finalizing the canonical examples pack for later readiness phases

## Verification
- git diff --check
- docs/examples-only change; no cargo tests run
