### PR TITLE
docs: sync readiness posture after gate 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 # Semantic
 Deterministic, contract-driven compiler/runtime system with SemCode emission, verifier admission, and VM execution.
 
-Semantic is built for reasoning rules, semantic state transitions, declarative Logos surfaces, and executable logic inside the broader PROMETHEUS system model.
+Semantic is a deterministic compiler/runtime system for contract-bound
+source-to-execution workflows. Current repository `main` includes broader
+language and platform work than the currently published stable line, so release
+reading must follow the canonical status model rather than assuming all landed
+behavior is promised.
 
 The public contract is centered in `docs/spec/*`. Historical roadmap notes and legacy compatibility shims remain in the repository, but they are not the primary source of truth for the current toolchain surface.
 
@@ -17,7 +21,8 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
   - `out of scope`
 - The canonical vocabulary for those layers is defined in
   `docs/roadmap/public_status_model.md`.
-- Semantic is in a post-v1 stabilization phase on `main`.
+- Semantic currently has a published stable line and a separate qualified
+  practical-programming reading.
 - The current published stable line is `v1.1.1`.
 - The current practical-programming qualification posture remains
   `qualified limited release`, not `public release`.
@@ -57,7 +62,7 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
 - Shared runtime vocabulary and quotas in `crates/sm-runtime-core`
 - Verified-only VM execution in `crates/sm-vm`
 - Canonical public CLI owner in `crates/smc-cli`
-- PROMETHEUS-facing boundary crates:
+- Additional boundary/runtime crates currently present on `main`:
   - `crates/prom-abi`
   - `crates/prom-cap`
   - `crates/prom-gates`

--- a/docs/roadmap/backlog.md
+++ b/docs/roadmap/backlog.md
@@ -1,141 +1,87 @@
-# Semantic v1 Backlog Seed
+# Semantic Readiness Backlog
 
-Current release-control wave:
+Status: release-maintenance backlog for the current repository truth
 
-- keep the active stable release line stable on `main`
-- keep new feature work paused while release-facing docs, asset smoke checks, and packaging stay aligned
-- keep active engineering work anchored to the canonical `main` source of truth
-  in
-  `docs/roadmap/language_maturity/mainline_source_of_truth_policy.md`
-- keep release-facing wording anchored to
-  `docs/roadmap/public_status_model.md`
+Read this document using the canonical status vocabulary in:
 
-Current release-maintenance wave:
+- `docs/roadmap/public_status_model.md`
 
-- keep `blueprint`, `milestones`, `backlog`, and `v1_readiness` aligned with
-  the published stable line
-- keep published release assets validated against representative source programs
-- keep release notes and compatibility statements honest about current narrow `v1` limits
+This backlog is not a promise to open a new language track by default.
+It exists to keep the published stable line, the qualified limited-release
+reading, and current-`main` reality aligned without silent scope widening.
 
-Current remaining `v1` wave:
+## Current Release-Control Wave
 
-- `fx` numeric contract notes now freeze the published stable `v1.1.1`
-  reading versus the forward-only current-`main` widening in
-  `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
-- forward stable release/tag policy is frozen for the current stable line in
-  `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`
+- keep the published stable line `v1.1.1` honest
+- keep the current practical-programming verdict honest:
+  `qualified limited release`, not `public release`
+- keep current-`main` landed widenings described as landed, not silently
+  promoted
 
-Current post-`v1` wave:
+## Current Required Maintenance Wave
 
-- the items listed below are landed on current `main` as frozen baseline
-  history; they are not automatically part of the published stable or
-  qualified-limited-release contour unless a later decision promotes them
-
-- `Runtime Ownership (tuple + direct record-field paths)` is completed and now
-  lives as frozen baseline history in `docs/spec/runtime_ownership.md`
-- `M7 UI Application Boundary` is now completed as first-wave baseline history
-  and is scoped in
-  `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
-- the language-maturity package after the completed post-stable runtime waves
-  is documented in:
-  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
-  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
-  - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
-- `M8.1 Text / String Surface` is completed as first-wave baseline history in
-  `docs/roadmap/language_maturity/text_type_full_scope.md`
-- `M8.2 Package Ecosystem Baseline` is now completed as first-wave baseline
-  history and is scoped in
-  `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-- `M8.3 Collections Surface` is now completed as first-wave baseline history
-  and is scoped in
-  `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-- `M8.4 First-Class Closures` is now completed as first-wave baseline history
-  and is scoped in
-  `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
-- `M9.1 Generics` is now completed as first-wave baseline history and is scoped
-  in `docs/roadmap/language_maturity/generics_full_scope.md`
-- `M9.3 Iterable Abstraction` is now completed as first-wave baseline history
-  and is scoped in
-  `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
-- `Source Language Contract Freeze` is completed and now lives as frozen
-  baseline history in
-  `docs/roadmap/language_maturity/source_language_contract.md`
-- `NEXT-1..NEXT-4` post-base closure tracks are completed and now live as
-  frozen baseline history in `docs/roadmap_next.md`
-- the retained non-owning TON618 compatibility perimeter is completed and now
-  lives as frozen baseline history in
-  `docs/roadmap/language_maturity/ton618_compatibility_perimeter_scope.md`
-- the first-wave PROMETHEUS host-call expansion track is completed and now
-  lives as frozen baseline history in
-  `docs/roadmap/language_maturity/prometheus_host_call_expansion_scope.md`
-- the first-wave persistence/replay backend track is completed and now lives as
-  frozen baseline history in
-  `docs/roadmap/language_maturity/persistence_replay_backend_scope.md`
-- the first-wave rule-side effect execution track is completed and now lives as
-  frozen baseline history in
-  `docs/roadmap/language_maturity/rule_side_effect_execution_scope.md`
-- the first-wave multi-session replay archive track is completed and now lives
-  as frozen baseline history in
-  `docs/roadmap/language_maturity/multi_session_replay_archive_scope.md`
-- the first-wave rollback persistence semantics track is completed and now
-  lives as frozen baseline history in
-  `docs/roadmap/language_maturity/rollback_persistence_semantics_scope.md`
-- the first-wave `fx` arithmetic expansion track is completed and now lives as
-  frozen baseline history in
-  `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
-- the first-wave `Option` / `Result` standard-forms track is completed and now
-  lives as frozen baseline history in
-  `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
-- the IR/runtime anti-drift package is completed and now lives as frozen
-  baseline history in:
-  - `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
-  - `docs/roadmap/language_maturity/semcode_version_discipline.md`
-  - `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
-
-Current next-focus wave:
-
-- no new blocker-removal stream is currently active on `main`
-- `Executable Module Entry Scope` is completed and now lives as frozen
-  baseline history in
-  `docs/roadmap/language_maturity/executable_module_entry_scope.md`
-- any broader practical-programming widening now requires:
-  - a new explicit scope decision
-  - a new qualification amendment or cycle under
-    `docs/roadmap/release_qualification/gate1_protocol.md`
-
-Current qualification wave:
-
-- `Gate 1 Release Qualification Protocol` in
-  `docs/roadmap/release_qualification/gate1_protocol.md`
-- the first `Gate 1` cycle is now completed through:
-  - `reports/g1_real_program_trial.md`
-  - `reports/g1_frontend_trust.md`
-  - `reports/g1_execution_integrity.md`
-  - `reports/g1_benchmark_baseline.md`
-  - `reports/g1_surface_expressiveness.md`
+- keep `README.md`, `milestones.md`, `v1_readiness.md`,
+  `compatibility_statement.md`, and `stable_release_policy.md` aligned with:
+  - `docs/roadmap/public_status_model.md`
   - `reports/g1_release_scope_statement.md`
