### PR TITLE
feat(ui-runtime): add in-memory event injection helper

### DIFF
--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -298,6 +298,11 @@ impl<B: UiBackendAdapter> DesktopSession<B> {
     pub fn backend(&self) -> &B {
         &self.backend
     }
+
+    /// Mutable access to the backend for reference and test configuration.
+    pub fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
+    }
 }
 
 // ── PR 6: Deterministic event polling and frame-token ownership ───────────────
@@ -543,6 +548,7 @@ pub struct InMemoryBackend {
     close_window_calls: usize,
     loop_iterations: usize,
     captured_frames: alloc::vec::Vec<alloc::vec::Vec<DrawCommand>>,
+    queued_events: alloc::vec::Vec<InputEvent>,
 }
 
 impl InMemoryBackend {
@@ -557,6 +563,7 @@ impl InMemoryBackend {
             close_window_calls: 0,
             loop_iterations,
             captured_frames: alloc::vec::Vec::new(),
+            queued_events: alloc::vec::Vec::new(),
         }
     }
 
@@ -578,6 +585,29 @@ impl InMemoryBackend {
 
     pub fn captured_frame_count(&self) -> usize {
         self.captured_frames.len()
+    }
+
+    pub fn push_event(&mut self, event: InputEvent) {
+        self.queued_events.push(event);
+    }
+
+    pub fn extend_events<I>(&mut self, events: I)
+    where
+        I: IntoIterator<Item = InputEvent>,
+    {
+        self.queued_events.extend(events);
+    }
+
+    pub fn queued_events(&self) -> &[InputEvent] {
+        &self.queued_events
+    }
+
+    pub fn queued_event_count(&self) -> usize {
+        self.queued_events.len()
+    }
+
+    pub fn drain_events(&mut self) -> alloc::vec::Vec<InputEvent> {
+        core::mem::replace(&mut self.queued_events, alloc::vec::Vec::new())
     }
 }
 

