### PR TITLE
frontend/control: admit while statement

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -326,6 +326,7 @@ fn tokenize_line(
                     "guard" => TokenKind::KwGuard,
                     "if" => TokenKind::KwIf,
                     "else" => TokenKind::KwElse,
+                    "while" => TokenKind::KwWhile,
                     "loop" => TokenKind::KwLoop,
                     "break" => TokenKind::KwBreak,
                     "where" => TokenKind::KwWhere,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -898,6 +898,11 @@ impl<'a> Parser<'a> {
                 }),
             });
         }
+        if self.eat(TokenKind::KwWhile) {
+            let condition = self.parse_expr()?;
+            let body = self.parse_block()?;
+            return Ok(self.arena.alloc_stmt(Stmt::While { condition, body }));
+        }
         if self.eat(TokenKind::KwGuard) {
             let condition = self.parse_expr()?;
             if !self.eat(TokenKind::KwElse) {
@@ -5191,6 +5196,31 @@ fn main() {
                 assert_eq!(program.arena.symbol_name(ctor.variant_name), "Ok");
             }
             other => panic!("expected typed let binding, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_while_statement_surface() {
+        let src = r#"
+fn main() {
+    let mut i: i32 = 0;
+    while i < 3 {
+        i = i + 1;
+    }
+    return;
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("while statement should parse");
+        let main = &program.functions[0];
+        match program.arena.stmt(main.body[1]) {
+            Stmt::While { condition, body } => {
+                assert!(matches!(program.arena.expr(*condition), Expr::Binary(_, _, _)));
+                assert_eq!(body.len(), 1);
+                assert!(matches!(program.arena.stmt(body[0]), Stmt::Assign { .. }));
+            }
+            other => panic!("expected while statement, got {:?}", other),
         }
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1288,6 +1288,43 @@ fn check_stmt(
             body_env.pop_scope();
             Ok(())
         }
+        Stmt::While { condition, body } => {
+            let condition_ty = infer_expr_type(
+                *condition,
+                arena,
+                env,
+                table,
+                record_table,
+                adt_table,
+                ret_ty.clone(),
+                loop_stack,
+                impl_list,
+            )?;
+            if condition_ty != Type::Bool {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "while condition must be bool; explicit compare is required for quad"
+                        .to_string(),
+                });
+            }
+            let mut body_env = env.clone();
+            body_env.push_scope();
+            for stmt in body {
+                check_stmt(
+                    *stmt,
+                    arena,
+                    &mut body_env,
+                    ret_ty.clone(),
+                    table,
+                    record_table,
+                    adt_table,
+                    loop_stack,
+                    impl_list,
+                )?;
+            }
+            body_env.pop_scope();
+            Ok(())
+        }
         Stmt::ForEach {
             name,
             iterable,
@@ -3146,6 +3183,36 @@ mod tests {
 
         let err = typecheck_source(src).expect_err("guard return payload must typecheck");
         assert!(err.message.contains("return type mismatch"));
+    }
+
+    #[test]
+    fn while_statement_with_bool_condition_typechecks() {
+        let src = r#"
+            fn main() {
+                let mut i: i32 = 0;
+                while i < 3 {
+                    i = i + 1;
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("while statement with bool condition should typecheck");
+    }
+
+    #[test]
+    fn while_statement_with_non_bool_condition_rejects() {
+        let src = r#"
+            fn main() {
+                while 1 {
+                    return;
+                }
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("non-bool while condition must reject");
+        assert!(err.message.contains("while condition must be bool"));
     }
 
     #[test]
@@ -7136,6 +7203,11 @@ fn check_loop_expr_stmt(
         Stmt::ForRange { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow for-range".to_string(),
+        }),
+        Stmt::While { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow while statement"
+                .to_string(),
         }),
         Stmt::ForEach { .. } => Err(FrontendError {
             pos: 0,

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -451,6 +451,10 @@ pub enum Stmt {
         range: ExprId,
         body: Vec<StmtId>,
     },
+    While {
+        condition: ExprId,
+        body: Vec<StmtId>,
+    },
     Guard {
         condition: ExprId,
         else_return: Option<ExprId>,
@@ -869,6 +873,7 @@ pub enum TokenKind {
     KwGuard,
     KwIf,
     KwElse,
+    KwWhile,
     KwLoop,
     KwBreak,
     KwWhere,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3885,6 +3885,75 @@ fn lower_for_range_stmt(
     )
 }
 
+fn lower_while_stmt(
+    condition: ExprId,
+    body: &[StmtId],
+    arena: &AstArena,
+    ctx: &mut LoweringCtx,
+    env: &mut ScopeEnv,
+    ret_ty: Type,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    append_record_update_write_events_from_expr(condition, arena, &mut ctx.ownership_events);
+    let id = ctx.next_if_id();
+    let test_label = format!("while_{}_test", id);
+    let body_label = format!("while_{}_body", id);
+    let end_label = format!("while_{}_end", id);
+
+    ctx.instrs.push(IrInstr::Label {
+        name: test_label.clone(),
+    });
+    let (cond_reg, cond_ty) = lower_expr(
+        condition,
+        arena,
+        &mut ctx.next_reg,
+        &mut ctx.instrs,
+        env,
+        &mut ctx.loop_stack,
+        fn_table,
+        record_table,
+        adt_table,
+        ret_ty.clone(),
+        &mut ctx.closure_state,
+    )?;
+    if cond_ty != Type::Bool {
+        return Err(FrontendError {
+            pos: 0,
+            message: "while condition must be bool".to_string(),
+        });
+    }
+
+    ctx.instrs.push(IrInstr::JmpIf {
+        cond: cond_reg,
+        label: body_label.clone(),
+    });
+    ctx.instrs.push(IrInstr::Jmp {
+        label: end_label.clone(),
+    });
+
+    ctx.instrs.push(IrInstr::Label { name: body_label });
+    let mut body_env = env.clone();
+    body_env.push_scope();
+    for stmt in body {
+        lower_stmt(
+            *stmt,
+            arena,
+            ctx,
+            &mut body_env,
+            ret_ty.clone(),
+            fn_table,
+            record_table,
+            adt_table,
+        )?;
+    }
+    body_env.pop_scope();
+    ctx.instrs.push(IrInstr::Jmp { label: test_label });
+    ctx.instrs.push(IrInstr::Label { name: end_label });
+    Ok(())
+}
+
 fn lower_for_each_stmt(
     name: SymbolId,
     iterable: ExprId,
@@ -4648,6 +4717,17 @@ fn lower_stmt(
         Stmt::ForRange { name, range, body } => lower_for_range_stmt(
             *name,
             *range,
+            body,
+            arena,
+            ctx,
+            env,
+            ret_ty,
+            fn_table,
+            record_table,
+            adt_table,
+        ),
+        Stmt::While { condition, body } => lower_while_stmt(
+            *condition,
             body,
             arena,
             ctx,
@@ -6387,6 +6467,11 @@ fn lower_loop_expr_stmt(
         Stmt::ForRange { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow for-range".to_string(),
+        }),
+        Stmt::While { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow while statement"
+                .to_string(),
         }),
         Stmt::ForEach { .. } => Err(FrontendError {
             pos: 0,
@@ -9507,6 +9592,34 @@ mod opt_tests {
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,
             IrInstr::LoadVar { name, .. } if name.starts_with("__loop_expr_")
+        )));
+    }
+
+    #[test]
+    fn lower_while_statement_to_test_body_and_end_labels() {
+        let src = r#"
+            fn main() {
+                let mut i: i32 = 0;
+                while i < 3 {
+                    i = i + 1;
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("while statement should lower");
+        let main = &ir[0];
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("while_") && name.ends_with("_test")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("while_") && name.ends_with("_body")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("while_") && name.ends_with("_end")
         )));
     }
 

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -686,6 +686,12 @@ fn collect_local_calls_from_stmt(
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }
         }
+        Stmt::While { condition, body } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
         Stmt::Guard {
             condition,
             else_return,

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -183,6 +183,9 @@ Current message families include:
   source/schema declarations
 - generated wire-contract build failure while canonicalizing tagged-union
   payload or patch-field types into artifact-surface type text
+- non-`bool` `while` condition
+- `break expr;` outside `loop` expression bodies, including inside `while`
+  statements
 - recursive record field graph
 - record type declared but not yet available in executable parameter/return annotation positions
 - duplicate field in record literal

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -526,6 +526,21 @@ Current v0 limit:
   `return`
 - `continue`, statement-loop, and richer control interaction are deferred
 
+## While Statement
+
+Current `while` statement semantics:
+
+- `while condition { ... }` is admitted as a statement form
+- the condition must typecheck as `bool`
+- lowering reuses the existing label/jump path; no new runtime carrier is
+  introduced for this slice
+
+Current v0 limit:
+
+- `while` is statement-only and does not produce a value
+- `continue`, bare `break;`, labeled loops, and statement `loop` remain
+  deferred
+
 ## Tuple Destructuring Bind
 
 Current tuple-destructuring semantics:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -581,6 +581,9 @@ Current honest limit:
   destructuring is not yet part of the stable `where` contract
 - `loop` is currently expression-only; statement-loop, `continue`, and bare
   `break;` are not yet part of the stable contract
+- `while condition { ... }` is admitted only as a statement form; value
+  `while`, labeled loops, and `continue` are not yet part of the stable
+  contract
 
 Current default-parameter rules:
 

--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -14,6 +14,7 @@ Current landed positive baseline includes:
 - same-family plain `i32` relational operators
 - same-family plain `i32` unary `-` and binary `+`, `-`, `*`
 - `let mut`, plain reassignment, and compound assignment over mutable locals
+- `while condition { ... }` statement loops with `bool` conditions
 - ordered `Sequence(T)` indexing and iteration
 - first-class closure capture
 

--- a/tests/fixtures/snake_benchmark/positive_while_loop.sm
+++ b/tests/fixtures/snake_benchmark/positive_while_loop.sm
@@ -1,0 +1,8 @@
+fn main() {
+    let mut i: i32 = 0;
+    while i < 3 {
+        i = i + 1;
+    }
+    assert(i == 3);
+    return;
+}

--- a/tests/snake_benchmark_gap_matrix.rs
+++ b/tests/snake_benchmark_gap_matrix.rs
@@ -69,6 +69,7 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
         "tests/fixtures/snake_benchmark/negative_i32_arithmetic.sm",
         "tests/fixtures/snake_benchmark/positive_let_mut.sm",
         "tests/fixtures/snake_benchmark/positive_reassignment.sm",
+        "tests/fixtures/snake_benchmark/positive_while_loop.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_indexing.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_iteration.sm",
         "tests/fixtures/snake_benchmark/positive_closure_capture.sm",
@@ -80,11 +81,6 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
 #[test]
 fn snake_benchmark_negative_gap_suite_reports_current_blockers() {
     let cases = [
-        (
-            "tests/fixtures/snake_benchmark/negative_while_loop.sm",
-            "E0000",
-            "while true",
-        ),
         (
             "tests/fixtures/snake_benchmark/negative_loop_break.sm",
             "E0000",

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -620,6 +620,12 @@ fn collect_local_calls_from_stmt(
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }
         }
+        Stmt::While { condition, body } => {
+            collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
         Stmt::Guard { condition, else_return } => {
             collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
             if let Some(expr) = else_return {


### PR DESCRIPTION
## Summary
- admit narrow \while condition { ... }\ statement loops with bool-only conditions
- lower while statements through the existing label/jump path without widening loop-expression semantics
- update benchmark gap coverage, executable bundling traversals, and spec docs for the admitted while slice

## Testing
- cargo test -q -p sm-front
- cargo test -q -p sm-ir
- cargo test -q --test snake_benchmark_gap_matrix
- cargo test -q --test public_api_contracts
- cargo test -q
- git diff --check