### PR TITLE
feat(ui-backend-native): add winit event-loop type scaffold

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -24,6 +24,15 @@ pub mod winit_placeholder {
     //!
     //! This module intentionally does not create windows or run an event loop yet.
 
+    use core::marker::PhantomData;
+
+    use winit::{
+        application::ApplicationHandler,
+        event::WindowEvent,
+        event_loop::ActiveEventLoop,
+        window::WindowId,
+    };
+
     /// Compile-time marker proving the `winit` crate is available behind the feature.
     pub const WINIT_BACKEND_PLACEHOLDER: bool = true;
 
@@ -32,6 +41,67 @@ pub mod winit_placeholder {
     /// Kept as a simple static marker to avoid touching native APIs in G3.
     pub const fn winit_backend_placeholder_enabled() -> bool {
         true
+    }
+
+    /// Returns a marker that anchors the current winit ApplicationHandler scaffold.
+    pub const fn winit_event_loop_scaffold_available() -> bool {
+        true
+    }
+
+    /// Type-level scaffold for future winit event-loop integration.
+    ///
+    /// This struct intentionally owns no `EventLoop`, no `Window`, and no OS handle.
+    /// It only proves that the native backend crate can compile against the
+    /// `winit` 0.30 ApplicationHandler surface behind the `winit-backend` feature.
+    #[derive(Debug, Default)]
+    pub struct WinitEventLoopScaffold {
+        resumed_calls: usize,
+        window_event_calls: usize,
+        close_requested: bool,
+        _not_send_sync_runtime: PhantomData<*const ()>,
+    }
+
+    impl WinitEventLoopScaffold {
+        pub const fn new() -> Self {
+            Self {
+                resumed_calls: 0,
+                window_event_calls: 0,
+                close_requested: false,
+                _not_send_sync_runtime: PhantomData,
+            }
+        }
+
+        pub const fn resumed_calls(&self) -> usize {
+            self.resumed_calls
+        }
+
+        pub const fn window_event_calls(&self) -> usize {
+            self.window_event_calls
+        }
+
+        pub const fn close_requested(&self) -> bool {
+            self.close_requested
+        }
+    }
+
+    impl ApplicationHandler for WinitEventLoopScaffold {
+        fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+            self.resumed_calls = self.resumed_calls.saturating_add(1);
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            _window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            self.window_event_calls = self.window_event_calls.saturating_add(1);
+
+            if matches!(event, WindowEvent::CloseRequested) {
+                self.close_requested = true;
+                event_loop.exit();
+            }
+        }
     }
 }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_scaffold_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_scaffold_contract.rs
@@ -1,0 +1,35 @@
+#[cfg(not(feature = "winit-backend"))]
+#[test]
+fn winit_event_loop_scaffold_is_disabled_by_default() {
+    assert!(!prom_ui_backend_native::winit_backend_feature_enabled());
+}
+
+#[cfg(feature = "winit-backend")]
+use prom_ui_backend_native::winit_placeholder::{
+    winit_event_loop_scaffold_available, WinitEventLoopScaffold,
+};
+
+#[cfg(feature = "winit-backend")]
+#[test]
+fn winit_event_loop_scaffold_is_available_under_feature() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_event_loop_scaffold_available());
+}
+
+#[cfg(feature = "winit-backend")]
+#[test]
+fn winit_event_loop_scaffold_starts_empty() {
+    let scaffold = WinitEventLoopScaffold::new();
+
+    assert_eq!(scaffold.resumed_calls(), 0);
+    assert_eq!(scaffold.window_event_calls(), 0);
+    assert!(!scaffold.close_requested());
+}
+
+#[cfg(feature = "winit-backend")]
+#[test]
+fn winit_event_loop_scaffold_implements_application_handler() {
+    fn assert_handler<T: winit::application::ApplicationHandler>() {}
+
+    assert_handler::<WinitEventLoopScaffold>();
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated winit event-loop type scaffold.
- Introduces `WinitEventLoopScaffold` behind `winit-backend`.
- Implements `winit::application::ApplicationHandler` for the scaffold.
- Adds compile-time tests proving the scaffold targets the winit 0.30 handler surface.

## Boundary

This PR does not run or create native platform objects.

No:
- `EventLoop::new`
- `run_app`
- `ActiveEventLoop::create_window`
- native window creation
- event translation
- rendering

The scaffold only compiles behind:

```text
--features winit-backend
```

## Out of scope

- Real native backend behavior
- Window creation
- Event loop execution
- Input translation
- DrawFrame rendering
- Backend trait changes
- Runtime API changes
- VM/verifier/SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`
