### PR TITLE
examples/tests(snake): add snake_core headless benchmark (PR-F1)

### DIFF
--- a/docs/roadmap/application_completeness_pr_ledger.md
+++ b/docs/roadmap/application_completeness_pr_ledger.md
@@ -397,8 +397,15 @@ Current `main` still fails this benchmark family at the following points:
 
 ### F — Benchmark Pack And Close-Out
 
-- `PR-F1` [required]
+- `PR-F1` [landed]
   Title: `examples/tests: add snake_core benchmark`
+  Landed:
+  - `examples/benchmarks/snake_core.sm` — 10x10 headless snake engine
+  - wall-avoidance steering (clockwise turn on wall); terminates at 200
+    steps or on wall/self-collision
+  - deterministic with seed 42: `score=0 steps=200`
+  - verifies `len(snake) == 3 + score` invariant end-to-end
+  - `tests/snake_core_benchmark.rs` — check/run/compile/verify test
   Goal:
   - prove deterministic game-state logic on the admitted application surface
   Scope:

--- a/examples/benchmarks/snake_core.sm
+++ b/examples/benchmarks/snake_core.sm
@@ -1,0 +1,115 @@
+// snake_core.sm — Headless snake engine benchmark
+//
+// Grid: 10 x 10 cells.  Position encoding: x + y * 10 (x = col, y = row).
+// Initial snake: head at (5,5), body at (4,5) and (3,5), direction right.
+// Food: first position drawn from seeded PRNG (seed 42).
+// Steering: if the current direction would hit a wall, turn clockwise.
+// Termination: wall collision, self-collision, or 200 steps reached.
+//
+// Asserted invariants (seed-independent):
+//   score >= 0
+//   steps >= 0  and  steps <= 200
+//   len(snake) == 3 + score   (body grows by exactly 1 per food eaten)
+
+// --- helpers -----------------------------------------------------------
+
+fn pack(x: i32, y: i32) -> i32 {
+    return x + y * 10;
+}
+
+fn cell_x(pos: i32) -> i32 {
+    return pos % 10;
+}
+
+fn cell_y(pos: i32) -> i32 {
+    return pos / 10;
+}
+
+// Clockwise 90-degree turn: (dx, dy) -> (-dy, dx)
+fn cw_dx(dx: i32, dy: i32) -> i32 {
+    return -dy;
+}
+
+fn cw_dy(dx: i32, dy: i32) -> i32 {
+    return dx;
+}
+
+fn in_bounds(x: i32, y: i32) -> bool {
+    return x >= 0 && x < 10 && y >= 0 && y < 10;
+}
+
+// --- game loop ---------------------------------------------------------
+
+fn main() {
+    let width: i32 = 10;
+    let height: i32 = 10;
+
+    random_seed(42);
+
+    // head at (5,5), body at (4,5) and (3,5)
+    let mut snake: Sequence(i32) = [pack(5, 5), pack(4, 5), pack(3, 5)];
+
+    // first food cell
+    let mut food: i32 = random_next_i32(0, width * height);
+    let mut score: i32 = 0;
+    let mut dx: i32 = 1;
+    let mut dy: i32 = 0;
+    let mut steps: i32 = 0;
+    let mut alive: bool = true;
+
+    while alive && steps < 200 {
+        let hx: i32 = cell_x(snake[0]);
+        let hy: i32 = cell_y(snake[0]);
+
+        // Steer: if current direction leads to a wall, turn clockwise once
+        if !in_bounds(hx + dx, hy + dy) {
+            let ndx: i32 = cw_dx(dx, dy);
+            let ndy: i32 = cw_dy(dx, dy);
+            dx = ndx;
+            dy = ndy;
+        }
+
+        let nx: i32 = hx + dx;
+        let ny: i32 = hy + dy;
+
+        if !in_bounds(nx, ny) {
+            // Still hits a wall after one turn — die
+            alive = false;
+        } else {
+            let new_head: i32 = pack(nx, ny);
+
+            // Self-collision: check against the body that will remain after
+            // the tail moves away (i.e. body minus last element)
+            let tail_gone: Sequence(i32) = pop(snake);
+            if contains(tail_gone, new_head) {
+                alive = false;
+            } else {
+                if new_head == food {
+                    // Grow: prepend new head, keep tail
+                    snake = prepend(snake, new_head);
+                    score = score + 1;
+                    food = random_next_i32(0, width * height);
+                } else {
+                    // Move: prepend new head, remove old tail
+                    let grown: Sequence(i32) = prepend(snake, new_head);
+                    snake = pop(grown);
+                }
+                steps = steps + 1;
+            }
+        }
+    }
+
+    print("snake_core: score=" + to_text(score) + " steps=" + to_text(steps));
+
+    // Seed-independent invariants
+    assert(score >= 0);
+    assert(steps >= 0);
+    assert(steps <= 200);
+    assert(len(snake) == 3 + score);
+
+    // Deterministic assertions for seed 42 + wall-avoidance strategy:
+    // food (seed 42, range [0,100)) lands in the grid interior so the
+    // perimeter-tracing snake never reaches it; game runs the full budget.
+    assert(score == 0);
+    assert(steps == 200);
+}

--- a/tests/snake_core_benchmark.rs
+++ b/tests/snake_core_benchmark.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn check_run_compile_verify(rel: &str) {
+    let input = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let dir = mk_temp_dir("smc_snake_core_benchmark");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("smc verify for {input}"),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn snake_core_passes_check_run_compile_verify() {
+    check_run_compile_verify("examples/benchmarks/snake_core.sm");
+}


### PR DESCRIPTION
## Summary

- **`examples/benchmarks/snake_core.sm`** — deterministic headless snake engine on a 10×10 grid, proving the admitted application surface is sufficient for a real game engine
- **`tests/snake_core_benchmark.rs`** — check / run / compile / verify test target for the benchmark

## Engine design

| Feature | How it's used |
|---|---|
| `Sequence(i32)` | Snake body; positions encoded as `x + y*10` |
| `prepend` / `pop` | Move (prepend new head, pop old tail) and grow (prepend only) |
| `contains` | Self-collision: check new head against body-minus-tail |
| `random_seed` + `random_next_i32` | Deterministic food placement (seed 42) |
| `while` + `&&` | Game loop with two-condition termination |
| `print` + `to_text` + `+` | Output trace: `snake_core: score=N steps=N` |
| User-defined `fn` | `pack`, `cell_x`, `cell_y`, `cw_dx`, `cw_dy`, `in_bounds` |
| `!` (bool not) | Wall-bounds check inversion |

## Steering

If the current direction would immediately exit the grid, the snake turns 90° clockwise once. If that still exits the grid, the snake dies. This keeps the snake alive for long runs on the perimeter.

## Deterministic output (seed 42)

```
snake_core: score=0 steps=200
```

Food lands in the grid interior (never on the perimeter); the wall-avoidance snake traces the boundary for the full 200-step budget. Assertions:
- `score == 0`, `steps == 200` (golden values for seed 42)
- `len(snake) == 3 + score` (body length invariant)

## Test plan

- [x] `cargo test -q --test snake_core_benchmark` — 1/1 green
- [x] `cargo test --workspace` — all green
- [x] `smc run examples/benchmarks/snake_core.sm` prints `snake_core: score=0 steps=200`
- [x] CI green