### PR TITLE
docs(tail/T4): allow(dead_code) audit — 0 suppressions masking production code

### DIFF
--- a/docs/roadmap/tail_t4_dead_code_audit.md
+++ b/docs/roadmap/tail_t4_dead_code_audit.md
@@ -1,0 +1,72 @@
+# M-Tail T4 — `allow(dead_code)` Audit
+
+Status: closed  
+Date: 2026-05-02
+
+## Scope
+
+Audit all `#[allow(dead_code)]` attributes across `crates/**/*.rs` and classify
+each as:
+
+- **legitimate** — correctly suppressing a warning on code that is genuinely
+  used but triggers a false positive (e.g. test-only types, re-export facades)
+- **masking unused production code** — suppressing a real warning on dead
+  production code that should be removed
+
+## Result
+
+| Category | Count |
+|----------|-------|
+| Total `#[allow(dead_code)]` attributes | 3 |
+| Legitimate suppressions | **3** |
+| Masking unused production code | **0** |
+
+## Per-Occurrence Analysis
+
+### `crates/sm-ir/src/lib.rs:20`
+
+```rust
+#[cfg(feature = "std")]
+#[allow(dead_code)]
+mod local_format;
+```
+
+**Classification: legitimate.**
+
+`local_format` is a private implementation module. All of its items are
+re-exported through the adjacent `pub mod semcode_format { pub use
+crate::local_format::... }`. The compiler warns because `local_format` itself
+is private and its individual items appear "unused" from the module perspective.
+The suppression is correct; removing it would produce spurious warnings without
+removing any code.
+
+### `crates/semantic-core-exec/src/lib.rs:1582` and `1589`
+
+```rust
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[allow(dead_code)]
+pub(crate) struct CoreProgramBuilder { ... }
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[allow(dead_code)]
+impl CoreProgramBuilder { ... }
+```
+
+**Classification: legitimate.**
+
+`CoreProgramBuilder` is a test-support builder. Its methods are called
+exclusively from `#[test]` functions (L2097, L2107, L2126, L2144, L2165,
+L2194, L2227, L2247, L2261, L2286, L2328, L2383). The compiler warns because
+`pub(crate)` items with no non-test callers appear dead. The suppression is
+correct; the type is genuinely used in tests and removing the attribute would
+produce spurious warnings.
+
+## Conclusion
+
+No `#[allow(dead_code)]` attribute is masking genuinely unused production code.
+All three suppressions are correct false-positive silencers on:
+
+- a private module backing a public re-export facade (`local_format`)
+- a test-only builder type used exclusively in `#[test]` functions (`CoreProgramBuilder`)
+
+T4 is closed. No further action required.


### PR DESCRIPTION
## Summary

Closes M-Tail T4: `#[allow(dead_code)]` surface audit.

Audited all **3** `#[allow(dead_code)]` attributes across `crates/**/*.rs`.

**Result: 0 suppressions masking unused production code.**

All 3 are legitimate false-positive silencers:

| Location | Reason |
|---|---|
| `sm-ir/src/lib.rs:20` | `local_format` — private module backing `pub mod semcode_format` re-export |
| `semantic-core-exec/src/lib.rs:1582+1589` | `CoreProgramBuilder` — test-only builder used exclusively in `#[test]` functions |

## Files Changed

- `docs/roadmap/tail_t4_dead_code_audit.md` — new audit record

## Test plan

- [x] Docs-only — `cargo check --workspace` unaffected
- [x] `git diff --check` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)