### PR TITLE
examples: finalize canonical examples pack

### DIFF
--- a/examples/canonical/README.md
+++ b/examples/canonical/README.md
@@ -1,0 +1,61 @@
+# Canonical Examples Pack
+
+Status: finalized canonical examples pack for `PR-D1`
+
+## Purpose
+
+This directory publishes the curated examples pack used by the current
+readiness contour.
+
+It replaces the earlier planning-only pack in:
+
+- `examples/readiness_draft_canonical/`
+
+This pack is intentionally split into:
+
+- five positive examples inside the current `qualified limited release` contour
+- one boundary example that shows a still-real limit honestly
+
+## Canonical Examples
+
+1. `cli_batch_core`
+   - purpose: small CLI-style computation core over `Sequence(i32)` and `text`
+   - current reading: `qualified limited release`
+
+2. `rule_state_decision`
+   - purpose: record-oriented rule/state decision logic with explicit
+     `Result(T, E)` handling
+   - current reading: `qualified limited release`
+
+3. `data_audit_record_iterable`
+   - purpose: data-heavy audit pass over direct-record `Iterable` dispatch
+   - current reading: `qualified limited release`
+
+4. `wave2_local_helper_import`
+   - purpose: admitted helper-module executable authoring with direct local-path
+     bare import
+   - current reading: `qualified limited release`
+
+5. `positive_selected_import`
+   - purpose: admitted helper-module executable authoring with direct local-path
+     selected import over the current function-only helper slice
+   - current reading: `qualified limited release`
+
+6. `boundary_alias_import`
+   - purpose: honest boundary example showing that top-level alias import on the
+     executable path is still rejected
+   - current reading: `out of scope`
+
+## Validation
+
+Canonical examples are validated by:
+
+```text
+cargo test -q --test canonical_examples
+```
+
+Positive examples are checked, compiled, verified, and run through the public
+`smc` command surface.
+
+The boundary example is checked to ensure the current diagnostic remains
+explicit and deterministic.

--- a/examples/canonical/boundary_alias_import/README.md
+++ b/examples/canonical/boundary_alias_import/README.md
@@ -1,0 +1,13 @@
+# boundary_alias_import
+
+- purpose: honest boundary example for the still-blocked top-level alias import
+  form on the executable path
+- demonstrates:
+  - `Import "helper.sm" as Helper`
+  - current executable-path narrowing
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.sm`
+- expected output:
+  - `check` fails
+  - the diagnostic contains:
+    `top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2`

--- a/examples/canonical/boundary_alias_import/Semantic.package
+++ b/examples/canonical/boundary_alias_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package negative_alias_import
+manifest_dir .
+module_root src

--- a/examples/canonical/boundary_alias_import/src/helper.sm
+++ b/examples/canonical/boundary_alias_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/canonical/boundary_alias_import/src/main.sm
+++ b/examples/canonical/boundary_alias_import/src/main.sm
@@ -1,0 +1,5 @@
+Import "helper.sm" as Helper
+
+fn main() {
+    return;
+}

--- a/examples/canonical/cli_batch_core/README.md
+++ b/examples/canonical/cli_batch_core/README.md
@@ -1,0 +1,16 @@
+# cli_batch_core
+
+- purpose: small CLI-style computation core over `Sequence(i32)` and `text`
+- demonstrates:
+  - `Sequence(i32)` literals and iteration
+  - `text` production and equality
+  - single-file executable authoring
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/cli_batch_core/src/main.sm`
+  - `cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm`
+  - `cargo run --bin smc -- compile examples/canonical/cli_batch_core/src/main.sm -o out.smc`
+  - `cargo run --bin smc -- verify out.smc`
+- expected output:
+  - `check` succeeds
+  - `run` exits successfully
+  - `verify` accepts the compiled `.smc`

--- a/examples/canonical/cli_batch_core/Semantic.package
+++ b/examples/canonical/cli_batch_core/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package cli_batch_core
+manifest_dir .
+module_root src

--- a/examples/canonical/cli_batch_core/src/main.sm
+++ b/examples/canonical/cli_batch_core/src/main.sm
@@ -1,0 +1,26 @@
+fn classify_exit(codes: Sequence(i32)) -> text {
+    let saw_error: bool = false;
+    let saw_retry: bool = false;
+    for code in codes {
+        if code == 9 {
+            saw_error ||= true;
+        }
+        if code == 2 {
+            saw_retry ||= true;
+        }
+    }
+    if saw_error == true {
+        return "error";
+    }
+    if saw_retry == true {
+        return "retry";
+    }
+    return "ok";
+}
+
+fn main() {
+    let argv_like: Sequence(i32) = [2, 1, 0];
+    let mode: text = classify_exit(argv_like);
+    assert(mode == "retry");
+    return;
+}

