### PR TITLE
docs(pcc): add Practical Core Completion v0.3

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
@@ -1,0 +1,47 @@
+# CTF-7 — Capability / Effect Denial Matrix
+
+Status: draft matrix
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file protects the boundary between deterministic VM execution and host effects.
+
+PCC is mainly a practical language-core phase. It should not silently widen host capabilities, effect behavior, or PROMETHEUS runtime access.
+
+## Matrix
+
+| Effect / boundary class | Status in PCC | Owner | Notes |
+|---|---|---|---|
+| Pure computation | allowed | sm-* | Must remain deterministic. |
+| Debug / trace output | internal only unless scoped | smc-cli / CTF | Must not become language output accidentally. |
+| `to_text` / formatting | planned | PCC-8 | Public stdlib, not debug_render. |
+| Assertion failure | planned | PCC-8 | Trap / diagnostic policy required. |
+| File IO | out-of-pcc | future capability scope | Not part of practical core. |
+| Network IO | out-of-pcc | future capability scope | Not part of practical core. |
+| Host gate read | out-of-pcc unless already stable | prom-abi / prom-cap | No widening in PCC. |
+| Host gate write | out-of-pcc unless already stable | prom-abi / prom-cap | No widening in PCC. |
+| Pulse emit | out-of-pcc unless already stable | prom-abi / prom-cap | No widening in PCC. |
+| UI event/frame effects | out-of-pcc | UI boundary track | Workbench / UI dessert track. |
+| Audit emission | internal runtime boundary | prom-audit | Not a public language output channel. |
+
+## Rules
+
+1. PCC features should default to pure deterministic execution.
+2. Any host interaction must be explicit capability work and probably out-of-PCC.
+3. Debug output must stay separate from user-facing language output.
+4. Local audit is not telemetry and not public language output.
+5. Capability denial must be deterministic and reportable.
+6. A denied effect must not partially mutate host state.
+
+## PR review checklist
+
+```text
+[ ] Does this PR introduce an effect?
+[ ] If yes, is it pure, debug-only, stdlib output, or host boundary?
+[ ] Does it require capability admission?
+[ ] Does verifier know about the capability?
+[ ] Is denial deterministic?
+[ ] Is host state unchanged on denial?
+[ ] Is this actually out-of-PCC?
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -1,0 +1,71 @@
+# CTF-3 — Determinism Matrix
+
+Status: draft matrix
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file tracks where Semantic must prove repeated behavior is stable for the same input, config, and admitted program.
+
+Determinism is not a slogan. Each PCC feature must add or reuse concrete fixtures.
+
+## Matrix
+
+| Area | Required deterministic property | Status | PCC owner |
+|---|---|---|---|
+| Lexer / parser | Same source produces same syntax result / diagnostic | audit-needed | PCC-0.5 |
+| Typecheck | Same source produces same type result / diagnostic ordering | audit-needed | PCC-0.5 |
+| Lowering | Same typed source produces same IR | audit-needed | PCC-0.5 |
+| IR passes | Same IR produces same optimized IR | audit-needed | PCC-0.5 / PCC-2+ |
+| SemCode emission | Same IR/options produce same bytes | audit-needed | PCC-0.5 |
+| Verifier | Same SemCode/config produces same accept/reject | audit-needed | CTF |
+| VM execution | Same verified program/config produces same result/trap | audit-needed | CTF |
+| Control flow | Loop execution is stable under same fuel/config | planned | PCC-1 |
+| Numeric behavior | Arithmetic result/trap is stable | planned | PCC-2 |
+| Text behavior | Text ops result/trap is stable | planned | PCC-3 |
+| Records | Field order, access, and value behavior are stable | planned | PCC-4 |
+| ADT + match | Variant order and match behavior are stable | planned | PCC-5 |
+| Option / Result | Helper and match behavior are stable | planned | PCC-6 |
+| Collections | Iteration and lookup ordering are stable | planned | PCC-7 |
+| Stdlib | Helper behavior is stable | planned | PCC-8 |
+| Project model | Module root and project check order are stable | planned | PCC-9 |
+
+## Minimum repeated-run rule
+
+For each feature phase:
+
+```text
+same input
+same config
+same environment assumptions
+  → same check result
+  → same emitted SemCode where emission is involved
+  → same verifier result
+  → same VM result/trap where execution is involved
+```
+
+## 7hell coupling
+
+Each 7hell stage should eventually emit deterministic machine-readable output.
+
+Minimum future output fields:
+
+```text
+stage
+status
+input_hash
+output_hash
+trace_hash, if applicable
+diagnostics_hash, if applicable
+```
+
+## Review checklist
+
+```text
+[ ] Does this PR add a new nondeterminism source?
+[ ] Does map/set iteration order affect output?
+[ ] Does diagnostic ordering stay stable?
+[ ] Does emitted byte order stay stable?
+[ ] Does VM result/trap stay stable under repeated run?
+[ ] Does 7hell need a deterministic fixture?
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
@@ -1,0 +1,76 @@
+# CTF-6 — Golden Trace Policy
+
+Status: draft policy
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+Golden traces are used to prove that source, lowering, SemCode, verifier, and VM behavior remain stable across changes.
+
+This file defines when a PCC feature needs new or updated golden traces.
+
+## Trace classes
+
+| Trace class | Purpose | PCC owner |
+|---|---|---|
+| Syntax trace | Parser/diagnostic stability | PCC-0.6 / PCC-1+ |
+| Type trace | Typecheck/diagnostic stability | PCC-0.6 / PCC-2+ |
+| IR trace | Lowering stability | PCC-1+ |
+| SemCode trace | Emission stability | PCC-1+ |
+| Verifier trace | Admission accept/reject stability | CTF / PCC feature phase |
+| VM trace | Runtime result/trap stability | CTF / PCC feature phase |
+| 7hell report | End-to-end qualification surface | PCC-0.6+ |
+
+## When a PR must add or update golden traces
+
+A PR must update golden traces when it changes:
+
+- accepted source syntax;
+- diagnostic behavior;
+- type inference or type compatibility;
+- lowering shape;
+- optimization output;
+- SemCode bytes;
+- verifier result;
+- VM result or trap;
+- runtime value representation;
+- capability/effect denial behavior;
+- 7hell output contract.
+
+## When a PR should not update golden traces
+
+A PR should not update golden traces when it is:
+
+- documentation-only;
+- internal refactor with byte-for-byte stable output;
+- test-only cleanup;
+- non-semantic formatting.
+
+If traces change unexpectedly, the PR must explain the reason.
+
+## Minimum trace metadata
+
+Future golden trace files should carry:
+
+```text
+source name
+feature phase
+input hash
+stage
+expected status
+expected diagnostic code, if any
+expected output hash, if any
+runtime config, if execution is involved
+```
+
+## Review checklist
+
+```text
+[ ] Did any accepted behavior change?
+[ ] Did any rejected behavior change?
+[ ] Did diagnostics change?
+[ ] Did emitted bytes change?
+[ ] Did runtime result/trap change?
+[ ] Did 7hell report shape change?
+[ ] Are trace changes intentional and explained?
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -1,0 +1,67 @@
+# Core Trust Freeze Lane
+
+Status: draft control lane
+Owner: language maturity / execution contract
+Parent plan: `docs/roadmap/language_maturity/practical_core_completion_v0_3.md`
+
+## Purpose
+
+Core Trust Freeze (CTF) is the parallel trust lane for Practical Core Completion.
+
+CTF exists because each PCC feature can change execution semantics. Runtime values, traps, verifier expectations, SymbolId assumptions, trace outputs, capability behavior, or golden traces must not drift silently while the language surface widens.
+
+CTF is not a final phase after PCC. It runs across PCC.
+
+## Files
+
+| File | Owner question |
+|---|---|
+| `runtime_value_registry.md` | Did the runtime value set change? |
+| `trap_taxonomy.md` | Did failure behavior or trap naming change? |
+| `determinism_matrix.md` | Does repeated execution remain deterministic? |
+| `symbolid_migration.md` | Did the change affect names, symbols, or hot-path lookup? |
+| `verifier_first_policy.md` | Does public execution still require admission before VM run? |
+| `golden_trace_policy.md` | Does the change require new or updated golden traces? |
+| `capability_effect_denial_matrix.md` | Did host/effect/capability behavior change? |
+
+## PR requirement
+
+Every PCC PR must include a CTF note.
+
+Use this form when execution trust files changed:
+
+```text
+CTF touched:
+  - docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
+  - docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
+Reason:
+  New RuntimeValue and trap behavior introduced by feature X.
+```
+
+Use this form when there is no trust-surface impact:
+
+```text
+CTF touched: none
+Reason: docs-only / parser-only / no runtime impact
+```
+
+## Minimum review checklist
+
+```text
+[ ] RuntimeValue set reviewed
+[ ] Trap taxonomy reviewed
+[ ] Determinism matrix reviewed
+[ ] SymbolId / string hot-path impact reviewed
+[ ] Verifier-first path preserved
+[ ] Golden trace need reviewed
+[ ] Capability/effect denial impact reviewed
+```
+
+## Freeze rule
+
+A CTF entry marked `freeze-candidate` must not change without:
+
+1. a reason;
+2. a linked PCC phase or issue;
+3. updated fixtures or tests where behavior changes;
+4. explicit release-status wording if public claims are affected.

--- a/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
@@ -1,0 +1,66 @@
+# CTF-1 — RuntimeValue Registry
+
+Status: draft registry
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file tracks the runtime value families that the verifier, VM, runtime-core, traces, and canonical examples must treat as part of the current execution surface.
+
+It is not a full VM implementation document. It is a trust registry.
+
+## Current registry shape
+
+Use the following table during PCC live audit.
+
+| Runtime value family | Status | PCC owner | Notes |
+|---|---|---|---|
+| `unit` | audit-needed | PCC-0.5 | Confirm current carrier and trace behavior. |
+| `bool` | audit-needed | PCC-0.5 | Confirm stable VM representation. |
+| `quad` | audit-needed | PCC-0.5 | Confirm `N/F/T/S` behavior and branch restrictions. |
+| `i32` | audit-needed | PCC-2 | Confirm arithmetic and trap behavior. |
+| `u32` | audit-needed | PCC-2 | Confirm arithmetic and conversion policy. |
+| `f64` | audit-needed | PCC-2 | Confirm deterministic profile and capability assumptions. |
+| `fx` | audit-needed | PCC-2 | Confirm fixed-point carrier and arithmetic scope. |
+| `text` | planned | PCC-3 | Literal / equality / concat / length only at PCC-3. |
+| `record` | planned | PCC-4 | Requires PCC-3.5 carrier note. |
+| `ADT` | planned | PCC-5 | Basic constructor + match path. |
+| `Option(T)` | planned | PCC-6 | Built on ADT / match assumptions. |
+| `Result(T,E)` | planned | PCC-6 | Built on ADT / match assumptions. |
+| `Sequence<T>` | planned | PCC-7 | Dynamic container; not record semantics. |
+| `Map<K,V>` | planned | PCC-7 | Dynamic container; key policy required. |
+| closure values | out-of-pcc unless audited | post-PCC / current-main audit | Do not widen in PCC unless explicitly pulled in. |
+| host handles | out-of-pcc | separate runtime boundary scope | Do not mix into practical core. |
+
+## Status meanings
+
+| Status | Meaning |
+|---|---|
+| `audit-needed` | Appears to exist, but PCC cannot rely on it until live audit confirms behavior. |
+| `planned` | Belongs to a PCC phase. |
+| `freeze-candidate` | Behavior is stable enough to protect from silent change. |
+| `frozen` | Public or release-facing contract. |
+| `out-of-pcc` | Not part of this plan. |
+
+## PR update rule
+
+A PR must update this registry if it:
+
+- adds a runtime value;
+- removes a runtime value;
+- changes value encoding;
+- changes equality or display behavior;
+- changes trace representation;
+- changes verifier admission assumptions;
+- changes VM trap behavior for the value.
+
+## Explicit debug boundary
+
+`debug_render` must not be registered as a language value conversion.
+
+```text
+debug_render != to_text
+debug_render is internal tooling only
+```
+
+Any public conversion belongs to PCC-8 Stdlib v0.

--- a/docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md
@@ -1,0 +1,42 @@
+# CTF-4 — SymbolId Migration Registry
+
+Status: draft registry
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file tracks whether names and symbol-like identifiers remain off the runtime hot path where compact IDs are required.
+
+PCC must not accidentally reintroduce string-based execution paths while adding practical language features.
+
+## Registry
+
+| Area | Expected form | Status | Notes |
+|---|---|---|---|
+| Source identifiers | source text / interned source symbols | audit-needed | Construction-layer concern. |
+| Type names | canonical type IDs or stable names before runtime | audit-needed | Must not leak into VM hot path accidentally. |
+| Function names in SemCode | stable table / verified references | audit-needed | Confirm current verifier/VM behavior. |
+| Runtime symbols | `SymbolId` / runtime symbol table | audit-needed | Must be deterministic. |
+| Debug names | append-only debug map | audit-needed | Debug only; not semantic lookup. |
+| Record fields | field ID or stable field descriptor | planned | PCC-4. |
+| ADT variants | variant ID or stable descriptor | planned | PCC-5. |
+| Option / Result variants | stable canonical variant IDs | planned | PCC-6. |
+| Collection keys | explicit key policy | planned | PCC-7. |
+
+## Rules
+
+1. Strings may exist for source, diagnostics, and debug rendering.
+2. Runtime dispatch must not depend on user-facing strings unless explicitly accepted and documented.
+3. Debug names are not semantic identity.
+4. Any new practical feature that introduces names must state where the canonical ID is created.
+5. If a PR introduces string lookup in VM execution, it must explain why and mark the debt.
+
+## Review checklist
+
+```text
+[ ] Does this feature introduce new named entities?
+[ ] Are those names resolved before runtime?
+[ ] Does VM execution use compact IDs or verified table indexes?
+[ ] Are debug names clearly separated from semantic identity?
+[ ] Does this require a new registry row?
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
@@ -1,0 +1,49 @@
+# CTF-2 — Trap Taxonomy
+
+Status: draft taxonomy
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file records the stable categories of execution failure that can appear after verifier admission or during VM/runtime execution.
+
+The goal is not to name every internal error. The goal is to prevent feature work from introducing untracked failure classes.
+
+## Draft taxonomy
+
+| Trap class | Status | Typical owner | Notes |
+|---|---|---|---|
+| Invalid bytecode / malformed SemCode | freeze-candidate | sm-verify | Should be rejected before VM execution. |
+| Unknown opcode | freeze-candidate | sm-verify / sm-vm | Public route should reject before dispatch. |
+| Invalid jump target | freeze-candidate | sm-verify | Must not become VM-only failure. |
+| Call target missing | freeze-candidate | sm-verify | Builtin exception policy must be explicit. |
+| Register budget exceeded | freeze-candidate | sm-verify / sm-runtime-core | Runtime quota coupling. |
+| Step fuel exceeded | freeze-candidate | sm-runtime-core / sm-vm | Deterministic bounded execution. |
+| Stack / frame budget exceeded | audit-needed | sm-runtime-core / sm-vm | Confirm current behavior. |
+| Numeric invalid operation | planned | PCC-2 | Division / overflow / unsupported numeric op policy. |
+| Text invalid operation | planned | PCC-3 | Bounds / invalid concat / invalid length policy if applicable. |
+| Record field error | planned | PCC-4 | Missing field / invalid projection policy. |
+| ADT match error | planned | PCC-5 | Non-exhaustive / invalid variant behavior. |
+| Option / Result misuse | planned | PCC-6 | Payload access and helper behavior. |
+| Collection bounds / missing key | planned | PCC-7 | Sequence index and map lookup behavior. |
+| Assertion failure | planned | PCC-8 | Stdlib assert behavior. |
+| Capability denied | audit-needed | CTF-7 | Must stay separate from raw VM failure. |
+| Host ABI denied / failed | out-of-pcc unless boundary touched | separate boundary scope | Not part of practical core unless explicitly changed. |
+
+## Rules
+
+1. Public execution should prefer verifier rejection before VM trap when the error is statically knowable.
+2. VM traps must be deterministic for the same verified program and execution config.
+3. Trap names must not be reused for semantically different failures.
+4. PCC PRs that add a new failure mode must update this file.
+5. Trap output must not depend on `debug_render` as a language feature.
+
+## Review checklist
+
+```text
+[ ] Is this error statically rejectable by verifier?
+[ ] If runtime-only, is the trap deterministic?
+[ ] Is the trap class already represented here?
+[ ] Does 7hell need a fixture for it?
+[ ] Does the golden trace policy need an update?
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
@@ -1,0 +1,61 @@
+# CTF-5 — Verifier-First Policy
+
+Status: draft policy
+Parent lane: `core_trust_freeze/index.md`
+
+## Purpose
+
+This file protects the public execution route:
+
+```text
+SemCode bytes
+  → verifier admission
+  → verified program
+  → VM execution
+```
+
+The VM must not become the first and only line of defense for public execution.
+
+## Policy
+
+1. Public `.smc` execution is verifier-first.
+2. Any direct VM helper must be internal, test-only, or explicitly documented as non-public.
+3. Statically knowable bytecode errors should be verifier rejects, not VM traps.
+4. Capability-bearing behavior must be admitted before execution.
+5. Debug rendering and disassembly may inspect data, but they must not define language semantics.
+
+## PCC review rules
+
+A PCC PR must update this file if it:
+
+- adds a SemCode section;
+- adds or changes opcodes;
+- changes verifier admission;
+- changes VM entrypoints;
+- changes capability-gated behavior;
+- adds debug or trace output that could be confused with language output.
+
+## Internal tooling boundary
+
+`debug_render` is allowed only as internal tooling.
+
+```text
+debug_render != to_text
+debug_render != public output API
+debug_render != stdlib conversion
+debug_render must not be used by canonical examples
+```
+
+`to_text` belongs to PCC-8 Stdlib v0 and must have a public type contract.
+
+## Review checklist
+
+```text
+[ ] Does the public route still require verifier admission?
+[ ] Did this PR add a VM bypass?
+[ ] If yes, is it test-only or explicitly non-public?
+[ ] Did this PR add a SemCode feature?
+[ ] Does sm-verify know about it?
+[ ] Does 7hell verify before run?
+[ ] Are debug helpers kept out of the language surface?
+```

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -1,0 +1,580 @@
+# Practical Core Completion v0.3
+
+Status: draft planning gate
+Owner: language maturity stream
+Scope: Semantic practical language core before readiness completion
+Non-goal: release claim widening
+
+## 0. Purpose
+
+Practical Core Completion (PCC) is the intermediate completion phase between the current `main` development line and any later readiness-completion / release-qualification plan.
+
+PCC exists because Semantic already has a strong staged compiler/runtime architecture, verifier-first execution, and PROMETHEUS boundary discipline, but the practical language surface still needs a controlled completion phase before the project can honestly enter final readiness.
+
+PCC v0.3 freezes the operational shape of that phase.
+
+```text
+Current Semantic
+  ↓
+PCC-0 Truth Reset
+  ↓
+Practical Core Completion phases
+  ↕
+Core Trust Freeze lane
+  ↕
+7hell progressive qualification
+  ↓
+Readiness Completion
+  ↓
+Release Qualification
+```
+
+## 1. Goal
+
+Bring Semantic to the point where small and medium programs can be written without relying on implementation accidents, bypasses, or knowledge of current frontend / VM gaps.
+
+The practical target is:
+
+```text
+Practical Semantic =
+  control flow
++ usable numbers
++ text
++ records
++ ADT + match
++ Option / Result
++ collections v0
++ minimal stdlib
++ project model v0
++ verified deterministic execution
++ canonical examples
++ 7hell qualification
+```
+
+## 2. Non-goals
+
+PCC does not include:
+
+- Workbench implementation;
+- UI application capability;
+- graphics / rendering;
+- browser or mobile targets;
+- IDE / LSP as a blocker;
+- macro system;
+- async / concurrency;
+- package registry;
+- broad generics / traits beyond readiness need;
+- LLM / TinyLM research;
+- GPU / Metal / AVX-512 backend work as required path;
+- quad hardware accelerator research;
+- PROMETHEUS runtime widening without explicit separate scope;
+- visual architecture experiments.
+
+Rule:
+
+```text
+If a task does not move PCC-0..PCC-9, CTF, or 7hell qualification,
+it does not belong to PCC.
+```
+
+## 3. Phase map
+
+```text
+PCC-0    Truth Reset
+PCC-0.5  Feature Matrix Live Audit
+PCC-0.6  7hell Skeleton Seed
+CTF-0    Core Trust Freeze directory
+
+PCC-1    Control Flow Core
+PCC-2    Numeric Core
+PCC-3    Text Core
+PCC-3.5  Data Carrier Design Note
+PCC-4    Records End-to-End
+PCC-5    ADT + Basic Match
+PCC-6    Option / Result
+PCC-7    Collections v0
+PCC-8    Stdlib v0
+PCC-9    Project Model v0
+```
+
+Parallel lanes:
+
+```text
+Core Trust Freeze lane
+7hell progressive qualification
+monthly waypoint review
+strict out-of-scope enforcement
+```
+
+## 4. PCC-0 — Truth Reset
+
+Purpose:
+
+- stop treating optimistic readiness language as current-state truth;
+- separate practical-core completion from readiness completion;
+- mark post-PCC work explicitly;
+- prevent Workbench / UI / research creep.
+
+Required outcomes:
+
+- readiness-completion plan is marked as post-PCC;
+- Wave 2 wording is aligned with practical-core completion and 7hell seed work;
+- Workbench remains in dessert track / post-PCC planning;
+- global out-of-scope block is visible;
+- PCC-0.5 and PCC-0.6 are opened before PCC-1.
+
+DoD:
+
+```text
+[ ] current-state wording no longer overclaims trusted readiness
+[ ] post-PCC readiness boundary is explicit
+[ ] Workbench / UI creep is excluded from PCC
+[ ] feature matrix audit is scheduled
+[ ] CTF directory exists
+[ ] 7hell skeleton task exists
+```
+
+## 5. PCC-0.5 — Feature Matrix Live Audit
+
+Purpose:
+
+Verify every uncertain feature status against current `main` before starting new feature work.
+
+Every status such as:
+
+```text
+confirmed / partial
+landed but needs audit
+closed but needs live check
+✅ / 🟡
+```
+
+must resolve into one of three states:
+
+| Result | Meaning |
+|---|---|
+| Confirmed Stable | Has test / golden / PR evidence and can be marked stable for PCC planning. |
+| Confirmed Partial | Exists, but the missing edge is explicit. |
+| Downgraded | Assumption did not survive live audit; feature moves to planned work. |
+
+DoD:
+
+```text
+[ ] no dual-status item remains unresolved
+[ ] each stable item has test / fixture / PR evidence
+[ ] each partial item names its missing edge
+[ ] each missing item is assigned to a PCC phase or excluded
+```
+
+## 6. PCC-0.6 — 7hell Skeleton Seed
+
+Purpose:
+
+Create `7hell` early as a diagnostic harness that grows with the language, rather than a final retrospective test.
+
+Initial command shape:
+
+```bash
+smc 7hell program.sm
+smc seven-hell program.sm
+```
+
+Initial stages:
+
+1. Syntax Hell
+2. Type Hell
+3. Lowering Hell
+4. Verifier Hell
+5. VM Hell
+6. Practical Hell
+7. User Pain / Diagnostics Hell
+
+Seed behavior:
+
+- command exists;
+- stage report exists;
+- JSON output exists;
+- shallow checks are acceptable at first;
+- each PCC phase adds its fixtures to the relevant stage.
+
+DoD:
+
+```text
+[ ] `smc 7hell` command or issue exists
+[ ] stage taxonomy is documented
+[ ] output contract is drafted
+[ ] first fixture group is attached to PCC-1
+```
+
+## 7. CTF-0 — Core Trust Freeze directory
+
+Core Trust Freeze is not a post-PCC phase. It is a parallel lane.
+
+Each language expansion can affect runtime values, traps, verifier rules, determinism, SymbolId assumptions, trace outputs, or capability denial behavior. Therefore each PCC PR must explicitly state whether it touches CTF material.
+
+Directory:
+
+```text
+docs/roadmap/language_maturity/core_trust_freeze/
+  index.md
+  runtime_value_registry.md
+  trap_taxonomy.md
+  determinism_matrix.md
+  symbolid_migration.md
+  verifier_first_policy.md
+  golden_trace_policy.md
+  capability_effect_denial_matrix.md
+```
+
+PR rule:
+
+```text
+CTF touched:
+  - runtime_value_registry.md
+  - trap_taxonomy.md
+  - determinism_matrix.md
+```
+
+or:
+
+```text
+CTF touched: none
+Reason: docs-only / parser-only / no runtime impact
+```
+
+## 8. PCC-1 — Control Flow Core
+
+Scope:
+
+- `while`;
+- statement `loop`;
+- `break`;
+- `continue`;
+- return-path and terminal CFG consistency;
+- diagnostics for invalid control exits.
+
+Feature DoD:
+
+```text
+[ ] loops parse
+[ ] loops typecheck
+[ ] loops lower to deterministic IR
+[ ] verifier accepts valid emitted SemCode
+[ ] VM executes canonical fixtures
+[ ] invalid exits produce stable diagnostics
+```
+
+Trust DoD:
+
+```text
+[ ] new IR / opcode shape documented if introduced
+[ ] trap taxonomy updated if needed
+[ ] determinism matrix gets loop fixtures
+[ ] 7hell stages include control-flow fixtures
+```
+
+## 9. PCC-2 — Numeric Core
+
+Scope:
+
+- complete practical arithmetic for admitted numeric families;
+- relationals and equality consistency;
+- division / invalid operation policy;
+- numeric traps;
+- deterministic behavior fixtures.
+
+Minimum surface:
+
+```text
+i32 / u32 / f64 / fx as applicable to current admitted profile
++ - * / where admitted
+relations
+safe failure behavior
+```
+
+Trust DoD:
+
+```text
+[ ] numeric RuntimeValue entries are frozen or marked draft
+[ ] numeric trap policy is documented
+[ ] determinism matrix includes arithmetic fixtures
+[ ] verifier rules and VM behavior match
+```
+
+## 10. PCC-3 — Text Core
+
+Scope:
+
+- text literal;
+- equality;
+- concat;
+- length;
+- runtime carrier.
+
+Explicitly not included in PCC-3:
+
+```text
+to_text(...)
+format(...)
+user-facing debug conversion
+```
+
+`to_text` belongs to PCC-8 Stdlib v0.
+
+Internal tooling rule:
+
+```text
+debug_render != to_text
+debug_render is not part of the language
+debug_render is not used in canonical examples
+debug_render is not exported as public stdlib API
+```
+
+## 11. PCC-3.5 — Data Carrier Design Note
+
+Purpose:
+
+Freeze the value / reference boundary before records and collections diverge.
+
+Minimum decision:
+
+| Type family | PCC v0 policy |
+|---|---|
+| `record` | value semantics |
+| record assignment | copy / move-by-value, no hidden reference |
+| `Sequence<T>` | runtime-managed dynamic container |
+| `Map<K,V>` | runtime-managed dynamic container |
+| collection assignment | explicit policy required before implementation |
+| collection mutation | only through defined stdlib/runtime operations |
+
+Rule:
+
+```text
+records are not heap containers
+collections are not records
+```
+
+Out of scope:
+
+- borrowed collections;
+- shared mutable collections;
+- persistent collections;
+- copy-on-write;
+- GC policy;
+- advanced ownership.
+
+## 12. PCC-4 — Records End-to-End
+
+Scope:
+
+- declaration;
+- construction;
+- field access;
+- assignment semantics according to PCC-3.5;
+- lowering;
+- runtime carrier;
+- verifier / VM path;
+- diagnostics.
+
+DoD:
+
+```text
+[ ] record examples pass check → compile → verify → run-smc
+[ ] invalid field access is diagnosed
+[ ] record value semantics are tested
+[ ] CTF registry is updated where runtime values change
+```
+
+## 13. PCC-5 — ADT + Basic Match
+
+Scope:
+
+- ADT declarations;
+- constructors;
+- payload access where admitted;
+- basic `match` over ADT;
+- initial exhaustiveness policy or explicit non-exhaustive limitation;
+- lowering and VM path.
+
+DoD:
+
+```text
+[ ] constructor fixtures pass full pipeline
+[ ] match fixtures pass full pipeline
+[ ] non-supported match shapes fail cleanly
+[ ] verifier and VM agree on ADT carrier rules
+```
+
+## 14. PCC-6 — Option / Result
+
+Scope:
+
+- `Option(T)`;
+- `Result(T, E)`;
+- constructors;
+- match helpers;
+- minimal helper functions if needed for examples.
+
+DoD:
+
+```text
+[ ] Option fixtures pass full pipeline
+[ ] Result fixtures pass full pipeline
+[ ] canonical failure-flow examples exist
+[ ] diagnostics for invalid payload usage are stable
+```
+
+## 15. PCC-7 — Collections v0
+
+Scope:
+
+- `Sequence<T>` minimum operations;
+- `Map<K,V>` minimum operations if admitted;
+- deterministic iteration policy;
+- bounds / missing-key behavior;
+- memory / quota interaction.
+
+DoD:
+
+```text
+[ ] collections have explicit carrier policy
+[ ] index / iteration behavior is deterministic
+[ ] failure behavior is trap-or-diagnostic stable
+[ ] 7hell includes practical collection fixtures
+```
+
+## 16. PCC-8 — Stdlib v0
+
+Scope:
+
+- `assert`;
+- math helpers;
+- text helpers;
+- `to_text` for admitted basic types;
+- sequence helpers;
+- map helpers;
+- Option / Result helpers.
+
+Rule:
+
+```text
+debug_render remains internal tooling and cannot substitute for to_text.
+```
+
+DoD:
+
+```text
+[ ] public helper list is documented
+[ ] each helper has type contract
+[ ] helper failures are diagnostic/trap stable
+[ ] canonical examples avoid internal debug helpers
+```
+
+## 17. PCC-9 — Project Model v0
+
+Scope:
+
+- `semantic.toml`;
+- `src/main.sm`;
+- `smc new` if admitted;
+- `smc check` project;
+- `smc run` project;
+- deterministic module roots;
+- project-level 7hell.
+
+DoD:
+
+```text
+[ ] minimal project layout is documented
+[ ] project check/run works or is explicitly scoped as follow-up
+[ ] project-level diagnostics are stable
+[ ] project fixtures exist
+```
+
+## 18. Waypoint review rule
+
+PCC uses a 4-week waypoint review. It is not a decorative status meeting; it is a control gate.
+
+Outcomes:
+
+```text
+A. On track
+   → continue current phase
+
+B. Behind, scope still valid
+   → continue with updated schedule / risk
+
+C. Behind, scope too large
+   → cut scope to minimum viable
+   → move overflow to post-PCC
+   → or rebuild the PCC forecast
+```
+
+Hard rule:
+
+```text
+If a PCC phase fails to move by DoD for two consecutive waypoint reviews,
+that phase scope must be explicitly reviewed.
+```
+
+Allowed scope decisions:
+
+- reduce to minimum viable;
+- split into sub-phase;
+- move nonessential pieces to post-PCC;
+- pause and rebaseline PCC forecast;
+- downgrade a formerly assumed requirement.
+
+## 19. Planning envelope
+
+These estimates are planning envelopes, not promises.
+
+| Phase | Envelope |
+|---|---:|
+| PCC-0 / 0.5 / 0.6 / CTF-0 | 1–2 weeks |
+| PCC-1 Control Flow | 2–3 weeks |
+| PCC-2 Numeric Core | 3–4 weeks |
+| PCC-3 Text Core | 1–2 weeks |
+| PCC-3.5 Carrier Note | 2–3 days |
+| PCC-4 Records | 3–4 weeks |
+| PCC-5 ADT + Match | 4–6 weeks |
+| PCC-6 Option / Result | 1–2 weeks |
+| PCC-7 Collections | 4–6 weeks |
+| PCC-8 Stdlib | 2–3 weeks |
+| PCC-9 Project Model | 2–3 weeks |
+| CTF overhead | +20–30% per feature phase |
+
+Realistic total horizon:
+
+```text
+minimum: 5–6 months
+realistic: 6–9 months
+with production shifts / breaks: 9–12 months
+```
+
+## 20. Gate before PCC-1
+
+PCC-1 must not start until these are complete:
+
+```text
+[ ] PCC-0 Truth Reset
+[ ] PCC-0.5 Feature Matrix Live Audit
+[ ] PCC-0.6 7hell Skeleton Seed
+[ ] CTF-0 Core Trust Freeze directory
+```
+
+This is intentional. PCC-1 starts after the project has one current state, one audit map, one diagnostic harness seed, and one trust-lane registry.
+
+## 21. Final formula
+
+```text
+PCC v0.3 =
+  Truth Reset
++ Live Audit
++ Practical Core Phases
++ parallel Core Trust Freeze
++ early 7hell
++ strict out-of-scope
++ waypoint decision rule
++ no debug_render public creep
+```


### PR DESCRIPTION
## Summary

Adds the Practical Core Completion v0.3 planning gate and the first Core Trust Freeze directory.

This PR is docs-only and does not change compiler, verifier, VM, runtime, or CLI behavior.

## Added

- `docs/roadmap/language_maturity/practical_core_completion_v0_3.md`
  - PCC phase map `PCC-0..PCC-9`
  - early `7hell` skeleton gate
  - parallel Core Trust Freeze lane
  - waypoint decision rule
  - strict out-of-scope list
  - `debug_render != to_text` rule

- `docs/roadmap/language_maturity/core_trust_freeze/index.md`
- `docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md`
- `docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md`
- `docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md`
- `docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md`
- `docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md`
- `docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md`
- `docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md`

## Intent

Freeze PCC v0.3 before feature work starts.

The important gate is:

```text
PCC-1 must not start until:
  PCC-0 Truth Reset
  PCC-0.5 Feature Matrix Live Audit
  PCC-0.6 7hell Skeleton Seed
  CTF-0 Core Trust Freeze directory
are complete.
```

## Validation

Docs-only PR. No local cargo commands were run from this ChatGPT session.

## CTF touched

Initial creation of the CTF lane:

- runtime value registry
- trap taxonomy
- determinism matrix
- SymbolId migration registry
- verifier-first policy
- golden trace policy
- capability/effect denial matrix
