### PR TITLE
docs(ui): define UI ABI and capability admission checklist

### DIFF
--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -5,6 +5,11 @@ Track: POST-UI
 Scope: ownership and boundaries only
 Implementation: out of scope
 
+Related:
+- `docs/spec/ui_contract_map.md`
+- `docs/spec/ui_abi_capability_admission.md`
+- `docs/roadmap/post_ui/ui_admission_checklist.md`
+
 ## 1. Purpose
 
 This document defines ownership boundaries for the Semantic UI/Application layer.

--- a/docs/roadmap/post_ui/ui_admission_checklist.md
+++ b/docs/roadmap/post_ui/ui_admission_checklist.md
@@ -1,0 +1,92 @@
+# POST-UI Admission Checklist
+
+Status: Draft
+Track: POST-UI
+Purpose: implementation gate for future UI PRs
+
+## 1. Why this checklist exists
+
+UI is a side-effect boundary.
+
+It must not bypass:
+
+- verifier admission;
+- capability checks;
+- runtime lifecycle checks;
+- host ABI discipline.
+
+## 2. PR gates
+
+### Gate UI-A - Contract gate
+
+Required before code changes:
+
+- `ui_ownership_map.md` exists.
+- `ui_contract_map.md` exists.
+- `ui_abi_capability_admission.md` exists.
+- first-slice operations are listed.
+- non-goals are explicit.
+
+### Gate UI-B - Capability gate
+
+Before executable UI operation support:
+
+- every UI operation maps to one `UiCapabilityKind`;
+- missing capability fails closed;
+- denial carries operation context;
+- default/gate manifests do not silently include UI capabilities.
+
+### Gate UI-C - Verifier gate
+
+Before VM execution support:
+
+- SemCode can expose required UI admission metadata;
+- verifier rejects unknown UI operation ids;
+- verifier rejects missing UI capabilities;
+- verifier keeps POST-UI outside stable profile.
+
+### Gate UI-D - Runtime lifecycle gate
+
+Before platform backend support:
+
+- window lifecycle state is explicit;
+- frame lifecycle state is explicit;
+- event polling state is explicit;
+- draw/frame submission cannot bypass lifecycle.
+
+### Gate UI-E - Audit/diagnostics gate
+
+Before user-facing release:
+
+- denials are diagnosable;
+- lifecycle violations are diagnosable;
+- host faults are separated from capability denials;
+- replay/event stream assumptions are documented.
+
+## 3. Implementation order
+
+```text
+B1 ownership docs
+  ↓
+B2 ABI/capability admission docs
+  ↓
+B3 prom-ui contract refinement
+  ↓
+B4 prom-cap UI admission tests
+  ↓
+B5 verifier UI admission plan
+  ↓
+B6 runtime lifecycle state plan
+  ↓
+implementation only after gates are clear
+```
+
+## 4. Stop rules
+
+Stop implementation if:
+
+- UI operation bypasses `prom-cap`;
+- UI runtime requires parser/typechecker knowledge;
+- VM stores native platform UI handles directly;
+- Workbench becomes owner of UI application contract;
+- stable-v1 docs imply UI is already shipped.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -27,6 +27,7 @@ Current documents in this PR:
 - `rules.md` - deterministic rule and agenda contract
 - `audit.md` - audit trail and replay metadata contract
 - `ui_contract_map.md` - POST-UI Semantic UI contract sketch and ownership map
+- `ui_abi_capability_admission.md` - POST-UI ABI/capability admission checklist for future UI operations
 
 Adjacent source-surface documents also remain relevant:
 