-- the current Gate 1 decision state remains `limited release` for the amended
-  admitted practical-programming contour
-- keep UI out of the first qualification contour unless UI is explicitly
-  admitted into a future release scope
+  - the actual published stable line
+- keep release bundle guidance and smoke validation aligned with the current
+  stable asset story
+- keep qualification reports and release-facing docs in sync after each
+  completed Gate amendment or rerun
+
+## Current Practical-Programming Reading
+
+Qualified limited-release contour currently includes:
+
+- single-file executable programs on the admitted source surface
+- narrow helper-module executable programs through direct local-path bare
+  imports
+- narrow helper-module executable programs through direct local-path selected
+  imports over function-only helper modules
+- rule/state-oriented programs over records, `quad`, and explicit
+  `Option` / `Result`
+- built-in `Sequence(T)` iteration
+- direct-record user-defined `Iterable` dispatch
+- verified execution through the admitted
+  `source -> sema -> IR -> SemCode -> verifier -> VM` path
+
+Still explicitly outside the current qualified contour:
+
+- broader executable-module authoring beyond the admitted bare/selected slice
+- full CLI application authoring with admitted argv/stdout/file IO
+- UI
+- broader generalized iterable dispatch
+
+## Landed On `main`, Not Yet Promised
+
+Current `main` contains widened surfaces beyond the published stable line.
+These remain landed and unpromoted unless a later explicit decision qualifies
+or publishes them.
+
+High-signal landed post-stable families include:
+
+- schema/boundary-core work
+- package baseline work
+- ordered sequence surface
+- built-in iterable surface and direct-record iterable dispatch
+- first-wave closures
+- first-wave generics
+- runtime ownership for tuple + direct record-field paths
+- first-wave UI application boundary
+- selected-import executable module entry
+
+## Default Rule For New Work
+
+- do not open a new feature track by inertia
 - do not treat landed-on-`main` behavior as automatically release-promised
-- rerun or amend Gate 1 only through a new explicit qualification cycle if the
-  admitted release contour is widened
+- if broader practical-programming widening is desired, require:
+  - a new explicit scope decision
+  - and a Gate amendment or new qualification cycle
 
-Foundational work already in place:
+## Execution Rule
 
-- repository discipline and architecture baseline
-- verifier and admit-then-execute baseline
-- `SymbolId` runtime model and quota enforcement
-- type completeness matrix and `u32` completion
-- `fx` end-to-end value path and verified-path `f64` builtin coverage
-- canonical `sm-profile`
-- narrow PROMETHEUS boundary and owner-split semantic runtime baseline
-- CI-enforced release bundle and compatibility checks
-
-Rule of execution:
-
-- do not start semantic runtime before verifier, runtime purity, and quotas are in place;
-- do not reopen scope while the active stable line is being maintained;
-- one PR equals one logical step;
-- contract/spec/tests come before cleanup and optimization.
+- one PR = one logical step
+- docs/spec/tests/report truth must move together
+- no silent scope movement
+- merge only on green local validation where applicable and green CI

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -1,198 +1,82 @@
-# Semantic v1 Compatibility Statement
+# Semantic Compatibility Statement
 
-Status: active stable release baseline
+Status: release-facing compatibility reading
 
-This document summarizes the current compatibility commitments for the
-repository state published on the active Semantic stable line.
+Read this document using the canonical status vocabulary in:
 
-Read this document using the canonical status vocabulary in
-`docs/roadmap/public_status_model.md`.
+- `docs/roadmap/public_status_model.md`
 
-In this document:
+This document should be read together with:
 
-- `published stable` refers to the active stable line and its commitments
-- `landed on main, not yet promised` refers to forward-only widenings that
-  exist on current `main` but are not part of the stable promise
+- `docs/roadmap/v1_readiness.md`
+- `reports/g1_release_scope_statement.md`
 
-## SemCode Compatibility
+## Purpose
 
-Current published-stable compatible SemCode families:
+This statement defines compatibility commitments honestly across three layers:
 
-- `SEMCODE0`
-- `SEMCODE1`
-- `SEMCODE2`
-- `SEMCODE3`
+- the published stable line
+- the currently qualified limited-release contour
+- landed-on-`main` behavior that is not yet promoted
 
-Current landed-on-`main`, not-yet-promised families:
+## Core Compatibility Rules
 
-- `SEMCODE4`
-- `SEMCODE5`
-- `SEMCODE6`
-- `SEMCODE7`
-- `SEMCODE8`
-- `SEMCODE9`
-- `SEMCOD10`
-- `SEMCOD11`
-- `SEMCOD12`
-- `SEMCOD13`
+- standard `.smc` execution is verifier-first
+- unknown or unsupported SemCode headers must reject explicitly
+- VM execution must not silently reinterpret unsupported payloads
+- profile and spec changes that alter meaning require explicit review
+- public CLI ownership remains centered in `smc-cli`
 
-Current compatibility rule:
+## Published Stable Compatibility
 
