### PR TITLE
docs(d-wave): freeze Map and PRNG benchmark baseline (PR-D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented in this file.
 
 ### Added (post-v1.1.1 language-maturity subtracks)
 
+- **D-wave baseline** (application-completeness program, D-wave):
+  - `Map(K, V)` persistent lookup tables — PR #404, 2026-05-03
+    - `map_empty()`, `map_contains`, `map_get`, `map_set` (functional update)
+    - admitted key types: `i32`, `u32`, `bool`, `text`, `quad`
+    - SemCode format `SEMCOD14`, capability `CAP_MAP_VALUES = 1 << 15`
+  - deterministic seeded PRNG — PR #405, 2026-05-03
+    - `random_seed(seed: i32)` — seeds the VM PRNG
+    - `random_next_i32(lo: i32, hi: i32) -> i32` — deterministic bounded value in `[lo, hi)`
+    - xorshift64 algorithm (period 2⁶⁴−1); range computed through `i64` to handle full `i32` span
+    - SemCode format `SEMCOD15`, capability `CAP_PRNG = 1 << 16`
+
 - **M9.4 Richer Pattern Surface**: five new pattern forms across owner layer, parser, and typecheck.
   - `MatchPattern::Wildcard` — bare `_` matches any scrutinee, binds nothing
   - `MatchPattern::Or(alts)` — pipe-separated alternatives `P1 | P2 | P3`

--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -292,7 +292,7 @@ Current `main` still fails this benchmark family at the following points:
 - `PR-D2` [landed]
   Title: `frontend/runtime: admit first-wave Map(K, V)`
   Landed:
-  - PR #404, 2026-05-03, merge SHA `6bcb1f62` (squash)
+  - PR #404, 2026-05-03, merge SHA `0eca4d60` (squash)
   Goal:
   - support Q-tables and visit counters directly in Semantic
   Scope:
@@ -328,8 +328,10 @@ Current `main` still fails this benchmark family at the following points:
   - deterministic PRNG tests green
   - CI green
 
-- `PR-D4` [required]
+- `PR-D4` [landed]
   Title: `docs/spec/tests: freeze map and PRNG benchmark baseline`
+  Landed:
+  - `docs/roadmap/d_wave_baseline.md` (PR #406, 2026-05-03)
   Goal:
   - close the state/random wave explicitly
   Scope:
@@ -338,8 +340,8 @@ Current `main` still fails this benchmark family at the following points:
   - `PR-D2` ✓ landed PR #404
   - `PR-D3` ✓ landed PR #405
   Gate:
-  - `cargo test -q`
-  - `cargo test -q --test public_api_contracts`
+  - docs-only
+  - `git diff --check`
   - CI green
 
 ### E — Observation Boundary

--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -67,6 +67,18 @@ Current `main` already admits these benchmark-relevant surfaces:
 - `pop(sequence) -> Sequence(T)` (landed PR #398)
 - first-class closures with immutable capture
 - the separate desktop UI boundary as a landed post-stable track
+- `Map(K, V)` persistent lookup tables with scalar key families (landed PR #404)
+  - `map_empty()` — contextual empty map; requires `let q: Map(K, V) = map_empty()`
+  - `map_contains(m, k) -> bool`
+  - `map_get(m, k, default) -> V`
+  - `map_set(m, k, v) -> Map(K, V)` — functional update; returns new map
+  - admitted key types: `i32`, `u32`, `bool`, `text`, `quad`
+  - SemCode format: `SEMCOD14`, capability `CAP_MAP_VALUES = 1 << 15`
+- deterministic seeded PRNG (landed PR #405)
+  - `random_seed(seed: i32)` — seeds the VM PRNG; valid as a statement
+  - `random_next_i32(lo: i32, hi: i32) -> i32` — deterministic bounded value in `[lo, hi)`
+  - xorshift64 (period 2⁶⁴−1); range computed through `i64` to handle the full `i32` span
+  - SemCode format: `SEMCOD15`, capability `CAP_PRNG = 1 << 16`
 
 Current `main` still fails this benchmark family at the following points:
 
@@ -75,8 +87,6 @@ Current `main` still fails this benchmark family at the following points:
 - plain reassignment
 - statement `while`
 - statement `loop` with bare `break;` and `continue`
-- a first-wave map/dictionary family for Q-tables and visit counts
-- a deterministic seeded pseudo-random source
 - text concatenation / minimal formatting for traces
 - a narrow admitted stdout experiment surface
 
@@ -279,8 +289,10 @@ Current `main` still fails this benchmark family at the following points:
   - `git diff --check`
   - CI green
 
-- `PR-D2` [required]
+- `PR-D2` [landed]
   Title: `frontend/runtime: admit first-wave Map(K, V)`
+  Landed:
+  - PR #404, 2026-05-03, merge SHA `6bcb1f62` (squash)
   Goal:
   - support Q-tables and visit counters directly in Semantic
   Scope:
@@ -299,8 +311,10 @@ Current `main` still fails this benchmark family at the following points:
   - targeted map tests green
   - CI green
 
-- `PR-D3` [required]
+- `PR-D3` [landed]
   Title: `stdlib/random: admit deterministic seeded PRNG`
+  Landed:
+  - PR #405, 2026-05-03, merge SHA `a586fc93` (squash)
   Goal:
   - support food spawning and exploration without host randomness
   Scope:
@@ -321,8 +335,8 @@ Current `main` still fails this benchmark family at the following points:
   Scope:
   - docs/spec/tests freeze only
   Depends on:
-  - `PR-D2`
-  - `PR-D3`
+  - `PR-D2` ✓ landed PR #404
+  - `PR-D3` ✓ landed PR #405
   Gate:
   - `cargo test -q`
   - `cargo test -q --test public_api_contracts`

--- a/docs/roadmap/d_wave_baseline.md
+++ b/docs/roadmap/d_wave_baseline.md
@@ -1,0 +1,71 @@
+# D-Wave Baseline — Frozen 2026-05-03
+
+This document records the closed D-wave of the application-completeness program.
+
+Read together with:
+
+- `docs/roadmap/application_completeness_pr_ledger.md`
+- `docs/roadmap/final_readiness_verdict.md`
+
+## What Landed
+
+### PR-D1 — Map surface scope doc [landed]
+
+Scope document: `docs/roadmap/first_wave_map_surface.md`
+
+Opened exactly one lookup-table family without making any runtime commitment.
+
+### PR-D2 — `Map(K, V)` runtime [landed, PR #404, 2026-05-03]
+
+Admitted `Map(K, V)` as a first-class persistent value type.
+
+Admitted operations:
+
+- `map_empty()` — contextual empty map; requires `let q: Map(K, V) = map_empty()`
+- `map_contains(m, k) -> bool`
+- `map_get(m, k, default) -> V`
+- `map_set(m, k, v) -> Map(K, V)` — functional update; returns new map
+
+Admitted key types: `i32`, `u32`, `bool`, `text`, `quad`
+
+SemCode format: `SEMCOD14` (`MAGIC14`), capability `CAP_MAP_VALUES = 1 << 15`
+
+Not admitted: mutable maps, set types, generic collection framework.
+
+### PR-D3 — deterministic seeded PRNG [landed, PR #405, 2026-05-03]
+
+Admitted two builtins:
+
+- `random_seed(seed: i32)` — seeds the VM PRNG; valid as a statement
+- `random_next_i32(lo: i32, hi: i32) -> i32` — deterministic bounded value in `[lo, hi)`
+
+Algorithm: xorshift64, period 2⁶⁴−1. Zero seed is coerced to 1 to avoid the
+fixed-point. Range is computed through `i64` arithmetic to handle spans wider
+than `i32::MAX` (e.g. `random_next_i32(-2000000000, 2000000000)`).
+
+Contract: `lo < hi` is enforced at runtime; `lo >= hi` produces a descriptive
+`RuntimeError`.
+
+SemCode format: `SEMCOD15` (`MAGIC15`), capability `CAP_PRNG = 1 << 16`
+
+Not admitted: cryptographic randomness, host-entropy sources, multiple
+independent PRNG streams.
+
+## What Is Not Admitted By This Wave
+
+- mutable map update in place
+- set / multiset families
+- `Map` iteration
+- any host-entropy source
+- multiple seeded PRNG streams
+
+## Evidence
+
+- All positive fixtures in `tests/fixtures/snake_benchmark/` pass `check`,
+  `run`, `compile`, and `verify` end-to-end as of this freeze.
+- `positive_map_basic.sm` covers empty construction, `set`, `get`, and
+  `contains`.
+- `positive_random_seeded.sm` covers determinism, range bounds, consecutive
+  state advancement, and the full `i32` cross-zero span.
+- `negative_random_invalid_range.sm` confirms the `lo >= hi` runtime contract.
+- `snake_benchmark_gap_matrix` test target is green on `main`.


### PR DESCRIPTION
## Summary

- Marks `PR-D2` (`Map(K, V)`, #404) and `PR-D3` (PRNG, #405) as `[landed]` in the application-completeness ledger, with PR numbers, dates, and merge SHAs
- Adds `Map(K, V)` and PRNG entries to `## Unreleased` in `CHANGELOG.md`
- Adds `docs/roadmap/d_wave_baseline.md` as the explicit freeze document for the D-wave
- Updates `PR-D4` ledger entry to reflect both dependencies met
- No runtime code changed

## What this closes

D-wave (lookup state + deterministic randomness) is now fully documented and frozen. The snake benchmark gap matrix already has positive coverage for both surfaces (`positive_map_basic.sm`, `positive_random_seeded.sm`) and the negative contract fixture (`negative_random_invalid_range.sm`).

## Gate

- docs-only PR (no `cargo test` required)
- `git diff --check` clean
- CI green