--- a/crates/prom-ui-runtime/tests/ui_in_memory_event_injection_contract.rs
+++ b/crates/prom-ui-runtime/tests/ui_in_memory_event_injection_contract.rs
@@ -1,0 +1,136 @@
+use prom_ui_runtime::{
+    DesktopSession, EventBuffer, InMemoryBackend, InputEvent, InputEventKind, LoopControl,
+    WindowConfig,
+};
+
+#[test]
+fn in_memory_backend_starts_with_empty_event_queue() {
+    let backend = InMemoryBackend::new();
+
+    assert_eq!(backend.queued_event_count(), 0);
+    assert!(backend.queued_events().is_empty());
+}
+
+#[test]
+fn in_memory_backend_push_event_preserves_payload() {
+    let mut backend = InMemoryBackend::new();
+
+    backend.push_event(InputEvent::new(InputEventKind::KeyDown { key_code: 65 }));
+    backend.push_event(InputEvent::new(InputEventKind::KeyUp { key_code: 65 }));
+
+    assert_eq!(backend.queued_event_count(), 2);
+    assert_eq!(
+        backend.queued_events()[0].kind,
+        InputEventKind::KeyDown { key_code: 65 }
+    );
+    assert_eq!(
+        backend.queued_events()[1].kind,
+        InputEventKind::KeyUp { key_code: 65 }
+    );
+}
+
+#[test]
+fn in_memory_backend_extend_events_preserves_order() {
+    let mut backend = InMemoryBackend::new();
+
+    backend.extend_events([
+        InputEvent::new(InputEventKind::KeyDown { key_code: 1 }),
+        InputEvent::new(InputEventKind::KeyUp { key_code: 1 }),
+        InputEvent::new(InputEventKind::CloseRequested),
+    ]);
+
+    let events = backend.queued_events();
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].kind, InputEventKind::KeyDown { key_code: 1 });
+    assert_eq!(events[1].kind, InputEventKind::KeyUp { key_code: 1 });
+    assert_eq!(events[2].kind, InputEventKind::CloseRequested);
+}
+
+#[test]
+fn in_memory_backend_drain_events_returns_and_clears_queue() {
+    let mut backend = InMemoryBackend::new();
+
+    backend.push_event(InputEvent::new(InputEventKind::KeyDown { key_code: 42 }));
+    backend.push_event(InputEvent::new(InputEventKind::CloseRequested));
+
+    let drained = backend.drain_events();
+
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0].kind, InputEventKind::KeyDown { key_code: 42 });
+    assert_eq!(drained[1].kind, InputEventKind::CloseRequested);
+
+    assert_eq!(backend.queued_event_count(), 0);
+    assert!(backend.queued_events().is_empty());
+}
+
+#[test]
+fn desktop_session_backend_mut_allows_in_memory_event_injection() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("InjectedEvents", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session
+        .backend_mut()
+        .push_event(InputEvent::new(InputEventKind::KeyDown { key_code: 77 }));
+
+    assert_eq!(session.backend().queued_event_count(), 1);
+    assert_eq!(
+        session.backend().queued_events()[0].kind,
+        InputEventKind::KeyDown { key_code: 77 }
+    );
+}
+
+#[test]
+fn injected_events_can_be_moved_into_event_buffer_and_polled() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("PollInjectedEvents", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session.backend_mut().extend_events([
+        InputEvent::new(InputEventKind::KeyDown { key_code: 11 }),
+        InputEvent::new(InputEventKind::KeyUp { key_code: 11 }),
+    ]);
+
+    session.run(|_| LoopControl::ExitRequested).unwrap();
+
+    let mut buffer = EventBuffer::new();
+    for event in session.backend_mut().drain_events() {
+        buffer.push(event);
+    }
+
+    let events = session.poll_events(&mut buffer).unwrap();
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].kind, InputEventKind::KeyDown { key_code: 11 });
+    assert_eq!(events[1].kind, InputEventKind::KeyUp { key_code: 11 });
+    assert_eq!(session.backend().queued_event_count(), 0);
+}
+
+#[test]
+fn failed_poll_does_not_clear_in_memory_backend_queue() {
+    let backend = InMemoryBackend::new();
+    let cfg = WindowConfig::new("FailedPollInjected", 640, 480);
+    let mut session = DesktopSession::create(backend, cfg).unwrap();
+
+    session
+        .backend_mut()
+        .push_event(InputEvent::new(InputEventKind::CloseRequested));
+
+    let mut buffer = EventBuffer::new();
+
+    let err = session
+        .poll_events(&mut buffer)
+        .expect_err("poll before run must fail");
+
+    assert!(matches!(
+        err,
+        prom_ui_runtime::UiRuntimeError::LifecycleViolation { .. }
+    ));
+
+    assert_eq!(session.backend().queued_event_count(), 1);
+    assert_eq!(
+        session.backend().queued_events()[0].kind,
+        InputEventKind::CloseRequested
+    );
+}


### PR DESCRIPTION
## Summary

- Adds deterministic event injection helpers to `InMemoryBackend`.
- Adds read/write event queue methods:
  - `push_event(...)`
  - `extend_events(...)`
  - `queued_events()`
  - `queued_event_count()`
  - `drain_events()`
- Adds `DesktopSession::backend_mut()` for reference/test backend configuration.
- Adds integration tests for event injection and manual polling through `EventBuffer`.

## What it provides

- Deterministic in-memory event queue.
- No platform event source.
- No backend trait change.
- No native window integration.
- Reference helper for future UI runtime tests.

## Important boundary

`InMemoryBackend` does not automatically pump events into `DesktopSession`.
Events are manually drained from the backend and pushed into `EventBuffer`.
This keeps E2 independent from platform event-loop design.

## Out of scope

- Native window backend
- Renderer
- winit / tao / wgpu
- Backend trait changes
- Automatic event pump
- VM integration
- Verifier integration
- SemCode changes
- HostCallId changes
- New UI operations
- New UI capabilities
- Workbench integration

## Validation

- [x] `cargo test -q -p prom-ui-runtime`
- [x] `git diff --check`