### PR TITLE
frontend/control: admit mutable locals and reassignment

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -99,6 +99,7 @@ pub type ImplTable = Vec<ImplDecl>;
 pub struct ScopeBinding {
     pub ty: Type,
     pub is_const: bool,
+    pub is_mutable: bool,
     /// M9.5 Wave C: true after the binding's value has been moved out (whole-variable).
     pub consumed: bool,
     /// M9.7: per-path availability for partial-move tracking.
@@ -144,6 +145,20 @@ impl ScopeEnv {
             ScopeBinding {
                 ty,
                 is_const: false,
+                is_mutable: false,
+                consumed: false,
+                path_state: Vec::new(),
+            },
+        );
+    }
+
+    pub fn insert_mut(&mut self, name: SymbolId, ty: Type) {
+        self.insert_binding(
+            name,
+            ScopeBinding {
+                ty,
+                is_const: false,
+                is_mutable: true,
                 consumed: false,
                 path_state: Vec::new(),
             },
@@ -152,7 +167,7 @@ impl ScopeEnv {
 
     pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
         self.insert_binding(name, ScopeBinding {
-            ty, is_const: true, consumed: false, path_state: Vec::new(),
+            ty, is_const: true, is_mutable: false, consumed: false, path_state: Vec::new(),
         });
     }
 
@@ -326,6 +341,12 @@ impl ScopeEnv {
 
     pub fn is_const(&self, name: SymbolId) -> bool {
         self.binding(name).map(|binding| binding.is_const).unwrap_or(false)
+    }
+
+    pub fn is_mutable(&self, name: SymbolId) -> bool {
+        self.binding(name)
+            .map(|binding| binding.is_mutable)
+            .unwrap_or(false)
     }
 
     fn binding(&self, name: SymbolId) -> Option<&ScopeBinding> {

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -720,7 +720,14 @@ impl<'a> Parser<'a> {
             return Ok(self.arena.alloc_stmt(Stmt::Const { name, ty, value }));
         }
         if self.eat(TokenKind::KwLet) {
+            let let_is_mut = self.eat_ident_text("mut");
             if self.eat(TokenKind::Underscore) {
+                if let_is_mut {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "let mut currently requires a plain binding target".to_string(),
+                    });
+                }
                 let ty = if self.eat(TokenKind::Colon) {
                     Some(self.parse_type()?)
                 } else {
@@ -740,6 +747,12 @@ impl<'a> Parser<'a> {
                 return Ok(self.arena.alloc_stmt(Stmt::Discard { ty, value }));
             }
             if self.eat(TokenKind::LParen) {
+                if let_is_mut {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "let mut currently requires a plain binding target".to_string(),
+                    });
+                }
                 let items = self.parse_tuple_pattern_items_after_lparen()?;
                 let ty = if self.eat(TokenKind::Colon) {
                     Some(self.parse_type()?)
@@ -786,6 +799,12 @@ impl<'a> Parser<'a> {
             }
             let name = self.expect_symbol()?;
             if self.check(TokenKind::LBrace) {
+                if let_is_mut {
+                    return Err(FrontendError {
+                        pos: self.pos(),
+                        message: "let mut currently requires a plain binding target".to_string(),
+                    });
+                }
                 self.expect(TokenKind::LBrace, "expected '{' after record pattern name")?;
                 let items = self.parse_record_pattern_items_after_lbrace()?;
                 self.expect(TokenKind::Assign, "expected '='")?;
@@ -823,7 +842,12 @@ impl<'a> Parser<'a> {
                 });
             }
             self.expect(TokenKind::Semi, "expected ';'")?;
-            return Ok(self.arena.alloc_stmt(Stmt::Let { name, ty, value }));
+            return Ok(self.arena.alloc_stmt(Stmt::Let {
+                name,
+                is_mut: let_is_mut,
+                ty,
+                value,
+            }));
         }
         if self.check(TokenKind::Ident) {
             if let Some(op) = self.peek_compound_assign_op() {
@@ -833,6 +857,13 @@ impl<'a> Parser<'a> {
                 self.expect(TokenKind::Semi, "expected ';'")?;
                 let lhs = self.arena.alloc_expr(Expr::Var(name));
                 let value = self.arena.alloc_expr(Expr::Binary(lhs, op, rhs));
+                return Ok(self.arena.alloc_stmt(Stmt::Assign { name, value }));
+            }
+            if self.peek_next_non_layout_kind() == Some(TokenKind::Assign) {
+                let name = self.expect_symbol()?;
+                self.expect(TokenKind::Assign, "expected '='")?;
+                let value = self.parse_expr()?;
+                self.expect(TokenKind::Semi, "expected ';'")?;
                 return Ok(self.arena.alloc_stmt(Stmt::Assign { name, value }));
             }
         }
@@ -1197,6 +1228,12 @@ impl<'a> Parser<'a> {
             TokenKind::OrOrAssign => Some(BinaryOp::OrOr),
             _ => None,
         }
+    }
+
+    fn peek_next_non_layout_kind(&self) -> Option<TokenKind> {
+        let current = self.next_non_layout_idx();
+        let next = self.next_non_layout_idx_from(current + 1);
+        self.tokens.get(next).map(|t| t.kind)
     }
 
     fn parse_if_after_kw_if(&mut self) -> Result<Stmt, FrontendError> {
@@ -1733,7 +1770,12 @@ impl<'a> Parser<'a> {
             };
             self.expect(TokenKind::Assign, "expected '=' in where binding")?;
             let value = self.parse_expr()?;
-            statements.push(self.arena.alloc_stmt(Stmt::Let { name, ty, value }));
+            statements.push(self.arena.alloc_stmt(Stmt::Let {
+                name,
+                is_mut: false,
+                ty,
+                value,
+            }));
             if self.eat(TokenKind::Comma) {
                 continue;
             }
@@ -1831,6 +1873,7 @@ impl<'a> Parser<'a> {
     ) -> Result<ExprId, FrontendError> {
         let binding = self.arena.alloc_stmt(Stmt::Let {
             name: param,
+            is_mut: false,
             ty: None,
             value: arg,
         });
@@ -3697,7 +3740,7 @@ fn main() { return; }
     fn rustlike_parser_accepts_compound_assignment() {
         let src = r#"
 fn main() {
-    let total: f64 = 1.0;
+    let mut total: f64 = 1.0;
     total += 2.0;
     return;
 }
@@ -3717,6 +3760,54 @@ fn main() {
         assert!(matches!(
             program.arena.expr(*rhs),
             Expr::NumericLiteral(NumericLiteral::F64(_))
+        ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_mutable_let_binding() {
+        let src = r#"
+fn main() {
+    let mut score: i32 = 0;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("let mut should parse");
+        let func = &program.functions[0];
+        let Stmt::Let {
+            name,
+            is_mut,
+            ty: Some(Type::I32),
+            ..
+        } = program.arena.stmt(func.body[0])
+        else {
+            panic!("expected mutable let binding");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "score");
+        assert!(*is_mut, "let mut binding should record mutability");
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_plain_reassignment_statement() {
+        let src = r#"
+fn main() {
+    let mut score: i32 = 0;
+    score = 1;
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("plain reassignment should parse");
+        let func = &program.functions[0];
+        let Stmt::Assign { name, value } = program.arena.stmt(func.body[1]) else {
+            panic!("expected plain assignment statement");
+        };
+        assert_eq!(program.arena.symbol_name(*name), "score");
+        assert!(matches!(
+            program.arena.expr(*value),
+            Expr::NumericLiteral(NumericLiteral::I32(1))
         ));
     }
 
@@ -3809,6 +3900,7 @@ fn main() {
             name,
             ty: Some(Type::Text),
             value,
+            ..
         } = program.arena.stmt(func.body[0])
         else {
             panic!("expected text-typed let binding");
@@ -3841,6 +3933,7 @@ fn main() {
             name,
             ty: Some(Type::Sequence(sequence_ty)),
             value,
+            ..
         } = program.arena.stmt(func.body[0])
         else {
             panic!("expected sequence-typed let binding");

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -720,7 +720,12 @@ fn check_stmt(
             env.insert_const(*name, final_ty);
             Ok(())
         }
-        Stmt::Let { name, ty, value } => {
+        Stmt::Let {
+            name,
+            is_mut,
+            ty,
+            value,
+        } => {
             if let Some(ann) = ty {
                 ensure_type_resolved(
                     ann,
@@ -771,7 +776,11 @@ fn check_stmt(
                 )?;
                 vt
             };
-            env.insert(*name, final_ty);
+            if *is_mut {
+                env.insert_mut(*name, final_ty);
+            } else {
+                env.insert(*name, final_ty);
+            }
             Ok(())
         }
         Stmt::LetTuple { items, ty, value } => {
@@ -3500,9 +3509,9 @@ mod tests {
     fn compound_assignment_typechecks_for_existing_scalar_rules() {
         let src = r#"
             fn main() {
-                let total: f64 = 1.0;
+                let mut total: f64 = 1.0;
                 total += 2.0;
-                let ready: bool = true;
+                let mut ready: bool = true;
                 ready &&= false;
                 return;
             }
@@ -3528,7 +3537,7 @@ mod tests {
     fn compound_assignment_reuses_operator_type_rules() {
         let src = r#"
             fn main() {
-                let total: f64 = 1.0;
+                let mut total: f64 = 1.0;
                 total += true;
                 return;
             }
@@ -3537,6 +3546,33 @@ mod tests {
         let err =
             typecheck_source(src).expect_err("compound assignment operator mismatch must reject");
         assert!(err.message.contains("f64 arithmetic requires f64 operands"));
+    }
+
+    #[test]
+    fn mutable_local_reassignment_typechecks() {
+        let src = r#"
+            fn main() {
+                let mut score: i32 = 0;
+                score = 1;
+                score += 2;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("mutable local reassignment should typecheck");
+    }
+
+    #[test]
+    fn plain_local_reassignment_typechecks() {
+        let src = r#"
+            fn main() {
+                let score: i32 = 0;
+                score = 1;
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("plain local reassignment should typecheck");
     }
 
     #[test]

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -397,6 +397,7 @@ pub enum Stmt {
     },
     Let {
         name: SymbolId,
+        is_mut: bool,
         ty: Option<Type>,
         value: ExprId,
     },

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -4368,7 +4368,12 @@ fn lower_stmt(
             });
             Ok(())
         }
-        Stmt::Let { name, ty, value } => {
+        Stmt::Let {
+            name,
+            is_mut,
+            ty,
+            value,
+        } => {
             append_record_update_write_events_from_expr(*value, arena, &mut ctx.ownership_events);
             let (reg, vty) = lower_expr_with_expected(
                 *value,
@@ -4385,7 +4390,11 @@ fn lower_stmt(
                 &mut ctx.closure_state,
             )?;
             let final_ty = if let Some(ann) = ty { ann.clone() } else { vty };
-            env.insert(*name, final_ty);
+            if *is_mut {
+                env.insert_mut(*name, final_ty);
+            } else {
+                env.insert(*name, final_ty);
+            }
             ctx.instrs.push(IrInstr::StoreVar {
                 name: resolve_symbol_name(arena, *name)?.to_string(),
                 src: reg,
@@ -5273,7 +5282,12 @@ fn lower_value_block_expr(
                     src: reg,
                 });
             }
-            Stmt::Let { name, ty, value } => {
+            Stmt::Let {
+                name,
+                is_mut,
+                ty,
+                value,
+            } => {
                 let (reg, vty) = lower_expr_with_expected(
                     *value,
                     arena,
@@ -5289,7 +5303,11 @@ fn lower_value_block_expr(
                     closure_state,
                 )?;
                 let final_ty = if let Some(ann) = ty { ann.clone() } else { vty };
-                block_env.insert(*name, final_ty);
+                if *is_mut {
+                    block_env.insert_mut(*name, final_ty);
+                } else {
+                    block_env.insert(*name, final_ty);
+                }
                 out.push(IrInstr::StoreVar {
                     name: resolve_symbol_name(arena, *name)?.to_string(),
                     src: reg,
@@ -8206,7 +8224,7 @@ mod opt_tests {
     fn lower_compound_assignment_to_read_modify_write() {
         let src = r#"
             fn main() {
-                let total: f64 = 1.0;
+                let mut total: f64 = 1.0;
                 total += 2.0;
                 return;
             }
@@ -8226,6 +8244,48 @@ mod opt_tests {
             main.instrs
                 .iter()
                 .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "total"))
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn lower_mutable_local_reassignment_to_store_path() {
+        let src = r#"
+            fn main() {
+                let mut score: i32 = 0;
+                score = 1;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("mutable local reassignment should lower");
+        let main = &ir[0];
+        assert!(
+            main.instrs
+                .iter()
+                .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "score"))
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn lower_plain_local_reassignment_to_store_path() {
+        let src = r#"
+            fn main() {
+                let score: i32 = 0;
+                score = 1;
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("plain local reassignment should lower");
+        let main = &ir[0];
+        assert!(
+            main.instrs
+                .iter()
+                .filter(|instr| matches!(instr, IrInstr::StoreVar { name, .. } if name == "score"))
                 .count()
                 >= 2
         );

--- a/docs/roadmap/full_readiness_non_ui.md
+++ b/docs/roadmap/full_readiness_non_ui.md
@@ -89,7 +89,6 @@ Purpose: close the practical programming layer.
 Capabilities to finish or classify:
 
 - public integer arithmetic;
-- mutable locals and reassignment;
 - `while`;
 - statement loops and control exits;
 - block expression consistency;

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -425,6 +425,13 @@ Current statement meaning:
 - `assert(condition);` terminates through the core fail-fast trap path when
   `condition` is `false`
 - expression statements evaluate for effect and then discard any produced value
+- `let name: T = expr;` introduces a local binding
+- `let mut name: T = expr;` is admitted as an explicit writable-local spelling in
+  the current Rust-like path
+- plain reassignment `name = expr;` is admitted for local bindings
+- compound assignment `name += expr;`, `name -= expr;`, `name *= expr;`,
+  `name /= expr;`, `name &&= expr;`, and `name ||= expr;` desugar through the
+  same assignment path
 - `return expr;` terminates the current function with that value
 - `return;` terminates a `unit`-returning function
 
@@ -433,7 +440,6 @@ Current non-goal:
 - the source contract does not claim deferred execution, generators, or
   coroutine-style statement behavior
 - `guard` does not yet support arbitrary `else { ... }` recovery blocks
-- plain reassignment `name = expr;` is not yet part of the public surface
 
 Current generated wire-contract limit:
 

--- a/docs/wiki/current_status.md
+++ b/docs/wiki/current_status.md
@@ -230,7 +230,6 @@ Current benchmark-positive baseline includes:
 Known benchmark-family blockers remain in the application-completeness stream rather than the cleanup milestone, including:
 
 - public integer arithmetic;
-- mutable locals / reassignment;
 - statement loops and control exits;
 - sequence utility layer;
 - first-wave map surface;

--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -13,6 +13,7 @@ Current landed positive baseline includes:
 - enum/control-flow basics
 - same-family plain `i32` relational operators
 - same-family plain `i32` unary `-` and binary `+`, `-`, `*`
+- `let mut`, plain reassignment, and compound assignment over mutable locals
 - ordered `Sequence(T)` indexing and iteration
 - first-class closure capture
 

--- a/tests/fixtures/snake_benchmark/positive_let_mut.sm
+++ b/tests/fixtures/snake_benchmark/positive_let_mut.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let mut score: i32 = 0;
+    score += 1;
+}

--- a/tests/fixtures/snake_benchmark/positive_reassignment.sm
+++ b/tests/fixtures/snake_benchmark/positive_reassignment.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let mut score: i32 = 0;
+    score = 1;
+}

--- a/tests/golden_snapshots/public_api/sm_front_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_front_lib.txt
@@ -37,6 +37,7 @@ pub type ImplTable = Vec<ImplDecl>;
 pub struct ScopeBinding {
 pub ty: Type,
 pub is_const: bool,
+pub is_mutable: bool,
 pub consumed: bool,
 pub path_state: Vec<(crate::types::PatternPath, crate::types::PathAvailability)>,
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -47,6 +48,7 @@ pub fn with_params(params: &[(SymbolId, Type)]) -> Self {
 pub fn push_scope(&mut self) {
 pub fn pop_scope(&mut self) {
 pub fn insert(&mut self, name: SymbolId, ty: Type) {
+pub fn insert_mut(&mut self, name: SymbolId, ty: Type) {
 pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
 pub fn mark_consumed(&mut self, name: SymbolId) {
 pub fn is_consumed(&self, name: SymbolId) -> bool {
@@ -55,6 +57,7 @@ pub fn check_path_available(
 pub fn check_capture_allowed(
 pub fn get(&self, name: SymbolId) -> Option<Type> {
 pub fn is_const(&self, name: SymbolId) -> bool {
+pub fn is_mutable(&self, name: SymbolId) -> bool {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
 #[cfg(any(feature = "alloc", feature = "std"))]

--- a/tests/snake_benchmark_gap_matrix.rs
+++ b/tests/snake_benchmark_gap_matrix.rs
@@ -67,6 +67,8 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
         "tests/fixtures/snake_benchmark/positive_enum_match.sm",
         "tests/fixtures/snake_benchmark/positive_i32_relational.sm",
         "tests/fixtures/snake_benchmark/negative_i32_arithmetic.sm",
+        "tests/fixtures/snake_benchmark/positive_let_mut.sm",
+        "tests/fixtures/snake_benchmark/positive_reassignment.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_indexing.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_iteration.sm",
         "tests/fixtures/snake_benchmark/positive_closure_capture.sm",
@@ -78,16 +80,6 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
 #[test]
 fn snake_benchmark_negative_gap_suite_reports_current_blockers() {
     let cases = [
-        (
-            "tests/fixtures/snake_benchmark/negative_let_mut.sm",
-            "E0000",
-            "let mut score: i32 = 0;",
-        ),
-        (
-            "tests/fixtures/snake_benchmark/negative_reassignment.sm",
-            "E0000",
-            "score = 1;",
-        ),
         (
             "tests/fixtures/snake_benchmark/negative_while_loop.sm",
             "E0000",


### PR DESCRIPTION
## Scope
- admit `let mut` in the Rust-like frontend
- admit plain reassignment statements `name = expr;`
- keep compound assignment on the existing assignment path
- update snake benchmark matrix and public docs/status to reflect the landed surface

## Included
- parser admission for `let mut` and plain reassignment
- frontend/typecheck/lowering coverage for reassignment paths
- benchmark fixtures for positive `let mut` / reassignment
- spec/status truth sync
- public API snapshot update for intentional `sm-front` contract drift

## Out of scope
- `while`
- loop/break/continue widening
- map/text/PRNG/stdout work
- mutability tightening for legacy non-const local assignments

## Local validation
- `cargo test -q -p sm-front`
- `cargo test -q -p sm-ir`
- `cargo test -q --test snake_benchmark_gap_matrix`
- `cargo test -q --test public_api_contracts`
- `cargo test -q`
- `git diff --check`