### PR TITLE
tests: re-synthesize gate 1.1 selected-import evidence

### DIFF
--- a/reports/g1_benchmark_baseline.md
+++ b/reports/g1_benchmark_baseline.md
@@ -34,6 +34,7 @@ representative executable programs already used in `Q1` and `Q3`:
 - medium rule/state program
 - data-heavy direct-record iterable program
 - narrow helper-module executable program using direct local-path bare import
+- narrow helper-module executable program using direct local-path selected import
 
 Measured stages:
 
@@ -50,8 +51,8 @@ This baseline does **not** include:
 - UI, which remains outside the current qualification contour
 - cache cold/warm behavior, because this first pass is intended to isolate the
   compiler/runtime pipeline rather than the filesystem cache path
-- out-of-scope executable module forms such as selected or alias imports,
-  because they are still intentionally outside the admitted contour
+- out-of-scope executable module forms such as alias, wildcard, re-export,
+  package-qualified, or namespace-qualified imports
 
 ## Reproducible Harness
 
@@ -72,8 +73,8 @@ The harness measures the public in-process APIs directly:
 - `run_verified_semcode(...)`
 
 For the admitted helper-module executable slice, the harness first applies the
-same deterministic direct local-path bare-import bundling rule that current
-`smc` uses before semantic checking/lowering.
+same deterministic direct local-path bare/selected-import bundling rule that
+current `smc` uses before semantic checking/lowering.
 
 Method:
 
@@ -105,46 +106,57 @@ measured_runs=7
 scenario=small_cli_core
 path=examples/qualification/g1_real_program_trial/cli_batch_core/src/main.sm
 snapshot=tokens:156 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:90 semcode_bytes:601 semcode_hash:416f22cbb9708ff7
-lex_us=min:28 median:38 max:84
-parse_us=min:61 median:92 max:208
-sema_us=min:221 median:327 max:579
-ir_us=min:254 median:377 max:719
-emit_us=min:321 median:400 max:741
-verify_us=min:24 median:26 max:37
-runtime_us=min:252 median:254 max:486
+lex_us=min:20 median:30 max:467
+parse_us=min:42 median:80 max:402
+sema_us=min:143 median:238 max:694
+ir_us=min:219 median:333 max:589
+emit_us=min:249 median:413 max:732
+verify_us=min:18 median:24 max:43
+runtime_us=min:172 median:257 max:437
 
 scenario=medium_rule_state
 path=examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm
 snapshot=tokens:226 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:100 semcode_bytes:654 semcode_hash:cb30d87c1081677e
-lex_us=min:39 median:45 max:143
-parse_us=min:106 median:143 max:282
-sema_us=min:364 median:485 max:995
-ir_us=min:441 median:618 max:1244
-emit_us=min:497 median:539 max:1273
-verify_us=min:27 median:28 max:57
-runtime_us=min:150 median:155 max:386
+lex_us=min:29 median:57 max:80
+parse_us=min:73 median:111 max:219
+sema_us=min:278 median:389 max:663
+ir_us=min:370 median:404 max:841
+emit_us=min:362 median:450 max:630
+verify_us=min:21 median:25 max:44
+runtime_us=min:111 median:156 max:253
 
 scenario=record_iterable_data
 path=examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm
 snapshot=tokens:359 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:3 ir_instructions:131 semcode_bytes:1030 semcode_hash:5ca7f7eee779e16f
-lex_us=min:63 median:110 max:219
-parse_us=min:179 median:208 max:427
-sema_us=min:604 median:669 max:1256
-ir_us=min:694 median:857 max:1194
-emit_us=min:783 median:825 max:1344
-verify_us=min:38 median:40 max:51
-runtime_us=min:425 median:432 max:620
+lex_us=min:60 median:116 max:160
+parse_us=min:121 median:199 max:291
+sema_us=min:517 median:655 max:1251
+ir_us=min:660 median:779 max:1443
+emit_us=min:604 median:944 max:1641
+verify_us=min:33 median:39 max:68
+runtime_us=min:322 median:391 max:836
 
 scenario=module_helper_entry
 path=examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm
 snapshot=tokens:57 parsed_functions:2 sema_warnings:0 sema_arena_nodes:0 ir_functions:2 ir_instructions:11 semcode_bytes:114 semcode_hash:6a3934431b5d325b
-lex_us=min:9 median:10 max:24
-parse_us=min:20 median:21 max:54
-sema_us=min:70 median:72 max:209
-ir_us=min:77 median:78 max:217
-emit_us=min:87 median:88 max:242
-verify_us=min:6 median:6 max:15
-runtime_us=min:27 median:27 max:69
+lex_us=min:14 median:16 max:33
+parse_us=min:32 median:37 max:42
+sema_us=min:111 median:136 max:203
+ir_us=min:109 median:144 max:167
+emit_us=min:140 median:171 max:258
+verify_us=min:10 median:13 max:163
+runtime_us=min:42 median:55 max:84
+
+scenario=selected_import_entry
+path=examples/qualification/executable_module_entry/positive_selected_import/src/main.sm
+snapshot=tokens:120 parsed_functions:4 sema_warnings:0 sema_arena_nodes:0 ir_functions:4 ir_instructions:31 semcode_bytes:368 semcode_hash:36399bf3e2417796
+lex_us=min:29 median:34 max:84
+parse_us=min:65 median:70 max:110
+sema_us=min:246 median:297 max:323
+ir_us=min:274 median:311 max:590
+emit_us=min:325 median:345 max:729
+verify_us=min:23 median:24 max:27
+runtime_us=min:96 median:98 max:144
 ```
 
 ## Interpretation
@@ -157,9 +169,9 @@ What the baseline currently shows:
   set
 - the data-heavy record iterable program is the heaviest admitted scenario in
   the current first-cycle pack, as expected
-- the admitted helper-module executable path sits close to the small single-file
-  core and does not introduce a disproportionate pipeline cost on current
-  `main`
+- the admitted helper-module executable paths, including selected-import
+  bundling, stay small relative to the heavier record-iterable scenario and do
+  not introduce a disproportionate pipeline cost on current `main`
 
 What it does **not** show:
 

--- a/reports/g1_execution_integrity.md
+++ b/reports/g1_execution_integrity.md
@@ -99,10 +99,10 @@ run=ok
 
 program=positive_selected_import
 sema:warnings=0 laws=0
-ir:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+ir:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
 semcode:magic=SEMCODE0 rev=1
-verify:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
-disasm:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+verify:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
+disasm:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
 run=ok
 ```
 