--- a/examples/canonical/data_audit_record_iterable/README.md
+++ b/examples/canonical/data_audit_record_iterable/README.md
@@ -1,0 +1,17 @@
+# data_audit_record_iterable
+
+- purpose: data-heavy audit pass over direct-record `Iterable` dispatch
+- demonstrates:
+  - direct-record `Iterable` impls
+  - `for value in samples`
+  - immutable record update with `with { ... }`
+  - boolean accumulation over record data
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/data_audit_record_iterable/src/main.sm`
+  - `cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm`
+  - `cargo run --bin smc -- compile examples/canonical/data_audit_record_iterable/src/main.sm -o out.smc`
+  - `cargo run --bin smc -- verify out.smc`
+- expected output:
+  - `check` succeeds
+  - `run` exits successfully
+  - `verify` accepts the compiled `.smc`

--- a/examples/canonical/data_audit_record_iterable/Semantic.package
+++ b/examples/canonical/data_audit_record_iterable/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package data_audit_record_iterable
+manifest_dir .
+module_root src

--- a/examples/canonical/data_audit_record_iterable/src/main.sm
+++ b/examples/canonical/data_audit_record_iterable/src/main.sm
@@ -1,0 +1,60 @@
+trait Iterable {
+    fn next(self: Self, index: i32) -> Option(i32);
+}
+
+record Samples {
+    first: i32,
+    second: i32,
+    third: i32,
+}
+
+record AuditSummary {
+    saw_alert: bool,
+    saw_retry: bool,
+}
+
+impl Iterable for Samples {
+    fn next(self: Self, index: i32) -> Option(i32) {
+        if index == 0 {
+            return Option::Some(self.first);
+        }
+        if index == 1 {
+            return Option::Some(self.second);
+        }
+        if index == 2 {
+            return Option::Some(self.third);
+        }
+        return Option::None;
+    }
+}
+
+fn summarize(samples: Samples) -> AuditSummary {
+    let saw_alert: bool = false;
+    let saw_retry: bool = false;
+    for value in samples {
+        if value == 9 {
+            saw_alert ||= true;
+        }
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return AuditSummary {
+        saw_alert: saw_alert,
+        saw_retry: saw_retry,
+    };
+}
+
+fn main() {
+    let samples: Samples = Samples {
+        first: 2,
+        second: 9,
+        third: 4,
+    };
+    let summary: AuditSummary = summarize(samples);
+    let patched: AuditSummary = summary with { saw_retry: false };
+    assert(summary.saw_alert == true);
+    assert(summary.saw_retry == true);
+    assert(patched.saw_retry == false);
+    return;
+}

--- a/examples/canonical/positive_selected_import/README.md
+++ b/examples/canonical/positive_selected_import/README.md
@@ -1,0 +1,17 @@
+# positive_selected_import
+
+- purpose: admitted helper-module executable authoring with direct local-path
+  selected import
+- demonstrates:
+  - `Import "helper.sm" { score }`
+  - function-only helper-module selected import
+  - deterministic selected-binding synthesis before executable semantic checking
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/positive_selected_import/src/main.sm`
+  - `cargo run --bin smc -- run examples/canonical/positive_selected_import/src/main.sm`
+  - `cargo run --bin smc -- compile examples/canonical/positive_selected_import/src/main.sm -o out.smc`
+  - `cargo run --bin smc -- verify out.smc`
+- expected output:
+  - `check` succeeds
+  - `run` exits successfully
+  - `verify` accepts the compiled `.smc`

--- a/examples/canonical/positive_selected_import/Semantic.package
+++ b/examples/canonical/positive_selected_import/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package positive_selected_import
+manifest_dir .
+module_root src

--- a/examples/canonical/positive_selected_import/src/helper.sm
+++ b/examples/canonical/positive_selected_import/src/helper.sm
@@ -1,0 +1,17 @@
+fn scale(value: i32) -> i32 {
+    if value == 2 {
+        return 3;
+    }
+    return value;
+}
+
+fn score(value: i32) -> i32 {
+    return scale(value);
+}
+
+fn hidden_bonus(value: i32) -> i32 {
+    if value == 0 {
+        return 100;
+    }
+    return value;
+}

--- a/examples/canonical/positive_selected_import/src/main.sm
+++ b/examples/canonical/positive_selected_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm" { score }
+
+fn main() {
+    let value: i32 = score(2);
+    assert(value == 3);
+    return;
+}

