### PR TITLE
frontend/control: admit statement loop and control exits

### DIFF
--- a/crates/sm-front/src/lexer.rs
+++ b/crates/sm-front/src/lexer.rs
@@ -329,6 +329,7 @@ fn tokenize_line(
                     "while" => TokenKind::KwWhile,
                     "loop" => TokenKind::KwLoop,
                     "break" => TokenKind::KwBreak,
+                    "continue" => TokenKind::KwContinue,
                     "where" => TokenKind::KwWhere,
                     "with" => TokenKind::KwWith,
                     "return" => TokenKind::KwReturn,

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -903,6 +903,10 @@ impl<'a> Parser<'a> {
             let body = self.parse_block()?;
             return Ok(self.arena.alloc_stmt(Stmt::While { condition, body }));
         }
+        if self.eat(TokenKind::KwLoop) {
+            let body = self.parse_block()?;
+            return Ok(self.arena.alloc_stmt(Stmt::Loop { body }));
+        }
         if self.eat(TokenKind::KwGuard) {
             let condition = self.parse_expr()?;
             if !self.eat(TokenKind::KwElse) {
@@ -961,14 +965,16 @@ impl<'a> Parser<'a> {
         }
         if self.eat(TokenKind::KwBreak) {
             if self.check(TokenKind::Semi) {
-                return Err(FrontendError {
-                    pos: self.pos(),
-                    message: "loop expression v0 currently requires break value".to_string(),
-                });
+                self.expect(TokenKind::Semi, "expected ';'")?;
+                return Ok(self.arena.alloc_stmt(Stmt::Break(None)));
             }
             let expr = self.parse_expr()?;
             self.expect(TokenKind::Semi, "expected ';'")?;
-            return Ok(self.arena.alloc_stmt(Stmt::Break(expr)));
+            return Ok(self.arena.alloc_stmt(Stmt::Break(Some(expr))));
+        }
+        if self.eat(TokenKind::KwContinue) {
+            self.expect(TokenKind::Semi, "expected ';'")?;
+            return Ok(self.arena.alloc_stmt(Stmt::Continue));
         }
         let expr = self.parse_expr()?;
         self.expect(TokenKind::Semi, "expected ';'")?;
@@ -5922,13 +5928,35 @@ fn main() {
             panic!("expected loop expression");
         };
         assert_eq!(loop_expr.body.len(), 1);
-        let Stmt::Break(expr_id) = program.arena.stmt(loop_expr.body[0]) else {
+        let Stmt::Break(Some(expr_id)) = program.arena.stmt(loop_expr.body[0]) else {
             panic!("expected break statement");
         };
         assert!(matches!(
             program.arena.expr(*expr_id),
             Expr::NumericLiteral(NumericLiteral::F64(_))
         ));
+    }
+
+    #[test]
+    fn rustlike_parser_accepts_statement_loop_with_continue_and_bare_break() {
+        let src = r#"
+fn main() {
+    loop {
+        continue;
+        break;
+    }
+}
+"#;
+
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("statement loop should parse");
+        let func = &program.functions[0];
+        let Stmt::Loop { body } = program.arena.stmt(func.body[0]) else {
+            panic!("expected statement loop");
+        };
+        assert_eq!(body.len(), 2);
+        assert!(matches!(program.arena.stmt(body[0]), Stmt::Continue));
+        assert!(matches!(program.arena.stmt(body[1]), Stmt::Break(None)));
     }
 
     #[test]
@@ -5982,19 +6010,23 @@ fn main() {
     }
 
     #[test]
-    fn rustlike_parser_rejects_break_without_value() {
+    fn rustlike_parser_accepts_bare_break_in_statement_loop_only() {
         let src = r#"
 fn main() {
-    let total: f64 = loop {
+    loop {
         break;
-    };
+    }
     return;
 }
 "#;
 
-        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
-            .expect_err("break without value must reject");
-        assert!(err.message.contains("requires break value"));
+        let program = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect("bare break in statement loop should parse");
+        let func = &program.functions[0];
+        let Stmt::Loop { body } = program.arena.stmt(func.body[0]) else {
+            panic!("expected statement loop");
+        };
+        assert!(matches!(program.arena.stmt(body[0]), Stmt::Break(None)));
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -648,7 +648,14 @@ fn ensure_invariant_result_usage(func: &Function, arena: &AstArena) -> Result<()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+enum LoopTypeFrameKind {
+    Expression,
+    Control,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct LoopTypeFrame {
+    kind: LoopTypeFrameKind,
     break_ty: Option<Type>,
 }
 
@@ -1309,6 +1316,10 @@ fn check_stmt(
             }
             let mut body_env = env.clone();
             body_env.push_scope();
+            loop_stack.push(LoopTypeFrame {
+                kind: LoopTypeFrameKind::Control,
+                break_ty: None,
+            });
             for stmt in body {
                 check_stmt(
                     *stmt,
@@ -1322,6 +1333,31 @@ fn check_stmt(
                     impl_list,
                 )?;
             }
+            let _ = loop_stack.pop().expect("control loop frame must exist");
+            body_env.pop_scope();
+            Ok(())
+        }
+        Stmt::Loop { body } => {
+            let mut body_env = env.clone();
+            body_env.push_scope();
+            loop_stack.push(LoopTypeFrame {
+                kind: LoopTypeFrameKind::Control,
+                break_ty: None,
+            });
+            for stmt in body {
+                check_stmt(
+                    *stmt,
+                    arena,
+                    &mut body_env,
+                    ret_ty.clone(),
+                    table,
+                    record_table,
+                    adt_table,
+                    loop_stack,
+                    impl_list,
+                )?;
+            }
+            let _ = loop_stack.pop().expect("control loop frame must exist");
             body_env.pop_scope();
             Ok(())
         }
@@ -1435,7 +1471,22 @@ fn check_stmt(
                 ),
             })
         }
-        Stmt::Break(value) => {
+        Stmt::Break(None) => {
+            let frame = loop_stack.last().ok_or(FrontendError {
+                pos: 0,
+                message: "bare break is allowed only inside while or statement loop"
+                    .to_string(),
+            })?;
+            if !matches!(frame.kind, LoopTypeFrameKind::Control) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "bare break is allowed only inside while or statement loop"
+                        .to_string(),
+                });
+            }
+            Ok(())
+        }
+        Stmt::Break(Some(value)) => {
             let break_ty = infer_expr_type(
                 *value,
                 arena,
@@ -1445,12 +1496,19 @@ fn check_stmt(
                 adt_table,
                 ret_ty,
                 loop_stack,
-            impl_list,
+                impl_list,
             )?;
             let frame = loop_stack.last_mut().ok_or(FrontendError {
                 pos: 0,
                 message: "break with value is allowed only inside loop expression".to_string(),
             })?;
+            if !matches!(frame.kind, LoopTypeFrameKind::Expression) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "break with value is allowed only inside loop expression"
+                        .to_string(),
+                });
+            }
             if let Some(expected) = &frame.break_ty {
                 if *expected != break_ty {
                     return Err(FrontendError {
@@ -1463,6 +1521,20 @@ fn check_stmt(
                 }
             } else {
                 frame.break_ty = Some(break_ty);
+            }
+            Ok(())
+        }
+        Stmt::Continue => {
+            let frame = loop_stack.last().ok_or(FrontendError {
+                pos: 0,
+                message: "continue is allowed only inside while or statement loop".to_string(),
+            })?;
+            if !matches!(frame.kind, LoopTypeFrameKind::Control) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "continue is allowed only inside while or statement loop"
+                        .to_string(),
+                });
             }
             Ok(())
         }
