### PR TITLE
docs(app): sync sequence helper ledger after PR-C1/C2 landing

### DIFF
--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -75,7 +75,6 @@ Current `main` still fails this benchmark family at the following points:
 - plain reassignment
 - statement `while`
 - statement `loop` with bare `break;` and `continue`
-- `Sequence(T)` utility layer: `len(sequence) -> i32`, `is_empty(sequence) -> bool`, `contains(sequence, value) -> bool`, `push(sequence, value) -> Sequence(T)`, `prepend(sequence, value) -> Sequence(T)`, and `pop(sequence) -> Sequence(T)`
 - a first-wave map/dictionary family for Q-tables and visit counts
 - a deterministic seeded pseudo-random source
 - text concatenation / minimal formatting for traces
@@ -207,7 +206,7 @@ Current `main` still fails this benchmark family at the following points:
   Goal:
   - close the imperative-core wave as one explicit contract
   Scope:
-  - docs/spec/tests freeze only
+  - docs/spec/tests sync only
   Depends on:
   - `PR-B1`
   - `PR-B2`

--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -60,6 +60,11 @@ Current `main` already admits these benchmark-relevant surfaces:
 - `text` literals, `text` type positions, and same-family text equality
 - `Sequence(T)` declared types, literals, indexing, equality, and `for value in sequence`
 - `len(sequence) -> i32` (landed PR #387)
+- `is_empty(sequence) -> bool` (landed PR #395)
+- `contains(sequence, value) -> bool` (landed PR #396)
+- `push(sequence, value) -> Sequence(T)` (landed PR #397)
+- `prepend(sequence, value) -> Sequence(T)` (landed PR #397)
+- `pop(sequence) -> Sequence(T)` (landed PR #398)
 - first-class closures with immutable capture
 - the separate desktop UI boundary as a landed post-stable track
 
@@ -70,7 +75,7 @@ Current `main` still fails this benchmark family at the following points:
 - plain reassignment
 - statement `while`
 - statement `loop` with bare `break;` and `continue`
-- `Sequence(T)` utility layer: `is_empty`, `push`, `pop`, and `contains` (partial — `len` landed)
+- `Sequence(T)` utility layer: `len(sequence) -> i32`, `is_empty(sequence) -> bool`, `contains(sequence, value) -> bool`, `push(sequence, value) -> Sequence(T)`, `prepend(sequence, value) -> Sequence(T)`, and `pop(sequence) -> Sequence(T)`
 - a first-wave map/dictionary family for Q-tables and visit counts
 - a deterministic seeded pseudo-random source
 - text concatenation / minimal formatting for traces
@@ -217,10 +222,12 @@ Current `main` still fails this benchmark family at the following points:
 
 ### C — Sequence Utility Layer
 
-- `PR-C1` [partial — `len` landed, `is_empty`/`contains` remain]
+- `PR-C1` [landed]
   Title: `stdlib/sequence: admit len/is_empty/contains`
-  Landed: `len(sequence) -> i32` (PR #387, 2026-05-02)
-  Remaining: `is_empty(sequence) -> bool`, `contains(sequence, value) -> bool`
+  Landed:
+  - `len(sequence) -> i32` (PR #387, 2026-05-02)
+  - `is_empty(sequence) -> bool` (PR #395, 2026-05-02)
+  - `contains(sequence, value) -> bool` (PR #396, 2026-05-02)
   Goal:
   - provide the minimum observation helpers needed for snake state logic
   Scope:
@@ -233,8 +240,16 @@ Current `main` still fails this benchmark family at the following points:
   - targeted sequence-helper tests green
   - CI green
 
-- `PR-C2` [required]
+- `PR-C2` [landed]
   Title: `stdlib/sequence: admit push/pop/prepend baseline`
+  Landed:
+  - `push(sequence, value) -> Sequence(T)` (PR #397, 2026-05-02)
+  - `prepend(sequence, value) -> Sequence(T)` (PR #397, 2026-05-02)
+  - `pop(sequence) -> Sequence(T)` (PR #398, 2026-05-02)
+  Note:
+  - these are persistent sequence helpers; they return new `Sequence(T)`
+    values and rely on existing `let mut` + reassignment for evolving
+    application state
   Goal:
   - make evolving snake bodies and traces practical without opening a broad
     collection redesign

--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -18,7 +18,16 @@ Current landed positive baseline includes:
 - statement `loop`, bare `break;`, and `continue;` for admitted control-flow
 - ordered `Sequence(T)` indexing and iteration
 - `len(sequence) -> i32`
+- `is_empty(sequence) -> bool`
+- `contains(sequence, value) -> bool` for admitted comparable scalar element types
+- persistent `push(sequence, value) -> Sequence(T)`
+- persistent `prepend(sequence, value) -> Sequence(T)`
+- persistent `pop(sequence) -> Sequence(T)`
 - first-class closure capture
+
+The sequence update helpers are functional/persistent. They do not mutate a
+sequence in place; benchmark code should assign the returned sequence when
+evolving state.
 
 This fixture pack intentionally does not yet freeze syntax for two blocker
 families:


### PR DESCRIPTION
## Summary

- Marks PR-C1 as landed after len, is_empty, and contains.
- Marks PR-C2 as landed after persistent push, prepend, and pop.
- Updates the snake benchmark fixture README positive baseline.
- Keeps remaining benchmark blockers explicit: Map, seeded PRNG, text formatting, stdout, benchmark examples.

## Test plan

- [x] git diff --check
- [ ] CI green