-- standard execution accepts only verified SemCode
-- verifier rejects unknown or unsupported SemCode headers
-- VM must not silently reinterpret unsupported headers
-- widening on current `main` is forward-only and additive, not a retroactive
-  widening of the published stable line
+The published stable line is:
 
-## ParserProfile Compatibility
+- `v1.1.1`
 
-Current profile contract baseline:
+Compatibility commitments at that layer apply only to what the stable line and
+its released assets actually promised.
 
-- schema owner: `sm-profile`
-- schema family: `ParserProfile`
-- public version baseline: `1.0`
+## Qualified Limited-Release Compatibility
 
-Current compatibility rule:
+The current Gate 1 verdict qualifies a narrow practical-programming contour.
+Compatibility-sensitive reading at that layer applies only to the admitted
+qualified contour documented in:
 
-- semantic meaning changes require explicit profile contract review
-- contract hash stability is required across canonical serialization roundtrips
+- `reports/g1_release_scope_statement.md`
 
-## CLI Compatibility
+That qualified contour is narrower than current `main`.
 
-Current compatibility-sensitive CLI surfaces:
+## Landed On `main`, Not Yet Promised
 
-- `smc profile show --json`
-- `smc doctor --json`
+Current `main` contains widened behavior beyond both the stable line and the
+current qualified contour.
 
-Current compatibility rule:
+Those surfaces must be read as:
 
-- documented machine-readable fields must not change silently
-- canonical CLI owner remains `smc-cli`; root process entrypoints must not become second CLI owners
+- landed on `main`, not yet promised
 
