### PR TITLE
docs(b-wave): freeze imperative core benchmark baseline

### DIFF
--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -192,22 +192,23 @@ Current `main` still fails this benchmark family at the following points:
   Note:
   - confirmed by PR-B1 audit; no new implementation required in this program
 
-- `PR-B5` [required]
+- `PR-B5` [landed]
   Title: `docs/spec/tests: freeze imperative core benchmark surface`
+  Landed:
+  - `docs/roadmap/b_wave_baseline.md` (PR-B5)
   Goal:
   - close the imperative-core wave as one explicit contract
   Scope:
-  - docs/spec/tests sync only
+  - docs/spec/tests freeze only
   Depends on:
-  - `PR-B1`
-  - `PR-B2`
-  - `PR-B3`
-  - `PR-B4`
-  - `PR-B4.5`
+  - `PR-B1` ✓ landed PR #407
+  - `PR-B2` ✓ landed PR #408
+  - `PR-B3` ✓ pre-program landed
+  - `PR-B4` ✓ pre-program landed
+  - `PR-B4.5` ✓ pre-program landed
   Gate:
-  - docs/spec/tests sync only
-  - `cargo test -q`
-  - `cargo test -q --test public_api_contracts`
+  - docs-only
+  - `git diff --check`
   - CI green
 
 ### C — Sequence Utility Layer

--- a/docs/roadmap/b_wave_baseline.md
+++ b/docs/roadmap/b_wave_baseline.md
@@ -1,0 +1,126 @@
+# B-Wave Baseline — Imperative Core
+
+Status: PR-B5 freeze document  
+Program: Semantic application-completeness / snake benchmark path  
+Scope type: docs/tests freeze  
+Runtime-code changes: none
+
+## Purpose
+
+This document freezes the B-wave imperative-core baseline after the landed
+application-completeness B-wave work.
+
+The B-wave closes the ordinary imperative substrate required by benchmark-class
+Semantic programs:
+
+- same-family `i32` comparisons;
+- same-family `i32` arithmetic;
+- mutable locals;
+- reassignment;
+- condition-driven loops;
+- open-ended loops;
+- loop exits.
+
+This document does not widen the public release contour and does not claim the
+snake benchmark pack is complete.
+
+## Landed Inputs
+
+| Item | Status | Evidence |
+|---|---:|---|
+| PR-B1 — imperative baseline audit | landed | PR #407, merge SHA `c228b167` |
+| PR-B2 — `i32 /` and `%` | landed | PR #408, merge SHA `d2226c19` |
+| PR-B3 — `let mut` + reassignment | pre-program landed | confirmed by PR-B1 audit fixtures |
+| PR-B4 — `while` | pre-program landed | confirmed by PR-B1 audit fixtures |
+| PR-B4.5 — `loop` / `break` / `continue` | pre-program landed | confirmed by PR-B1 audit fixtures |
+
+## Frozen Positive Surface
+
+The following imperative surfaces are part of the current benchmark-relevant
+positive baseline on `main`:
+
+| Surface | Status |
+|---|---:|
+| `i32 > i32` | admitted |
+| `i32 < i32` | admitted |
+| `i32 >= i32` | admitted |
+| `i32 <= i32` | admitted |
+| `i32 + i32` | admitted |
+| `i32 - i32` | admitted |
+| `i32 * i32` | admitted |
+| `i32 / i32` | admitted |
+| `i32 % i32` | admitted |
+| unary `-i32` | admitted |
+| `let mut` mutable locals | admitted |
+| plain reassignment | admitted |
+| compound assignment over mutable locals | admitted |
+| `while condition { ... }` | admitted |
+| statement `loop { ... }` | admitted |
+| bare `break;` inside loop | admitted |
+| `continue;` inside loop | admitted |
+
+## Frozen Runtime Contracts
+
+### Division by zero
+
+`i32 / i32` traps at runtime when the divisor is zero.
+
+This must not host-panic. It is represented as a VM runtime trap.
+
+### Modulo by zero
+
+`i32 % i32` traps at runtime when the divisor is zero.
+
+This must not host-panic. It is represented as a VM runtime trap.
+
+### Arithmetic overflow
+
+The VM must avoid host panic for overflow-sensitive integer division/modulo
+cases such as `i32::MIN / -1` and `i32::MIN % -1`.
+
+Those cases are handled through checked arithmetic and mapped to the runtime
+trap taxonomy.
+
+## Frozen Negative Surface
+
+The following negative contracts remain intentionally covered:
+
+- bare `break;` outside `while` / statement `loop` is rejected;
+- `continue;` outside `while` / statement `loop` is rejected;
+- division by zero fails at runtime;
+- modulo by zero fails at runtime.
+
+## Out Of Scope
+
+B-wave does not add or claim:
+
+- `u32` arithmetic completion;
+- `f64` or `fx` widening beyond the existing contour;
+- measured-numeric widening;
+- text concatenation;
+- formatting;
+- stdout / print surface;
+- file I/O;
+- browser or UI ownership;
+- snake benchmark completion.
+
+## Remaining Application-Completeness Gaps
+
+After B-wave, the active blockers for the benchmark family are outside the
+imperative core:
+
+- text concatenation / minimal formatting for traces;
+- narrow admitted stdout experiment surface;
+- canonical benchmark examples and close-out evidence.
+
+## DoD
+
+B-wave is considered frozen when:
+
+- the application-completeness ledger marks PR-B1 through PR-B5 closed or
+  pre-program landed where appropriate;
+- the snake benchmark gap matrix carries positive fixtures for the admitted
+  imperative surface;
+- runtime-negative fixtures cover division/modulo by zero;
+- no runtime-code changes are included in PR-B5;
+- CI is green.

