### PR TITLE
feat(ui-backend-native): add native backend crate skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/prom-audit",
     "crates/prom-ui",
     "crates/prom-ui-runtime",
+    "crates/prom-ui-backend-native",
     "crates/prom-ui-demo",
     "crates/core-lab",
     "crates/semantic-core-backend",

--- a/crates/prom-ui-backend-native/Cargo.toml
+++ b/crates/prom-ui-backend-native/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "prom-ui-backend-native"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = ["prom-ui-runtime/std"]
+
+[dependencies]
+prom-ui = { path = "../prom-ui", default-features = false }
+prom-ui-runtime = { path = "../prom-ui-runtime", default-features = false }

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -1,0 +1,64 @@
+//! Native backend crate skeleton for Semantic UI.
+//!
+//! This crate is the future home of platform-specific UI backend code.
+//! It intentionally does not create native windows yet.
+//!
+//! Boundary:
+//! - `prom-ui-runtime` remains platform-neutral.
+//! - Native/window dependencies belong here, not in `prom-ui-runtime`.
+//! - The only current seam is `UiBackendAdapter`.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use prom_ui::UiOperationId;
+use prom_ui_runtime::{DrawFrame, LoopControl, UiBackendAdapter, UiRuntimeError, WindowConfig};
+
+/// Skeleton native backend.
+///
+/// This type is intentionally not wired to a platform windowing library yet.
+/// It exists to lock the crate boundary before real native integration.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NativeBackend {
+    platform_wired: bool,
+}
+
+impl NativeBackend {
+    /// Create an unwired native backend skeleton.
+    pub const fn new() -> Self {
+        Self {
+            platform_wired: false,
+        }
+    }
+
+    /// Returns whether this backend is connected to a real platform implementation.
+    ///
+    /// For G2 this must remain `false`.
+    pub const fn is_platform_wired(&self) -> bool {
+        self.platform_wired
+    }
+}
+
+impl UiBackendAdapter for NativeBackend {
+    fn create_window(&mut self, _config: &WindowConfig) -> Result<(), UiRuntimeError> {
+        Err(UiRuntimeError::OperationNotAdmitted(
+            UiOperationId::WindowCreate,
+        ))
+    }
+
+    fn close_window(&mut self) {
+        // No-op while the backend is not platform-wired.
+    }
+
+    fn run_event_loop<F: FnMut(LoopControl)>(
+        &mut self,
+        _on_event: F,
+    ) -> Result<(), UiRuntimeError> {
+        Err(UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun))
+    }
+
+    fn draw_frame(&mut self, _frame: &DrawFrame) -> Result<(), UiRuntimeError> {
+        Err(UiRuntimeError::OperationNotAdmitted(
+            UiOperationId::FrameSubmit,
+        ))
+    }
+}

--- a/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
@@ -1,0 +1,66 @@
+use prom_ui::UiOperationId;
+use prom_ui_backend_native::NativeBackend;
+use prom_ui_runtime::{
+    DesktopSession, DrawFrame, UiBackendAdapter, UiRuntimeError, WindowConfig,
+};
+
+#[test]
+fn native_backend_skeleton_is_not_platform_wired() {
+    let backend = NativeBackend::new();
+
+    assert!(!backend.is_platform_wired());
+}
+
+#[test]
+fn native_backend_create_window_fails_closed() {
+    let backend = NativeBackend::new();
+    let cfg = WindowConfig::new("NativeSkeleton", 640, 480);
+
+    let err = match DesktopSession::create(backend, cfg) {
+        Ok(_) => panic!("native skeleton must not create a real session yet"),
+        Err(err) => err,
+    };
+
+    assert_eq!(
+        err,
+        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowCreate)
+    );
+}
+
+#[test]
+fn native_backend_run_event_loop_fails_closed() {
+    let mut backend = NativeBackend::new();
+
+    let err = backend
+        .run_event_loop(|_| {})
+        .expect_err("unwired native backend must reject run_event_loop");
+
+    assert_eq!(
+        err,
+        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun)
+    );
+}
+
+#[test]
+fn native_backend_draw_frame_fails_closed() {
+    let mut backend = NativeBackend::new();
+    let frame = DrawFrame::new();
+
+    let err = backend
+        .draw_frame(&frame)
+        .expect_err("unwired native backend must reject draw_frame");
+
+    assert_eq!(
+        err,
+        UiRuntimeError::OperationNotAdmitted(UiOperationId::FrameSubmit)
+    );
+}
+
+#[test]
+fn native_backend_close_window_is_noop_before_platform_wiring() {
+    let mut backend = NativeBackend::new();
+
+    backend.close_window();
+
+    assert!(!backend.is_platform_wired());
+}


### PR DESCRIPTION
## Summary

- Adds `prom-ui-backend-native` as a separate native backend crate skeleton.
- Adds `NativeBackend` as an unwired backend placeholder.
- Implements `UiBackendAdapter` for `NativeBackend`.
- Keeps all native operations fail-closed until platform integration exists.
- Adds skeleton contract tests.

## Boundary

Native backend code now has a crate boundary:

```text
crates/prom-ui-backend-native
  -> depends on prom-ui-runtime
  -> implements UiBackendAdapter
```

`prom-ui-runtime` remains platform-neutral.

## Current behavior

`NativeBackend` is not platform-wired yet:

- `create_window(...)` returns `OperationNotAdmitted(WindowCreate)`
- `run_event_loop(...)` returns `OperationNotAdmitted(WindowRun)`
- `draw_frame(...)` returns `OperationNotAdmitted(FrameSubmit)`
- `close_window()` is a no-op

## Out of scope

- winit / tao / wgpu
- native window creation
- renderer
- event translation
- backend trait changes
- runtime API changes
- VM integration
- verifier integration
- SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`
