### PR TITLE
docs(ui): align UI contract terminology with prom-ui surface

### DIFF
--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -75,9 +75,9 @@ Every effectful UI operation must have an explicit capability path.
 
 Examples:
 
-- `CAP_UI_WINDOW`
-- `CAP_UI_EVENTS`
-- `CAP_UI_DRAW`
+- `DesktopSession`
+- `InputPoll`
+- `FrameEmit`
 
 ### Rule UI-3 - VM is not a UI runtime
 

--- a/docs/roadmap/post_ui/ui_admission_checklist.md
+++ b/docs/roadmap/post_ui/ui_admission_checklist.md
@@ -31,7 +31,7 @@ Required before code changes:
 
 Before executable UI operation support:
 
-- every UI operation maps to one `UiCapabilityKind`;
+- every `UiOperationId` maps to one `UiCapabilityKind`;
 - missing capability fails closed;
 - denial carries operation context;
 - default/gate manifests do not silently include UI capabilities.
@@ -41,8 +41,8 @@ Before executable UI operation support:
 Before VM execution support:
 
 - SemCode can expose required UI admission metadata;
-- verifier rejects unknown UI operation ids;
-- verifier rejects missing UI capabilities;
+- verifier rejects unknown `UiOperationId` values;
+- verifier rejects missing `UiCapabilityKind` values;
 - verifier keeps POST-UI outside stable profile.
 
 ### Gate UI-D - Runtime lifecycle gate

--- a/docs/spec/ui_abi_capability_admission.md
+++ b/docs/spec/ui_abi_capability_admission.md
@@ -27,7 +27,7 @@ Current code-level facts:
 
 ## 3. Existing UI operation surface
 
-Current `prom-ui` operation identities:
+Current `prom-ui` UI operation identities:
 
 ```text
 WindowCreate

--- a/docs/spec/ui_contract_map.md
+++ b/docs/spec/ui_contract_map.md
@@ -21,7 +21,7 @@ It defines contract ownership and first-slice semantics.
 ```text
 UI Program
   ↓
-UI Host Calls
+UI Operations
   ↓
 UI Capabilities
   ↓
@@ -32,20 +32,19 @@ Frame Lifecycle
 Draw Command Buffer
 ```
 
-## 3. UI host call families
+## 3. UI operation families
 
-First slice host calls:
+Current `prom-ui` UI operation identities:
 
 ```text
-UiWindowCreate
-UiWindowClose
-UiPollEvent
-UiBeginFrame
-UiEndFrame
-UiDrawClear
-UiDrawRect
-UiDrawText
+WindowCreate
+WindowRun
+WindowClose
+EventPoll
+FrameSubmit
 ```
+
+These names intentionally match `UiOperationId`.
 
 Out of first slice:
 
@@ -58,20 +57,38 @@ UiClipboard
 UiDragDrop
 UiGpuPipeline
 UiNetworkResource
+MultiWindow
+BrowserTarget
+MobileTarget
 ```
+
+These are not current `UiOperationId` values.
+They are future/non-goal categories only.
 
 ## 4. Capability contract
 
+Current `prom-ui` capability identities:
+
 | Capability | Allows | Does not allow |
 | --- | --- | --- |
-| `CAP_UI_WINDOW` | create/close window | drawing or input access |
-| `CAP_UI_EVENTS` | poll/read UI events | drawing, window creation |
-| `CAP_UI_DRAW` | submit draw commands | event polling or window creation |
+| `DesktopSession` | create/run/close one desktop UI session | event polling or frame submission by itself |
+| `InputPoll` | poll/read UI events in an admitted session | window creation or frame submission |
+| `FrameEmit` | submit a frame through the admitted UI surface | event polling or window creation |
+
+Operation mapping:
+
+| UI operation | Required capability |
+| --- | --- |
+| `WindowCreate` | `DesktopSession` |
+| `WindowRun` | `DesktopSession` |
+| `WindowClose` | `DesktopSession` |
+| `EventPoll` | `InputPoll` |
+| `FrameSubmit` | `FrameEmit` |
 
 Admission rule:
 
 ```text
-If SemCode contains UI host calls,
+If SemCode contains admitted UI operations,
 the declared capability manifest must include matching UI capabilities.
 ```
 
@@ -98,24 +115,40 @@ Given the same event stream, Semantic UI program execution must be replayable.
 
 ## 6. Frame lifecycle v0
 
-Valid order:
+Current `prom-ui` exposes frame submission as a coarse operation:
 
 ```text
-UiBeginFrame(window)
-  UiDraw*
-UiEndFrame(window)
+FrameSubmit
 ```
 
-Invalid:
+The detailed internal frame lifecycle is still a future runtime contract.
 
-- draw before begin frame;
-- nested begin frame;
-- end frame without begin;
-- draw after close window.
+Valid future runtime order remains conceptually:
+
+```text
+begin frame
+  collect draw commands
+submit frame
+```
+
+Invalid future runtime cases:
+
+- frame submission before a desktop session exists;
+- frame submission after window close;
+- nested frame submission if the runtime model later forbids it;
+- drawing/frame emission without `FrameEmit`.
 
 ## 7. Draw command model v0
 
-Minimal commands:
+Current `prom-ui` does not expose individual draw commands as operation identities.
+
+Current public operation:
+
+```text
+FrameSubmit
+```
+
+Conceptual future draw-command payload may include:
 
 ```text
 Clear
@@ -126,7 +159,8 @@ Line
 
 Rules:
 
-- commands are submitted to a frame buffer / command buffer;
+- draw commands are payload concepts for future frame submission;
+- `Clear`, `Rect`, `Text`, and `Line` are not current `UiOperationId` values;
 - Semantic VM does not draw pixels directly;
 - backend-specific rendering is owned by `prom-ui-runtime`.
 


### PR DESCRIPTION
## Summary

- Aligns POST-UI docs with the current `prom-ui` operation and capability names.
- Replaces placeholder UI terms with current `UiOperationId` / `UiCapabilityKind` terminology.
- Clarifies that individual draw commands and detailed frame lifecycle names are future/conceptual, not current `prom-ui` operation identities.

## Current canonical names

Capabilities:
- `DesktopSession`
- `InputPoll`
- `FrameEmit`

Operations:
- `WindowCreate`
- `WindowRun`
- `WindowClose`
- `EventPoll`
- `FrameSubmit`

## Out of scope

- Runtime implementation
- Rust code changes
- New UI operations
- New UI capabilities
- New HostCallId variants
- SemCode format changes
- Verifier changes
- VM changes
- Workbench integration

## Validation

- [x] `git diff --check`
- [x] stale placeholder terminology checked in POST-UI docs