-## PROMETHEUS Runtime Compatibility
-
-Current compatibility-sensitive `prom-*` surfaces:
-
-- capability manifest schema/version
-- gate registry validation behavior
-- runtime session descriptor fields
-- canonical audit event families used by orchestration helpers
-
-Current compatibility rule:
-
-- changes to these surfaces require:
-  - spec updates
-  - runtime matrix and golden updates
-  - compatibility review
-- boundary and public API CI guards must remain green for the current contract-sensitive crates
-
-Current `v1` scope commitment:
-
-- compatibility commitments for `prom-*` apply only to the narrow ABI/capability/gate surface already implemented in the repository
-- the published `v1.1.1` line keeps `fx` narrower than the widened first-wave
-  plain `fx` arithmetic now admitted on current `main`
-- that stable-vs-main `fx` distinction is frozen in
-  `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
-- post-stable admitted calls such as `StateQuery`, `StateUpdate`, `EventPost`,
-  and `ClockRead` remain outside the current `v1.1.1` compatibility envelope
-- support for those wider calls on current `main` is a forward-only repo-main
-  contract, not a retroactive widening of the published stable tag
-- the same forward-only reading also applies to persisted archive
-  materialization/loading for `StateSnapshotArchive` and `AuditReplayArchive`
-- the same forward-only reading also applies to first-wave multi-session replay
-  archive ownership/materialization for `MultiSessionReplayArchive`
-- the same forward-only reading also applies to first-wave rule-side effect
-  execution for declared `StateWrite` and `AuditNote`
-- the same forward-only reading also applies to first-wave rollback persistence
-  semantics for `StateRollbackArtifact` ownership and deterministic
-  `SemanticStateStore::apply_rollback(...)`
-- the same forward-only reading also applies to first-wave executable `text`
-  through `SEMCODE8` and the narrow literal/equality runtime carrier on
-  current `main`
-- the same forward-only reading also applies to the first-wave package
-  ecosystem baseline on current `main`, including `Semantic.package`,
-  deterministic local-path dependency loading, and package-qualified imports
-- the same forward-only reading also applies to the first-wave ordered
-  sequence collection surface on current `main`, including `Sequence(type)`,
-  bracketed literals, same-family equality, `expr[index]`, and `SEMCODE9`
-- the same forward-only reading also applies to the built-in executable
-  iterable loop slice on current `main`, including `for x in collection` over
-  `Sequence(type)`, canonical `SEQUENCE_LEN` lowering, and `SEMCOD13`
-- the same forward-only reading also applies to the first-wave first-class
-  closure surface on current `main`, including `Closure(T -> U)`, standalone
-  closure literals, immutable capture, direct invocation, and `SEMCOD10`
-- the same forward-only reading also applies to the first-wave tuple-only
-  runtime ownership metadata transport on current `main`, including lowered
-  borrow/write path events, canonical `AccessPath`, and `SEMCOD11`
-- the same forward-only reading also applies to the direct record-field
-  runtime ownership extension on current `main`, including `Field(SymbolId)` in
-  `AccessPath`, `OWN0` field-path payloads, `SEMCOD12`, verifier admission, VM
-  frame-local borrow tracking, and `BorrowWriteConflict` overlap rejection
-- the tuple + direct record-field runtime ownership track is complete on
-  current `main`; no additional runtime ownership scope is implied beyond the
-  admitted contract listed above
-- the same forward-only reading also applies to the first-wave generics surface
-  on current `main`, including type-parameter syntax for functions, records, and
-  ADTs, deterministic call-site monomorphisation, and the narrow
-  `TypeVar`-to-concrete substitution model
-- the same forward-only reading also applies to the first-wave UI application
-  boundary on current `main`, including single-window session ownership
-  (`DesktopSession`), deterministic event polling (`EventBuffer`), frame-token
-  ownership (`FrameToken`), and the minimal draw-command family (`DrawCommand`,
-  `DrawFrame`) as exercised by the canonical `prom-ui-demo` application
+They are not erased, but they also do not inherit compatibility promises
+automatically.
 
 ## Explicit Non-Commitments
 
-The repository does not yet claim final compatibility guarantees for:
+The repository does not currently claim final compatibility guarantees for:
 
-- `fx` arithmetic semantics beyond the current admitted first-wave plain
-  unary/binary contract on `main`
-- implicit coercion from non-literal non-`fx` expressions into `fx`
-- `fx[unit]` arithmetic
-- any wider PROMETHEUS host-call families beyond the currently admitted
-  first-wave post-stable pack
-- replay archive semantics beyond the current admitted first-wave
-  `MultiSessionReplayArchive` ownership/materialization contract
-- rollback persistence semantics beyond the current admitted first-wave
-  artifact ownership and deterministic apply/restore contract
-- rule-side effect execution semantics beyond the current admitted first-wave
-  declared `StateWrite` / `AuditNote` contract
-- text semantics beyond the current admitted first-wave literal/equality
-  contract on `main`
-- package ecosystem semantics beyond the current admitted first-wave local-path
-  manifest/dependency baseline on `main`
-- collection semantics beyond the current admitted first-wave ordered sequence
-  carrier/index/equality contract on `main`
-- closure semantics beyond the current admitted first-wave `Closure(T -> U)`
-  family, immutable capture, and direct invocation contract on `main`
-- runtime ownership metadata semantics beyond the current admitted tuple +
-  direct record-field `AccessPath` transport on `main`, including `Borrow` /
-  `Write` event encoding, `SEMCOD11` / `SEMCOD12`, verifier admission,
-  frame-local borrow lifetime, and `BorrowWriteConflict` overlap rejection
-  (ADT payload paths, schema paths, partial release, advanced aliasing,
-  inter-frame persistence, and indirect field projection are not claimed)
-- generics semantics beyond the current admitted first-wave type-parameter
-  family, call-site substitution, and monomorphisation contract on `main`
-  (trait/protocol bounds, higher-kinded types, variance, and specialisation are
-  not claimed)
-- UI application boundary semantics beyond the current admitted first-wave
-  owner-layer contract on `main` (general widget framework, multi-window,
-  browser/mobile targets, forked graphics stack, and shader-language ownership
-  are not claimed)
-- broader packaged release layout beyond the current stable assets
+- broader executable-module authoring beyond the admitted bare/selected helper
+  slice
+- full CLI application authoring with admitted argv/stdout/file IO
+- UI beyond any later explicitly qualified contour
+- broader generalized iterable dispatch
+- any landed-on-`main` widening that has not yet been explicitly promoted by a
+  later release or qualification decision
 
 ## Release Honesty Rule
 
-This compatibility statement must stay aligned with:
+Compatibility wording must stay aligned with:
 
 - `docs/spec/`
 - `docs/roadmap/v1_readiness.md`
-- `docs/roadmap/runtime_validation_policy.md`
+- `reports/g1_release_scope_statement.md`
 
-If a surface is not yet fully stabilized, it must remain listed as a non-commitment rather than being implied as release-stable.
-
-Published stable releases should keep this statement aligned with:
-
-- the current tag notes
-- packaged Windows assets (`smc.exe`, `svm.exe`, and bundled zip)
-- the active `main` branch behavior
+If a surface is only landed on current `main`, it must be described that way
+rather than implied as stable or qualified.

--- a/docs/roadmap/milestones.md
+++ b/docs/roadmap/milestones.md
@@ -1,163 +1,91 @@
-# Semantic v1 Milestones
+# Semantic Readiness Milestones
 
-This document is a milestone/checkpoint map, not the authority for the current
-release-facing verdict.
+Status: historical checkpoint map, not release-verdict authority
 
-Read milestone statuses through the canonical status vocabulary in
-`docs/roadmap/public_status_model.md`.
+Read this document using the canonical status vocabulary in:
 
-Use:
+- `docs/roadmap/public_status_model.md`
 
-- `docs/roadmap/v1_readiness.md` for the current published-stable posture
-- `reports/g1_release_scope_statement.md` for the current qualified-limited
-  practical-programming verdict
+For the current release-facing posture, use:
 
-Do not treat a milestone or subtrack marked as completed on current `main` as
-automatically published stable or release-promised.
+- `docs/roadmap/v1_readiness.md`
+- `reports/g1_release_scope_statement.md`
+
+## Purpose
+
+This document records the major milestone families already landed in the
+repository.
+
+It should not be read as:
+
+- automatic stable publication
+- automatic qualification
+- authority for the current release verdict
+
+Milestones can be completed in code while still remaining only:
+
+- `landed on main, not yet promised`
+- or outside the current qualified contour
+
+## Historical Milestone Families
 
 - `M0 Repository Discipline`
-  - architecture docs
-  - crate map
-  - legacy freeze policy
-  - PR/review governance
-  - PR template
-  - architecture review checklist
-  - current status: baseline largely in place
+  - process baseline
+  - architecture map
+  - ownership/governance conventions
+  - current reading: landed baseline
+
 - `M1 Core Contract`
-  - `sm-verify`
-  - `SymbolId` runtime
-  - quotas and admit-then-execute
-  - current status: strong baseline exists in code and tests
-- `M2 Language Completion`
-  - `u32` / `fx`
-  - optimizer minimum set
-  - `sm-profile`
-  - type completeness matrix
-  - optimizer review checklist
-  - current stable-note checkpoint: `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
-  - current completed post-stable expansion checkpoint:
-    `docs/roadmap/language_maturity/fx_arithmetic_full_scope.md`
-  - current completed post-stable units checkpoint:
-    `docs/roadmap/language_maturity/units_of_measure_scope.md`
-  - current completed post-stable standard-forms checkpoint:
-    `docs/roadmap/language_maturity/option_result_standard_forms_scope.md`
-- `M3 Platform Formalization`
+  - verifier-first execution
+  - runtime quotas
+  - owner boundaries for core crates
+  - current reading: landed baseline
+
+- `M2 Language/Core Surface`
+  - source frontend
+  - type completeness work
+  - SemCode family growth
+  - current reading: mixed between published stable and landed-on-`main`
+    widenings
+
+- `M3 Toolchain Formalization`
   - spec bundle
