### PR TITLE
docs: sync readiness truth after Gate 1.1

### DIFF
--- a/docs/roadmap/module_authoring_wave_decision.md
+++ b/docs/roadmap/module_authoring_wave_decision.md
@@ -21,7 +21,7 @@ Draft canonical examples used for this note:
 - `examples/readiness_draft_canonical/module_selected_import_settlement`
 - `examples/readiness_draft_canonical/module_selected_import_audit_report`
 
-Current admitted executable module contour:
+Executable module contour at decision time:
 
 - direct local-path bare helper-module imports
 - direct helper declarations bundled into the executable semantic path
@@ -112,6 +112,16 @@ Observed friction:
 Chosen wave:
 
 - `selected import`
+
+Post-decision reading:
+
+- this note records why `selected import` was chosen at the time
+- it is not the authority for the current admitted executable contour after the
+  later `B2` implementation and `C1` Gate 1.1 re-synthesis work
+- current factual release-facing reading now lives in:
+  - `docs/roadmap/v1_readiness.md`
+  - `reports/g1_release_scope_statement.md`
+  - `docs/roadmap/language_maturity/executable_module_entry_scope.md`
 
 ## Why `selected import` Wins
 

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -11,7 +11,7 @@ reading for the repository.
 
 ## Current Posture
 
-The repository currently spans three different factual layers:
+The repository currently spans four different factual layers:
 
 - `published stable`
   - the stable line is `v1.1.1`
@@ -20,6 +20,9 @@ The repository currently spans three different factual layers:
 - `landed on main, not yet promised`
   - widened surfaces present on current `main` but not yet promoted into either
     the stable line or the qualified contour
+- `out of scope`
+  - surfaces still intentionally excluded from the current qualified contour and
+    current stable promise
 
 Current top-level reading:
 


### PR DESCRIPTION
## Summary
- align `v1_readiness` with the canonical four-layer public status model after Gate 1.1
- clarify that `module_authoring_wave_decision` is historical decision-time evidence, not current contour authority
- keep the post-C1 readiness reading honest without widening scope

## Validation
- git diff --check

Refs #334