### PR TITLE
tests: add negative executable import boundary matrix

### DIFF
--- a/examples/qualification/executable_module_entry/negative_alias_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_alias_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_alias_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_alias_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_alias_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/negative_alias_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_alias_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "helper.sm" as Helper
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_cycle_bare_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_cycle_bare_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_cycle_bare_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/a.sm
+++ b/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/a.sm
@@ -1,0 +1,5 @@
+Import "b.sm"
+
+fn score_a() -> i32 {
+    return score_b();
+}

--- a/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/b.sm
+++ b/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/b.sm
@@ -1,0 +1,5 @@
+Import "a.sm"
+
+fn score_b() -> i32 {
+    return score_a();
+}

--- a/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_cycle_bare_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "a.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_duplicate_symbol_collision
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/left.sm
+++ b/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/left.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/main.sm
@@ -1,0 +1,6 @@
+Import "left.sm"
+Import "right.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/right.sm
+++ b/examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/right.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value + 1;
+}

--- a/examples/qualification/executable_module_entry/negative_namespace_collision/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_namespace_collision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_namespace_collision
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_namespace_collision/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_namespace_collision/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value + 1;
+}

--- a/examples/qualification/executable_module_entry/negative_namespace_collision/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_namespace_collision/src/main.sm
@@ -1,0 +1,9 @@
+Import "helper.sm"
+
+fn score(value: i32) -> i32 {
+    return value;
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_package_qualified_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_package_qualified_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_package_qualified_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "math::core.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_reexport_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_reexport_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_reexport_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_reexport_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_reexport_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/negative_reexport_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_reexport_import/src/main.sm
@@ -1,0 +1,5 @@
+Import pub "helper.sm" { score }
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_selected_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_selected_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_selected_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_selected_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_selected_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/negative_selected_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_selected_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "helper.sm" { score }
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_wildcard_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_wildcard_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_wildcard_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_wildcard_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_wildcard_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/negative_wildcard_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_wildcard_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "helper.sm" *
+
+fn main() {
+    return;
+}

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -13,9 +13,62 @@ fn cli_ok(command: &str, rel: &str) {
         .unwrap_or_else(|err| panic!("smc {command} failed for {path}: {err}"));
 }
 
+fn cli_err(command: &str, rel: &str) -> String {
+    let path = repo_path(rel);
+    smc_cli::run(vec![command.to_string(), path.clone()])
+        .expect_err(&format!("smc {command} unexpectedly passed for {path}"))
+}
+
 #[test]
 fn executable_module_entry_wave2_local_helper_import_checks_and_runs() {
     let rel = "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
     cli_ok("check", rel);
     cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_negative_out_of_scope_import_forms_report_wave2_boundary() {
+    let wave2_boundary =
+        "top-level executable Import currently admits only direct local-path helper-module imports in wave2";
+    let cases = [
+        "examples/qualification/executable_module_entry/negative_alias_import/src/main.sm",
+        "examples/qualification/executable_module_entry/negative_selected_import/src/main.sm",
+        "examples/qualification/executable_module_entry/negative_wildcard_import/src/main.sm",
+        "examples/qualification/executable_module_entry/negative_reexport_import/src/main.sm",
+        "examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm",
+    ];
+
+    for rel in cases {
+        let err = cli_err("check", rel);
+        assert!(
+            err.contains(wave2_boundary),
+            "expected wave2 executable import boundary diagnostic for {rel}, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn executable_module_entry_negative_graph_and_namespace_cases_report_explicit_failures() {
+    let cases = [
+        (
+            "examples/qualification/executable_module_entry/negative_cycle_bare_import/src/main.sm",
+            "cyclic executable helper import detected:",
+        ),
+        (
+            "examples/qualification/executable_module_entry/negative_duplicate_symbol_collision/src/main.sm",
+            "duplicate function 'score'",
+        ),
+        (
+            "examples/qualification/executable_module_entry/negative_namespace_collision/src/main.sm",
+            "duplicate function 'score'",
+        ),
+    ];
+
+    for (rel, needle) in cases {
+        let err = cli_err("check", rel);
+        assert!(
+            err.contains(needle),
+            "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add negative executable-path fixtures for every still out-of-scope import form in the current wave2 contour
- add explicit boundary cases for cyclic helper imports, duplicate imported symbols, and flattened root/helper namespace collisions
- extend the executable module entry test harness to assert the observed reject surface through the public smc check path

## Scope
- PR-B1.1
- tests/fixtures only
- no module widening
- no factual release-claim changes

## Covered cases
- alias import rejects
- selected import rejects
- wildcard import rejects
- re-export import rejects
- package-qualified import rejects
- cyclic helper imports reject explicitly
- duplicate imported symbol collisions reject explicitly
- root/helper namespace collisions reject explicitly

## Verification
- cargo test -q --test executable_module_entry
- cargo test -q
- cargo test -q --test public_api_contracts
- git diff --check