--- a/reports/g1_execution_integrity.md
+++ b/reports/g1_execution_integrity.md
@@ -39,6 +39,7 @@ Representative source fixtures reused from `Q1`:
 - `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
 - `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
 - `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
+- `examples/qualification/executable_module_entry/positive_selected_import/src/main.sm`
 
 Canonical harness:
 
@@ -56,8 +57,8 @@ The harness goes through the public compiler/runtime surface:
 - `disasm_semcode(...)`
 
 For the admitted helper-module executable slice, the harness first applies the
-same deterministic direct local-path bare-import bundling rule that current
-`smc` uses before semantic checking/lowering.
+same deterministic direct local-path bare/selected-import bundling rule that
+current `smc` uses before semantic checking/lowering.
 
 ## Representative Stage Snapshots
 
@@ -95,6 +96,14 @@ semcode:magic=SEMCODE0 rev=1
 verify:names=main,score
 disasm:names=main,score
 run=ok
+
+program=positive_selected_import
+sema:warnings=0 laws=0
+ir:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+semcode:magic=SEMCODE0 rev=1
+verify:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+disasm:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+run=ok
 ```
 
 What this proves:
@@ -103,7 +112,8 @@ What this proves:
   through verifier and disasm
 - the current executable iterable slice reaches SemCode and VM without semantic
   disappearance
-- the admitted helper-module executable slice also reaches SemCode and VM
+- the admitted helper-module executable slice, including selected-import
+  bundling, also reaches SemCode and VM
   without semantic disappearance
 - the public `run_verified_semcode(...)` path stays successful after verifier
   admission
@@ -148,10 +158,10 @@ Both fixes were narrow and directly tied to Q3 evidence integrity.
 
 ## Boundary Notes
 
-The selected-import executable helper program from `Q1` still remains outside
-the admitted contour, so it is not counted here as an execution-integrity
-failure. The current admitted executable module-entry slice is only the direct
-local-path bare-import form.
+The admitted executable module-entry slice now includes direct local-path bare
+imports plus direct local-path selected imports over function-only helper
+modules. Alias, wildcard, re-export, package-qualified, and
+namespace-qualified executable import forms remain outside the admitted contour.
 
 ## Q3 Verdict
 

--- a/reports/g1_frontend_trust.md
+++ b/reports/g1_frontend_trust.md
@@ -36,6 +36,7 @@ Canonical positive fixtures:
 - `examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm`
 - `examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm`
 - `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
+- `examples/qualification/executable_module_entry/positive_selected_import/src/main.sm`
 
 Canonical negative fixtures:
 
@@ -208,7 +209,7 @@ Trusted zones on current `main`:
 - sequence-loop admission
 - direct-record iterable trait/impl admission
 - where-clause source sugar
-- direct local-path bare executable helper-module imports
+- direct local-path bare and selected executable helper-module imports
 - contextual `Option` / `Result` match admission
 - negative diagnostics for iterable contract shape, standard-form scope, and
   out-of-scope executable import forms

--- a/reports/g1_real_program_trial.md
+++ b/reports/g1_real_program_trial.md
@@ -36,6 +36,7 @@ Canonical committed trial programs:
 - `examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm`
 - `examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm`
 - `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
+- `examples/qualification/executable_module_entry/positive_selected_import/src/main.sm`
 
 Canonical reproducible harness:
 
@@ -136,6 +137,7 @@ Reason:
 Path:
 
 - `examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm`
+- `examples/qualification/executable_module_entry/positive_selected_import/src/main.sm`
 
 Intent:
 
@@ -145,7 +147,7 @@ Observed behavior:
 
 - `smc check` passes
 - `smc run` passes
-- direct local-path helper-module imports now execute through the full
+- direct local-path bare and selected helper-module imports now execute through the full
   `source -> sema -> IR -> SemCode -> verifier -> VM` path on current `main`
 
 Verdict:

--- a/reports/g1_release_scope_statement.md
+++ b/reports/g1_release_scope_statement.md
@@ -54,7 +54,7 @@ The evidence does **not** support a broader practical-programming claim because:
 
 - practical CLI-style authoring remains incomplete
 - executable-module authoring is now admitted only for the narrow direct
-  local-path bare-import helper-module slice
+  local-path bare/selected-import helper-module slice
 - the admitted contour is still narrow enough that broader ecosystem/program
   authoring would be overstated
 
@@ -64,6 +64,7 @@ The currently qualified release contour is:
 
 - single-file executable programs on the admitted current source surface
 - narrow helper-module executable programs using direct local-path bare imports
+  and direct local-path selected imports over function-only helper modules
 - rule/state-oriented programs using records, `quad`, and explicit
   `Option` / `Result` handling
 - built-in `Sequence(T)` iteration
@@ -78,10 +79,10 @@ The currently qualified release contour is:
 The following are **not** qualified by this Gate 1 cycle and must remain
 outside the release promise:
 
-- alias, selected, wildcard, public re-export, package-qualified, and
+- alias, wildcard, public re-export, package-qualified, and
   namespace-qualified executable import forms
 - broader practical-programming claims beyond the admitted single-file plus
-  bare helper-module contour
+  bare/selected helper-module contour
 - full CLI application authoring with admitted argv/stdout/file IO
 - UI, which remains outside the current qualification contour
 - ADT iterable dispatch

--- a/reports/g1_surface_expressiveness.md
+++ b/reports/g1_surface_expressiveness.md
@@ -42,16 +42,16 @@ The current language surface reads naturally for:
 - explicit `Option` / `Result` handling through contextual constructors and
   exhaustive `match`
 - narrow direct-record iterable dispatch with `for x in collection`
-- narrow helper-module executable authoring through direct local-path bare
-  imports
+- narrow helper-module executable authoring through direct local-path bare and
+  selected imports
 
 Evidence:
 
 - `reports/g1_real_program_trial.md` marked the rule/state program as
   `natural`
 - `reports/g1_frontend_trust.md` marked sequence loops, direct-record iterable
-  admission, where-clause source sugar, and direct local-path bare helper-module
-  imports as `trusted`
+  admission, where-clause source sugar, and direct local-path bare/selected
+  helper-module imports as `trusted`
 - `reports/g1_execution_integrity.md` confirmed end-to-end semantic
   preservation on the representative admitted programs
 
@@ -83,14 +83,13 @@ Why this is only `tolerable`:
 ### Blocked zone
 
 The current surface is still blocked for broader executable-module authoring
