### PR TITLE
frontend/cli: admit selected executable imports

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -29,7 +29,7 @@ fn iterable_for_impl_out_of_scope_message() -> &'static str {
 }
 
 fn executable_import_wave2_out_of_scope_message() -> &'static str {
-    "top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope"
+    "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope"
 }
 
 fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
@@ -37,7 +37,6 @@ fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
         if import.reexport
             || import.wildcard
             || import.alias.is_some()
-            || !import.select_items.is_empty()
             || import.spec.contains("::")
         {
             return Err(FrontendError {
@@ -2467,7 +2466,7 @@ mod tests {
     }
 
     #[test]
-    fn executable_selected_import_rejects_as_wave2_out_of_scope() {
+    fn executable_selected_import_typechecks_in_wave2() {
         let src = r#"
             Import "helper.sm" { Foo }
 
@@ -2476,11 +2475,7 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src)
-            .expect_err("selected executable import must stay out of scope in wave2");
-        assert!(err
-            .message
-            .contains(executable_import_wave2_out_of_scope_message()));
+        typecheck_source(src).expect("selected executable import should typecheck in wave2");
     }
 
     #[test]

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -1,4 +1,5 @@
 use ton618_core::diagnostics::diagnostic_catalog;
+use crate::executable_bundle::read_source_with_package_admission;
 use crate::incremental::{
     emit_trace, module_graph_fingerprint, module_graph_module_count, read_graph_hash,
     update_cache_index, CacheEvent, CacheReason, ModuleGraphSnapshot,
@@ -44,114 +45,6 @@ fn ensure_package_module_admission(path: &Path) -> Result<(), String> {
     admit_package_entry_module(path)
         .map(|_| ())
         .map_err(|e| e.to_string())
-}
-
-fn executable_import_wave2_out_of_scope_message() -> &'static str {
-    "top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope"
-}
-
-fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
-    ensure_package_module_admission(path)?;
-    let canonical = path
-        .canonicalize()
-        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
-    let source = std::fs::read_to_string(&canonical)
-        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
-    let parser_profile = cli_profile();
-    let program = match parse_program_with_profile(&source, &parser_profile) {
-        Ok(program) => program,
-        Err(_) => return Ok(source),
-    };
-    if program.imports.is_empty() {
-        return Ok(source);
-    }
-    let mut visiting = Vec::new();
-    let mut loaded = HashSet::new();
-    let mut modules = Vec::new();
-    collect_executable_bundle(
-        &canonical,
-        &parser_profile,
-        &mut visiting,
-        &mut loaded,
-        &mut modules,
-    )?;
-    let mut bundle = String::new();
-    for (idx, (_path, module_source)) in modules.into_iter().enumerate() {
-        if idx > 0 {
-            bundle.push_str("\n\n");
-        }
-        bundle.push_str(&module_source);
-        if !module_source.ends_with('\n') {
-            bundle.push('\n');
-        }
-    }
-    Ok(bundle)
-}
-
-fn collect_executable_bundle(
-    path: &Path,
-    parser_profile: &ParserProfile,
-    visiting: &mut Vec<PathBuf>,
-    loaded: &mut HashSet<PathBuf>,
-    modules: &mut Vec<(PathBuf, String)>,
-) -> Result<(), String> {
-    ensure_package_module_admission(path)?;
-    let canonical = path
-        .canonicalize()
-        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
-    if loaded.contains(&canonical) {
-        return Ok(());
-    }
-    if let Some(pos) = visiting.iter().position(|entry| entry == &canonical) {
-        let mut chain = visiting[pos..]
-            .iter()
-            .map(|entry| entry.to_string_lossy().replace('\\', "/"))
-            .collect::<Vec<_>>();
-        chain.push(canonical.to_string_lossy().replace('\\', "/"));
-        return Err(format!(
-            "cyclic executable helper import detected: {}",
-            chain.join(" -> ")
-        ));
-    }
-    visiting.push(canonical.clone());
-    let source = std::fs::read_to_string(&canonical)
-        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
-    let program = parse_program_with_profile(&source, parser_profile).map_err(|e| {
-        format!(
-            "executable helper module '{}' must parse on the Rust-like source path: {}",
-            canonical.display(),
-            e
-        )
-    })?;
-    for import in &program.imports {
-        validate_executable_bundle_import(&canonical, import)?;
-        let child = resolve_package_import_path(&canonical, &import.spec)
-            .map_err(|e| format!("{}: {}", canonical.display(), e))?;
-        collect_executable_bundle(&child, parser_profile, visiting, loaded, modules)?;
-    }
-    let _ = visiting.pop();
-    loaded.insert(canonical.clone());
-    modules.push((canonical, source));
-    Ok(())
-}
-
-fn validate_executable_bundle_import(
-    importer: &Path,
-    import: &sm_front::types::ExecutableImport,
-) -> Result<(), String> {
-    if import.reexport
-        || import.wildcard
-        || import.alias.is_some()
-        || !import.select_items.is_empty()
-        || import.spec.contains("::")
-    {
-        return Err(format!(
-            "{} in '{}'",
-            executable_import_wave2_out_of_scope_message(),
-            importer.display()
-        ));
-    }
-    Ok(())
 }
 
 fn cli_profile() -> ParserProfile {
@@ -1920,8 +1813,8 @@ fn score(value: i32) -> i32 {
     }
 
     #[test]
-    fn executable_bundle_rejects_selected_imports_in_wave2() {
-        let dir = mk_temp_dir("smc_exec_bundle_selected_blocked");
+    fn executable_bundle_admits_selected_imports_in_wave2() {
+        let dir = mk_temp_dir("smc_exec_bundle_selected_allowed");
         let root = dir.join("main.sm");
         let helper = dir.join("helper.sm");
         std::fs::write(
@@ -1945,9 +1838,12 @@ fn score(value: i32) -> i32 {
         )
         .expect("write helper");
 
-        let err = read_source_with_package_admission(&root)
-            .expect_err("selected executable import must stay out of scope in wave2");
-        assert!(err.contains(executable_import_wave2_out_of_scope_message()));
+        let bundled = read_source_with_package_admission(&root).expect("bundle selected import");
+        assert!(bundled.contains("Import \"helper.sm\" { score }"));
+        assert!(bundled.contains("fn execsel_"));
+        assert!(bundled.contains("fn score(value: i32) -> i32"));
+        assert!(bundled.contains("return execsel_"));
+        assert!(bundled.find("fn score").unwrap() < bundled.find("fn main").unwrap());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -1,0 +1,861 @@
+use crate::package_manifest::{admit_package_entry_module, resolve_package_import_path};
+use sm_front::types::{
+    AstArena, ExecutableImport, Expr, ExprId, Function, Stmt, StmtId, SymbolId, TokenKind, Type,
+};
+use sm_front::{lex, parse_program_with_profile, ParserProfile};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+pub(crate) fn executable_import_wave2_out_of_scope_message() -> &'static str {
+    "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope"
+}
+
+pub(crate) fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
+    admit_package_entry_module(path)
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let parser_profile = ParserProfile::foundation_default();
+    let program = match parse_program_with_profile(&source, &parser_profile) {
+        Ok(program) => program,
+        Err(_) => return Ok(source),
+    };
+    if program.imports.is_empty() {
+        return Ok(source);
+    }
+    let mut visiting = Vec::<PathBuf>::new();
+    let mut planned = BTreeMap::<PathBuf, ExecutableBundleModule>::new();
+    let mut order = Vec::<PathBuf>::new();
+    collect_executable_bundle_plan(
+        &canonical,
+        ExecutableBundleMode::Full,
+        &parser_profile,
+        &mut visiting,
+        &mut planned,
+        &mut order,
+    )?;
+    let mut bundle = String::new();
+    for (idx, module_path) in order.into_iter().enumerate() {
+        let module = planned.get(&module_path).ok_or_else(|| {
+            format!(
+                "missing executable bundle module '{}'",
+                module_path.display()
+            )
+        })?;
+        let module_source = render_executable_bundle_module(module)?;
+        if idx > 0 {
+            bundle.push_str("\n\n");
+        }
+        bundle.push_str(&module_source);
+        if !module_source.ends_with('\n') {
+            bundle.push('\n');
+        }
+    }
+    Ok(bundle)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SelectedExecutableBindings {
+    by_symbol: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl SelectedExecutableBindings {
+    fn insert(&mut self, original: String, public_name: String) {
+        self.by_symbol
+            .entry(original)
+            .or_default()
+            .insert(public_name);
+    }
+
+    fn merge_from(&mut self, other: &SelectedExecutableBindings) {
+        for (original, public_names) in &other.by_symbol {
+            for public_name in public_names {
+                self.insert(original.clone(), public_name.clone());
+            }
+        }
+    }
+
+    fn selected_names(&self) -> BTreeSet<String> {
+        self.by_symbol.keys().cloned().collect()
+    }
+
+    fn public_bindings(&self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        for (original, public_names) in &self.by_symbol {
+            for public_name in public_names {
+                out.push((original.clone(), public_name.clone()));
+            }
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecutableBundleMode {
+    Full,
+    Selected(SelectedExecutableBindings),
+}
+
+impl ExecutableBundleMode {
+    fn merge(&mut self, requested: ExecutableBundleMode) {
+        match requested {
+            ExecutableBundleMode::Full => *self = ExecutableBundleMode::Full,
+            ExecutableBundleMode::Selected(bindings) => match self {
+                ExecutableBundleMode::Full => {}
+                ExecutableBundleMode::Selected(existing) => existing.merge_from(&bindings),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExecutableBundleModule {
+    path: PathBuf,
+    source: String,
+    program: sm_front::Program,
+    mode: ExecutableBundleMode,
+}
+
+fn collect_executable_bundle_plan(
+    path: &Path,
+    requested_mode: ExecutableBundleMode,
+    parser_profile: &ParserProfile,
+    visiting: &mut Vec<PathBuf>,
+    planned: &mut BTreeMap<PathBuf, ExecutableBundleModule>,
+    order: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    admit_package_entry_module(path)
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    if let Some(existing) = planned.get_mut(&canonical) {
+        existing.mode.merge(requested_mode);
+        return Ok(());
+    }
+    if let Some(pos) = visiting.iter().position(|entry| entry == &canonical) {
+        let mut chain = visiting[pos..]
+            .iter()
+            .map(|entry| entry.to_string_lossy().replace('\\', "/"))
+            .collect::<Vec<_>>();
+        chain.push(canonical.to_string_lossy().replace('\\', "/"));
+        return Err(format!(
+            "cyclic executable helper import detected: {}",
+            chain.join(" -> ")
+        ));
+    }
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let program = parse_program_with_profile(&source, parser_profile).map_err(|e| {
+        format!(
+            "executable helper module '{}' must parse on the Rust-like source path: {}",
+            canonical.display(),
+            e
+        )
+    })?;
+    visiting.push(canonical.clone());
+    for import in &program.imports {
+        validate_executable_bundle_import(&canonical, import)?;
+        let child = resolve_package_import_path(&canonical, &import.spec)
+            .map_err(|e| format!("{}: {}", canonical.display(), e))?;
+        let child_mode = requested_bundle_mode_for_import(&program.arena, import);
+        collect_executable_bundle_plan(
+            &child,
+            child_mode,
+            parser_profile,
+            visiting,
+            planned,
+            order,
+        )?;
+    }
+    let _ = visiting.pop();
+    planned.insert(
+        canonical.clone(),
+        ExecutableBundleModule {
+            path: canonical.clone(),
+            source,
+            program,
+            mode: requested_mode,
+        },
+    );
+    order.push(canonical);
+    Ok(())
+}
+
+fn requested_bundle_mode_for_import(
+    arena: &AstArena,
+    import: &ExecutableImport,
+) -> ExecutableBundleMode {
+    if import.select_items.is_empty() {
+        return ExecutableBundleMode::Full;
+    }
+    let mut bindings = SelectedExecutableBindings::default();
+    for item in &import.select_items {
+        let original = arena.symbol_name(item.name).to_string();
+        let public_name = item
+            .alias
+            .map(|sym| arena.symbol_name(sym).to_string())
+            .unwrap_or_else(|| original.clone());
+        bindings.insert(original, public_name);
+    }
+    ExecutableBundleMode::Selected(bindings)
+}
+
+fn validate_executable_bundle_import(
+    importer: &Path,
+    import: &ExecutableImport,
+) -> Result<(), String> {
+    if import.reexport || import.wildcard || import.alias.is_some() || import.spec.contains("::") {
+        return Err(format!(
+            "{} in '{}'",
+            executable_import_wave2_out_of_scope_message(),
+            importer.display()
+        ));
+    }
+    Ok(())
+}
+
+fn render_executable_bundle_module(module: &ExecutableBundleModule) -> Result<String, String> {
+    match &module.mode {
+        ExecutableBundleMode::Full => Ok(module.source.clone()),
+        ExecutableBundleMode::Selected(bindings) => {
+            synthesize_selected_executable_module(module, bindings)
+        }
+    }
+}
+
+fn selected_executable_import_function_only_message(importer: &Path, spec: &str) -> String {
+    format!(
+        "selected executable helper import '{}' in '{}' currently supports function-only helper modules; records, enums, schemas, traits, and impls remain out of scope",
+        spec,
+        importer.display()
+    )
+}
+
+fn selected_executable_import_missing_symbol_message(
+    importer: &Path,
+    spec: &str,
+    symbol: &str,
+) -> String {
+    format!(
+        "selected executable helper import '{}' in '{}' is missing symbol '{}'",
+        spec,
+        importer.display(),
+        symbol
+    )
+}
+
+fn selected_executable_import_public_collision_message(
+    importer: &Path,
+    spec: &str,
+    public_name: &str,
+) -> String {
+    format!(
+        "selected executable helper import '{}' in '{}' binds duplicate public symbol '{}'",
+        spec,
+        importer.display(),
+        public_name
+    )
+}
+
+fn selected_executable_import_wrapper_gap_message(
+    importer: &Path,
+    spec: &str,
+    symbol: &str,
+) -> String {
+    format!(
+        "selected executable helper import '{}' in '{}' currently supports helper functions without defaulted parameters; '{}' stays out of scope",
+        spec,
+        importer.display(),
+        symbol
+    )
+}
+
+fn synthesize_selected_executable_module(
+    module: &ExecutableBundleModule,
+    bindings: &SelectedExecutableBindings,
+) -> Result<String, String> {
+    if !module.program.records.is_empty()
+        || !module.program.adts.is_empty()
+        || !module.program.schemas.is_empty()
+        || !module.program.traits.is_empty()
+        || !module.program.impls.is_empty()
+    {
+        return Err(selected_executable_import_function_only_message(
+            &module.path,
+            &module
+                .path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy(),
+        ));
+    }
+
+    let function_sources = extract_top_level_function_sources(&module.source)?;
+    let mut functions_by_name = BTreeMap::<String, &Function>::new();
+    for func in &module.program.functions {
+        let name = module.program.arena.symbol_name(func.name).to_string();
+        functions_by_name.insert(name, func);
+    }
+
+    for selected in bindings.selected_names() {
+        if !functions_by_name.contains_key(&selected) {
+            return Err(selected_executable_import_missing_symbol_message(
+                &module.path,
+                &module
+                    .path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+                &selected,
+            ));
+        }
+    }
+
+    let required = collect_required_local_functions(
+        &module.program.arena,
+        &functions_by_name,
+        &bindings.selected_names(),
+    );
+    let prefix = format!(
+        "execsel_{:016x}_",
+        fnv1a64(module.path.to_string_lossy().as_bytes())
+    );
+    let mut rename_map = BTreeMap::<String, String>::new();
+    for name in &required {
+        rename_map.insert(name.clone(), format!("{prefix}{name}"));
+    }
+
+    let mut public_names = BTreeSet::new();
+    for (_original, public_name) in bindings.public_bindings() {
+        if !public_names.insert(public_name.clone()) {
+            return Err(selected_executable_import_public_collision_message(
+                &module.path,
+                &module
+                    .path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+                &public_name,
+            ));
+        }
+    }
+
+    let mut pieces = Vec::<String>::new();
+    for (name, source) in &function_sources {
+        if !required.contains(name) {
+            continue;
+        }
+        pieces.push(rewrite_selected_function_source(source, &rename_map)?);
+    }
+    for (original, public_name) in bindings.public_bindings() {
+        let func = functions_by_name.get(&original).ok_or_else(|| {
+            selected_executable_import_missing_symbol_message(
+                &module.path,
+                &module
+                    .path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+                &original,
+            )
+        })?;
+        let internal = rename_map.get(&original).ok_or_else(|| {
+            format!(
+                "missing internal executable selected-import binding for '{}' in '{}'",
+                original,
+                module.path.display()
+            )
+        })?;
+        pieces.push(render_selected_import_wrapper(
+            &module.path,
+            &module.program.arena,
+            func,
+            &module
+                .path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy(),
+            &public_name,
+            internal,
+        )?);
+    }
+
+    Ok(pieces.join("\n\n"))
+}
+
+fn extract_top_level_function_sources(source: &str) -> Result<Vec<(String, String)>, String> {
+    let tokens = lex(source).map_err(|e| e.to_string())?;
+    if tokens.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut starts = Vec::<usize>::new();
+    let mut brace_depth = 0i32;
+    for (idx, token) in tokens.iter().enumerate() {
+        if brace_depth == 0
+            && matches!(
+                token.kind,
+                TokenKind::KwImport
+                    | TokenKind::KwFn
+                    | TokenKind::KwRecord
+                    | TokenKind::KwSchema
+                    | TokenKind::KwEnum
+                    | TokenKind::KwTrait
+                    | TokenKind::KwImpl
+            )
+        {
+            starts.push(idx);
+        }
+        match token.kind {
+            TokenKind::LBrace => brace_depth += 1,
+            TokenKind::RBrace => brace_depth -= 1,
+            _ => {}
+        }
+    }
+
+    let mut out = Vec::<(String, String)>::new();
+    for (pos, start_idx) in starts.iter().enumerate() {
+        let token = &tokens[*start_idx];
+        if token.kind != TokenKind::KwFn {
+            continue;
+        }
+        let end_pos = if let Some(next_idx) = starts.get(pos + 1) {
+            tokens[*next_idx].pos
+        } else {
+            source.len()
+        };
+        let name_token = tokens
+            .iter()
+            .enumerate()
+            .skip(*start_idx + 1)
+            .find_map(|(_idx, tok)| (tok.kind == TokenKind::Ident).then_some(tok))
+            .ok_or_else(|| "malformed top-level function declaration".to_string())?;
+        let snippet = source[token.pos..end_pos].trim().to_string();
+        out.push((name_token.text.clone(), snippet));
+    }
+    Ok(out)
+}
+
+fn rewrite_selected_function_source(
+    source: &str,
+    rename_map: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    let tokens = lex(source).map_err(|e| e.to_string())?;
+    let fn_idx = tokens
+        .iter()
+        .position(|tok| tok.kind == TokenKind::KwFn)
+        .ok_or_else(|| "expected function token in selected helper source".to_string())?;
+    let name_idx = tokens
+        .iter()
+        .enumerate()
+        .skip(fn_idx + 1)
+        .find_map(|(idx, tok)| (tok.kind == TokenKind::Ident).then_some(idx))
+        .ok_or_else(|| "expected function name in selected helper source".to_string())?;
+
+    let mut replacements = Vec::<(usize, usize, String)>::new();
+    let decl = &tokens[name_idx];
+    if let Some(new_name) = rename_map.get(&decl.text) {
+        replacements.push((decl.pos, decl.pos + decl.text.len(), new_name.clone()));
+    }
+
+    for idx in 0..tokens.len() {
+        let token = &tokens[idx];
+        if token.kind != TokenKind::Ident || idx == name_idx {
+            continue;
+        }
+        let Some(new_name) = rename_map.get(&token.text) else {
+            continue;
+        };
+        let next_kind = tokens.get(idx + 1).map(|tok| tok.kind);
+        let prev_kind = idx
+            .checked_sub(1)
+            .and_then(|pos| tokens.get(pos))
+            .map(|tok| tok.kind);
+        if next_kind == Some(TokenKind::LParen) && prev_kind != Some(TokenKind::Dot) {
+            replacements.push((token.pos, token.pos + token.text.len(), new_name.clone()));
+        }
+    }
+
+    replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut out = source.to_string();
+    for (start, end, replacement) in replacements {
+        out.replace_range(start..end, &replacement);
+    }
+    Ok(out)
+}
+
+fn render_selected_import_wrapper(
+    importer: &Path,
+    arena: &AstArena,
+    func: &Function,
+    spec: &str,
+    public_name: &str,
+    internal_name: &str,
+) -> Result<String, String> {
+    if func.param_defaults.iter().any(|default| default.is_some()) {
+        return Err(selected_executable_import_wrapper_gap_message(
+            importer,
+            spec,
+            arena.symbol_name(func.name),
+        ));
+    }
+    let type_params = render_type_params_with_bounds(arena, &func.type_params, &func.trait_bounds);
+    let params = func
+        .params
+        .iter()
+        .map(|(name, ty)| format!("{}: {}", arena.symbol_name(*name), render_type(arena, ty)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let args = func
+        .params
+        .iter()
+        .map(|(name, _)| arena.symbol_name(*name).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if func.ret == Type::Unit {
+        Ok(format!(
+            "fn {public_name}{type_params}({params}) {{\n    {internal_name}({args});\n    return;\n}}"
+        ))
+    } else {
+        Ok(format!(
+            "fn {public_name}{type_params}({params}) -> {} {{\n    return {internal_name}({args});\n}}",
+            render_type(arena, &func.ret)
+        ))
+    }
+}
+
+fn render_type_params_with_bounds(
+    arena: &AstArena,
+    type_params: &[SymbolId],
+    trait_bounds: &[sm_front::types::TraitBound],
+) -> String {
+    if type_params.is_empty() {
+        return String::new();
+    }
+    let mut rendered = Vec::<String>::new();
+    for param in type_params {
+        let mut item = arena.symbol_name(*param).to_string();
+        let bounds = trait_bounds
+            .iter()
+            .filter(|bound| bound.param == *param)
+            .map(|bound| arena.symbol_name(bound.bound).to_string())
+            .collect::<Vec<_>>();
+        if !bounds.is_empty() {
+            item.push_str(": ");
+            item.push_str(&bounds.join(" + "));
+        }
+        rendered.push(item);
+    }
+    format!("<{}>", rendered.join(", "))
+}
+
+fn render_type(arena: &AstArena, ty: &Type) -> String {
+    match ty {
+        Type::Quad => "quad".to_string(),
+        Type::QVec(width) => format!("qvec{}", width),
+        Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
+        Type::Sequence(sequence) => format!("Sequence({})", render_type(arena, &sequence.item)),
+        Type::Closure(closure) => format!(
+            "fn({}) -> {}",
+            render_type(arena, &closure.param),
+            render_type(arena, &closure.ret)
+        ),
+        Type::I32 => "i32".to_string(),
+        Type::U32 => "u32".to_string(),
+        Type::Fx => "fx".to_string(),
+        Type::F64 => "f64".to_string(),
+        Type::Measured(base, unit) => {
+            format!("{}[{}]", render_type(arena, base), arena.symbol_name(*unit))
+        }
+        Type::RangeI32 => "RangeI32".to_string(),
+        Type::Tuple(items) => format!(
+            "({})",
+            items
+                .iter()
+                .map(|item| render_type(arena, item))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Type::Option(inner) => format!("Option({})", render_type(arena, inner)),
+        Type::Result(ok, err) => format!(
+            "Result({}, {})",
+            render_type(arena, ok),
+            render_type(arena, err)
+        ),
+        Type::Record(name) | Type::Adt(name) | Type::TypeVar(name) => {
+            arena.symbol_name(*name).to_string()
+        }
+        Type::Unit => "()".to_string(),
+    }
+}
+
+fn collect_required_local_functions(
+    arena: &AstArena,
+    functions_by_name: &BTreeMap<String, &Function>,
+    selected: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut required = BTreeSet::<String>::new();
+    let mut queue: Vec<String> = selected.iter().cloned().collect();
+    while let Some(name) = queue.pop() {
+        if !required.insert(name.clone()) {
+            continue;
+        }
+        let Some(func) = functions_by_name.get(&name) else {
+            continue;
+        };
+        let mut deps = BTreeSet::<String>::new();
+        collect_local_calls_from_function(arena, func, functions_by_name, &mut deps);
+        for dep in deps {
+            if !required.contains(&dep) {
+                queue.push(dep);
+            }
+        }
+    }
+    required
+}
+
+fn collect_local_calls_from_function(
+    arena: &AstArena,
+    func: &Function,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    for default in &func.param_defaults {
+        if let Some(expr) = default {
+            collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+        }
+    }
+    for expr in &func.requires {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for expr in &func.ensures {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for expr in &func.invariants {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for stmt in &func.body {
+        collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+    }
+}
+
+fn collect_local_calls_from_stmt(
+    arena: &AstArena,
+    stmt_id: StmtId,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    match arena.stmt(stmt_id) {
+        Stmt::Const { value, .. }
+        | Stmt::Let { value, .. }
+        | Stmt::Discard { value, .. }
+        | Stmt::Assign { value, .. }
+        | Stmt::AssignTuple { value, .. }
+        | Stmt::Break(value) => {
+            collect_local_calls_from_expr(arena, *value, functions_by_name, out)
+        }
+        Stmt::LetTuple { value, .. } | Stmt::LetRecord { value, .. } => {
+            collect_local_calls_from_expr(arena, *value, functions_by_name, out);
+        }
+        Stmt::LetElseRecord {
+            value, else_return, ..
+        }
+        | Stmt::LetElseTuple {
+            value, else_return, ..
+        } => {
+            collect_local_calls_from_expr(arena, *value, functions_by_name, out);
+            if let Some(expr) = else_return {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::ForEach { iterable, body, .. } => {
+            collect_local_calls_from_expr(arena, *iterable, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::ForRange { range, body, .. } => {
+            collect_local_calls_from_expr(arena, *range, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Guard {
+            condition,
+            else_return,
+        } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            if let Some(expr) = else_return {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in then_block {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+            for stmt in else_block {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Match {
+            scrutinee,
+            arms,
+            default,
+        } => {
+            collect_local_calls_from_expr(arena, *scrutinee, functions_by_name, out);
+            for arm in arms {
+                if let Some(guard) = arm.guard {
+                    collect_local_calls_from_expr(arena, guard, functions_by_name, out);
+                }
+                for stmt in &arm.block {
+                    collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+                }
+            }
+            for stmt in default {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Return(expr) => {
+            if let Some(expr) = expr {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::Expr(expr) => collect_local_calls_from_expr(arena, *expr, functions_by_name, out),
+    }
+}
+
+fn collect_local_calls_from_expr(
+    arena: &AstArena,
+    expr_id: ExprId,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    match arena.expr(expr_id) {
+        Expr::SequenceLiteral(sequence) => {
+            for item in &sequence.items {
+                collect_local_calls_from_expr(arena, *item, functions_by_name, out);
+            }
+        }
+        Expr::Tuple(items) => {
+            for item in items {
+                collect_local_calls_from_expr(arena, *item, functions_by_name, out);
+            }
+        }
+        Expr::RecordLiteral(record) => {
+            for field in &record.fields {
+                collect_local_calls_from_expr(arena, field.value, functions_by_name, out);
+            }
+        }
+        Expr::RecordField(record) => {
+            collect_local_calls_from_expr(arena, record.base, functions_by_name, out);
+        }
+        Expr::SequenceIndex(index) => {
+            collect_local_calls_from_expr(arena, index.base, functions_by_name, out);
+            collect_local_calls_from_expr(arena, index.index, functions_by_name, out);
+        }
+        Expr::Closure(closure) => {
+            collect_local_calls_from_expr(arena, closure.body, functions_by_name, out);
+        }
+        Expr::RecordUpdate(update) => {
+            collect_local_calls_from_expr(arena, update.base, functions_by_name, out);
+            for field in &update.fields {
+                collect_local_calls_from_expr(arena, field.value, functions_by_name, out);
+            }
+        }
+        Expr::AdtCtor(ctor) => {
+            for payload in &ctor.payload {
+                collect_local_calls_from_expr(arena, *payload, functions_by_name, out);
+            }
+        }
+        Expr::Call(callee, args) => {
+            let callee_name = arena.symbol_name(*callee).to_string();
+            if functions_by_name.contains_key(&callee_name) {
+                out.insert(callee_name);
+            }
+            for arg in args {
+                collect_local_calls_from_expr(arena, arg.value, functions_by_name, out);
+            }
+        }
+        Expr::Unary(_, inner) => {
+            collect_local_calls_from_expr(arena, *inner, functions_by_name, out)
+        }
+        Expr::Binary(left, _, right) => {
+            collect_local_calls_from_expr(arena, *left, functions_by_name, out);
+            collect_local_calls_from_expr(arena, *right, functions_by_name, out);
+        }
+        Expr::Range(range) => {
+            collect_local_calls_from_expr(arena, range.start, functions_by_name, out);
+            collect_local_calls_from_expr(arena, range.end, functions_by_name, out);
+        }
+        Expr::Block(block) => {
+            for stmt in &block.statements {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+            collect_local_calls_from_expr(arena, block.tail, functions_by_name, out);
+        }
+        Expr::If(expr) => {
+            collect_local_calls_from_expr(arena, expr.condition, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.then_block, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.else_block, functions_by_name, out);
+        }
+        Expr::IfLet(expr) => {
+            collect_local_calls_from_expr(arena, expr.value, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.then_block, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.else_block, functions_by_name, out);
+        }
+        Expr::Match(expr) => {
+            collect_local_calls_from_expr(arena, expr.scrutinee, functions_by_name, out);
+            for arm in &expr.arms {
+                if let Some(guard) = arm.guard {
+                    collect_local_calls_from_expr(arena, guard, functions_by_name, out);
+                }
+                collect_local_calls_from_block(arena, &arm.block, functions_by_name, out);
+            }
+            if let Some(default) = &expr.default {
+                collect_local_calls_from_block(arena, default, functions_by_name, out);
+            }
+        }
+        Expr::Loop(loop_expr) => {
+            for stmt in &loop_expr.body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Expr::QuadLiteral(_)
+        | Expr::BoolLiteral(_)
+        | Expr::TextLiteral(_)
+        | Expr::NumericLiteral(_)
+        | Expr::Var(_) => {}
+    }
+}
+
+fn collect_local_calls_from_block(
+    arena: &AstArena,
+    block: &sm_front::types::BlockExpr,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    for stmt in &block.statements {
+        collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+    }
+    collect_local_calls_from_expr(arena, block.tail, functions_by_name, out);
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -7,6 +7,8 @@ mod api_contract;
 #[cfg(feature = "std")]
 mod config;
 #[cfg(feature = "std")]
+mod executable_bundle;
+#[cfg(feature = "std")]
 mod formatter;
 #[cfg(feature = "std")]
 mod incremental;

--- a/docs/roadmap/language_maturity/executable_module_entry_scope.md
+++ b/docs/roadmap/language_maturity/executable_module_entry_scope.md
@@ -60,6 +60,8 @@ Those reports originally showed:
 The landed first wave now admits only:
 
 - direct local-path executable helper-module imports
+- direct local-path selected executable helper-module imports with optional
+  per-symbol alias inside the current function-only helper slice
 - one root executable entry module containing `fn main()`
 - imported executable declarations needed for ordinary helper-module programs
 
@@ -70,6 +72,9 @@ silently widening into a general package or registry system.
 
 - top-level `Import` admission on the executable source path
 - direct local-path helper-module loading for executable module graphs
+- direct local-path selected helper imports for function-only helper modules,
+  including deterministic synthesis of the requested public bindings plus the
+  required local helper-function call closure
 - imported executable declarations for current source items such as:
   - `fn`
   - `record`
@@ -122,7 +127,9 @@ silently widening into a general package or registry system.
 - build the executable helper-module graph before semantic checking
 - make direct local-path helper-module declarations available to the executable
   semantic path through deterministic bundling
-- keep alias, selected, wildcard, re-export, and package-qualified executable
+- admit direct local-path selected helper imports only for the current
+  function-only helper slice
+- keep top-level alias, wildcard, re-export, and package-qualified executable
   import forms explicitly out of scope
 
 ### Wave 3 — Lowering / CLI / End-To-End
@@ -146,6 +153,8 @@ The widened admitted contour is now frozen as:
 
 - single-file executable programs
 - narrow helper-module executable programs using direct local-path bare imports
+- narrow helper-module executable programs using direct local-path selected
+  imports over function-only helper modules
 
 The updated Gate 1 evidence keeps the overall decision state at:
 

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -66,13 +66,19 @@ Current executable-path admission is narrower:
 
 - direct local-path bare imports such as `Import "helper.sm"` are admitted for
   deterministic helper-module loading
+- direct local-path selected imports such as
+  `Import "helper.sm" { Foo, Bar as Baz }` are now also admitted on the
+  executable path when the imported helper module stays within the current
+  function-only helper slice
 - imported helper-module declarations are bundled into the executable semantic
   path before checking/lowering
+- selected executable helper imports materialize only the requested public
+  bindings plus the required local helper-function call closure before
+  checking/lowering
 
 The following executable import forms remain out of scope on current `main`:
 
-- explicit alias imports
-- selected imports
+- explicit top-level alias imports
 - wildcard imports
 - public re-exports
 - package-qualified executable imports

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -33,10 +33,15 @@ Current rules:
 - top-level executable `Import` directives now admit one narrow module-entry
   slice on current `main`:
   - direct local-path bare imports such as `Import "helper.sm"`
+  - direct local-path selected imports such as
+    `Import "helper.sm" { Foo, Bar as Baz }` when the imported helper module
+    stays within the current function-only helper slice
   - deterministic helper-module bundling before executable semantic checking
+  - selected executable helper imports synthesize only the requested public
+    bindings plus the required local helper-function call closure before
+    executable semantic checking
 - the current executable path still does **not** admit:
-  - alias imports
-  - selected imports
+  - top-level alias imports
   - wildcard imports
   - public re-exports
   - package-qualified executable imports

--- a/examples/qualification/executable_module_entry/negative_selected_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/negative_selected_import/src/helper.sm
@@ -1,3 +1,0 @@
-fn score(value: i32) -> i32 {
-    return value;
-}

--- a/examples/qualification/executable_module_entry/positive_selected_import/Semantic.package
+++ b/examples/qualification/executable_module_entry/positive_selected_import/Semantic.package
@@ -1,4 +1,4 @@
 format 1
-package negative_selected_import
+package positive_selected_import
 manifest_dir .
 module_root src

--- a/examples/qualification/executable_module_entry/positive_selected_import/src/helper.sm
+++ b/examples/qualification/executable_module_entry/positive_selected_import/src/helper.sm
@@ -1,0 +1,17 @@
+fn scale(value: i32) -> i32 {
+    if value == 2 {
+        return 3;
+    }
+    return value;
+}
+
+fn score(value: i32) -> i32 {
+    return scale(value);
+}
+
+fn hidden_bonus(value: i32) -> i32 {
+    if value == 0 {
+        return 100;
+    }
+    return value;
+}

--- a/examples/qualification/executable_module_entry/positive_selected_import/src/main.sm
+++ b/examples/qualification/executable_module_entry/positive_selected_import/src/main.sm
@@ -1,5 +1,7 @@
 Import "helper.sm" { score }
 
 fn main() {
+    let value: i32 = score(2);
+    assert(value == 3);
     return;
 }

--- a/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/Semantic.package
+++ b/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_selected_import_alias_collision
+manifest_dir .
+module_root src

--- a/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/left.sm
+++ b/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/left.sm
@@ -1,0 +1,10 @@
+fn local_bias(value: i32) -> i32 {
+    if value == 2 {
+        return 12;
+    }
+    return value;
+}
+
+fn score(value: i32) -> i32 {
+    return local_bias(value);
+}

--- a/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/main.sm
+++ b/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/main.sm
@@ -1,0 +1,10 @@
+Import "left.sm" { score as left_score }
+Import "right.sm" { score as right_score }
+
+fn main() {
+    let left: i32 = left_score(2);
+    let right: i32 = right_score(3);
+    assert(left == 12);
+    assert(right == 103);
+    return;
+}

--- a/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/right.sm
+++ b/examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/right.sm
@@ -1,0 +1,10 @@
+fn local_bias(value: i32) -> i32 {
+    if value == 3 {
+        return 103;
+    }
+    return value;
+}
+
+fn score(value: i32) -> i32 {
+    return local_bias(value);
+}

--- a/examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm
+++ b/examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm
@@ -1,7 +1,5 @@
-Import "helper.sm" { score }
+Import "helper.sm" as Helper
 
 fn main() {
-    let value: i32 = score(1);
-    assert(value == 1);
     return;
 }

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -113,7 +113,7 @@ Fixture:
 
 Observed diagnostic:
 
-- contains `top-level executable Import currently admits only direct local-path helper-module imports in wave2`
+- contains `top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2`
 
 Assessment:
 
@@ -216,8 +216,9 @@ Trusted zones on current `main`:
 Still trust-reducing zones:
 
 - broader executable-module authoring remains intentionally narrow because
-  alias/selected/wildcard/re-export/package-qualified forms are still out of
-  scope on the executable path
+  top-level alias/wildcard/re-export/package-qualified forms are still out of
+  scope on the executable path even though direct local-path selected imports
+  are now admitted
 - this is no longer a parser trust failure, but it still limits the broader
   practical-programming contour
 

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -155,7 +155,7 @@ Verdict:
 Reason:
 
 - ordinary helper-module authoring now works without hidden compiler shortcuts
-- the admitted slice is still narrow because selected, alias, wildcard,
+- the admitted slice is still narrow because top-level alias, wildcard,
   re-export, and package-qualified executable imports remain out of scope
 
 ## Additional Friction Found During Authoring
@@ -164,12 +164,12 @@ Two extra limitations showed up while drafting the trial programs:
 
 - direct `i32` accumulation through `+=` produced
   `f64 arithmetic requires f64 operands, got I32 and I32`
-- the selected-import helper-module variant in
-  `examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm`
+- the top-level alias helper-module variant in
+  `examples/qualification/executable_module_entry/negative_alias_import/src/main.sm`
   still rejects with:
 
 ```text
-top-level executable Import currently admits only direct local-path helper-module imports in wave2; alias, selected, wildcard, re-export, and package-qualified import forms remain out of scope
+top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope
 ```
 
 Those probes are not counted as separate formal trial-family programs, but they
@@ -179,7 +179,7 @@ are relevant evidence:
 - integer arithmetic ergonomics still require more trust work before a broader
   practical-readiness claim
 - executable module authoring is now admitted only for the narrow direct
-  local-path bare-import slice
+  local-path bare/selected-import slice
 
 ## Q1 Summary
 
@@ -189,10 +189,12 @@ Current `main` can already support:
 - rule/state-oriented executable programs
 - narrow data programs over `Sequence(T)` and direct-record `Iterable` impls
 - narrow helper-module executable programs using direct local-path bare imports
+- narrow helper-module executable programs using direct local-path selected
+  imports over function-only helper modules
 
 Current `main` does **not** yet prove:
 
-- broader executable module authoring beyond the direct local-path bare-import
+- broader executable module authoring beyond the direct local-path bare/selected-import
   slice
 - full CLI-style practical usability with admitted IO/process interaction
 
@@ -212,7 +214,7 @@ Operational conclusion:
 
 - Semantic is already capable of writing some real small programs
 - Semantic is now also capable of ordinary helper-module executable authoring
-  through direct local-path bare imports
+  through direct local-path bare imports and direct local-path selected imports
 - Semantic is not yet qualified to claim broad practical-programming readiness
   because executable-module authoring remains narrow and full CLI-style
   practicality is still outside the admitted contour

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -53,7 +53,22 @@ fn compile_bytes(rel: &str) -> Vec<u8> {
 
 #[test]
 fn executable_module_entry_wave2_local_helper_import_checks_and_runs() {
-    let rel = "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
+    let rel =
+        "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_selected_import_checks_and_runs() {
+    let rel = "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn executable_module_entry_selected_import_aliases_relieve_helper_collisions() {
+    let rel = "examples/qualification/executable_module_entry/positive_selected_import_alias_collision/src/main.sm";
     cli_ok("check", rel);
     cli_ok("run", rel);
 }
@@ -87,10 +102,9 @@ fn executable_module_entry_helper_graph_compile_is_deterministic() {
 #[test]
 fn executable_module_entry_negative_out_of_scope_import_forms_report_wave2_boundary() {
     let wave2_boundary =
-        "top-level executable Import currently admits only direct local-path helper-module imports in wave2";
+        "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2";
     let cases = [
         "examples/qualification/executable_module_entry/negative_alias_import/src/main.sm",
-        "examples/qualification/executable_module_entry/negative_selected_import/src/main.sm",
         "examples/qualification/executable_module_entry/negative_wildcard_import/src/main.sm",
         "examples/qualification/executable_module_entry/negative_reexport_import/src/main.sm",
         "examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm",

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -36,7 +36,7 @@ fn g1_frontend_negative_suite_reports_expected_diagnostics() {
     let cases = [
         (
             "examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm",
-            "top-level executable Import currently admits only direct local-path helper-module imports in wave2",
+            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2",
         ),
         (
             "examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm",

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -35,8 +35,7 @@ fn g1_rule_state_decision_checks_and_runs() {
 
 #[test]
 fn g1_data_audit_record_iterable_checks_and_runs() {
-    let rel =
-        "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm";
+    let rel = "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm";
     cli_ok("check", rel);
     cli_ok("run", rel);
 }
@@ -50,18 +49,18 @@ fn g1_module_helpers_program_checks_and_runs() {
 }
 
 #[test]
-fn g1_selected_import_module_program_remains_out_of_scope() {
-    let rel = "examples/qualification/g1_real_program_trial/module_helpers_blocked/src/main.sm";
+fn g1_top_level_alias_module_program_remains_out_of_scope() {
+    let rel = "examples/qualification/executable_module_entry/negative_alias_import/src/main.sm";
     let check_err = cli_err("check", rel);
     assert!(
         check_err.contains(
-            "top-level executable Import currently admits only direct local-path helper-module imports in wave2"
+            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
         )
     );
     let run_err = cli_err("run", rel);
     assert!(
         run_err.contains(
-            "top-level executable Import currently admits only direct local-path helper-module imports in wave2"
+            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
         )
     );
 }


### PR DESCRIPTION
## Summary
- admit direct local-path selected imports on the executable path as the chosen B2 wave
- add CLI-side selected helper bundling for function-only helper modules with optional per-symbol aliases
- convert the old selected-import negative probe into positive fixtures and tighten related boundary evidence/tests

## Scope
- exactly one widening wave: selected import
- no top-level alias import, wildcard, re-export, package-qualified executable import, or namespace-qualified executable access widening
- narrow spec/scope sync only for the admitted selected-import helper-function slice

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts
- cargo test -q --test executable_module_entry