-  - stable CLI
-  - version contracts
-  - current status: broad formalization baseline exists and owner alignment is already reflected in code
-  - optimizer owner is fixed to `sm-ir` for the current `v1` baseline
-  - SemCode format owner is fixed to `sm-ir` for the current `v1` baseline
-  - public CLI owner is fixed to `smc-cli` for the current `v1` baseline
-  - `docs/spec/syntax.md`
-  - `docs/spec/types.md`
-  - `docs/spec/ir.md`
-  - `docs/spec/verifier.md`
-  - `docs/spec/semcode.md`
-  - `docs/spec/profile.md`
-  - `docs/spec/vm.md`
-  - `docs/spec/quotas.md`
-  - `docs/spec/cli.md`
-  - current completed post-stable source-contract freeze checkpoint:
-    `docs/roadmap/language_maturity/source_language_contract.md`
-  - current completed post-qualification executable module entry checkpoint:
-    `docs/roadmap/language_maturity/executable_module_entry_scope.md`
-  - current completed post-stable IR hardening checkpoint:
-    `docs/roadmap/language_maturity/ir_v1_contract_freeze.md`
-  - current completed post-stable SemCode version-discipline checkpoint:
-    `docs/roadmap/language_maturity/semcode_version_discipline.md`
-- `M4 PROMETHEUS Boundary`
-  - ABI
-  - capabilities
-  - gates
-  - current state: narrow working boundary exists and is fixed as the official `v1` scope
-  - first-wave post-stable host-call expansion is now completed on `main`
-  - published `v1.1.1` still keeps the narrower boundary as its official stable commitment
-  - current completed post-stable expansion checkpoint:
-    `docs/roadmap/language_maturity/prometheus_host_call_expansion_scope.md`
-  - `docs/spec/abi.md`
-  - `docs/spec/capabilities.md`
-  - `docs/spec/gates.md`
-- `M5 Semantic Runtime`
-  - state
-  - rules
-  - orchestration
-  - audit
-  - semantic runtime integration checklist
-  - `docs/spec/runtime.md`
-  - `docs/spec/state.md`
-  - `docs/spec/rules.md`
-  - `docs/spec/audit.md`
-  - current state: owner-split runtime baseline exists
-  - richer runtime semantics remain non-blocking for the current narrow `v1`
-  - current completed post-stable persistence/replay checkpoint:
-    `docs/roadmap/language_maturity/persistence_replay_backend_scope.md`
-  - current completed post-stable rule execution checkpoint:
-    `docs/roadmap/language_maturity/rule_side_effect_execution_scope.md`
-  - current completed post-stable replay expansion checkpoint:
-    `docs/roadmap/language_maturity/multi_session_replay_archive_scope.md`
-  - current completed post-stable rollback checkpoint:
-    `docs/roadmap/language_maturity/rollback_persistence_semantics_scope.md`
-  - current completed post-stable runtime-boundary hardening checkpoint:
-    `docs/roadmap/language_maturity/runtime_boundary_hardening.md`
-- `M6 v1 Lockdown`
-  - freezes
-  - golden baselines
-  - validation matrix
-  - `tests/prometheus_runtime_matrix.rs`
-  - `tests/prometheus_runtime_goldens.rs`
-  - `tests/prometheus_runtime_negative_goldens.rs`
-  - `tests/prometheus_runtime_compat_matrix.rs`
-  - `docs/roadmap/runtime_validation_policy.md`
-  - `docs/roadmap/v1_readiness.md`
-  - `docs/roadmap/release_bundle_checklist.md`
-  - `docs/roadmap/compatibility_statement.md`
-  - current state: validation artifacts, CI-enforced release gates, and the
-    published stable `v1.1.1` governance baseline all exist on `main`
-  - current stable-note checkpoints:
-    - `docs/roadmap/language_maturity/release_version_cut_decision.md`
-    - `docs/roadmap/language_maturity/forward_stable_release_tag_policy.md`
-- `M7 UI Application Boundary`
-  - desktop window lifecycle
-  - explicit UI capability/admission ownership
-  - deterministic event polling and frame lifecycle
-  - minimal draw-command family and one canonical demo application
-  - current status: completed post-stable milestone
-  - scope checkpoint:
-    `docs/roadmap/language_maturity/ui_application_boundary_scope.md`
-- `M8 Everyday Expressiveness Foundation`
-  - text / strings
-  - package ecosystem baseline
-  - collections
-  - first-class closures
-  - current status: completed post-stable language-maturity package
-  - planning docs:
-    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_roadmap.md`
-    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_blueprint.md`
-    - `docs/roadmap/language_maturity/m8_everyday_expressiveness_phased_implementation_plan.md`
-  - current completed first subtrack:
-    `docs/roadmap/language_maturity/text_type_full_scope.md`
-  - current completed second subtrack:
-    `docs/roadmap/language_maturity/package_ecosystem_baseline_scope.md`
-  - current completed third subtrack:
-    `docs/roadmap/language_maturity/collections_surface_full_scope.md`
-  - current completed fourth subtrack:
-    `docs/roadmap/language_maturity/first_class_closures_full_scope.md`
-  - planning rule:
-    - keep package baseline earlier than broad abstraction machinery
-    - keep one active stream at a time
-    - keep UI/platform expansion separate from language-maturity work
-- `M9 General Abstraction Layer`
-  - generics / parametric polymorphism
-  - traits / protocols / interfaces
-  - iterable abstraction
-  - richer pattern surface
-  - current status: completed post-stable language-maturity package
-  - completed subtracks:
-    - M9.1: `docs/roadmap/language_maturity/generics_full_scope.md`
-    - M9.2: `docs/roadmap/language_maturity/traits_full_scope.md`
-    - M9.3: `docs/roadmap/language_maturity/iterable_abstraction_full_scope.md`
-    - M9.4: richer pattern surface (Wildcard, Or, IntRange, nested tuple, if-let)
-  - planning rule:
-    - keep one active stream at a time
-    - keep UI/platform expansion separate from language-maturity work
+  - CLI ownership
+  - SemCode contract ownership
+  - current reading: landed baseline
+
+- `M4 Boundary And Runtime Layering`
+  - `prom-*` owner split
+  - runtime/state/rules/audit layering
+  - current reading: landed baseline, with stable-vs-main commitments governed
+    elsewhere
+
+- `M5 Validation And Qualification`
+  - release bundle checks
+  - compatibility checks
+  - Gate 1 protocol
+  - Gate 1 evidence and synthesis reports
+  - current reading: first Gate 1 cycle completed; current verdict is
+    `qualified limited release`
+
+- `M6 Post-Stable Language Waves`
+  - schemas
+  - package baseline
+  - ordered sequence surface
+  - iterable surface
+  - closures
+  - generics
+  - runtime ownership
+  - UI application boundary
+  - selected-import executable module entry
+  - current reading: landed on `main`, not automatically published stable and
+    not automatically qualified
+
+## Operational Reading
+
+If a milestone family is completed in code:
+
+- check `docs/roadmap/v1_readiness.md` for the release-facing reading
+- check `reports/g1_release_scope_statement.md` for the current practical
+  qualification reading
+- do not infer promotion from this milestone map alone

