### PR TITLE
feat(ui-backend-native): add feature-gated winit dependency placeholder

### DIFF
--- a/crates/prom-ui-backend-native/Cargo.toml
+++ b/crates/prom-ui-backend-native/Cargo.toml
@@ -9,7 +9,9 @@ path = "src/lib.rs"
 [features]
 default = ["std"]
 std = ["prom-ui-runtime/std"]
+winit-backend = ["std", "dep:winit"]
 
 [dependencies]
 prom-ui = { path = "../prom-ui", default-features = false }
 prom-ui-runtime = { path = "../prom-ui-runtime", default-features = false }
+winit = { version = "0.30.13", optional = true, default-features = false }

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -13,6 +13,28 @@
 use prom_ui::UiOperationId;
 use prom_ui_runtime::{DrawFrame, LoopControl, UiBackendAdapter, UiRuntimeError, WindowConfig};
 
+/// Returns whether this crate was compiled with the `winit-backend` feature.
+pub const fn winit_backend_feature_enabled() -> bool {
+    cfg!(feature = "winit-backend")
+}
+
+#[cfg(feature = "winit-backend")]
+pub mod winit_placeholder {
+    //! Feature-gated placeholder for future winit integration.
+    //!
+    //! This module intentionally does not create windows or run an event loop yet.
+
+    /// Compile-time marker proving the `winit` crate is available behind the feature.
+    pub const WINIT_BACKEND_PLACEHOLDER: bool = true;
+
+    /// Return the winit crate version selected by Cargo.
+    ///
+    /// Kept as a simple static marker to avoid touching native APIs in G3.
+    pub const fn winit_backend_placeholder_enabled() -> bool {
+        true
+    }
+}
+
 /// Skeleton native backend.
 ///
 /// This type is intentionally not wired to a platform windowing library yet.

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_feature_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_feature_contract.rs
@@ -1,0 +1,13 @@
+#[cfg(not(feature = "winit-backend"))]
+#[test]
+fn winit_backend_feature_is_disabled_by_default() {
+    assert!(!prom_ui_backend_native::winit_backend_feature_enabled());
+}
+
+#[cfg(feature = "winit-backend")]
+#[test]
+fn winit_backend_feature_exposes_placeholder_module() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(prom_ui_backend_native::winit_placeholder::WINIT_BACKEND_PLACEHOLDER);
+    assert!(prom_ui_backend_native::winit_placeholder::winit_backend_placeholder_enabled());
+}


### PR DESCRIPTION
## Summary

- Adds `winit` as an optional dependency of `prom-ui-backend-native`.
- Adds `winit-backend` feature flag.
- Keeps the default native backend build platform-free.
- Adds a compile-time placeholder module behind `winit-backend`.
- Adds tests for default-disabled and feature-enabled behavior.

## Boundary

`winit` is allowed only inside:

```text
crates/prom-ui-backend-native
```

`prom-ui-runtime` remains platform-neutral.

## Current behavior

No real native backend behavior is added.

- No window creation
- No event loop
- No event translation
- No rendering
- No backend trait changes

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`
