### PR TITLE
feat(ui-backend-native): add winit window config translation scaffold

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -26,11 +26,13 @@ pub mod winit_placeholder {
 
     use core::marker::PhantomData;
 
+    use prom_ui_runtime::WindowConfig;
     use winit::{
         application::ApplicationHandler,
+        dpi::LogicalSize,
         event::WindowEvent,
         event_loop::ActiveEventLoop,
-        window::WindowId,
+        window::{Window, WindowAttributes, WindowId},
     };
 
     /// Compile-time marker proving the `winit` crate is available behind the feature.
@@ -45,6 +47,23 @@ pub mod winit_placeholder {
 
     /// Returns a marker that anchors the current winit ApplicationHandler scaffold.
     pub const fn winit_event_loop_scaffold_available() -> bool {
+        true
+    }
+
+    /// Translate Semantic UI `WindowConfig` into winit `WindowAttributes`.
+    ///
+    /// This function does not create a native window.
+    /// It only prepares attributes for a future `ActiveEventLoop::create_window(...)` call.
+    pub fn window_config_to_winit_attributes(config: &WindowConfig) -> WindowAttributes {
+        Window::default_attributes()
+            .with_title(config.title.clone())
+            .with_inner_size(LogicalSize::new(config.width as f64, config.height as f64))
+            .with_visible(true)
+            .with_resizable(true)
+    }
+
+    /// Returns whether the winit window config translation scaffold is available.
+    pub const fn winit_window_config_translation_available() -> bool {
         true
     }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_window_config_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_window_config_contract.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::{
+    window_config_to_winit_attributes, winit_window_config_translation_available,
+};
+use prom_ui_runtime::WindowConfig;
+use winit::{dpi::Size, window::WindowAttributes};
+
+#[test]
+fn winit_window_config_translation_scaffold_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_window_config_translation_available());
+}
+
+#[test]
+fn window_config_translates_title() {
+    let config = WindowConfig::new("Semantic Native", 800, 600);
+
+    let attrs = window_config_to_winit_attributes(&config);
+
+    assert_eq!(attrs.title, "Semantic Native");
+}
+
+#[test]
+fn window_config_translates_inner_size() {
+    let config = WindowConfig::new("Size", 1024, 768);
+
+    let attrs = window_config_to_winit_attributes(&config);
+
+    let size = attrs
+        .inner_size
+        .expect("inner_size must be set by translation");
+
+    match size {
+        Size::Logical(logical) => {
+            assert_eq!(logical.width, 1024.0);
+            assert_eq!(logical.height, 768.0);
+        }
+        other => panic!("expected logical size, got {other:?}"),
+    }
+}
+
+#[test]
+fn window_config_translation_sets_safe_defaults() {
+    let config = WindowConfig::new("Defaults", 640, 480);
+
+    let attrs = window_config_to_winit_attributes(&config);
+
+    assert!(attrs.visible);
+    assert!(attrs.resizable);
+}
+
+#[test]
+fn window_config_translation_returns_winit_window_attributes() {
+    fn assert_attrs(_: WindowAttributes) {}
+
+    let config = WindowConfig::new("TypeCheck", 320, 240);
+    let attrs = window_config_to_winit_attributes(&config);
+
+    assert_attrs(attrs);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated winit window config translation scaffold.
- Translates `prom_ui_runtime::WindowConfig` into `winit::window::WindowAttributes`.
- Uses `Window::default_attributes()` and builder methods.
- Adds tests for title, logical inner size, and safe defaults.

## Boundary

This PR only prepares window attributes.

No:
- `EventLoop::new`
- `run_app`
- `ActiveEventLoop::create_window`
- native window creation
- event translation
- rendering
- backend trait changes
- runtime API changes

## Translation

```text
WindowConfig.title  -> WindowAttributes.title
WindowConfig.width  -> WindowAttributes.inner_size.width
WindowConfig.height -> WindowAttributes.inner_size.height
```

Safe defaults:

- visible = true
- resizable = true

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`
