### PR TITLE
docs: publish final readiness verdict

### DIFF
--- a/docs/roadmap/final_readiness_verdict.md
+++ b/docs/roadmap/final_readiness_verdict.md
@@ -1,0 +1,200 @@
+# Semantic Final Readiness Verdict
+
+Status: canonical final readiness decision for the current completion cycle
+
+Read this document using the canonical status vocabulary in:
+
+- `docs/roadmap/public_status_model.md`
+
+Read this verdict together with:
+
+- `docs/roadmap/v1_readiness.md`
+- `reports/g1_release_scope_statement.md`
+- `reports/cold_start_rehearsal_2026-04-24.md`
+- `docs/release_artifact_model.md`
+
+## Verdict
+
+`ready for strong limited release`
+
+## Scope Of This Verdict
+
+This verdict completes the current readiness-completion cycle for the repository
+as currently documented and validated.
+
+It does not:
+
+- upgrade the repository to `public release`
+- silently widen the qualified practical-programming contour
+- silently widen the published stable promise beyond `v1.1.1`
+- treat all landed-on-`main` behavior as release-promised
+
+## Why This Is The Correct Verdict
+
+The current evidence supports a strong release-facing conclusion, but only at
+the limited-release layer.
+
+The current repository now has all of the following in place:
+
+- a stable status vocabulary and authority order
+- a current release-facing posture reading
+- a completed Gate 1 practical-programming verdict
+- canonical examples and onboarding guidance
+- a real cold-start rehearsal note from a fresh worktree
+- a release artifact model tied to actual bundle and smoke validation
+- green validation expectations for the release-facing gates named in the
+  current docs
+
+Taken together, that is enough to support an explicit final readiness judgment
+for a disciplined limited-release posture.
+
+## Final Review Checklist
+
+### F1 — Technical Core
+
+Reading:
+
+- pass for the admitted verified path
+
+Basis:
+
+- `reports/g1_release_scope_statement.md`
+- `reports/g1_execution_integrity.md`
+- `reports/g1_benchmark_baseline.md`
+- `docs/roadmap/v1_readiness.md`
+
+Interpretation:
+
+- the admitted
+  `source -> sema -> IR -> SemCode -> verifier -> VM`
+  path is trusted for the current qualified contour
+- deterministic and verifier-first execution remains part of the current
+  release-facing reading
+
+### F2 — Practical Programming
+
+Reading:
+
+- pass for a narrow practical contour
+
+Basis:
+
+- `reports/g1_release_scope_statement.md`
+- `reports/g1_real_program_trial.md`
+- `reports/g1_surface_expressiveness.md`
+
+Interpretation:
+
+- real small programs can be authored, checked, compiled, verified, and run
+  within the currently admitted contour
+- that contour is strong enough for a disciplined limited release
+- that contour is still too narrow for a broader public-release claim
+
+### F3 — Module Story
+
+Reading:
+
+- pass for the admitted narrow executable-helper contour
+
+Basis:
+
+- `reports/g1_release_scope_statement.md`
+- `docs/roadmap/v1_readiness.md`
+
+Interpretation:
+
+- direct local-path bare imports and direct local-path selected imports over
+  function-only helper modules are now part of the current qualified contour
+- broader module/import authoring remains intentionally outside the current
+  release promise
+
+### F4 — External Usability
+
+Reading:
+
+- pass for the documented onboarding path
+
+Basis:
+
+- `docs/getting_started.md`
+- `docs/examples_index.md`
+- `reports/cold_start_rehearsal_2026-04-24.md`
+
+Interpretation:
+
+- a strong external engineer can follow the documented productive loop on a
+  fresh worktree without hidden author-only steps
+- the cold-start rehearsal did not uncover a blocker that required a
+  continuation fix cycle
+
+### F5 — Public Truth
+
+Reading:
+
+- pass
+
+Basis:
+
+- `docs/roadmap/public_status_model.md`
+- `docs/roadmap/v1_readiness.md`
+- `reports/g1_release_scope_statement.md`
+- `docs/release_artifact_model.md`
+
+Interpretation:
+
+- the release-facing truth layers now agree on the distinction between:
+  - `published stable`
+  - `qualified limited release`
+  - `landed on main, not yet promised`
+  - `out of scope`
+
+## Why This Is Not `public release`
+
+The current evidence still does not justify a broader public-release claim.
+
+The limiting factors remain explicit:
+
+- the qualified practical-programming contour is still intentionally narrow
+- broader executable-module authoring is still not qualified
+- full CLI application authoring with admitted argv/stdout/file IO is still not
+  qualified
+- UI remains outside the current qualified contour
+- multiple landed-on-`main` post-stable waves remain unpromoted
+
+That means the honest upper bound of the present evidence is:
+
+- `ready for strong limited release`
+
+not:
+
+- `ready for public release`
+
+## Continuation Decision
+
+The verdict is **not**:
+
+- `one final narrow blocker-removal cycle is still required`
+
+Reason:
+
+- the final review found no remaining blocker that must be removed before the
+  repository can honestly hold the current limited-release posture
+- recent contingency slots were reviewed through evidence and were not triggered
+
+Any future widening work now requires:
+
+- a new explicit scope decision
+- and, where required, a Gate amendment or a new Gate cycle
+
+## Operational Outcome
+
+The current readiness-completion program is complete with this result:
+
+- Semantic is ready for a **strong limited release** posture
+
+That result should be read together with these persistent boundaries:
+
+- the published stable line remains `v1.1.1`
+- current `main` still contains wider landed behavior that is not yet promoted
+- future widening should be handled as a new explicit continuation stream, not
+  as an implicit extension of this completed readiness cycle


### PR DESCRIPTION
## Summary
- add the canonical final readiness verdict for the completed A-F cycle
- record the evidence-backed decision as `ready for strong limited release`
- make explicit why this is not `public release` and why no continuation blocker-removal cycle is triggered

## Testing
- git diff --cached --check

## Ledger
- closes #334
- verdict: `ready for strong limited release`