-beyond the admitted bare local-path helper-module slice.
+beyond the admitted bare/selected local-path helper-module slice.
 
 Evidence:
 
-- `reports/g1_real_program_trial.md` preserved the selected-import helper-module
-  probe as an explicit blocked boundary
-- `reports/g1_frontend_trust.md` confirms that selected/alias/wildcard/re-export
-  executable import forms remain out of scope with deterministic diagnostics
+- `reports/g1_frontend_trust.md` confirms that alias/wildcard/re-export and
+  broader executable import forms remain out of scope with deterministic
+  diagnostics
 
 This matters because a language can be technically executable while still
 impose a much narrower practical-authoring contour than a broader public-release
@@ -102,7 +101,7 @@ Current trust-reducing friction that does not break the admitted contour, but
 still matters for practical readiness:
 
 - broader executable-module entry remains outside the admitted contour beyond
-  the direct local-path bare-import slice
+  the direct local-path bare/selected-import slice
 - CLI-style programs remain core-only rather than fully user-facing
 - integer arithmetic ergonomics still show rough edges, as seen in the `i32`
   `+=` probe noted in `Q1`

--- a/tests/g1_benchmark_baseline.rs
+++ b/tests/g1_benchmark_baseline.rs
@@ -1,8 +1,9 @@
 use std::{
-    fs,
-    path::PathBuf,
     time::{Duration, Instant},
 };
