### PR TITLE
docs(ui): define Semantic UI ownership map

### DIFF
--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -1,0 +1,137 @@
+# Semantic UI Ownership Map
+
+Status: Draft
+Track: POST-UI
+Scope: ownership and boundaries only
+Implementation: out of scope
+
+## 1. Purpose
+
+This document defines ownership boundaries for the Semantic UI/Application layer.
+
+The UI layer must not become:
+
+- a second compiler;
+- a VM policy layer;
+- a hidden host side-effect path;
+- a Workbench-only feature;
+- a widget/layout framework in the first slice.
+
+## 2. Layer position
+
+Semantic UI lives after verified execution and before platform-native rendering.
+
+```text
+Semantic source
+  ↓
+SemCode
+  ↓
+Verifier admission
+  ↓
+VM
+  ↓
+prom-abi HostCallEnvelope
+  ↓
+prom-cap capability check
+  ↓
+prom-ui contract types
+  ↓
+prom-ui-runtime
+  ↓
+platform backend
+```
+
+## 3. Ownership matrix
+
+| Entity | Owner | May read | May mutate/execute | Must not own |
+| --- | --- | --- | --- | --- |
+| UI source surface | `sm-front` / `sm-sema` | `sm-ir`, `sm-emit` | nobody | `sm-vm`, `prom-ui-runtime` |
+| UI call lowering | `sm-ir` / `sm-emit` | `sm-verify`, `sm-vm` | nobody | `prom-ui` |
+| UI ABI call IDs | `prom-abi` | `sm-verify`, `sm-vm`, `prom-runtime`, `prom-ui-runtime` | `prom-runtime` dispatches | `sm-front`, `sm-sema` |
+| UI capabilities | `prom-cap` | `sm-verify`, `prom-runtime`, `prom-ui-runtime` | `prom-cap` / `prom-runtime` | `sm-vm` policy logic |
+| UI event model | `prom-ui` | `prom-ui-runtime`, apps, tests | `prom-ui-runtime` produces events | `sm-front`, `sm-vm` |
+| Window lifecycle contract | `prom-ui` | `prom-ui-runtime`, `prom-runtime` | `prom-ui-runtime` | `sm-vm` |
+| Draw command model | `prom-ui` | `prom-ui-runtime`, tests | `prom-ui-runtime` consumes | VM internals |
+| Frame lifecycle | `prom-ui` | `prom-ui-runtime` | `prom-ui-runtime` | compiler layers |
+| Platform backend | `prom-ui-runtime` or backend crate | nobody outside runtime boundary | backend implementation | `prom-ui` contract crate |
+| Demo app | `prom-ui-demo` | tests / docs | demo only | core contracts |
+
+## 4. Boundary rules
+
+### Rule UI-1 - ABI-only host access
+
+UI effects must go through `prom-abi`.
+
+No UI crate may create an alternate side-effect path into the host.
+
+### Rule UI-2 - Capability before UI effect
+
+Every effectful UI operation must have an explicit capability path.
+
+Examples:
+
+- `CAP_UI_WINDOW`
+- `CAP_UI_EVENTS`
+- `CAP_UI_DRAW`
+
+### Rule UI-3 - VM is not a UI runtime
+
+The VM may dispatch admitted host calls, but must not:
+
+- own windows;
+- store platform handles as native UI objects;
+- interpret widget semantics;
+- perform layout;
+- own UI capability policy.
+
+### Rule UI-4 - UI runtime is not a compiler
+
+`prom-ui-runtime` must not:
+
+- parse `.sm`;
+- typecheck Semantic source;
+- lower AST/IR;
+- verify SemCode structure.
+
+### Rule UI-5 - Determinism boundary
+
+UI execution is deterministic only under the same admitted program, same config, same capability context, and same external event stream.
+
+```text
+program determinism ≠ environment determinism
+```
+
+### Rule UI-6 - First slice is immediate-mode command boundary
+
+The first UI slice is:
+
+- window lifecycle;
+- event polling;
+- frame begin/end;
+- minimal draw commands.
+
+It is not:
+
+- widget framework;
+- layout engine;
+- retained UI tree;
+- browser target;
+- mobile target;
+- GPU/shader pipeline.
+
+## 5. Workbench separation
+
+Workbench may later visualize or drive UI app builds, but it does not own the Semantic UI application contract.
+
+Workbench is tooling/operator surface.
+Semantic UI is application/runtime boundary.
+
+## 6. DoD
+
+This document is complete when:
+
+- every UI concept has one owner;
+- VM/compiler/runtime boundaries are explicit;
+- forbidden ownership leaks are listed;
+- Workbench is separated from UI application boundary;
+- capability and ABI ownership are explicit.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -26,6 +26,7 @@ Current documents in this PR:
 - `state.md` - semantic state model and invariants
 - `rules.md` - deterministic rule and agenda contract
 - `audit.md` - audit trail and replay metadata contract