@@ -3216,6 +3288,49 @@ mod tests {
     }
 
     #[test]
+    fn statement_loop_with_continue_and_bare_break_typechecks() {
+        let src = r#"
+            fn main() {
+                let mut i: i32 = 0;
+                loop {
+                    i = i + 1;
+                    if i < 3 {
+                        continue;
+                    }
+                    break;
+                }
+                return;
+            }
+        "#;
+
+        typecheck_source(src).expect("statement loop control exits should typecheck");
+    }
+
+    #[test]
+    fn bare_break_outside_loop_rejects() {
+        let src = r#"
+            fn main() {
+                break;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("bare break outside loop must reject");
+        assert!(err.message.contains("bare break is allowed only inside while or statement loop"));
+    }
+
+    #[test]
+    fn continue_outside_loop_rejects() {
+        let src = r#"
+            fn main() {
+                continue;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("continue outside loop must reject");
+        assert!(err.message.contains("continue is allowed only inside while or statement loop"));
+    }
+
+    #[test]
     fn expression_bodied_function_reuses_return_typing() {
         let src = r#"
             fn id(x: f64) -> f64 = x;
@@ -4454,6 +4569,23 @@ mod tests {
         assert!(err
             .message
             .contains("break with value is allowed only inside loop expression"));
+    }
+
+    #[test]
+    fn loop_expression_rejects_continue_in_body() {
+        let src = r#"
+            fn main() {
+                let value: f64 = loop {
+                    continue;
+                };
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src).expect_err("continue in loop expression body must reject");
+        assert!(err
+            .message
+            .contains("loop expression body currently does not allow guard clause or return"));
     }
 
     #[test]
@@ -7162,7 +7294,10 @@ fn infer_loop_expr_type(
 ) -> Result<Type, FrontendError> {
     let mut body_env = env.clone();
     body_env.push_scope();
-    loop_stack.push(LoopTypeFrame { break_ty: None });
+    loop_stack.push(LoopTypeFrame {
+        kind: LoopTypeFrameKind::Expression,
+        break_ty: None,
+    });
     for stmt in &loop_expr.body {
         check_loop_expr_stmt(
             *stmt,
@@ -7209,12 +7344,17 @@ fn check_loop_expr_stmt(
             message: "loop expression body currently does not allow while statement"
                 .to_string(),
         }),
+        Stmt::Loop { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow statement loop"
+                .to_string(),
+        }),
         Stmt::ForEach { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow iterable for-each"
                 .to_string(),
         }),
-        Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
+        Stmt::Guard { .. } | Stmt::Return(..) | Stmt::Continue => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow guard clause or return"
                 .to_string(),

--- a/crates/sm-front/src/types.rs
+++ b/crates/sm-front/src/types.rs
@@ -455,6 +455,9 @@ pub enum Stmt {
         condition: ExprId,
         body: Vec<StmtId>,
     },
+    Loop {
+        body: Vec<StmtId>,
+    },
     Guard {
         condition: ExprId,
         else_return: Option<ExprId>,
@@ -469,7 +472,8 @@ pub enum Stmt {
         arms: Vec<MatchArm>,
         default: Vec<StmtId>,
     },
-    Break(ExprId),
+    Break(Option<ExprId>),
+    Continue,
     Return(Option<ExprId>),
     Expr(ExprId),
 }
@@ -876,6 +880,7 @@ pub enum TokenKind {
     KwWhile,
     KwLoop,
     KwBreak,
+    KwContinue,
     KwWhere,
     KwWith,
     KwReturn,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3902,6 +3902,15 @@ fn lower_while_stmt(
     let body_label = format!("while_{}_body", id);
     let end_label = format!("while_{}_end", id);
 
+    ctx.loop_stack.push(LoopLoweringFrame {
+        kind: LoopLoweringFrameKind::Control,
+        end_label: end_label.clone(),
+        continue_label: test_label.clone(),
+        result_name: String::new(),
+        result_ty: None,
+        expected_ty: None,
+    });
+
     ctx.instrs.push(IrInstr::Label {
         name: test_label.clone(),
     });
@@ -3949,7 +3958,53 @@ fn lower_while_stmt(
         )?;
     }
     body_env.pop_scope();
+    let _ = ctx.loop_stack.pop().expect("control loop frame must exist");
     ctx.instrs.push(IrInstr::Jmp { label: test_label });
+    ctx.instrs.push(IrInstr::Label { name: end_label });
+    Ok(())
+}
+
+fn lower_statement_loop(
+    body: &[StmtId],
+    arena: &AstArena,
+    ctx: &mut LoweringCtx,
+    env: &mut ScopeEnv,
+    ret_ty: Type,
+    fn_table: &FnTable,
+    record_table: &RecordTable,
+    adt_table: &AdtTable,
+) -> Result<(), FrontendError> {
+    let id = ctx.next_if_id();
+    let start_label = format!("loop_stmt_{}_start", id);
+    let end_label = format!("loop_stmt_{}_end", id);
+    ctx.loop_stack.push(LoopLoweringFrame {
+        kind: LoopLoweringFrameKind::Control,
+        end_label: end_label.clone(),
+        continue_label: start_label.clone(),
+        result_name: String::new(),
+        result_ty: None,
+        expected_ty: None,
+    });
+    ctx.instrs.push(IrInstr::Label {
+        name: start_label.clone(),
+    });
+    let mut body_env = env.clone();
+    body_env.push_scope();
+    for stmt in body {
+        lower_stmt(
+            *stmt,
+            arena,
+            ctx,
+            &mut body_env,
+            ret_ty.clone(),
+            fn_table,
+            record_table,
+            adt_table,
+        )?;
+    }
+    body_env.pop_scope();
+    let _ = ctx.loop_stack.pop().expect("control loop frame must exist");
+    ctx.instrs.push(IrInstr::Jmp { label: start_label });
     ctx.instrs.push(IrInstr::Label { name: end_label });
     Ok(())
 }
@@ -4737,6 +4792,16 @@ fn lower_stmt(
             record_table,
             adt_table,
         ),
+        Stmt::Loop { body } => lower_statement_loop(
+            body,
+            arena,
+            ctx,
+            env,
+            ret_ty,
+            fn_table,
+            record_table,
+            adt_table,
+        ),
         Stmt::ForEach {
             name,
             iterable,
@@ -4755,12 +4820,37 @@ fn lower_stmt(
             record_table,
             adt_table,
         ),
-        Stmt::Break(value) => {
+        Stmt::Break(None) => {
+            let frame = ctx.loop_stack.last().ok_or(FrontendError {
+                pos: 0,
+                message: "bare break is allowed only inside while or statement loop"
+                    .to_string(),
+            })?;
+            if !matches!(frame.kind, LoopLoweringFrameKind::Control) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "bare break is allowed only inside while or statement loop"
+                        .to_string(),
+                });
+            }
+            ctx.instrs.push(IrInstr::Jmp {
+                label: frame.end_label.clone(),
+            });
+            Ok(())
+        }
+        Stmt::Break(Some(value)) => {
             let (expected_break, end_label, result_name, prior_result_ty) = {
                 let frame = ctx.loop_stack.last().ok_or(FrontendError {
                     pos: 0,
                     message: "break with value is allowed only inside loop expression".to_string(),
                 })?;
+                if !matches!(frame.kind, LoopLoweringFrameKind::Expression) {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: "break with value is allowed only inside loop expression"
+                            .to_string(),
+                    });
+                }
                 (
                     frame.result_ty.clone().or(frame.expected_ty.clone()),
                     frame.end_label.clone(),
@@ -4805,6 +4895,23 @@ fn lower_stmt(
                 src: reg,
             });
             ctx.instrs.push(IrInstr::Jmp { label: end_label });
+            Ok(())
+        }
+        Stmt::Continue => {
+            let frame = ctx.loop_stack.last().ok_or(FrontendError {
+                pos: 0,
+                message: "continue is allowed only inside while or statement loop".to_string(),
+            })?;
+            if !matches!(frame.kind, LoopLoweringFrameKind::Control) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "continue is allowed only inside while or statement loop"
+                        .to_string(),
+                });
+            }
+            ctx.instrs.push(IrInstr::Jmp {
+                label: frame.continue_label.clone(),
+            });
             Ok(())
         }
         Stmt::Guard {
@@ -6391,7 +6498,9 @@ fn lower_loop_expr(
     let result_name = format!("__loop_expr_{}_result", id);
 
     loop_stack.push(LoopLoweringFrame {
+        kind: LoopLoweringFrameKind::Expression,
         end_label: end_label.clone(),
+        continue_label: start_label.clone(),
         result_name: result_name.clone(),
         result_ty: None,
         expected_ty: expected.clone(),
@@ -6473,12 +6582,17 @@ fn lower_loop_expr_stmt(
             message: "loop expression body currently does not allow while statement"
                 .to_string(),
         }),
+        Stmt::Loop { .. } => Err(FrontendError {
+            pos: 0,
+            message: "loop expression body currently does not allow statement loop"
+                .to_string(),
+        }),
         Stmt::ForEach { .. } => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow iterable for-each"
                 .to_string(),
         }),
-        Stmt::Guard { .. } | Stmt::Return(..) => Err(FrontendError {
+        Stmt::Guard { .. } | Stmt::Return(..) | Stmt::Continue => Err(FrontendError {
             pos: 0,
             message: "loop expression body currently does not allow guard clause or return"
                 .to_string(),
@@ -7441,10 +7555,18 @@ struct LoweringCtx {
 
 #[derive(Debug, Clone)]
 struct LoopLoweringFrame {
+    kind: LoopLoweringFrameKind,
     end_label: String,
+    continue_label: String,
     result_name: String,
     result_ty: Option<Type>,
     expected_ty: Option<Type>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopLoweringFrameKind {
+    Expression,
+    Control,
 }
 
 impl LoweringCtx {
@@ -9620,6 +9742,34 @@ mod opt_tests {
         assert!(main.instrs.iter().any(|instr| matches!(
             instr,
             IrInstr::Label { name } if name.starts_with("while_") && name.ends_with("_end")
+        )));
+    }
+
+    #[test]
+    fn lower_statement_loop_with_continue_and_bare_break() {
+        let src = r#"
+            fn main() {
+                let mut i: i32 = 0;
+                loop {
+                    i = i + 1;
+                    if i < 3 {
+                        continue;
+                    }
+                    break;
+                }
+                return;
+            }
+        "#;
+
+        let ir = compile_program_to_ir(src).expect("statement loop should lower");
+        let main = &ir[0];
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("loop_stmt_") && name.ends_with("_start")
+        )));
+        assert!(main.instrs.iter().any(|instr| matches!(
+            instr,
+            IrInstr::Label { name } if name.starts_with("loop_stmt_") && name.ends_with("_end")
         )));
     }
 

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -656,10 +656,11 @@ fn collect_local_calls_from_stmt(
         | Stmt::Let { value, .. }
         | Stmt::Discard { value, .. }
         | Stmt::Assign { value, .. }
-        | Stmt::AssignTuple { value, .. }
-        | Stmt::Break(value) => {
+        | Stmt::AssignTuple { value, .. } => {
             collect_local_calls_from_expr(arena, *value, functions_by_name, out)
         }
+        Stmt::Break(Some(value)) => collect_local_calls_from_expr(arena, *value, functions_by_name, out),
+        Stmt::Break(None) | Stmt::Continue => {}
         Stmt::LetTuple { value, .. } | Stmt::LetRecord { value, .. } => {
             collect_local_calls_from_expr(arena, *value, functions_by_name, out);
         }
@@ -688,6 +689,11 @@ fn collect_local_calls_from_stmt(
         }
         Stmt::While { condition, body } => {
             collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Loop { body } => {
             for stmt in body {
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }

--- a/docs/spec/diagnostics.md
+++ b/docs/spec/diagnostics.md
@@ -186,6 +186,8 @@ Current message families include:
 - non-`bool` `while` condition
 - `break expr;` outside `loop` expression bodies, including inside `while`
   statements
+- bare `break;` outside admitted `while` or statement-loop context
+- `continue;` outside admitted `while` or statement-loop context
 - recursive record field graph
 - record type declared but not yet available in executable parameter/return annotation positions
 - duplicate field in record literal

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -538,8 +538,24 @@ Current `while` statement semantics:
 Current v0 limit:
 
 - `while` is statement-only and does not produce a value
-- `continue`, bare `break;`, labeled loops, and statement `loop` remain
-  deferred
+- labeled loops remain deferred
+
+## Statement Loop And Control Exits
+
+Current statement-loop semantics:
+
+- `loop { ... }` is admitted as a statement form
+- bare `break;` exits the innermost admitted `while` or statement `loop`
+- `continue;` resumes the next iteration of the innermost admitted `while` or
+  statement `loop`
+- lowering reuses the existing label/jump path; no new runtime carrier is
+  introduced for this slice
+
+Current v0 limit:
+
+- statement `loop` does not produce a value
+- `break expr;` remains restricted to loop-expression bodies
+- labeled loops remain deferred
 
 ## Tuple Destructuring Bind
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -579,11 +579,13 @@ Current honest limit:
 - `where` is currently expression-suffix sugar only
 - `where` bindings currently use ordinary local names only; tuple/record
   destructuring is not yet part of the stable `where` contract
-- `loop` is currently expression-only; statement-loop, `continue`, and bare
-  `break;` are not yet part of the stable contract
+- `loop` is admitted both as a value-producing expression form and as a
+  statement form
+- `break expr;` is currently valid only inside loop-expression bodies
+- bare `break;` and `continue;` are currently valid only inside admitted
+  `while` and statement-loop bodies
 - `while condition { ... }` is admitted only as a statement form; value
-  `while`, labeled loops, and `continue` are not yet part of the stable
-  contract
+  `while` and labeled loops are not yet part of the stable contract
 
 Current default-parameter rules:
 

--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -15,6 +15,7 @@ Current landed positive baseline includes:
 - same-family plain `i32` unary `-` and binary `+`, `-`, `*`
 - `let mut`, plain reassignment, and compound assignment over mutable locals
 - `while condition { ... }` statement loops with `bool` conditions
+- statement `loop`, bare `break;`, and `continue;` for admitted control-flow
 - ordered `Sequence(T)` indexing and iteration
 - first-class closure capture
 

--- a/tests/fixtures/snake_benchmark/negative_continue_statement.sm
+++ b/tests/fixtures/snake_benchmark/negative_continue_statement.sm
@@ -1,5 +1,3 @@
 fn main() {
-    loop {
-        continue;
-    }
+    continue;
 }

--- a/tests/fixtures/snake_benchmark/negative_loop_break.sm
+++ b/tests/fixtures/snake_benchmark/negative_loop_break.sm
@@ -1,5 +1,3 @@
 fn main() {
-    loop {
-        break;
-    }
+    break;
 }

--- a/tests/fixtures/snake_benchmark/positive_loop_control.sm
+++ b/tests/fixtures/snake_benchmark/positive_loop_control.sm
@@ -1,0 +1,12 @@
+fn main() {
+    let mut i: i32 = 0;
+    loop {
+        i = i + 1;
+        if i < 3 {
+            continue;
+        }
+        break;
+    }
+    assert(i == 3);
+    return;
+}

--- a/tests/snake_benchmark_gap_matrix.rs
+++ b/tests/snake_benchmark_gap_matrix.rs
@@ -70,6 +70,7 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
         "tests/fixtures/snake_benchmark/positive_let_mut.sm",
         "tests/fixtures/snake_benchmark/positive_reassignment.sm",
         "tests/fixtures/snake_benchmark/positive_while_loop.sm",
+        "tests/fixtures/snake_benchmark/positive_loop_control.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_indexing.sm",
         "tests/fixtures/snake_benchmark/positive_sequence_iteration.sm",
         "tests/fixtures/snake_benchmark/positive_closure_capture.sm",
@@ -81,16 +82,6 @@ fn snake_benchmark_positive_surface_passes_end_to_end() {
 #[test]
 fn snake_benchmark_negative_gap_suite_reports_current_blockers() {
     let cases = [
-        (
-            "tests/fixtures/snake_benchmark/negative_loop_break.sm",
-            "E0000",
-            "loop expression v0 currently requires break value",
-        ),
-        (
-            "tests/fixtures/snake_benchmark/negative_continue_statement.sm",
-            "E0000",
-            "continue;",
-        ),
         (
             "tests/fixtures/snake_benchmark/negative_sequence_len.sm",
             "E0201",

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -596,8 +596,9 @@ fn collect_local_calls_from_stmt(
         | Stmt::Let { value, .. }
         | Stmt::Discard { value, .. }
         | Stmt::Assign { value, .. }
-        | Stmt::AssignTuple { value, .. }
-        | Stmt::Break(value) => collect_local_calls_from_expr(arena, *value, functions_by_name, out),
+        | Stmt::AssignTuple { value, .. } => collect_local_calls_from_expr(arena, *value, functions_by_name, out),
+        Stmt::Break(Some(value)) => collect_local_calls_from_expr(arena, *value, functions_by_name, out),
+        Stmt::Break(None) | Stmt::Continue => {}
         Stmt::LetTuple { value, .. } | Stmt::LetRecord { value, .. } => {
             collect_local_calls_from_expr(arena, *value, functions_by_name, out);
         }
@@ -622,6 +623,11 @@ fn collect_local_calls_from_stmt(
         }
         Stmt::While { condition, body } => {
             collect_local_calls_from_expr(arena, *condition, functions_by_name, out);
+            for stmt in body {
+                collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
+            }
+        }
+        Stmt::Loop { body } => {
             for stmt in body {
                 collect_local_calls_from_stmt(arena, *stmt, functions_by_name, out);
             }


### PR DESCRIPTION
## Summary
- admit narrow statement \loop { ... }\, bare \reak;\, and \continue;\ without widening value-carrying loop semantics
- extend typecheck/lowering loop-context handling so admitted \while\ and statement loops support control exits deterministically
- sync benchmark fixtures, executable-bundle traversals, and spec docs for the landed control slice

## Testing
- cargo test -q -p sm-front
- cargo test -q -p sm-ir
- cargo test -q --test snake_benchmark_gap_matrix
- cargo test -q --test public_api_contracts
- cargo test -q
- git diff --check