### PR TITLE
feat(ui-runtime): add in-memory reference backend

### DIFF
--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -293,6 +293,11 @@ impl<B: UiBackendAdapter> DesktopSession<B> {
     pub fn state(&self) -> SessionState {
         self.lifecycle.state()
     }
+
+    /// Read-only access to the backend for tests and reference inspection.
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
 }
 
 // ── PR 6: Deterministic event polling and frame-token ownership ───────────────
@@ -524,6 +529,90 @@ impl DrawFrame {
     /// Returns `true` if no commands have been pushed.
     pub fn is_empty(&self) -> bool {
         self.commands.is_empty()
+    }
+}
+
+/// Deterministic in-memory reference backend.
+///
+/// This backend does not create native windows and does not render pixels.
+/// It records lifecycle calls and submitted draw frames for tests/reference use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InMemoryBackend {
+    config: Option<WindowConfig>,
+    run_event_loop_calls: usize,
+    close_window_calls: usize,
+    loop_iterations: usize,
+    captured_frames: alloc::vec::Vec<alloc::vec::Vec<DrawCommand>>,
+}
+
+impl InMemoryBackend {
+    pub fn new() -> Self {
+        Self::with_loop_iterations(1)
+    }
+
+    pub fn with_loop_iterations(loop_iterations: usize) -> Self {
+        Self {
+            config: None,
+            run_event_loop_calls: 0,
+            close_window_calls: 0,
+            loop_iterations,
+            captured_frames: alloc::vec::Vec::new(),
+        }
+    }
+
+    pub fn config(&self) -> Option<&WindowConfig> {
+        self.config.as_ref()
+    }
+
+    pub fn run_event_loop_calls(&self) -> usize {
+        self.run_event_loop_calls
+    }
+
+    pub fn close_window_calls(&self) -> usize {
+        self.close_window_calls
+    }
+
+    pub fn captured_frames(&self) -> &[alloc::vec::Vec<DrawCommand>] {
+        &self.captured_frames
+    }
+
+    pub fn captured_frame_count(&self) -> usize {
+        self.captured_frames.len()
+    }
+}
+
+impl Default for InMemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UiBackendAdapter for InMemoryBackend {
+    fn create_window(&mut self, config: &WindowConfig) -> Result<(), UiRuntimeError> {
+        self.config = Some(config.clone());
+        Ok(())
+    }
+
+    fn close_window(&mut self) {
+        self.close_window_calls = self.close_window_calls.saturating_add(1);
+    }
+
+    fn run_event_loop<F: FnMut(LoopControl)>(
+        &mut self,
+        mut on_event: F,
+    ) -> Result<(), UiRuntimeError> {
+        self.run_event_loop_calls = self.run_event_loop_calls.saturating_add(1);
+
+        for _ in 0..self.loop_iterations {
+            on_event(LoopControl::Continue);
+        }
+
+        Ok(())
+    }
+
+    fn draw_frame(&mut self, frame: &DrawFrame) -> Result<(), UiRuntimeError> {
+        self.captured_frames.push(frame.commands().to_vec());
+        Ok(())
     }
 }
 

