### PR TITLE
tests: add snake benchmark gap matrix

### DIFF
--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -1,0 +1,24 @@
+Snake benchmark gap matrix fixtures for `PR-A2`.
+
+Purpose:
+
+- freeze the current pass baseline for already-landed benchmark-critical source
+  surfaces
+- freeze the current fail baseline for still-missing snake blockers that
+  already have a meaningful current source spelling
+
+This fixture pack intentionally does not yet freeze syntax for two blocker
+families:
+
+- seeded deterministic pseudo-random source
+- narrow stdout experiment surface
+
+Reason:
+
+- current `main` and the application-completeness ledger define those blocker
+  families, but they do not yet define one canonical source spelling
+- this PR must not invent fake API names just to make the matrix look more
+  complete
+
+Those two gaps remain part of the benchmark blocker set and should be frozen in
+tests only after their scope PRs choose the public source forms.

--- a/tests/fixtures/snake_benchmark/negative_continue_statement.sm
+++ b/tests/fixtures/snake_benchmark/negative_continue_statement.sm
@@ -1,0 +1,5 @@
+fn main() {
+    loop {
+        continue;
+    }
+}

--- a/tests/fixtures/snake_benchmark/negative_i32_arithmetic.sm
+++ b/tests/fixtures/snake_benchmark/negative_i32_arithmetic.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let total: i32 = 1 + 2;
+    assert(total == 3);
+}

--- a/tests/fixtures/snake_benchmark/negative_let_mut.sm
+++ b/tests/fixtures/snake_benchmark/negative_let_mut.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let mut score: i32 = 0;
+}

--- a/tests/fixtures/snake_benchmark/negative_loop_break.sm
+++ b/tests/fixtures/snake_benchmark/negative_loop_break.sm
@@ -1,0 +1,5 @@
+fn main() {
+    loop {
+        break;
+    }
+}

--- a/tests/fixtures/snake_benchmark/negative_map_surface.sm
+++ b/tests/fixtures/snake_benchmark/negative_map_surface.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let visits: Map(text, i32) = Map::empty();
+}

--- a/tests/fixtures/snake_benchmark/negative_reassignment.sm
+++ b/tests/fixtures/snake_benchmark/negative_reassignment.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let score: i32 = 0;
+    score = 1;
+}

--- a/tests/fixtures/snake_benchmark/negative_relational_operator.sm
+++ b/tests/fixtures/snake_benchmark/negative_relational_operator.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let ok: bool = 2 >= 1;
+    assert(ok);
+}

--- a/tests/fixtures/snake_benchmark/negative_sequence_len.sm
+++ b/tests/fixtures/snake_benchmark/negative_sequence_len.sm
@@ -1,0 +1,5 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    let size: i32 = len(values);
+    assert(size == 3);
+}

--- a/tests/fixtures/snake_benchmark/negative_sequence_push.sm
+++ b/tests/fixtures/snake_benchmark/negative_sequence_push.sm
@@ -1,0 +1,5 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    let next: Sequence(i32) = push(values, 4);
+    assert(next[0] == 1);
+}

--- a/tests/fixtures/snake_benchmark/negative_text_concatenation.sm
+++ b/tests/fixtures/snake_benchmark/negative_text_concatenation.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let label: text = "alpha" + "beta";
+    assert(label == "alphabeta");
+}

--- a/tests/fixtures/snake_benchmark/negative_while_loop.sm
+++ b/tests/fixtures/snake_benchmark/negative_while_loop.sm
@@ -1,0 +1,5 @@
+fn main() {
+    while true {
+        return;
+    }
+}

--- a/tests/fixtures/snake_benchmark/positive_closure_capture.sm
+++ b/tests/fixtures/snake_benchmark/positive_closure_capture.sm
@@ -1,0 +1,7 @@
+fn main() {
+    let offset: f64 = 1.0;
+    let add: Closure(f64 -> f64) = (x => x + offset);
+    let total: f64 = add(2.0);
+    assert(total == 3.0);
+    return;
+}

--- a/tests/fixtures/snake_benchmark/positive_enum_match.sm
+++ b/tests/fixtures/snake_benchmark/positive_enum_match.sm
@@ -1,0 +1,21 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn label(dir: Direction) -> text {
+    let out: text = match dir {
+        Direction::Up => { "Up" }
+        Direction::Right => { "Right" }
+        Direction::Down => { "Down" }
+        Direction::Left => { "Left" }
+    };
+    return out;
+}
+
+fn main() {
+    assert(label(Direction::Right) == "Right");
+    return;
+}