--- a/examples/canonical/rule_state_decision/README.md
+++ b/examples/canonical/rule_state_decision/README.md
@@ -1,0 +1,18 @@
+# rule_state_decision
+
+- purpose: record-oriented rule/state decision logic with explicit
+  `Result(T, E)` handling
+- demonstrates:
+  - nominal records
+  - `quad`
+  - contextual `Result::Ok` / `Result::Err`
+  - explicit `match` settlement
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/rule_state_decision/src/main.sm`
+  - `cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm`
+  - `cargo run --bin smc -- compile examples/canonical/rule_state_decision/src/main.sm -o out.smc`
+  - `cargo run --bin smc -- verify out.smc`
+- expected output:
+  - `check` succeeds
+  - `run` exits successfully
+  - `verify` accepts the compiled `.smc`

--- a/examples/canonical/rule_state_decision/Semantic.package
+++ b/examples/canonical/rule_state_decision/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package rule_state_decision
+manifest_dir .
+module_root src

--- a/examples/canonical/rule_state_decision/src/main.sm
+++ b/examples/canonical/rule_state_decision/src/main.sm
@@ -1,0 +1,35 @@
+record DecisionContext {
+    camera: quad,
+    override_state: quad,
+    ready: bool,
+}
+
+fn decide(ctx: DecisionContext) -> Result(quad, quad) {
+    if ctx.override_state == T {
+        return Result::Ok(T);
+    }
+    if ctx.override_state == F {
+        return Result::Ok(F);
+    }
+    if ctx.camera == N {
+        return Result::Err(N);
+    }
+    if ctx.ready == true {
+        return Result::Ok(T);
+    }
+    return Result::Err(S);
+}
+
+fn main() {
+    let ctx: DecisionContext = DecisionContext {
+        camera: T,
+        override_state: S,
+        ready: true,
+    };
+    let verdict: quad = match decide(ctx) {
+        Result::Ok(value) => { value }
+        Result::Err(code) => { code }
+    };
+    assert(verdict == T);
+    return;
+}

--- a/examples/canonical/wave2_local_helper_import/README.md
+++ b/examples/canonical/wave2_local_helper_import/README.md
@@ -1,0 +1,17 @@
+# wave2_local_helper_import
+
+- purpose: admitted helper-module executable authoring with direct local-path
+  bare import
+- demonstrates:
+  - `Import "helper.sm"`
+  - deterministic helper-module bundling
+  - end-to-end `check -> compile -> verify -> run` on a multi-file executable
+- commands:
+  - `cargo run --bin smc -- check examples/canonical/wave2_local_helper_import/src/main.sm`
+  - `cargo run --bin smc -- run examples/canonical/wave2_local_helper_import/src/main.sm`
+  - `cargo run --bin smc -- compile examples/canonical/wave2_local_helper_import/src/main.sm -o out.smc`
+  - `cargo run --bin smc -- verify out.smc`
+- expected output:
+  - `check` succeeds
+  - `run` exits successfully
+  - `verify` accepts the compiled `.smc`

--- a/examples/canonical/wave2_local_helper_import/src/helper.sm
+++ b/examples/canonical/wave2_local_helper_import/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/canonical/wave2_local_helper_import/src/main.sm
+++ b/examples/canonical/wave2_local_helper_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -1,0 +1,89 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn check_run_compile_verify(rel: &str) {
+    let input = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let dir = mk_temp_dir("smc_canonical_examples");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("smc verify for {input}"),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn canonical_positive_examples_check_run_compile_and_verify() {
+    for rel in [
+        "examples/canonical/cli_batch_core/src/main.sm",
+        "examples/canonical/rule_state_decision/src/main.sm",
+        "examples/canonical/data_audit_record_iterable/src/main.sm",
+        "examples/canonical/wave2_local_helper_import/src/main.sm",
+        "examples/canonical/positive_selected_import/src/main.sm",
+    ] {
+        check_run_compile_verify(rel);
+    }
+}
+
+#[test]
+fn canonical_boundary_example_reports_current_alias_limit() {
+    let input = repo_path("examples/canonical/boundary_alias_import/src/main.sm");
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains(
+            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
+        ),
+        "expected executable alias boundary diagnostic, got: {err}"
+    );
+}


### PR DESCRIPTION
examples: finalize canonical examples pack

## Summary
- publish a curated canonical examples pack for the current readiness contour
- include 5 positive examples and 1 honest executable-import boundary example
- add canonical example coverage in tests/canonical_examples.rs

## Validation
- cargo test -q --test canonical_examples
- cargo test -q
- cargo test -q --test public_api_contracts
- git diff --check

Refs #334