### PR TITLE
docs(ui): define Semantic UI DNA

### DIFF
--- a/docs/dna/SEMANTIC_UI_DNA.md
+++ b/docs/dna/SEMANTIC_UI_DNA.md
@@ -1,0 +1,128 @@
+# Semantic UI DNA
+
+Status: architecture doctrine
+Track: POST-UI / Semantic UI Application Boundary
+Scope type: documentation only
+
+## Core Principle
+
+Semantic UI is a Semantic-native UI architecture.
+
+It is not a fork, clone, wrapper, or derivative UI toolkit.
+
+Semantic UI may study proven open-source UI systems, but Semantic owns its own:
+
+- UI Tree;
+- UI AST;
+- UI IR;
+- state/update/event model;
+- capability/effect discipline;
+- diagnostics and fault model;
+- renderer adapter contract.
+
+## Formula
+
+```text
+Semantic UI =
+  Semantic-owned UI model
++ Semantic-owned contracts
++ Semantic-owned state/update model
++ Semantic UI AST
++ Semantic UI IR
++ capability/effect rules
++ renderer adapters
+
+External projects =
+  architectural references, not owners
+```
+
+## Lineage
+
+Semantic UI draws architectural inspiration from:
+
+| Source | Studied area | Accepted influence | Explicit non-adoption |
+| --- | --- | --- | --- |
+| Slint | declarative UI language, components, properties, callbacks | declarative UI genes, property binding, renderer separation | no `.slint` language copy, no runtime adoption, no license obligations without audit |
+| Lapce / Floem | Rust-native editor/workbench architecture | editor/workbench structure, state/layout ideas, performance expectations | no full editor fork, no forced lifecycle adoption |
+| Makepad | live design and Rust UI runtime ideas | live design feedback loop, visual iteration, rendering architecture ideas | no runtime import as Semantic owner |
+| Zed / GPUI | high-performance editor UX | command routing, workspace/panel UX, editor responsiveness | no GPUI ownership of Semantic UI |
+| Tauri | Rust backend plus frontend shell model | shell/bridge pattern, IPC inspiration, MVP adapter idea | no WebView/browser ownership of Semantic state |
+| Monaco / CodeMirror | mature code editor surface | temporary editor-layer interaction patterns | no web-only IDE commitment |
+| React Flow / Cytoscape / ELK | graph and layout interaction patterns | subgraph, compound node, graph layout ideas | no ownership of Semantic GraphStore |
+
+## Inspiration vs Dependency vs Derivative
+
+Semantic UI distinguishes three levels:
+
+| Level | Meaning | Required handling |
+| --- | --- | --- |
+| Inspiration | idea, pattern, architecture principle | record in `third_party_influence.md` |
+| Dependency | actual crate/npm/library used by the repo | record in `third_party_dependencies.md` with license notes |
+| Derivative / fork | copied or modified code | requires explicit license compliance and copyright notices |
+
+Target posture:
+
+```text
+Mostly inspiration.
+Some dependencies only when deliberately admitted.
+No silent derivative code.
+```
+
+## Semantic Ownership
+
+Semantic UI owns:
+
+- UI Tree;
+- UI AST;
+- UI IR;
+- state/update/event model;
+- action/effect model;
+- capability admission;
+- diagnostics;
+- graph/fault localization model;
+- renderer contract.
+
+Renderer backends may exist, but they do not own the Semantic UI model.
+
+## Renderer Boundary
+
+Renderer adapters are implementation boundaries.
+
+Allowed future backend families may include:
+
+- terminal/text prototype;
+- HTML/SVG adapter;
+- Canvas adapter;
+- native adapter;
+- GPU-backed adapter.
+
+None of these becomes the Semantic language boundary by default.
+
+## Non-Goals
+
+Semantic UI does not claim:
+
+- browser/DOM ownership;
+- WebView ownership;
+- widget framework adoption;
+- Slint/Floem/Makepad/Zed/Tauri runtime adoption;
+- GPU/shader pipeline ownership;
+- CSS/layout engine ownership;
+- copied third-party code;
+- public release widening;
+- that external UI projects are dependencies unless listed as dependencies.
+
+## Design Rule
+
+```text
+Semantic defines the model.
+Renderer adapts to Semantic.
+Semantic does not adapt itself to a foreign UI lifecycle.
+```
+
+## Close
+
+Semantic UI acknowledges the open-source ecosystem honestly while preserving its own architecture.
+
+It studies systems.
+It does not become them.