--- a/tests/fixtures/snake_benchmark/positive_sequence_indexing.sm
+++ b/tests/fixtures/snake_benchmark/positive_sequence_indexing.sm
@@ -1,0 +1,7 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    let head: i32 = values[0];
+    assert(head == 1);
+    assert(values == [1, 2, 3]);
+    return;
+}

--- a/tests/fixtures/snake_benchmark/positive_sequence_iteration.sm
+++ b/tests/fixtures/snake_benchmark/positive_sequence_iteration.sm
@@ -1,0 +1,15 @@
+fn classify(values: Sequence(i32)) -> bool {
+    let saw_retry: bool = false;
+    for value in values {
+        if value == 2 {
+            saw_retry ||= true;
+        }
+    }
+    return saw_retry;
+}
+
+fn main() {
+    let right: bool = classify([0, 2, 4]);
+    assert(right == true);
+    return;
+}

--- a/tests/fixtures/snake_benchmark/positive_text_equality.sm
+++ b/tests/fixtures/snake_benchmark/positive_text_equality.sm
@@ -1,0 +1,11 @@
+fn echo(x: text) -> text {
+    return x;
+}
+
+fn main() {
+    let left: text = "alpha";
+    let right: text = echo("alpha");
+    assert(left == right);
+    assert(left != "beta");
+    return;
+}

--- a/tests/snake_benchmark_gap_matrix.rs
+++ b/tests/snake_benchmark_gap_matrix.rs
@@ -1,0 +1,151 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn check_run_compile_verify(rel: &str) {
+    let input = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let dir = mk_temp_dir("smc_snake_benchmark_gap_matrix");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("smc verify for {input}"),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn snake_benchmark_positive_surface_passes_end_to_end() {
+    for rel in [
+        "tests/fixtures/snake_benchmark/positive_text_equality.sm",
+        "tests/fixtures/snake_benchmark/positive_enum_match.sm",
+        "tests/fixtures/snake_benchmark/positive_sequence_indexing.sm",
+        "tests/fixtures/snake_benchmark/positive_sequence_iteration.sm",
+        "tests/fixtures/snake_benchmark/positive_closure_capture.sm",
+    ] {
+        check_run_compile_verify(rel);
+    }
+}
+
+#[test]
+fn snake_benchmark_negative_gap_suite_reports_current_blockers() {
+    let cases = [
+        (
+            "tests/fixtures/snake_benchmark/negative_relational_operator.sm",
+            "E0000",
+            "2 >= 1;",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_i32_arithmetic.sm",
+            "E0201",
+            "f64 arithmetic requires f64 operands",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_let_mut.sm",
+            "E0000",
+            "let mut score: i32 = 0;",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_reassignment.sm",
+            "E0000",
+            "score = 1;",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_while_loop.sm",
+            "E0000",
+            "while true",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_loop_break.sm",
+            "E0000",
+            "loop expression v0 currently requires break value",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_continue_statement.sm",
+            "E0000",
+            "continue;",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_sequence_len.sm",
+            "E0201",
+            "unknown function 'len'",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_sequence_push.sm",
+            "E0201",
+            "unknown function 'push'",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_map_surface.sm",
+            "E0000",
+            "Map(text, i32)",
+        ),
+        (
+            "tests/fixtures/snake_benchmark/negative_text_concatenation.sm",
+            "E0201",
+            "text concatenation is not part of the current M8.1 Wave 2 contract",
+        ),
+    ];
+
+    for (rel, code, needle) in cases {
+        let input = repo_path(rel);
+        let err = cli_err(
+            vec!["check".to_string(), input.clone()],
+            &format!("smc check for {input}"),
+        );
+        assert!(
+            err.contains(&format!("Error [{code}]")),
+            "expected diagnostic code {code} for {rel}, got: {err}"
+        );
+        assert!(
+            err.contains(needle),
+            "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused snake benchmark gap-matrix test target
- freeze current-main positives for text, enum match, sequence indexing/iteration, and closure capture
- freeze current missing blockers for relational operators, i32 arithmetic, mutability, while/loop control, sequence helpers, map surface, and text concatenation

## Notes
- seeded PRNG and stdout gaps are documented in the fixture README but not frozen as syntax fixtures yet because current docs have not chosen canonical source spellings for them

## Validation
- cargo test -q --test snake_benchmark_gap_matrix
- cargo test -q
- cargo test -q --test public_api_contracts
- git diff --check