### PR TITLE
docs: add getting started and examples index

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ cargo run --bin smc -- run-smc program.smc
 cargo run --bin svm -- disasm program.smc
 ```
 
+For a fuller onboarding path, see:
+
+- `docs/getting_started.md`
+- `docs/examples_index.md`
+
 ## Current CLI Surface
 Current command families exposed by `smc`:
 - `compile`

--- a/docs/examples_index.md
+++ b/docs/examples_index.md
@@ -1,0 +1,99 @@
+# Examples Index
+
+Status: current-main index for the curated canonical examples pack
+
+## Purpose
+
+This index maps the current canonical examples to their intent, current reading,
+and recommended first command.
+
+The canonical examples pack lives in:
+
+- `examples/canonical/`
+
+The older planning-only pack remains in:
+
+- `examples/readiness_draft_canonical/`
+
+The draft pack is historical context. The canonical pack is the current
+onboarding and readiness-facing examples surface.
+
+## Canonical Examples
+
+### `cli_batch_core`
+
+- path: `examples/canonical/cli_batch_core/`
+- purpose: small CLI-style computation core over `Sequence(i32)` and `text`
+- current reading: `qualified limited release`
+- first command:
+
+```powershell
+cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm
+```
+
+### `rule_state_decision`
+
+- path: `examples/canonical/rule_state_decision/`
+- purpose: record-oriented rule/state decision logic with explicit `Result(T, E)` handling
+- current reading: `qualified limited release`
+- first command:
+
+```powershell
+cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm
+```
+
+### `data_audit_record_iterable`
+
+- path: `examples/canonical/data_audit_record_iterable/`
+- purpose: direct-record `Iterable` data traversal and audit-style processing
+- current reading: `qualified limited release`
+- first command:
+
+```powershell
+cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm
+```
+
+### `wave2_local_helper_import`
+
+- path: `examples/canonical/wave2_local_helper_import/`
+- purpose: admitted helper-module executable authoring with direct local-path bare import
+- current reading: `qualified limited release`
+- first command:
+
+```powershell
+cargo run --bin smc -- check examples/canonical/wave2_local_helper_import/src/main.sm
+```
+
+### `positive_selected_import`
+
+- path: `examples/canonical/positive_selected_import/`
+- purpose: admitted helper-module executable authoring with direct local-path selected import
+- current reading: `qualified limited release`
+- first command:
+
+```powershell
+cargo run --bin smc -- check examples/canonical/positive_selected_import/src/main.sm
+```
+
+### `boundary_alias_import`
+
+- path: `examples/canonical/boundary_alias_import/`
+- purpose: honest boundary example showing that executable-path alias import is still rejected
+- current reading: `out of scope`
+- first command:
+
+```powershell
+cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.sm
+```
+
+Expected result:
+
+- this example should fail with the current executable import boundary diagnostic
+
+## Validation
+
+The canonical examples pack is covered by:
+
+```powershell
+cargo test -q --test canonical_examples
+```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,135 @@
+# Getting Started
+
+Status: current-main onboarding guide for the current public toolchain surface
+
+## Purpose
+
+This guide gives an external engineer the shortest honest path from clone to:
+
+- building the public CLI entrypoints
+- checking and running a minimal program
+- compiling and verifying a `.smc` artifact
+- running one canonical example from the current readiness contour
+
+This is an onboarding guide, not a release-promotion document. Current `main`
+includes landed work beyond the published stable line, so release reading still
+follows the status model in `docs/roadmap/public_status_model.md`.
+
+## Prerequisites
+
+- Rust toolchain installed
+- repository cloned locally
+- commands run from repository root
+
+## Build The Public Entry Points
+
+```powershell
+cargo build --bin smc --bin svm
+```
+
+## Minimal Source Loop
+
+Create a minimal source file:
+
+```powershell
+@'
+fn main() {
+    return;
+}
+'@ | Set-Content program.sm
+```
+
+Check the source:
+
+```powershell
+cargo run --bin smc -- check program.sm
+```
+
+Run the source directly:
+
+```powershell
+cargo run --bin smc -- run program.sm
+```
+
+Compile to SemCode:
+
+```powershell
+cargo run --bin smc -- compile program.sm -o program.smc
+```
+
+Verify the compiled artifact:
+
+```powershell
+cargo run --bin smc -- verify program.smc
+```
+
+Run the verified `.smc` artifact:
+
+```powershell
+cargo run --bin smc -- run-smc program.smc
+```
+
+Disassemble the compiled artifact:
+
+```powershell
+cargo run --bin svm -- disasm program.smc
+```
+
+## Canonical Example Loop
+
+The current curated examples pack lives in:
+
+- `examples/canonical/`
+
+Start with:
+
+- `examples/canonical/cli_batch_core/src/main.sm`
+
+Check it:
+
+```powershell
+cargo run --bin smc -- check examples/canonical/cli_batch_core/src/main.sm
+```
+
+Run it:
+
+```powershell
+cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm
+```
+
+Compile and verify it:
+
+```powershell
+cargo run --bin smc -- compile examples/canonical/cli_batch_core/src/main.sm -o cli_batch_core.smc
+cargo run --bin smc -- verify cli_batch_core.smc
+```
+
+If you want a broader tour of the curated pack, see `docs/examples_index.md`.
+
+## Current Public CLI References
+
+For the current admitted CLI surface, see:
+
+- `docs/spec/cli.md`
+
+For the canonical spec bundle, start at:
+
+- `docs/spec/index.md`
+
+## Validation
+
+Useful repository-level checks during onboarding:
+
+```powershell
+cargo test -q
+cargo test -q --test public_api_contracts
+cargo test -q --test canonical_examples
+```
+
+## Boundary Reminder
+
+The canonical examples pack includes one honest boundary example:
+
+- `examples/canonical/boundary_alias_import/`
+
+It exists to show a real current limit, not a supported workflow.


### PR DESCRIPTION
docs: add getting started and examples index

## Summary
- add a current-main getting started guide for the public toolchain loop
- add an examples index tied to the canonical examples pack
- link both docs from the repository README quickstart section

## Validation
- git diff --check

Refs #334