+
+#[path = "support/executable_bundle_support.rs"]
+mod executable_bundle_support;
 
 use semantic_language::{
     frontend::{
@@ -59,65 +60,6 @@ struct StageDurations {
     emit: Duration,
     verify: Duration,
     runtime: Duration,
-}
-
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn bundle_source(rel: &str) -> String {
-    let root = PathBuf::from(repo_path(rel));
-    let parser_profile = ParserProfile::foundation_default();
-    let mut loaded = Vec::new();
-    let mut visiting = Vec::new();
-    let mut modules = Vec::new();
-    collect_bundle_modules(&root, &parser_profile, &mut loaded, &mut visiting, &mut modules);
-    modules.join("\n\n")
-}
-
-fn collect_bundle_modules(
-    path: &PathBuf,
-    parser_profile: &ParserProfile,
-    loaded: &mut Vec<PathBuf>,
-    visiting: &mut Vec<PathBuf>,
-    modules: &mut Vec<String>,
-) {
-    let canonical = path
-        .canonicalize()
-        .unwrap_or_else(|err| panic!("resolve failed for {}: {err}", path.display()));
-    if loaded.iter().any(|entry| entry == &canonical) {
-        return;
-    }
-    if visiting.iter().any(|entry| entry == &canonical) {
-        panic!("cyclic executable helper import detected at {}", canonical.display());
-    }
-    visiting.push(canonical.clone());
-    let source = fs::read_to_string(&canonical)
-        .unwrap_or_else(|err| panic!("read failed for {}: {err}", canonical.display()));
-    let program = parse_program_with_profile(&source, parser_profile)
-        .unwrap_or_else(|err| panic!("parse failed for {}: {err}", canonical.display()));
-    for import in &program.imports {
-        assert!(
-            !import.reexport
-                && !import.wildcard
-                && import.alias.is_none()
-                && import.select_items.is_empty()
-                && !import.spec.contains("::"),
-            "out-of-scope executable import leaked into bundled contour for {}",
-            canonical.display()
-        );
-        let child = canonical
-            .parent()
-            .expect("module parent")
-            .join(&import.spec);
-        collect_bundle_modules(&child, parser_profile, loaded, visiting, modules);
-    }
-    let _ = visiting.pop();
-    loaded.push(canonical);
-    modules.push(source);
 }
 
 fn fnv1a64(bytes: &[u8]) -> u64 {
@@ -182,7 +124,7 @@ fn summarize(mut values: Vec<u128>) -> StageStats {
 }
 
 fn measure_scenario(label: &'static str, rel: &'static str) -> ScenarioBaseline {
-    let src = bundle_source(rel);
+    let src = executable_bundle_support::bundle_source(rel);
     let profile = ParserProfile::foundation_default();
 
     for _ in 0..WARMUP_RUNS {
@@ -284,6 +226,10 @@ fn g1_benchmark_baseline_collects_reproducible_pipeline_metrics() {
         measure_scenario(
             "module_helper_entry",
             "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
+        ),
+        measure_scenario(
+            "selected_import_entry",
+            "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm",
         ),
     ];
 

--- a/tests/g1_execution_integrity.rs
+++ b/tests/g1_execution_integrity.rs
@@ -32,13 +32,24 @@ fn csv(values: &[String]) -> String {
     values.join(",")
 }
 
+fn normalize_selected_import_name(name: &str) -> String {
+    if let Some(rest) = name.strip_prefix("execsel_") {
+        if let Some((hash, suffix)) = rest.split_once('_') {
+            if hash.len() == 16 && hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+                return format!("execsel_<stable>_{suffix}");
+            }
+        }
+    }
+    name.to_string()
+}
+
 fn disasm_function_names(disasm: &str) -> Vec<String> {
     disasm
         .lines()
         .filter_map(|line| {
             line.strip_prefix("fn ")
                 .and_then(|rest| rest.split(": code=").next())
-                .map(|name| name.to_string())
+                .map(normalize_selected_import_name)
         })
         .collect()
 }
@@ -56,11 +67,14 @@ fn execution_summary(rel: &str) -> String {
     magic.copy_from_slice(&bytes[..8]);
     let header = header_spec_from_magic(&magic).expect("known header");
 
-    let mut ir_names: Vec<String> = ir.iter().map(|func| func.name.clone()).collect();
+    let mut ir_names: Vec<String> = ir
+        .iter()
+        .map(|func| normalize_selected_import_name(&func.name))
+        .collect();
     let mut verified_names: Vec<String> = verified
         .functions
         .iter()
-        .map(|func| func.name.clone())
+        .map(|func| normalize_selected_import_name(&func.name))
         .collect();
     let mut disasm_names = disasm_function_names(&disasm);
 
@@ -138,10 +152,10 @@ run=ok
 
 program=positive_selected_import
 sema:warnings=0 laws=0
-ir:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+ir:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
 semcode:magic=SEMCODE0 rev=1
-verify:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
-disasm:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+verify:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
+disasm:names=execsel_<stable>_scale,execsel_<stable>_score,main,score
 run=ok
 
 ";

--- a/tests/g1_execution_integrity.rs
+++ b/tests/g1_execution_integrity.rs
@@ -1,7 +1,10 @@
 use std::{fs, path::PathBuf};
 
+#[path = "support/executable_bundle_support.rs"]
+mod executable_bundle_support;
+
 use semantic_language::{
-    frontend::{compile_program_to_ir, compile_program_to_semcode, parse_program_with_profile, ParserProfile},
+    frontend::{compile_program_to_ir, compile_program_to_semcode},
     semantics::check_source,
     semcode_format::header_spec_from_magic,
     semcode_verify::{verify_semcode, VerificationCode},
@@ -19,58 +22,6 @@ fn repo_path(rel: &str) -> String {
 fn source_text(rel: &str) -> String {
     let path = repo_path(rel);
     fs::read_to_string(&path).unwrap_or_else(|err| panic!("read failed for {path}: {err}"))
-}
-
-fn bundle_source(rel: &str) -> String {
-    let root = PathBuf::from(repo_path(rel));
-    let parser_profile = ParserProfile::foundation_default();
-    let mut loaded = Vec::new();
-    let mut visiting = Vec::new();
-    let mut modules = Vec::new();
-    collect_bundle_modules(&root, &parser_profile, &mut loaded, &mut visiting, &mut modules);
-    modules.join("\n\n")
-}
-
-fn collect_bundle_modules(
-    path: &PathBuf,
-    parser_profile: &ParserProfile,
-    loaded: &mut Vec<PathBuf>,
-    visiting: &mut Vec<PathBuf>,
-    modules: &mut Vec<String>,
-) {
-    let canonical = path
-        .canonicalize()
-        .unwrap_or_else(|err| panic!("resolve failed for {}: {err}", path.display()));
-    if loaded.iter().any(|entry| entry == &canonical) {
-        return;
-    }
-    if visiting.iter().any(|entry| entry == &canonical) {
-        panic!("cyclic executable helper import detected at {}", canonical.display());
-    }
-    visiting.push(canonical.clone());
-    let source = fs::read_to_string(&canonical)
-        .unwrap_or_else(|err| panic!("read failed for {}: {err}", canonical.display()));
-    let program = parse_program_with_profile(&source, parser_profile)
-        .unwrap_or_else(|err| panic!("parse failed for {}: {err}", canonical.display()));
-    for import in &program.imports {
-        assert!(
-            !import.reexport
-                && !import.wildcard
-                && import.alias.is_none()
-                && import.select_items.is_empty()
-                && !import.spec.contains("::"),
-            "out-of-scope executable import leaked into bundled contour for {}",
-            canonical.display()
-        );
-        let child = canonical
-            .parent()
-            .expect("module parent")
-            .join(&import.spec);
-        collect_bundle_modules(&child, parser_profile, loaded, visiting, modules);
-    }
-    let _ = visiting.pop();
-    loaded.push(canonical);
-    modules.push(source);
 }
 
 fn label_for(rel: &str) -> &str {
@@ -93,7 +44,7 @@ fn disasm_function_names(disasm: &str) -> Vec<String> {
 }
 
 fn execution_summary(rel: &str) -> String {
-    let src = bundle_source(rel);
+    let src = executable_bundle_support::bundle_source(rel);
     let sema = check_source(&src).expect("semantic check");
     let ir = compile_program_to_ir(&src).expect("compile ir");
     let bytes = compile_program_to_semcode(&src).expect("compile semcode");
@@ -146,6 +97,7 @@ fn g1_execution_integrity_stage_summaries_match_current_baseline() {
         "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
         "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
         "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
+        "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm",
     ] {
         observed.push_str(&execution_summary(rel));
         observed.push('\n');
@@ -184,6 +136,14 @@ verify:names=main,score
 disasm:names=main,score
 run=ok
 
+program=positive_selected_import
+sema:warnings=0 laws=0
+ir:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+semcode:magic=SEMCODE0 rev=1
+verify:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+disasm:names=execsel_009b0c640fd25d8f_scale,execsel_009b0c640fd25d8f_score,main,score
+run=ok
+
 ";
     assert_eq!(observed, expected);
 }
@@ -195,8 +155,9 @@ fn g1_execution_integrity_repeated_compiles_are_byte_stable() {
         "examples/qualification/g1_real_program_trial/rule_state_decision/src/main.sm",
         "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
         "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
+        "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm",
     ] {
-        let src = bundle_source(rel);
+        let src = executable_bundle_support::bundle_source(rel);
 
         let first = compile_program_to_semcode(&src).expect("first compile");
         let second = compile_program_to_semcode(&src).expect("second compile");

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -1,20 +1,14 @@
-use std::path::PathBuf;
-
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
+#[path = "support/executable_bundle_support.rs"]
+mod executable_bundle_support;
 
 fn check_ok(rel: &str) {
-    let path = repo_path(rel);
+    let path = executable_bundle_support::repo_path(rel);
     smc_cli::run(vec!["check".to_string(), path.clone()])
         .unwrap_or_else(|err| panic!("smc check unexpectedly failed for {path}: {err}"));
 }
 
 fn check_err(rel: &str) -> String {
-    let path = repo_path(rel);
+    let path = executable_bundle_support::repo_path(rel);
     smc_cli::run(vec!["check".to_string(), path.clone()])
         .expect_err(&format!("smc check unexpectedly passed for {path}"))
 }
@@ -26,6 +20,7 @@ fn g1_frontend_positive_suite_passes() {
         "examples/qualification/g1_frontend_trust/positive_record_iterable/src/main.sm",
         "examples/qualification/g1_frontend_trust/positive_where_clause/src/main.sm",
         "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm",
+        "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm",
     ] {
         check_ok(rel);
     }

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -1,20 +1,14 @@
-use std::path::PathBuf;
-
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
+#[path = "support/executable_bundle_support.rs"]
+mod executable_bundle_support;
 
 fn cli_ok(command: &str, rel: &str) {
-    let path = repo_path(rel);
+    let path = executable_bundle_support::repo_path(rel);
     smc_cli::run(vec![command.to_string(), path.clone()])
         .unwrap_or_else(|err| panic!("smc {command} failed for {path}: {err}"));
 }
 
 fn cli_err(command: &str, rel: &str) -> String {
-    let path = repo_path(rel);
+    let path = executable_bundle_support::repo_path(rel);
     smc_cli::run(vec![command.to_string(), path.clone()])
         .expect_err(&format!("smc {command} unexpectedly passed for {path}"))
 }
@@ -44,6 +38,13 @@ fn g1_data_audit_record_iterable_checks_and_runs() {
 fn g1_module_helpers_program_checks_and_runs() {
     let rel =
         "examples/qualification/executable_module_entry/wave2_local_helper_import/src/main.sm";
+    cli_ok("check", rel);
+    cli_ok("run", rel);
+}
+
+#[test]
+fn g1_selected_import_module_program_checks_and_runs() {
+    let rel = "examples/qualification/executable_module_entry/positive_selected_import/src/main.sm";
     cli_ok("check", rel);
     cli_ok("run", rel);
 }

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -1,0 +1,782 @@
+use sm_front::types::{
+    AstArena, ExecutableImport, Expr, ExprId, Function, Stmt, StmtId, SymbolId, TokenKind, Type,
+};
+use sm_front::{lex, parse_program_with_profile, ParserProfile};
+use smc_cli::{admit_package_entry_module, resolve_package_import_path};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+pub fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+pub fn bundle_source(rel: &str) -> String {
+    let root = PathBuf::from(repo_path(rel));
+    read_source_with_package_admission(&root)
+        .unwrap_or_else(|err| panic!("bundle failed for {}: {err}", root.display()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SelectedExecutableBindings {
+    by_symbol: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl SelectedExecutableBindings {
+    fn insert(&mut self, original: String, public_name: String) {
+        self.by_symbol
+            .entry(original)
+            .or_default()
+            .insert(public_name);
+    }
+
+    fn merge_from(&mut self, other: &SelectedExecutableBindings) {
+        for (original, public_names) in &other.by_symbol {
+            for public_name in public_names {
+                self.insert(original.clone(), public_name.clone());
+            }
+        }
+    }
+
+    fn selected_names(&self) -> BTreeSet<String> {
+        self.by_symbol.keys().cloned().collect()
+    }
+
+    fn public_bindings(&self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        for (original, public_names) in &self.by_symbol {
+            for public_name in public_names {
+                out.push((original.clone(), public_name.clone()));
+            }
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecutableBundleMode {
+    Full,
+    Selected(SelectedExecutableBindings),
+}
+
+impl ExecutableBundleMode {
+    fn merge(&mut self, requested: ExecutableBundleMode) {
+        match requested {
+            ExecutableBundleMode::Full => *self = ExecutableBundleMode::Full,
+            ExecutableBundleMode::Selected(bindings) => match self {
+                ExecutableBundleMode::Full => {}
+                ExecutableBundleMode::Selected(existing) => existing.merge_from(&bindings),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExecutableBundleModule {
+    path: PathBuf,
+    source: String,
+    program: sm_front::Program,
+    mode: ExecutableBundleMode,
+}
+
+fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
+    admit_package_entry_module(path)
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let parser_profile = ParserProfile::foundation_default();
+    let program = match parse_program_with_profile(&source, &parser_profile) {
+        Ok(program) => program,
+        Err(_) => return Ok(source),
+    };
+    if program.imports.is_empty() {
+        return Ok(source);
+    }
+    let mut visiting = Vec::<PathBuf>::new();
+    let mut planned = BTreeMap::<PathBuf, ExecutableBundleModule>::new();
+    let mut order = Vec::<PathBuf>::new();
+    collect_executable_bundle_plan(
+        &canonical,
+        ExecutableBundleMode::Full,
+        &parser_profile,
+        &mut visiting,
+        &mut planned,
+        &mut order,
+    )?;
+    let mut bundle = String::new();
+    for (idx, module_path) in order.into_iter().enumerate() {
+        let module = planned.get(&module_path).ok_or_else(|| {
+            format!(
+                "missing executable bundle module '{}'",
+                module_path.display()
+            )
+        })?;
+        let module_source = render_executable_bundle_module(module)?;
+        if idx > 0 {
+            bundle.push_str("\n\n");
+        }
+        bundle.push_str(&module_source);
+        if !module_source.ends_with('\n') {
+            bundle.push('\n');
+        }
+    }
+    Ok(bundle)
+}
+
+fn collect_executable_bundle_plan(
+    path: &Path,
+    requested_mode: ExecutableBundleMode,
+    parser_profile: &ParserProfile,
+    visiting: &mut Vec<PathBuf>,
+    planned: &mut BTreeMap<PathBuf, ExecutableBundleModule>,
+    order: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    admit_package_entry_module(path)
+        .map(|_| ())
+        .map_err(|e| e.to_string())?;
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("failed to resolve '{}': {}", path.display(), e))?;
+    if let Some(existing) = planned.get_mut(&canonical) {
+        existing.mode.merge(requested_mode);
+        return Ok(());
+    }
+    if let Some(pos) = visiting.iter().position(|entry| entry == &canonical) {
+        let mut chain = visiting[pos..]
+            .iter()
+            .map(|entry| entry.to_string_lossy().replace('\\', "/"))
+            .collect::<Vec<_>>();
+        chain.push(canonical.to_string_lossy().replace('\\', "/"));
+        return Err(format!(
+            "cyclic executable helper import detected: {}",
+            chain.join(" -> ")
+        ));
+    }
+    let source = std::fs::read_to_string(&canonical)
+        .map_err(|e| format!("failed to read '{}': {}", canonical.display(), e))?;
+    let program = parse_program_with_profile(&source, parser_profile).map_err(|e| {
+        format!(
+            "executable helper module '{}' must parse on the Rust-like source path: {}",
+            canonical.display(),
+            e
+        )
+    })?;
+    visiting.push(canonical.clone());
+    for import in &program.imports {
+        validate_executable_bundle_import(&canonical, import)?;
+        let child = resolve_package_import_path(&canonical, &import.spec)
+            .map_err(|e| format!("{}: {}", canonical.display(), e))?;
+        let child_mode = requested_bundle_mode_for_import(&program.arena, import);
+        collect_executable_bundle_plan(
+            &child,
+            child_mode,
+            parser_profile,
+            visiting,
+            planned,
+            order,
+        )?;
+    }
+    let _ = visiting.pop();
+    planned.insert(
+        canonical.clone(),
+        ExecutableBundleModule {
+            path: canonical.clone(),
+            source,
+            program,
+            mode: requested_mode,
+        },
+    );
+    order.push(canonical);
+    Ok(())
+}
+
+fn requested_bundle_mode_for_import(
+    arena: &AstArena,
+    import: &ExecutableImport,
+) -> ExecutableBundleMode {
+    if import.select_items.is_empty() {
+        return ExecutableBundleMode::Full;
+    }
+    let mut bindings = SelectedExecutableBindings::default();
+    for item in &import.select_items {
+        let original = arena.symbol_name(item.name).to_string();
+        let public_name = item
+            .alias
+            .map(|sym| arena.symbol_name(sym).to_string())
+            .unwrap_or_else(|| original.clone());
+        bindings.insert(original, public_name);
+    }
+    ExecutableBundleMode::Selected(bindings)
+}
+
+fn validate_executable_bundle_import(
+    importer: &Path,
+    import: &ExecutableImport,
+) -> Result<(), String> {
+    if import.reexport || import.wildcard || import.alias.is_some() || import.spec.contains("::") {
+        return Err(format!(
+            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope in '{}'",
+            importer.display()
+        ));
+    }
+    Ok(())
+}
+
+fn render_executable_bundle_module(module: &ExecutableBundleModule) -> Result<String, String> {
+    match &module.mode {
+        ExecutableBundleMode::Full => Ok(module.source.clone()),
+        ExecutableBundleMode::Selected(bindings) => {
+            synthesize_selected_executable_module(module, bindings)
+        }
+    }
+}
+
+fn synthesize_selected_executable_module(
+    module: &ExecutableBundleModule,
+    bindings: &SelectedExecutableBindings,
+) -> Result<String, String> {
+    if !module.program.records.is_empty()
+        || !module.program.adts.is_empty()
+        || !module.program.schemas.is_empty()
+        || !module.program.traits.is_empty()
+        || !module.program.impls.is_empty()
+    {
+        return Err(format!(
+            "selected executable helper import '{}' in '{}' currently supports function-only helper modules; records, enums, schemas, traits, and impls remain out of scope",
+            module.path.file_name().unwrap_or_default().to_string_lossy(),
+            module.path.display()
+        ));
+    }
+
+    let function_sources = extract_top_level_function_sources(&module.source)?;
+    let mut functions_by_name = BTreeMap::<String, &Function>::new();
+    for func in &module.program.functions {
+        let name = module.program.arena.symbol_name(func.name).to_string();
+        functions_by_name.insert(name, func);
+    }
+
+    for selected in bindings.selected_names() {
+        if !functions_by_name.contains_key(&selected) {
+            return Err(format!(
+                "selected executable helper import '{}' in '{}' is missing symbol '{}'",
+                module.path.file_name().unwrap_or_default().to_string_lossy(),
+                module.path.display(),
+                selected
+            ));
+        }
+    }
+
+    let required = collect_required_local_functions(
+        &module.program.arena,
+        &functions_by_name,
+        &bindings.selected_names(),
+    );
+    let prefix = format!(
+        "execsel_{:016x}_",
+        fnv1a64(module.path.to_string_lossy().as_bytes())
+    );
+    let mut rename_map = BTreeMap::<String, String>::new();
+    for name in &required {
+        rename_map.insert(name.clone(), format!("{prefix}{name}"));
+    }
+
+    let mut public_names = BTreeSet::new();
+    for (_original, public_name) in bindings.public_bindings() {
+        if !public_names.insert(public_name.clone()) {
+            return Err(format!(
+                "selected executable helper import '{}' in '{}' binds duplicate public symbol '{}'",
+                module.path.file_name().unwrap_or_default().to_string_lossy(),
+                module.path.display(),
+                public_name
+            ));
+        }
+    }
+
+    let mut pieces = Vec::<String>::new();
+    for (name, source) in &function_sources {
+        if required.contains(name) {
+            pieces.push(rewrite_selected_function_source(source, &rename_map)?);
+        }
+    }
+
+    for (original, public_name) in bindings.public_bindings() {
+        let func = functions_by_name.get(&original).ok_or_else(|| {
+            format!(
+                "selected executable helper import '{}' in '{}' is missing symbol '{}'",
+                module.path.file_name().unwrap_or_default().to_string_lossy(),
+                module.path.display(),
+                original
+            )
+        })?;
+        let internal = rename_map.get(&original).ok_or_else(|| {
+            format!(
+                "missing internal executable selected-import binding for '{}' in '{}'",
+                original,
+                module.path.display()
+            )
+        })?;
+        pieces.push(render_selected_import_wrapper(
+            &module.program.arena,
+            func,
+            &public_name,
+            internal,
+        )?);
+    }
+
+    Ok(pieces.join("\n\n"))
+}
+
+fn extract_top_level_function_sources(source: &str) -> Result<Vec<(String, String)>, String> {
+    let tokens = lex(source).map_err(|e| e.to_string())?;
+    if tokens.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut starts = Vec::<usize>::new();
+    let mut brace_depth = 0i32;
+    for (idx, token) in tokens.iter().enumerate() {
+        if brace_depth == 0
+            && matches!(
+                token.kind,
+                TokenKind::KwImport
+                    | TokenKind::KwFn
+                    | TokenKind::KwRecord
+                    | TokenKind::KwSchema
+                    | TokenKind::KwEnum
+                    | TokenKind::KwTrait
+                    | TokenKind::KwImpl
+            )
+        {
+            starts.push(idx);
+        }
+        match token.kind {
+            TokenKind::LBrace => brace_depth += 1,
+            TokenKind::RBrace => brace_depth -= 1,
+            _ => {}
+        }
+    }
+
+    let mut out = Vec::<(String, String)>::new();
+    for (pos, start_idx) in starts.iter().enumerate() {
+        let token = &tokens[*start_idx];
+        if token.kind != TokenKind::KwFn {
+            continue;
+        }
+        let end_pos = if let Some(next_idx) = starts.get(pos + 1) {
+            tokens[*next_idx].pos
+        } else {
+            source.len()
+        };
+        let name_token = tokens
+            .iter()
+            .enumerate()
+            .skip(*start_idx + 1)
+            .find_map(|(_idx, tok)| (tok.kind == TokenKind::Ident).then_some(tok))
+            .ok_or_else(|| "malformed top-level function declaration".to_string())?;
+        let snippet = source[token.pos..end_pos].trim().to_string();
+        out.push((name_token.text.clone(), snippet));
+    }
+    Ok(out)
+}
+
+fn rewrite_selected_function_source(
+    source: &str,
+    rename_map: &BTreeMap<String, String>,
+) -> Result<String, String> {
+    let tokens = lex(source).map_err(|e| e.to_string())?;
+    let fn_idx = tokens
+        .iter()
+        .position(|tok| tok.kind == TokenKind::KwFn)
+        .ok_or_else(|| "expected function token in selected helper source".to_string())?;
+    let name_idx = tokens
+        .iter()
+        .enumerate()
+        .skip(fn_idx + 1)
+        .find_map(|(idx, tok)| (tok.kind == TokenKind::Ident).then_some(idx))
+        .ok_or_else(|| "expected function name in selected helper source".to_string())?;
+
+    let mut replacements = Vec::<(usize, usize, String)>::new();
+    let decl = &tokens[name_idx];
+    if let Some(new_name) = rename_map.get(&decl.text) {
+        replacements.push((decl.pos, decl.pos + decl.text.len(), new_name.clone()));
+    }
+
+    for idx in 0..tokens.len() {
+        let token = &tokens[idx];
+        if token.kind != TokenKind::Ident || idx == name_idx {
+            continue;
+        }
+        let Some(new_name) = rename_map.get(&token.text) else {
+            continue;
+        };
+        let next_kind = tokens.get(idx + 1).map(|tok| tok.kind);
+        let prev_kind = idx
+            .checked_sub(1)
+            .and_then(|pos| tokens.get(pos))
+            .map(|tok| tok.kind);
+        if next_kind == Some(TokenKind::LParen) && prev_kind != Some(TokenKind::Dot) {
+            replacements.push((token.pos, token.pos + token.text.len(), new_name.clone()));
+        }
+    }
+
+    replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    let mut out = source.to_string();
+    for (start, end, replacement) in replacements {
+        out.replace_range(start..end, &replacement);
+    }
+    Ok(out)
+}
+
+fn render_selected_import_wrapper(
+    arena: &AstArena,
+    func: &Function,
+    public_name: &str,
+    internal_name: &str,
+) -> Result<String, String> {
+    if func.param_defaults.iter().any(|default| default.is_some()) {
+        return Err(format!(
+            "selected executable helper import currently supports helper functions without defaulted parameters; '{}' stays out of scope",
+            arena.symbol_name(func.name)
+        ));
+    }
+    let type_params = render_type_params_with_bounds(arena, &func.type_params, &func.trait_bounds);
+    let params = func
+        .params
+        .iter()
+        .map(|(name, ty)| format!("{}: {}", arena.symbol_name(*name), render_type(arena, ty)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let args = func
+        .params
+        .iter()
+        .map(|(name, _)| arena.symbol_name(*name).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if func.ret == Type::Unit {
+        Ok(format!(
+            "fn {public_name}{type_params}({params}) {{\n    {internal_name}({args});\n    return;\n}}"
+        ))
+    } else {
+        Ok(format!(
+            "fn {public_name}{type_params}({params}) -> {} {{\n    return {internal_name}({args});\n}}",
+            render_type(arena, &func.ret)
+        ))
+    }
+}
+
+fn render_type_params_with_bounds(
+    arena: &AstArena,
+    type_params: &[SymbolId],
+    trait_bounds: &[sm_front::types::TraitBound],
+) -> String {
+    if type_params.is_empty() {
+        return String::new();
+    }
+    let mut rendered = Vec::<String>::new();
+    for param in type_params {
+        let mut item = arena.symbol_name(*param).to_string();
+        let bounds = trait_bounds
+            .iter()
+            .filter(|bound| bound.param == *param)
+            .map(|bound| arena.symbol_name(bound.bound).to_string())
+            .collect::<Vec<_>>();
+        if !bounds.is_empty() {
+            item.push_str(": ");
+            item.push_str(&bounds.join(" + "));
+        }
+        rendered.push(item);
+    }
+    format!("<{}>", rendered.join(", "))
+}
+
+fn render_type(arena: &AstArena, ty: &Type) -> String {
+    match ty {
+        Type::Quad => "quad".to_string(),
+        Type::QVec(width) => format!("qvec{}", width),
+        Type::Bool => "bool".to_string(),
+        Type::Text => "text".to_string(),
+        Type::Sequence(sequence) => format!("Sequence({})", render_type(arena, &sequence.item)),
+        Type::Closure(closure) => format!(
+            "fn({}) -> {}",
+            render_type(arena, &closure.param),
+            render_type(arena, &closure.ret)
+        ),
+        Type::I32 => "i32".to_string(),
+        Type::U32 => "u32".to_string(),
+        Type::Fx => "fx".to_string(),
+        Type::F64 => "f64".to_string(),
+        Type::Measured(base, unit) => {
+            format!("{}[{}]", render_type(arena, base), arena.symbol_name(*unit))
+        }
+        Type::RangeI32 => "RangeI32".to_string(),
+        Type::Tuple(items) => format!(
+            "({})",
+            items
+                .iter()
+                .map(|item| render_type(arena, item))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Type::Option(inner) => format!("Option({})", render_type(arena, inner)),
+        Type::Result(ok, err) => format!(
+            "Result({}, {})",
+            render_type(arena, ok),
+            render_type(arena, err)
+        ),
+        Type::Record(name) | Type::Adt(name) | Type::TypeVar(name) => {
+            arena.symbol_name(*name).to_string()
+        }
+        Type::Unit => "()".to_string(),
+    }
+}
+
+fn collect_required_local_functions(
+    arena: &AstArena,
+    functions_by_name: &BTreeMap<String, &Function>,
+    selected: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut required = BTreeSet::<String>::new();
+    let mut queue: Vec<String> = selected.iter().cloned().collect();
+    while let Some(name) = queue.pop() {
+        if !required.insert(name.clone()) {
+            continue;
+        }
+        let Some(func) = functions_by_name.get(&name) else {
+            continue;
+        };
+        let mut deps = BTreeSet::<String>::new();
+        collect_local_calls_from_function(arena, func, functions_by_name, &mut deps);
+        for dep in deps {
+            if !required.contains(&dep) {
+                queue.push(dep);
+            }
+        }
+    }
+    required
+}
+
+fn collect_local_calls_from_function(
+    arena: &AstArena,
+    func: &Function,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    for default in &func.param_defaults {
+        if let Some(expr) = default {
+            collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+        }
+    }
+    for expr in &func.requires {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for expr in &func.ensures {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for expr in &func.invariants {
+        collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+    }
+    for stmt in &func.body {
+        collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+    }
+}
+
+fn collect_local_calls_from_stmt(
+    arena: &AstArena,
+    stmt_id: StmtId,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    match arena.stmt(stmt_id) {
+        Stmt::Const { value, .. }
+        | Stmt::Let { value, .. }
+        | Stmt::Discard { value, .. }
+        | Stmt::Assign { value, .. }
+        | Stmt::AssignTuple { value, .. }
+        | Stmt::Break(value) => collect_local_calls_from_expr(arena, *value, functions_by_name, out),
+        Stmt::LetTuple { value, .. } | Stmt::LetRecord { value, .. } => {
+            collect_local_calls_from_expr(arena, *value, functions_by_name, out);
+        }
+        Stmt::LetElseRecord { value, else_return, .. }
+        | Stmt::LetElseTuple { value, else_return, .. } => {
+            collect_local_calls_from_expr(arena, *value, functions_by_name, out);
+            if let Some(expr) = else_return {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::ForEach { iterable, body, .. } => {
+            collect_local_calls_from_expr(arena, *iterable, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::ForRange { range, body, .. } => {
+            collect_local_calls_from_expr(arena, *range, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Guard { condition, else_return } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            if let Some(expr) = else_return {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::If { condition, then_block, else_block } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in then_block {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+            for stmt in else_block {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Match { scrutinee, arms, default } => {
+            collect_local_calls_from_expr(arena, *scrutinee, functions_by_name, out);
+            for arm in arms {
+                if let Some(guard) = arm.guard {
+                    collect_local_calls_from_expr(arena, guard, functions_by_name, out);
+                }
+                for stmt in &arm.block {
+                    collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+                }
+            }
+            for stmt in default {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Return(expr) => {
+            if let Some(expr) = expr {
+                collect_local_calls_from_expr(arena, *expr, functions_by_name, out);
+            }
+        }
+        Stmt::Expr(expr) => collect_local_calls_from_expr(arena, *expr, functions_by_name, out),
+    }
+}
+
+fn collect_local_calls_from_expr(
+    arena: &AstArena,
+    expr_id: ExprId,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    match arena.expr(expr_id) {
+        Expr::SequenceLiteral(sequence) => {
+            for item in &sequence.items {
+                collect_local_calls_from_expr(arena, *item, functions_by_name, out);
+            }
+        }
+        Expr::Tuple(items) => {
+            for item in items {
+                collect_local_calls_from_expr(arena, *item, functions_by_name, out);
+            }
+        }
+        Expr::RecordLiteral(record) => {
+            for field in &record.fields {
+                collect_local_calls_from_expr(arena, field.value, functions_by_name, out);
+            }
+        }
+        Expr::RecordField(record) => {
+            collect_local_calls_from_expr(arena, record.base, functions_by_name, out);
+        }
+        Expr::SequenceIndex(index) => {
+            collect_local_calls_from_expr(arena, index.base, functions_by_name, out);
+            collect_local_calls_from_expr(arena, index.index, functions_by_name, out);
+        }
+        Expr::Closure(closure) => {
+            collect_local_calls_from_expr(arena, closure.body, functions_by_name, out);
+        }
+        Expr::RecordUpdate(update) => {
+            collect_local_calls_from_expr(arena, update.base, functions_by_name, out);
+            for field in &update.fields {
+                collect_local_calls_from_expr(arena, field.value, functions_by_name, out);
+            }
+        }
+        Expr::AdtCtor(ctor) => {
+            for payload in &ctor.payload {
+                collect_local_calls_from_expr(arena, *payload, functions_by_name, out);
+            }
+        }
+        Expr::Call(callee, args) => {
+            let callee_name = arena.symbol_name(*callee).to_string();
+            if functions_by_name.contains_key(&callee_name) {
+                out.insert(callee_name);
+            }
+            for arg in args {
+                collect_local_calls_from_expr(arena, arg.value, functions_by_name, out);
+            }
+        }
+        Expr::Unary(_, inner) => collect_local_calls_from_expr(arena, *inner, functions_by_name, out),
+        Expr::Binary(left, _, right) => {
+            collect_local_calls_from_expr(arena, *left, functions_by_name, out);
+            collect_local_calls_from_expr(arena, *right, functions_by_name, out);
+        }
+        Expr::Range(range) => {
+            collect_local_calls_from_expr(arena, range.start, functions_by_name, out);
+            collect_local_calls_from_expr(arena, range.end, functions_by_name, out);
+        }
+        Expr::Block(block) => {
+            for stmt in &block.statements {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+            collect_local_calls_from_expr(arena, block.tail, functions_by_name, out);
+        }
+        Expr::If(expr) => {
+            collect_local_calls_from_expr(arena, expr.condition, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.then_block, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.else_block, functions_by_name, out);
+        }
+        Expr::IfLet(expr) => {
+            collect_local_calls_from_expr(arena, expr.value, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.then_block, functions_by_name, out);
+            collect_local_calls_from_block(arena, &expr.else_block, functions_by_name, out);
+        }
+        Expr::Match(expr) => {
+            collect_local_calls_from_expr(arena, expr.scrutinee, functions_by_name, out);
+            for arm in &expr.arms {
+                if let Some(guard) = arm.guard {
+                    collect_local_calls_from_expr(arena, guard, functions_by_name, out);
+                }
+                collect_local_calls_from_block(arena, &arm.block, functions_by_name, out);
+            }
+            if let Some(default) = &expr.default {
+                collect_local_calls_from_block(arena, default, functions_by_name, out);
+            }
+        }
+        Expr::Loop(loop_expr) => {
+            for stmt in &loop_expr.body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Expr::QuadLiteral(_)
+        | Expr::BoolLiteral(_)
+        | Expr::TextLiteral(_)
+        | Expr::NumericLiteral(_)
+        | Expr::Var(_) => {}
+    }
+}
+
+fn collect_local_calls_from_block(
+    arena: &AstArena,
+    block: &sm_front::types::BlockExpr,
+    functions_by_name: &BTreeMap<String, &Function>,
+    out: &mut BTreeSet<String>,
+) {
+    for stmt in &block.statements {
+        collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+    }
+    collect_local_calls_from_expr(arena, block.tail, functions_by_name, out);
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}


### PR DESCRIPTION
## Summary
- add shared selected-import-aware executable bundle support for Gate 1.1 qualification tests
- extend Q1/Q2/Q3/Q4 qualification harnesses to cover admitted selected executable imports
- re-synthesize Q1/Q2/Q3/Q4/Q5 and release-scope reports to match current-main evidence

## Validation
- cargo test -q
- cargo test -q --test public_api_contracts
- cargo test -q --test g1_real_program_trial
- cargo test -q --test g1_frontend_trust
- cargo test -q --test g1_execution_integrity
- cargo test -q --test g1_benchmark_baseline -- --nocapture
- git diff --check

Refs #334