### PR TITLE
tests: harden current executable helper-module contour

### DIFF
--- a/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_multi_hop_cycle_bare_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/a.sm
+++ b/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/a.sm
@@ -1,0 +1,5 @@
+Import "b.sm"
+
+fn score_a() -> i32 {
+    return score_b();
+}

--- a/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/b.sm
+++ b/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/b.sm
@@ -1,0 +1,5 @@
+Import "c.sm"
+
+fn score_b() -> i32 {
+    return score_c();
+}

--- a/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/c.sm
+++ b/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/c.sm
@@ -1,0 +1,5 @@
+Import "a.sm"
+
+fn score_c() -> i32 {
+    return score_a();
+}

--- a/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "a.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/Semantic.package
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_transitive_duplicate_symbol_collision
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/alpha.sm
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/alpha.sm
@@ -1,0 +1,7 @@
+fn score() -> i32 {
+    return 1;
+}
+
+fn alpha_score() -> i32 {
+    return score();
+}

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/beta.sm
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/beta.sm
@@ -1,0 +1,7 @@
+fn score() -> i32 {
+    return 2;
+}
+
+fn beta_score() -> i32 {
+    return score();
+}

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/left.sm
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/left.sm
@@ -1,0 +1,5 @@
+Import "alpha.sm"
+
+fn left_score() -> i32 {
+    return alpha_score();
+}

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/main.sm
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/main.sm
@@ -1,0 +1,6 @@
+Import "left.sm"
+Import "right.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/right.sm
+++ b/examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/right.sm
@@ -1,0 +1,5 @@
+Import "beta.sm"
+
+fn right_score() -> i32 {
+    return beta_score();
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_direct_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/positive_repeated_direct_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_repeated_direct_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/positive_repeated_direct_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_direct_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_direct_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_direct_import/src/main.sm
@@ -1,0 +1,8 @@
+Import "helper.sm"
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_transitive_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/positive_repeated_transitive_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_repeated_transitive_import
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/left.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/left.sm
@@ -1,0 +1,8 @@
+Import "shared.sm"
+
+fn left_score() -> i32 {
+    if shared_value() == T {
+        return 3;
+    }
+    return 0;
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/main.sm
@@ -1,0 +1,10 @@
+Import "left.sm"
+Import "right.sm"
+
+fn main() {
+    let left: i32 = left_score();
+    let right: i32 = right_score();
+    assert(left == 3);
+    assert(right == 4);
+    return;
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/right.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/right.sm
@@ -1,0 +1,8 @@
+Import "shared.sm"
+
+fn right_score() -> i32 {
+    if shared_value() == T {
+        return 4;
+    }
+    return 0;
+}

--- a/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/shared.sm
+++ b/examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/shared.sm
@@ -1,0 +1,3 @@
+fn shared_value() -> quad {
+    return T;
+}

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_path(rel: &str) -> String {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -19,11 +20,68 @@ fn cli_err(command: &str, rel: &str) -> String {
         .expect_err(&format!("smc {command} unexpectedly passed for {path}"))
 }
 
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn compile_bytes(rel: &str) -> Vec<u8> {
+    let input = repo_path(rel);
+    let dir = mk_temp_dir("smc_exec_compile_determinism");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    smc_cli::run(vec![
+        "compile".to_string(),
+        input.clone(),
+        "-o".to_string(),
+        out_arg.clone(),
+    ])
+    .unwrap_or_else(|err| panic!("smc compile failed for {input}: {err}"));
+    let bytes = std::fs::read(&out).expect("compiled bytes");
+    let _ = std::fs::remove_dir_all(&dir);
+    bytes
+}
+
 #[test]
 fn executable_module_entry_wave2_local_helper_import_checks_and_runs() {
     let rel = "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
     cli_ok("check", rel);
     cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_repeated_direct_import_is_deduped() {
+    let rel =
+        "examples/qualification/executable_module_entry/positive_repeated_direct_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_repeated_transitive_helper_import_is_deduped() {
+    let rel = "examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_helper_graph_compile_is_deterministic() {
+    let rel = "examples/qualification/executable_module_entry/positive_repeated_transitive_import/src/main.sm";
+    let first = compile_bytes(rel);
+    let second = compile_bytes(rel);
+    assert_eq!(
+        first, second,
+        "helper-module compile output must stay deterministic across repeated builds"
+    );
 }
 
 #[test]
@@ -62,6 +120,10 @@ fn executable_module_entry_negative_graph_and_namespace_cases_report_explicit_fa
             "examples/qualification/executable_module_entry/negative_namespace_collision/src/main.sm",
             "duplicate function 'score'",
         ),
+        (
+            "examples/qualification/executable_module_entry/negative_transitive_duplicate_symbol_collision/src/main.sm",
+            "duplicate function 'score'",
+        ),
     ];
 
     for (rel, needle) in cases {
@@ -69,6 +131,23 @@ fn executable_module_entry_negative_graph_and_namespace_cases_report_explicit_fa
         assert!(
             err.contains(needle),
             "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn executable_module_entry_multi_hop_cycle_reports_deterministic_chain() {
+    let rel =
+        "examples/qualification/executable_module_entry/negative_multi_hop_cycle_bare_import/src/main.sm";
+    let err = cli_err("check", rel);
+    assert!(
+        err.contains("cyclic executable helper import detected:"),
+        "expected cycle diagnostic, got: {err}"
+    );
+    for needle in ["a.sm", "b.sm", "c.sm"] {
+        assert!(
+            err.contains(needle),
+            "expected cycle diagnostic to mention {needle}, got: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- harden the currently admitted narrow executable helper-module contour with positive and negative graph coverage
- add repeated-import, transitive-import, multi-hop cycle, and transitive duplicate-collision fixtures
- freeze deterministic compile behavior for an admitted helper-module graph

## Scope
- PR-B1.2
- tests/fixtures only
- no module widening
- no factual release-claim changes

## Covered cases
- repeated direct import of the same helper stays admitted
- repeated transitive helper import stays admitted and deduped
- helper-graph compile output stays deterministic across repeated builds
- multi-hop helper cycles reject explicitly
- transitive duplicate helper symbol collisions reject explicitly
- root/helper collision coverage remains exercised in the executable module suite

## Out of scope
- selected import implementation
- namespace-qualified executable access
- any docs/spec widening beyond current admitted contour

## Verification
- cargo test -q --test executable_module_entry
- cargo test -q
- cargo test -q --test public_api_contracts
- git diff --check