--- a/docs/roadmap/stable_release_policy.md
+++ b/docs/roadmap/stable_release_policy.md
@@ -1,74 +1,85 @@
 # Semantic Stable Release Policy
 
-Status: stable release discipline
+Status: release-governance policy for the published stable line
 
-This document defines the release discipline that governed the `v1.1.1` stable
-cut and should continue to govern forward stable releases without reopening
-scope.
+Read this document using the canonical status vocabulary in:
 
-Read this policy using the canonical status vocabulary in
-`docs/roadmap/public_status_model.md`.
+- `docs/roadmap/public_status_model.md`
 
-This document governs the `published stable` line.
-It does not automatically promote behavior that is merely landed on current
-`main`.
+This policy governs:
 
-## Scope Freeze
+- the published stable line
 
-While the repository is preparing or validating a stable release:
+It does not automatically promote:
 
-- do not add new ABI calls
-- do not widen the current PROMETHEUS `v1` scope
-- do not expand runtime semantics beyond the current narrow contract
-- do not turn post-`v1` items into release blockers
+- landed-on-`main` behavior
+- or the current qualified limited-release contour
 
-Allowed changes during the release-validation window:
+## Current Stable Reading
+
+The current published stable line is:
+
+- `v1.1.1`
+
+Current practical-programming qualification is separate and remains:
+
+- `qualified limited release`
+
+Those are distinct decisions.
+
+## Scope Freeze Rule
+
+While maintaining or validating the stable line:
+
+- do not silently widen the stable promise
+- do not treat landed-on-`main` work as stable by default
+- do not reopen broader feature scope through release-maintenance PRs
+
+Allowed stable-line work:
 
 - release-facing docs sync
 - release asset validation
 - packaging fixes
-- emergency correctness fixes that are rerun through the full validation contour
-
-Disallowed interpretation:
-
-- landed-on-`main`, not-yet-promised behavior must not be treated as part of
-  the stable line unless an explicit later release decision promotes it
+- narrow correctness fixes that are rerun through the full validation contour
 
 ## Stable Tag Preconditions
 
-A stable tag is allowed only if all of the following remain true on `main`:
+A stable tag or stable-line refresh is allowed only if all relevant release
+validation remains green, including:
 
-- `cargo test --workspace` is green
-- boundary and ownership guard tests are green
-- public API inventory is green
-- runtime matrix, goldens, negative goldens, and compatibility matrix are green
-- `pwsh -File scripts/verify_release_bundle.ps1` is green
-- `pwsh -File scripts/verify_release_assets.ps1 -Tag <tag> -AssetsDirectory <downloaded-assets-dir>` is green
-- published release assets pass the smoke matrix in `docs/roadmap/release_asset_smoke_matrix.md`
-- readiness and compatibility documents match actual repository behavior
+- workspace tests
+- boundary and ownership guards
+- public API compatibility checks
+- release bundle verification
+- release asset smoke verification
+- release-facing docs matching actual repository behavior
 
-## Tag Rule
+## Promotion Rule
 
-- do not rewrite or force-move published stable tags
-- beta tags may advance as forward-only prerelease markers
-- the first stable tag after a beta line must use a non-conflicting stable version
-- if any older stable tag already exists, choose the next forward version rather than rewriting history
+Behavior should be described as `published stable` only when:
+
+- the stable line explicitly promises it
+- supporting release assets and validation cover it
+
+Landed behavior on current `main` remains unpromoted until an explicit later
+decision promotes it.
 
 ## Publish Rule
 
-The stable release notes should include:
+Stable release notes should state:
 
-- the exact source commit on `main`
+- the exact released commit
 - the validated asset set
-- current ready surfaces
-- explicit known limits that remain outside the stable commitment
+- the stable-ready surfaces
+- the known limits that remain outside the stable promise
 
 ## Non-Commitments
 
-The following remain outside the stable-release critical path unless explicitly promoted by a separate decision:
+The following remain outside the stable-release critical path unless explicitly
+promoted later:
 
-- richer `fx` arithmetic beyond the current value path
-- wider PROMETHEUS host-call families
-- persistence and replay backends
-- richer rule-side effect execution semantics
-- broad naming or branding rewrites
+- broader practical-programming widening beyond the current stable promise
+- broader executable-module authoring
+- UI
+- broader runtime and ecosystem work already landed on `main` but not yet
+  promoted

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -1,219 +1,137 @@
 # Semantic v1 Readiness
 
-Status: published stable release line
+Status: current release-facing posture authority
 
-This document summarizes the current release-facing readiness state for Semantic v1.
+Read this document using the canonical status vocabulary in:
 
-Read this document using the canonical status vocabulary in
-`docs/roadmap/public_status_model.md`.
+- `docs/roadmap/public_status_model.md`
 
-Within that model, this document is the authority for the current
-release-facing posture.
+Within that authority order, this document is the primary release-facing
+reading for the repository.
 
-## Current Readiness Position
+## Current Posture
 
-Current repository state has working coverage for:
+The repository currently spans three different factual layers:
 
-- repository governance and ownership rules
-- verified SemCode execution
-- runtime quota contract
-- canonical profile contract
-- IR verification and minimum optimizer pipeline
-- PROMETHEUS ABI, capability, and gate boundaries
-- PROMETHEUS runtime, state, rules, and audit owner crates
-- semantic runtime validation matrix and golden baselines
-- tuple + direct record-field runtime ownership, including deterministic
-  `BorrowWriteConflict` enforcement and end-to-end regression coverage
-- CI-enforced boundary, public API, runtime, and release-bundle gates
-- explicit SemCode version/capability discipline through the admitted
-  `SEMCODE0`..`SEMCOD13` family on current `main`
+- `published stable`
+  - the stable line is `v1.1.1`
+- `qualified limited release`
+  - the current practical-programming verdict from the completed Gate 1 cycle
+- `landed on main, not yet promised`
+  - widened surfaces present on current `main` but not yet promoted into either
+    the stable line or the qualified contour
 
-This means the repository has crossed from architecture-only planning into a
-published stable release line for the current contract surfaces.
+Current top-level reading:
 
-Current `v1` boundary decision:
+- Semantic is **not** currently positioned as `public release`
+- Semantic is currently qualified only for a **limited release** practical
+  contour
+- current `main` contains wider landed work than the stable line and wider
+  landed work than the current qualified contour
 