--- a/docs/spec/ui_abi_capability_admission.md
+++ b/docs/spec/ui_abi_capability_admission.md
@@ -1,0 +1,181 @@
+# UI ABI and Capability Admission
+
+Status: Draft
+Track: POST-UI
+Scope: admission checklist and ABI/capability bridge only
+Implementation: out of scope
+
+## 1. Purpose
+
+This document defines how future Semantic UI operations must pass through:
+
+- `prom-ui` operation identity;
+- `prom-cap` UI capability checking;
+- `prom-abi` host boundary rules;
+- future `sm-verify` admission checks.
+
+It does not introduce executable UI support.
+
+## 2. Current boundary facts
+
+Current code-level facts:
+
+- `prom-ui` owns UI operation identity and UI capability taxonomy.
+- `prom-cap` owns UI capability admission and denial reporting.
+- `prom-abi` owns general host-call descriptors and effect/determinism classes.
+- `sm-verify` owns SemCode admission before VM execution.
+
+## 3. Existing UI operation surface
+
+Current `prom-ui` operation identities:
+
+```text
+WindowCreate
+WindowRun
+WindowClose
+EventPoll
+FrameSubmit
+```
+
+Current required capability mapping:
+
+| UI operation | Required UI capability |
+| --- | --- |
+| `WindowCreate` | `DesktopSession` |
+| `WindowRun` | `DesktopSession` |
+| `WindowClose` | `DesktopSession` |
+| `EventPoll` | `InputPoll` |
+| `FrameSubmit` | `FrameEmit` |
+
+## 4. Admission rule
+
+A UI operation is admissible only if all of these are true:
+
+```text
+operation is known
+AND operation is inside the admitted UI surface
+AND matching UI capability is declared
+AND manifest schema/version is valid
+AND verifier can see the required UI admission metadata
+AND runtime checks the same capability before dispatch
+```
+
+No UI operation may execute only because it reached the VM.
+
+## 5. ABI bridge rule
+
+UI execution must not create a private side-effect path.
+
+Allowed future paths:
+
+```text
+SemCode UI operation
+  ↓
+sm-verify admission
+  ↓
+VM host bridge
+  ↓
+prom-cap UI capability check
+  ↓
+prom-ui-runtime
+  ↓
+platform backend
+```
+
+If future work maps UI operations into `prom-abi`, that mapping must preserve:
+
+- effect class;
+- determinism class;
+- stability class;
+- return-value contract;
+- capability requirement.
+
+## 6. Effect classification
+
+Recommended first-slice classification:
+
+| UI operation | Effect class | Determinism class | Returns value |
+| --- | --- | --- | --- |
+| `WindowCreate` | HostWrite | HostBound | implementation-defined / handle-like token only |
+| `WindowRun` | HostWrite / EventEmit boundary | HostBound | false |
+| `WindowClose` | HostWrite | HostBound | false |
+| `EventPoll` | HostQuery | HostBound | true |
+| `FrameSubmit` | HostWrite | HostBound | false |
+
+Notes:
+
+- UI is host-bound.
+- Replay determinism requires the same admitted program, same runtime config, same capability context, and same event stream.
+- Platform timing is not part of Semantic deterministic core.
+
+## 7. Verifier admission checklist
+
+Future verifier support must reject SemCode when:
+
+- UI operation id is unknown;
+- UI operation is encoded without required metadata;
+- required UI capability is missing from declared manifest/capability bits;
+- UI operation appears in a stable-v1 profile where POST-UI is not admitted;
+- frame/event/window operation violates static profile constraints, if any are expressible statically.
+
+Future verifier support must not:
+
+- parse UI source syntax;
+- own UI runtime state;
+- execute UI operations;
+- validate platform handles;
+- perform layout/widget checks.
+
+## 8. Runtime admission checklist
+
+Future runtime/VM bridge must check:
+
+- manifest validity;
+- `require_ui_op(operation)`;
+- session/window lifecycle state;
+- frame lifecycle state;
+- event polling boundary;
+- draw/frame submission boundary.
+
+Runtime must fail closed.
+
+## 9. Capability denial behavior
+
+Missing UI capability must produce structured denial equivalent to:
+
+```text
+UiCapabilityDenied {
+  capability,
+  operation,
+  code: MissingCapability,
+  manifest,
+  message
+}
+```
+
+Denial must be observable through local diagnostics/audit path once audit integration exists.
+
+## 10. Stable-line rule
+
+UI remains POST-UI / post-stable unless explicitly promoted.
+
+No B2 document may claim:
+
+- UI is part of published stable v1;
+- UI operations are executable today;
+- UI verifier admission is already implemented;
+- UI runtime is complete.
+
+## 11. Non-goals
+
+This document does not add:
+
+- new opcodes;
+- new SemCode header bits;
+- new `HostCallId` variants;
+- implementation in `prom-abi`;
+- implementation in `prom-cap`;
+- implementation in `sm-verify`;
+- implementation in `sm-vm`;
+- demo applications;
+- Workbench integration.

--- a/docs/spec/ui_contract_map.md
+++ b/docs/spec/ui_contract_map.md
@@ -5,6 +5,10 @@ Track: POST-UI
 Scope: public contract sketch only
 Implementation: out of scope
 
+Related:
+- `docs/spec/ui_abi_capability_admission.md`
+- `docs/architecture/ui_ownership_map.md`
+
 ## 1. Purpose
 
 This document defines the minimal UI contracts that future implementation PRs must follow.


### PR DESCRIPTION
## Summary

- Adds POST-UI ABI/capability admission documentation.
- Defines the future UI admission checklist across `prom-ui`, `prom-cap`, `prom-abi`, and `sm-verify`.
- Adds a roadmap checklist for future UI implementation gates.
- Links the new admission docs from the UI ownership and UI contract docs.

## Key points

- UI operations remain POST-UI / post-stable.
- This PR does not make UI executable.
- UI operations must fail closed without explicit UI capability admission.
- Future verifier support must reject unknown or non-admitted UI operations.
- Runtime must still enforce UI capability and lifecycle checks before dispatch.

## Changed files

- `docs/spec/ui_abi_capability_admission.md`
- `docs/roadmap/post_ui/ui_admission_checklist.md`
- `docs/spec/index.md`
- `docs/spec/ui_contract_map.md`
- `docs/architecture/ui_ownership_map.md`

## Out of scope

- Runtime implementation
- Rust code changes
- New opcodes
- SemCode format changes
- New `HostCallId` variants
- New capability variants
- Workbench integration
- Demo app
- Platform backend

## Validation

- [x] `git diff --check`