--- a/tests/fixtures/snake_benchmark/README.md
+++ b/tests/fixtures/snake_benchmark/README.md
@@ -1,4 +1,4 @@
-Snake benchmark gap matrix fixtures for `PR-A2`.
+Snake benchmark gap matrix fixtures for the application-completeness program.
 
 Purpose:
 
@@ -24,23 +24,35 @@ Current landed positive baseline includes:
 - persistent `prepend(sequence, value) -> Sequence(T)`
 - persistent `pop(sequence) -> Sequence(T)`
 - first-class closure capture
+- persistent `Map(K, V)` lookup tables with scalar key families
+- deterministic seeded PRNG through `random_seed` and `random_next_i32`
 
 The sequence update helpers are functional/persistent. They do not mutate a
 sequence in place; benchmark code should assign the returned sequence when
 evolving state.
 
-This fixture pack intentionally does not yet freeze syntax for two blocker
-families:
+The map update helper is also functional/persistent. `map_set` returns a new
+`Map(K, V)` value; benchmark code should assign the returned map when evolving
+Q-tables or visit counters.
 
-- seeded deterministic pseudo-random source
+Current runtime-negative baseline includes:
+
+- invalid PRNG range (`lo >= hi`)
+- `i32` division by zero
+- `i32` modulo by zero
+
+Current static-negative baseline includes:
+
+- `map_empty()` without contextual `Map(K, V)` type
+- discarded statement-form `map_empty();`
+- text concatenation before PR-E1
+- bare `break;` outside `while` / statement `loop`
+- `continue;` outside `while` / statement `loop`
+
+Remaining benchmark blocker families:
+
+- text concatenation / minimal formatting for traces
 - narrow stdout experiment surface
 
-Reason:
-
-- current `main` and the application-completeness ledger define those blocker
-  families, but they do not yet define one canonical source spelling
-- this PR must not invent fake API names just to make the matrix look more
-  complete
-
-Those two gaps remain part of the benchmark blocker set and should be frozen in
-tests only after their scope PRs choose the public source forms.
+Those remaining gaps should be frozen in tests only after their scope PRs choose
+the public source forms.


### PR DESCRIPTION
## Summary

- Adds `docs/roadmap/b_wave_baseline.md` as the PR-B5 freeze document for the imperative-core B-wave.
- Marks PR-B5 as landed in the application-completeness ledger.
- Freezes the admitted B-wave surface: i32 relationals, i32 arithmetic including `/` and `%`, mutable locals, reassignment, while, loop, break, and continue.
- Syncs the snake benchmark fixture README with the current Map, PRNG, B-wave runtime-negative, and remaining blocker baseline.
- Does not change runtime, parser, lowering, verifier, VM, or CI code.

## Test plan

- [x] docs-only change
- [x] no runtime-code changes
- [x] CI green