### PR TITLE
docs/spec: sync benchmark-critical current-main truth

### DIFF
--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -243,8 +243,8 @@ Current message families include:
   post-stable `fx` arithmetic slice
 - explicit gap messages for text concatenation or text arithmetic beyond the
   current `M8.1` Wave 3 literal/equality/runtime surface
-- explicit gap messages for ordered sequence iteration or collection-helper
-  forms beyond the current `M8.3` first-wave carrier/index/equality surface
+- explicit gap messages for collection-helper forms beyond the current `M8.3`
+  first-wave iterable/carrier/index/equality surface
 - explicit source/runtime failures for non-`i32` sequence indexes, negative
   sequence indexes, or out-of-bounds sequence indexes in the current `M8.3`
   first-wave execution path
@@ -258,8 +258,8 @@ Current honest limit:
 - current `main` now also admits verified runtime execution for the same narrow
   text literal/equality surface
 - current `main` now also admits executable ordered sequence literals,
-  same-family equality, and `expr[index]` through the current `M8.3`
-  first-wave carrier path
+  same-family equality, `expr[index]`, and `for value in sequence` through the
+  current `M8.3` first-wave carrier/iterable path
 - current `main` still reports explicit gap messages for text arithmetic beyond
   equality until later `M8.1` waves land
 - generated validation failures are currently documented as deterministic plan

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -384,8 +384,12 @@ Current active collections checkpoint on `main`:
   ordered sequence and `index` is `i32`
 - same-family equality is now admitted for ordered sequence values when the
   item type already supports stable equality
-- iteration, `len`, `is_empty`, maps, sets, and generic collection
-  abstractions are not part of the current `M8.3` first-wave syntax contract
+- `for name in collection { ... }` is now part of the current syntax contract
+  through the narrow `Iterable` owner-layer loop surface described below
+- built-in `Sequence(type)` values now participate in that admitted iterable
+  loop path on current `main`
+- `len`, `is_empty`, maps, sets, and generic collection abstractions are not
+  part of the current `M8.3` first-wave syntax contract
 
 Current v0 range-literal limits:
 

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -108,7 +108,9 @@ Current honest baseline:
 
 Current first-wave limits:
 
-- immutable capture only is the intended direction for the first-wave family
+- current `main` admits immutable capture inventory for that first-wave family
+- immutable capture only remains the intended direction for the first-wave
+  family
 - direct invocation only is the intended call model for that family
 - direct invocation currently requires exactly one positional argument
 - closure equality is not part of the current contract
@@ -320,8 +322,10 @@ Current active collections checkpoint on `main`:
   sequence family
 - current `main` now admits `expr[index]` when the base is an admitted ordered
   sequence and the index is `i32`
-- current `main` still does not admit iteration, `len`, or `is_empty` for
-  that sequence family in the current `M8.3` first-wave surface
+- current `main` now admits `for value in sequence { ... }` for that sequence
+  family through the current first-wave iterable loop surface
+- current `main` still does not admit `len` or `is_empty` for that sequence
+  family in the current `M8.3` first-wave surface
 
 Current active closures checkpoint on `main`:
 


### PR DESCRIPTION
## Summary
- sync benchmark-critical spec docs with already-landed current-main truth
- state explicitly that built-in `Sequence(T)` now participates in the admitted iterable loop path
- make `types.md` and `diagnostics.md` stop describing sequence iteration as a remaining gap

## Validation
- git diff --check