+- `ui_contract_map.md` - POST-UI Semantic UI contract sketch and ownership map
 
 Adjacent source-surface documents also remain relevant:
 

--- a/docs/spec/ui_contract_map.md
+++ b/docs/spec/ui_contract_map.md
@@ -1,0 +1,162 @@
+# Semantic UI Contract Map
+
+Status: Draft
+Track: POST-UI
+Scope: public contract sketch only
+Implementation: out of scope
+
+## 1. Purpose
+
+This document defines the minimal UI contracts that future implementation PRs must follow.
+
+It does not define final syntax.
+It defines contract ownership and first-slice semantics.
+
+## 2. Minimal UI contract stack
+
+```text
+UI Program
+  ↓
+UI Host Calls
+  ↓
+UI Capabilities
+  ↓
+UI Event Stream
+  ↓
+Frame Lifecycle
+  ↓
+Draw Command Buffer
+```
+
+## 3. UI host call families
+
+First slice host calls:
+
+```text
+UiWindowCreate
+UiWindowClose
+UiPollEvent
+UiBeginFrame
+UiEndFrame
+UiDrawClear
+UiDrawRect
+UiDrawText
+```
+
+Out of first slice:
+
+```text
+UiImage
+UiFontLoad
+UiLayout
+UiWidget
+UiClipboard
+UiDragDrop
+UiGpuPipeline
+UiNetworkResource
+```
+
+## 4. Capability contract
+
+| Capability | Allows | Does not allow |
+| --- | --- | --- |
+| `CAP_UI_WINDOW` | create/close window | drawing or input access |
+| `CAP_UI_EVENTS` | poll/read UI events | drawing, window creation |
+| `CAP_UI_DRAW` | submit draw commands | event polling or window creation |
+
+Admission rule:
+
+```text
+If SemCode contains UI host calls,
+the declared capability manifest must include matching UI capabilities.
+```
+
+## 5. Event model v0
+
+Minimal event set:
+
+```text
+Quit
+KeyDown
+KeyUp
+MouseMove
+MouseDown
+MouseUp
+Resize
+Tick
+```
+
+Event stream rule:
+
+```text
+Given the same event stream, Semantic UI program execution must be replayable.
+```
+
+## 6. Frame lifecycle v0
+
+Valid order:
+
+```text
+UiBeginFrame(window)
+  UiDraw*
+UiEndFrame(window)
+```
+
+Invalid:
+
+- draw before begin frame;
+- nested begin frame;
+- end frame without begin;
+- draw after close window.
+
+## 7. Draw command model v0
+
+Minimal commands:
+
+```text
+Clear
+Rect
+Text
+Line
+```
+
+Rules:
+
+- commands are submitted to a frame buffer / command buffer;
+- Semantic VM does not draw pixels directly;
+- backend-specific rendering is owned by `prom-ui-runtime`.
+
+## 8. Contract map
+
+| Contract | Owner | Verified by | Executed by |
+| --- | --- | --- | --- |
+| UI call IDs | `prom-abi` | `sm-verify` | `prom-runtime` / `sm-vm` host bridge |
+| UI capability requirements | `prom-cap` | `sm-verify` / `prom-runtime` | `prom-runtime` |
+| Event representation | `prom-ui` | tests / spec | `prom-ui-runtime` |
+| Frame state machine | `prom-ui` contract, `prom-ui-runtime` enforcement | tests | `prom-ui-runtime` |
+| Draw command schema | `prom-ui` | tests | `prom-ui-runtime` |
+| Platform rendering | backend crate | backend tests | backend crate |
+
+## 9. Non-goals
+
+This PR does not introduce:
+
+- UI syntax;
+- new opcodes;
+- SemCode format changes;
+- new capabilities in code;
+- runtime implementation;
+- Workbench integration;
+- demo app;
+- platform backend.
+
+## 10. Acceptance
+
+The contract is acceptable when future implementation PRs can answer:
+
+1. Where is this UI concept owned?
+2. Does this cross VM/runtime/compiler boundaries correctly?
+3. Which capability gates it?
+4. Which ABI call represents it?
+5. Is it deterministic under replayed event stream?
+6. Is it inside or outside first UI slice?


### PR DESCRIPTION
## Summary

- Adds the Semantic UI ownership map for the POST-UI track.
- Adds the Semantic UI contract map for first-slice UI contracts.
- Clarifies ownership boundaries across VM, ABI, capability, prom-ui, prom-ui-runtime, and demo application layers.
- Separates UI inspiration/reference from runtime ownership.
- Marks the UI scope in `docs/spec/index.md`.
- Does not add UI runtime behavior, new opcodes, or implementation code.

## Test plan

- [x] docs-only change
- [x] git diff --check
- [x] CI green
