### PR TITLE
docs: define release artifact model

### DIFF
--- a/docs/release_artifact_model.md
+++ b/docs/release_artifact_model.md
@@ -1,0 +1,135 @@
+# Semantic Release Artifact Model
+
+Status: release-facing artifact authority for published stable assets
+
+Read this document using the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Read this document together with:
+
+- `docs/roadmap/v1_readiness.md`
+- `docs/roadmap/stable_release_policy.md`
+- `docs/roadmap/compatibility_statement.md`
+- `docs/roadmap/release_bundle_checklist.md`
+- `docs/roadmap/release_asset_smoke_matrix.md`
+
+## Purpose
+
+This document answers four release-facing questions explicitly:
+
+- what do I download
+- what platform is actually supported by the published artifacts
+- what is promised by those artifacts
+- what is not yet promised even if it exists on current `main`
+
+## Current Published Stable Artifact Set
+
+The current published stable line is:
+
+- `v1.1.1`
+
+The currently published downloadable stable artifacts are:
+
+| Artifact | Kind | Platform scope | Role | Validation basis |
+| --- | --- | --- | --- | --- |
+| `smc.exe` | standalone executable | Windows x64 | packaged Semantic compiler / CLI entrypoint for the published stable line | included in release bundle verification and downloaded-asset smoke validation |
+| `svm.exe` | standalone executable | Windows x64 | packaged SemCode VM / disassembler for the published stable line | included in release bundle verification and downloaded-asset smoke validation |
+| `semantic-language-windows-x64-v1.1.1.zip` | packaged archive | Windows x64 | convenience bundle containing the published `smc.exe` and `svm.exe` pair | zip contents and hashes are verified against the standalone assets |
+
+## Supported Platform Scope
+
+The published downloadable artifact promise is currently:
+
+- Windows x64 only
+
+This document does not promise:
+
+- Linux release binaries
+- macOS release binaries
+- parity for unreleased local builds on other host platforms
+
+Source checkout and local compilation on other hosts may work, but that is not
+the same thing as a published binary-artifact promise.
+
+## What A User Downloads
+
+For the published stable line today:
+
+- download `smc.exe` when the standalone compiler / CLI entrypoint is needed
+- download `svm.exe` when the standalone VM / disassembler is needed
+- download `semantic-language-windows-x64-v1.1.1.zip` when the packaged tool
+  pair is preferred
+
+The release-facing meaning of those assets comes from the repository docs named
+above, not from the binary filenames alone.
+
+## What These Artifacts Currently Promise
+
+The published stable artifact set currently promises:
+
+- the exact tagged stable line `v1.1.1`
+- the Windows x64 packaged `smc.exe` / `svm.exe` tool pair
+- release bundle verification through `scripts/verify_release_bundle.ps1`
+- downloaded-asset smoke validation through `scripts/verify_release_assets.ps1`
+- the current release-facing reading in:
+  - `docs/roadmap/v1_readiness.md`
+  - `docs/roadmap/stable_release_policy.md`
+  - `docs/roadmap/compatibility_statement.md`
+  - `docs/roadmap/release_asset_smoke_matrix.md`
+
+The currently validated downloaded-asset smoke path is explicitly grounded in:
+
+- `smc.exe compile <source>.sm -o <source>.smc`
+- `svm.exe run <source>.smc`
+- `svm.exe disasm <source>.smc`
+
+That smoke baseline proves the published asset pair is packaging-valid for the
+current stable line.
+
+## Validation Artifacts Versus User-Facing Artifacts
+
+The release process also produces validation artifacts.
+
+Those are not separate user runtime downloads; they are release-governance
+evidence for the published assets.
+
+Current release-governance artifacts include:
+
+- release bundle manifests emitted by `scripts/verify_release_bundle.ps1`
+- release asset smoke reports emitted by `scripts/verify_release_assets.ps1`
+- the checklist and smoke matrix docs that define what those scripts must prove
+
+These artifacts exist to validate the published assets, not to widen the
+stable promise.
+
+## What Is Not Yet Promised
+
+The following must not be inferred from the current published stable artifacts:
+
+- landed-on-`main` widenings that are not explicitly promoted
+- broader practical-programming scope beyond the current qualified contour
+- broader executable-module authoring beyond the currently qualified slice
+- package, schema, UI, or other post-stable waves merely because related code
+  exists on current `main`
+- Workbench beta packaging or beta smoke evidence as part of the core stable
+  artifact set
+
+Current-`main` behavior and current stable artifacts are related, but they are
+not the same promise surface.
+
+## Authority And Drift Rule
+
+This document stays truthful only if it remains aligned with:
+
+- `docs/roadmap/v1_readiness.md`
+- `docs/roadmap/stable_release_policy.md`
+- `docs/roadmap/compatibility_statement.md`
+- `docs/roadmap/release_bundle_checklist.md`
+- `docs/roadmap/release_asset_smoke_matrix.md`
+- `scripts/verify_release_bundle.ps1`
+- `scripts/verify_release_assets.ps1`
+
+If any of those drift from the real published asset set or supported platform
+scope, the release-facing reading is no longer honest and must be corrected
+before the next release-facing decision.