-- the official `v1` PROMETHEUS scope is the existing narrow ABI/capability/gate boundary
-- wider planned host calls are not part of the current `v1` commitment
-- ownership alignment for optimizer, SemCode, and CLI is already implemented in code
-- the active stable `v1.1.1` line is published from `main`
-- the first `Gate 1` qualification cycle is completed and currently supports
-  only a `limited release` decision for the admitted practical-programming
-  contour documented in `reports/g1_release_scope_statement.md`
+## Published Stable
 
-Status reading:
+The published stable line remains:
 
-- `published stable`: the `v1.1.1` line and its stable assets
-- `qualified limited release`: the admitted practical-programming contour
-  documented by the completed first `Gate 1` cycle
-- `landed on main, not yet promised`: widened current-`main` surfaces listed
-  under `Current Known Limits` as excluded from the published stable line
-- `out of scope`: behavior explicitly excluded from both the current stable
-  line and the current qualified contour
+- `v1.1.1`
 
-## Current Artifact List
+It should be read as the stable publication baseline, not as a complete
+description of everything already landed on current `main`.
 
-Current v1-facing artifact families in the repository:
+## Qualified Limited Release
 
-- architecture bundle
-  - `docs/architecture/`
-- roadmap bundle
-  - `docs/roadmap/milestones.md`
-  - `docs/roadmap/type_completeness_matrix.md`
-  - `docs/roadmap/runtime_validation_policy.md`
-  - `docs/roadmap/release_bundle_checklist.md`
-  - `docs/roadmap/release_qualification/gate1_protocol.md`
-  - `docs/roadmap/compatibility_statement.md`
-  - `docs/roadmap/release_asset_smoke_matrix.md`
-  - `docs/roadmap/stable_release_policy.md`
-- spec bundle
-  - `docs/spec/`
-- CLI/tooling surface
-  - `smc`
-  - `svm`
-- published stable assets
-  - `smc.exe`
-  - `svm.exe`
-  - Windows release zip
-- semantic runtime validation
-  - `tests/prometheus_runtime_matrix.rs`
-  - `tests/prometheus_runtime_goldens.rs`
-  - `tests/prometheus_runtime_negative_goldens.rs`
-  - `tests/prometheus_runtime_compat_matrix.rs`
+The completed Gate 1 evidence currently supports a narrow practical-programming
+contour documented in:
 
-## Current Ready Surfaces
+- `reports/g1_release_scope_statement.md`
 
-Currently ready or substantially stabilized surfaces:
+That qualified contour includes:
 
-- `sm-verify`
-- verified-only VM execution path
-- `sm-runtime-core`
-- runtime ownership pipeline for tuple + direct record-field paths
-- `sm-profile`
-- `sm-ir` verification and minimum optimizer contract
-- `prom-abi`
-- `prom-cap`
-- `prom-gates`
-- `prom-runtime`
-- `prom-state`
-- `prom-rules`
-- `prom-audit`
+- single-file executable programs on the admitted source surface
+- narrow helper-module executable programs using direct local-path bare imports
+- narrow helper-module executable programs using direct local-path selected
+  imports over function-only helper modules
+- rule/state-oriented programs over records, `quad`, and explicit
+  `Option` / `Result`
+- built-in `Sequence(T)` iteration
+- direct-record user-defined `Iterable` dispatch
+- verified execution through the admitted
+  `source -> sema -> IR -> SemCode -> verifier -> VM` path
+
+This is enough for:
+
+- `qualified limited release`
+
+It is not enough for:
+
+- `public release`
+
+## Landed On `main`, Not Yet Promised
+
+Current `main` contains widened surfaces beyond both:
+
+- the published stable line
+- and the currently qualified practical-programming contour
+
+High-signal landed families include:
+
+- schema/boundary-core work
+- package baseline work
+- ordered sequence surface
+- iterable surface
+- first-wave closures
+- first-wave generics
+- runtime ownership for tuple + direct record-field paths
+- first-wave UI application boundary
+- selected-import executable module entry
+
+These surfaces must stay explicitly unpromoted until a later scope decision and
+qualification or release decision promotes them.
 
 ## Current Known Limits
 
-The following limits remain explicit and should be treated as release-facing honesty requirements:
+The following release-facing limits remain explicit:
 
-- the published `v1.1.1` line intentionally excludes first-wave plain `fx`
-  unary/binary arithmetic, even though current `main` now admits deterministic
-  plain `fx` arithmetic with canonical lowering/verified execution under
-  `SEMCODE3`
-- the canonical stable-vs-main `fx` reading is frozen in
-  `docs/roadmap/language_maturity/fx_numeric_contract_notes.md`
-- the published `v1.1.1` line intentionally excludes post-stable PROMETHEUS
-  calls such as `StateQuery`, `StateUpdate`, `EventPost`, and `ClockRead`,
-  even though current `main` now admits them as a forward-only widened boundary
-- the published `v1.1.1` line intentionally excludes first-wave rule-side
-  effect execution, even though current `main` now admits narrow declared
-  `StateWrite` and `AuditNote` execution
-- the published `v1.1.1` line intentionally excludes post-stable persisted
-  archive materialization/loading, even though current `main` now admits narrow
-  `StateSnapshotArchive` and `AuditReplayArchive` ownership/materialization
-- the published `v1.1.1` line intentionally excludes multi-session replay
-  archives, even though current `main` now admits narrow
-  `MultiSessionReplayArchive` ownership/materialization
-- the published `v1.1.1` line intentionally excludes rollback persistence
-  semantics, even though current `main` now admits narrow
-  `StateRollbackArtifact` ownership and deterministic
-  `SemanticStateStore::apply_rollback(...)`
-- the published `v1.1.1` line intentionally excludes executable `text`, even
-  though current `main` now admits first-wave text literals/equality through
-  canonical `SEMCODE8`, verifier admission, and VM execution
-- the published `v1.1.1` line intentionally excludes the first-wave package
-  ecosystem baseline, even though current `main` now admits `Semantic.package`
-  parsing, package entry-module admission, and deterministic local-path
-  dependency loading for package-qualified imports
-- the published `v1.1.1` line intentionally excludes the landed `v0.3`
-  schema/boundary-core wave, even though current `main` now admits canonical
-  schema declarations with record/tagged-union forms, role markers, version
-  metadata, deterministic validation-plan derivation, canonical config-contract
-  parsing/validation, generated API/wire artifacts, and deterministic schema
-  compatibility/migration metadata
-- current `main` now admits one narrow executable-module-entry slice through
-  direct local-path bare imports such as `Import "helper.sm"`, but broader
-  alias/selected/wildcard/public re-export/package-qualified/namespace-qualified
-  executable module authoring remains outside the current release-promised
+- broader executable-module authoring beyond the admitted bare/selected slice
+  is not currently qualified
+- full CLI application authoring with admitted argv/stdout/file IO is not
+  currently qualified
+- UI remains outside the current qualified contour
+- broader generalized iterable dispatch remains outside the current qualified
   contour