--- a/crates/prom-ui-runtime/tests/ui_in_memory_backend_contract.rs
+++ b/crates/prom-ui-runtime/tests/ui_in_memory_backend_contract.rs
@@ -1,0 +1,132 @@
+use prom_ui_runtime::{
+    Color, DesktopSession, DrawCommand, DrawFrame, EventBuffer, InMemoryBackend, InputEvent,
+    InputEventKind, LoopControl, Rect, SessionState, WindowConfig,
+};
+
+#[test]
+fn in_memory_backend_records_window_config() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("Memory", 640, 480);
+
+    let session = DesktopSession::create(backend, cfg).unwrap();
+
+    let stored = session.backend().config().expect("config must be recorded");
+    assert_eq!(stored.title, "Memory");
+    assert_eq!(stored.width, 640);
+    assert_eq!(stored.height, 480);
+    assert_eq!(session.state(), SessionState::Created);
+}
+
+#[test]
+fn in_memory_backend_counts_run_event_loop_calls() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("RunCounter", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session.run(|_| LoopControl::ExitRequested).unwrap();
+
+    assert_eq!(session.backend().run_event_loop_calls(), 1);
+    assert_eq!(session.state(), SessionState::Running);
+}
+
+#[test]
+fn in_memory_backend_captures_submitted_frame_payload() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("FrameCapture", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session.run(|_| LoopControl::ExitRequested).unwrap();
+
+    let mut frame = DrawFrame::new();
+    frame.clear(Color::BLACK);
+    frame.fill_rect(Rect::new(1, 2, 3, 4), Color::GREEN);
+    frame.draw_text("hello", 5, 6, Color::BLUE);
+
+    session.submit_frame(&frame).unwrap();
+
+    let frames = session.backend().captured_frames();
+    assert_eq!(frames.len(), 1);
+
+    assert_eq!(
+        frames[0],
+        vec![
+            DrawCommand::Clear {
+                color: Color::BLACK,
+            },
+            DrawCommand::FillRect {
+                rect: Rect::new(1, 2, 3, 4),
+                color: Color::GREEN,
+            },
+            DrawCommand::DrawText {
+                text: "hello".into(),
+                x: 5,
+                y: 6,
+                color: Color::BLUE,
+            },
+        ]
+    );
+}
+
+#[test]
+fn in_memory_backend_captures_tick_frame_payload() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("TickCapture", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session.run(|_| LoopControl::ExitRequested).unwrap();
+
+    let mut buffer = EventBuffer::new();
+    buffer.push(InputEvent::new(InputEventKind::KeyDown { key_code: 65 }));
+
+    let control = session
+        .tick_frame(&mut buffer, |events, frame| {
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].kind, InputEventKind::KeyDown { key_code: 65 });
+
+            frame.clear(Color::WHITE);
+            LoopControl::Continue
+        })
+        .unwrap();
+
+    assert_eq!(control, LoopControl::Continue);
+
+    let frames = session.backend().captured_frames();
+    assert_eq!(frames.len(), 1);
+    assert_eq!(
+        frames[0],
+        vec![DrawCommand::Clear {
+            color: Color::WHITE,
+        }]
+    );
+}
+
+#[test]
+fn in_memory_backend_counts_close_calls() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("CloseCounter", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session.close().unwrap();
+
+    assert_eq!(session.backend().close_window_calls(), 1);
+    assert_eq!(session.state(), SessionState::Closed);
+}
+
+#[test]
+fn in_memory_backend_does_not_capture_rejected_frame() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("RejectedFrame", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    let mut frame = DrawFrame::new();
+    frame.clear(Color::RED);
+
+    let err = session.submit_frame(&frame).unwrap_err();
+
+    assert!(matches!(
+        err,
+        prom_ui_runtime::UiRuntimeError::LifecycleViolation { .. }
+    ));
+
+    assert_eq!(session.backend().captured_frame_count(), 0);
+}


### PR DESCRIPTION
## Summary

- Adds `InMemoryBackend` as a deterministic reference implementation of `UiBackendAdapter`.
- Records window configuration, event-loop calls, close calls, and submitted draw frames in memory.
- Adds read-only `DesktopSession::backend()` access for reference/test inspection.
- Adds integration tests for in-memory backend behavior.

## What it provides

- A platform-free reference backend.
- No native window creation.
- No renderer.
- No external backend dependency.
- A deterministic backend baseline for future runtime tests.

## What it records

- `WindowConfig`
- `run_event_loop(...)` call count
- `close_window()` call count
- submitted `DrawFrame` command payloads

## Out of scope

- Native window backend
- Renderer
- winit / tao / wgpu
- VM integration
- Verifier integration
- SemCode changes
- HostCallId changes
- New UI operations
- New UI capabilities
- Workbench integration

## Validation

- [x] `cargo test -q -p prom-ui-runtime`
- [x] `git diff --check`