--- a/docs/legal/third_party_dependencies.md
+++ b/docs/legal/third_party_dependencies.md
@@ -1,0 +1,54 @@
+# Third-Party Dependency Register
+
+Status: dependency register placeholder
+Scope: actual admitted third-party dependencies only
+
+## Purpose
+
+This file records actual third-party dependencies used by Semantic UI or related UI adapters.
+
+Do not add a project here merely because it inspired the architecture.
+
+A project belongs here only if it is actually used as:
+
+- a Rust crate;
+- an npm package;
+- a vendored library;
+- a linked runtime dependency;
+- copied source code;
+- modified fork.
+
+## Current Semantic UI dependency status
+
+As of this document:
+
+```text
+No Semantic UI third-party runtime dependency is admitted by this document.
+```
+
+## Future Entry Format
+
+| Dependency | Version/source | Purpose | License | Notes |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD |
+
+## Rule
+
+Before adding a dependency:
+
+- check license;
+- check transitive dependencies;
+- check whether it affects the Semantic language/runtime boundary;
+- document whether it is runtime, build-time, dev-only, or adapter-only.
+
+## Non-Dependency Note
+
+The following projects may be listed in `third_party_influence.md` as architectural influences, but are not dependencies unless explicitly added here:
+
+- Slint
+- Lapce / Floem
+- Makepad
+- Zed / GPUI
+- Tauri
+- Monaco / CodeMirror
+- React Flow / Cytoscape / ELK

--- a/docs/legal/third_party_influence.md
+++ b/docs/legal/third_party_influence.md
@@ -1,0 +1,41 @@
+# Third-Party Influence Register
+
+Status: documentation-only influence register
+Scope: architectural inspiration, not dependency inventory
+
+## Purpose
+
+This file records third-party projects that influenced Semantic UI architecture thinking.
+
+An entry in this file does not mean:
+
+- the project is a dependency;
+- code was copied;
+- Semantic UI is a derivative work;
+- the project owns any part of Semantic runtime.
+
+Actual dependencies must be recorded separately in:
+
+```text
+docs/legal/third_party_dependencies.md
+```
+
+## Influence Entries
+
+| Project | Influence type | Notes |
+| --- | --- | --- |
+| Slint | declarative UI, component/property model, renderer separation | architecture reference only |
+| Lapce / Floem | Rust-native editor/workbench patterns | architecture reference only |
+| Makepad | live design and rendering-loop ideas | architecture reference only |
+| Zed / GPUI | high-performance editor UX and command/workspace model | architecture reference only |
+| Tauri | shell/bridge/IPC pattern | architecture reference only |
+| Monaco / CodeMirror | mature code editor interaction model | possible temporary adapter reference |
+| React Flow / Cytoscape / ELK | graph/layout/subgraph interaction patterns | architecture reference only |
+
+## Rule
+
+```text
+Influence is not dependency.
+Dependency is not derivative.
+Derivative code requires explicit legal handling.
+```

--- a/docs/roadmap/language_maturity/ui_application_boundary_scope.md
+++ b/docs/roadmap/language_maturity/ui_application_boundary_scope.md
@@ -124,3 +124,11 @@ Even after this track lands, the repository still does not claim:
 - a forked graphics stack
 - shader-language ownership
 - a promise that UI support is already part of the published `v1.1.1` line
+
+## Semantic UI DNA
+
+The next POST-UI architecture layer is governed by:
+
+- `docs/dna/SEMANTIC_UI_DNA.md`
+
+This keeps the completed M7 first-wave UI boundary distinct from later Semantic UI architecture-selection work.


### PR DESCRIPTION
## Summary

- Adds the Semantic UI DNA doctrine.
- Records third-party architectural influences separately from dependencies.
- Defines the boundary between inspiration, dependency, and derivative/fork.
- States that Semantic UI owns its own UI Tree, UI AST, UI IR, state/update/event model, capability/effect model, diagnostics, and renderer contract.
- Adds a placeholder register for actual third-party dependencies.
- Adds a small reference from the completed M7 UI scope to the new DNA document.
- Does not add runtime code, renderer code, dependencies, or UI behavior.

## Test plan

- [x] docs-only change
- [x] git diff --check
- [x] CI green