--- a/docs/roadmap/compatibility_statement.md
+++ b/docs/roadmap/compatibility_statement.md
@@ -8,6 +8,7 @@ Read this document using the canonical status vocabulary in:
 
 This document should be read together with:
 
+- `docs/release_artifact_model.md`
 - `docs/roadmap/v1_readiness.md`
 - `reports/g1_release_scope_statement.md`
 

--- a/docs/roadmap/release_bundle_checklist.md
+++ b/docs/roadmap/release_bundle_checklist.md
@@ -9,6 +9,7 @@ prerelease `v1` bundle.
 
 Verify the bundle includes:
 
+- `docs/release_artifact_model.md`
 - `docs/architecture/`
 - `docs/spec/`
 - `docs/roadmap/v1_readiness.md`

--- a/docs/roadmap/stable_release_policy.md
+++ b/docs/roadmap/stable_release_policy.md
@@ -6,6 +6,10 @@ Read this document using the canonical status vocabulary in:
 
 - `docs/roadmap/public_status_model.md`
 
+Read this policy together with:
+
+- `docs/release_artifact_model.md`
+
 This policy governs:
 
 - the published stable line
@@ -69,6 +73,7 @@ decision promotes it.
 Stable release notes should state:
 
 - the exact released commit
+- the artifact model for the published asset set
 - the validated asset set
 - the stable-ready surfaces
 - the known limits that remain outside the stable promise

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -41,6 +41,11 @@ The published stable line remains:
 It should be read as the stable publication baseline, not as a complete
 description of everything already landed on current `main`.
 
+The current published artifact set and platform scope for that stable line are
+defined in:
+
+- `docs/release_artifact_model.md`
+
 ## Qualified Limited Release
 
 The completed Gate 1 evidence currently supports a narrow practical-programming

--- a/scripts/verify_release_bundle.ps1
+++ b/scripts/verify_release_bundle.ps1
@@ -16,6 +16,7 @@ $requiredDirectories = @(
 )
 
 $requiredFiles = @(
+    "docs/release_artifact_model.md",
     "docs/roadmap/v1_readiness.md",
     "docs/roadmap/runtime_validation_policy.md",
     "docs/roadmap/release_bundle_checklist.md",
@@ -50,6 +51,7 @@ if ($missing.Count -gt 0) {
 $manifest = [ordered]@{
     generated_at = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssK")
     documentation_bundle = @(
+        "docs/release_artifact_model.md",
         "docs/architecture",
         "docs/spec",
         "docs/roadmap/v1_readiness.md",


### PR DESCRIPTION
## Summary
- add a canonical release artifact model for the published stable asset set
- define the current supported platform scope honestly as Windows x64 only
- connect the new model to the existing release bundle verification flow

## Testing
- pwsh -File scripts/verify_release_bundle.ps1
- git diff --cached --check

## Ledger
- closes the PR-E1 step in #334
- no new release promise beyond the published stable asset set