-- the published `v1.1.1` line intentionally excludes the first-wave ordered
-  sequence collection surface, even though current `main` now admits
-  `Sequence(type)`, bracketed literals, same-family equality, `expr[index]`,
-  and canonical verified execution through `SEMCODE9`
-- the published `v1.1.1` line intentionally excludes the built-in executable
-  iterable loop slice, even though current `main` now admits `for x in
-  collection` over `Sequence(type)` through canonical `SEQUENCE_LEN` lowering
-  and verified execution under `SEMCOD13`, plus direct-record user-defined
-  `Iterable` impl dispatch through the admitted
-  `fn next(self: Self, index: i32) -> Option(Item)` contract; broader
-  ADT/schema/generalized iterable dispatch remains out of scope
-- the published `v1.1.1` line intentionally excludes the first-wave first-class
-  closure surface, even though current `main` now admits `Closure(T -> U)`,
-  standalone closure literals, immutable capture, direct invocation, and
-  canonical verified execution through `SEMCOD10`
-- the published `v1.1.1` line intentionally excludes the first-wave generics
-  surface, even though current `main` now admits type-parameter syntax for
-  functions, records, and ADTs, and deterministic call-site monomorphisation
-  under the narrow `TypeVar`-to-concrete substitution model
-- the published `v1.1.1` line intentionally excludes the completed runtime
-  ownership track on current `main`, even though `main` now admits tuple +
-  direct record-field `AccessPath` transport, verifier admission, frame-local
-  borrow tracking, deterministic `BorrowWriteConflict` rejection, and e2e
-  regression coverage; unsupported scope remains explicit for ADT payload
-  paths, schema paths, partial release, aliasing graphs, inter-frame
-  persistence, and indirect projections
-- the published `v1.1.1` line intentionally excludes the first-wave UI
-  application boundary, even though current `main` now admits single-window
-  session ownership, deterministic event polling, frame-token ownership, and
-  the minimal `DrawCommand`/`DrawFrame` family as exercised by `prom-ui-demo`
-- current `main` still does not claim rollback, retry/compensation, or generic
-  mixed-family rule-effect execution semantics
-- current `main` still does not claim rollback, migration, recovery, or
-  runtime replay engine semantics for persisted archives
-- current `main` still does not claim implicit coercion into `fx`, `fx[unit]`
-  arithmetic, or full arithmetic parity between `fx` and `f64`
-- current `main` still does not claim rollback artifact text materialization,
-  crash-resume, inter-session repair, or generic transaction semantics
-- final stable packaging and tag policy remain narrower than the long-term distribution plan
+- landed-on-`main` widenings beyond the above admitted contour are not
+  automatically part of the stable line and are not automatically qualified
 
-## Current Release Gate
+## Current Release Gates
 
-The repository should be treated as release-valid only if all of the following stay green:
+Release-facing truth should be treated as valid only while the relevant
+validation remains green:
 
 - `cargo test --workspace`
 - boundary and ownership guard tests
 - `cargo test --test public_api_contracts`
-- `pwsh -File scripts/verify_release_bundle.ps1 -ManifestPath <path>`
-- `pwsh -File scripts/verify_release_assets.ps1 -Tag <tag> -AssetsDirectory <downloaded-assets-dir>`
-- semantic runtime matrix tests
-- semantic runtime golden tests
-- semantic runtime negative golden tests
-- semantic runtime compatibility matrix tests
+- release bundle verification
+- release asset smoke verification
+- compatibility/runtime validation checks used by the current release process
 
-## Next Release Maintenance Steps
+## Next Release-Maintenance Steps
 
-Current highest-signal remaining work after the first stable `v1.1.1` tag:
+The highest-signal remaining release-maintenance work is:
 
-1. keep release-facing docs aligned with the published stable line on `main`
-2. rerun representative asset smoke for every forward release tag
-3. keep narrow `v1` limits explicit unless a separate scope decision promotes them
-4. run the internal Gate 1 qualification program in
-   `docs/roadmap/release_qualification/gate1_protocol.md`; use
-   `reports/g1_release_scope_statement.md` as the current authority and rerun
-   Gate 1 before widening any broader release-readiness claim
-5. treat any broader practical-programming widening as a new explicit scope
-   decision plus a Gate 1 amendment or new qualification cycle
-6. treat any future widening as a forward versioned release, not silent drift
+1. keep release-facing docs aligned with:
+   - `docs/roadmap/public_status_model.md`
+   - `reports/g1_release_scope_statement.md`
+   - actual stable assets and actual current-`main` behavior
+2. keep packaged stable assets and smoke validation aligned
+3. avoid reopening scope during release-maintenance work
+4. require a new explicit scope decision plus Gate amendment/new Gate cycle
+   before any broader practical-programming widening is promoted
 
 ## Contract Rule
 
-No document in this readiness summary should be used to silently overstate completeness.
+This document must not:
 
-If a surface is only partially complete, it must remain listed under `Current Known Limits` until tests, docs, and behavior all align.
+- silently promote landed-on-`main` behavior into the stable line
+- silently promote landed-on-`main` behavior into the qualified contour
+- blur the distinction between published stable, qualified, landed, and out of
+  scope


### PR DESCRIPTION
## Summary
- sync README and core roadmap docs to the current post-Gate 1.1 authority order
- separate published stable `v1.1.1` from the current qualified limited-release contour
- keep landed-on-main widenings explicit without silently promoting them into stable or qualified status

## Validation
- git diff --check

Refs #334