### PR TITLE
feat(ui-backend-native): add winit event translation scaffold

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -30,8 +30,9 @@ pub mod winit_placeholder {
     use winit::{
         application::ApplicationHandler,
         dpi::LogicalSize,
-        event::WindowEvent,
+        event::{ElementState, WindowEvent},
         event_loop::ActiveEventLoop,
+        keyboard::{KeyCode, PhysicalKey},
         window::{Window, WindowAttributes, WindowId},
     };
 
@@ -65,6 +66,72 @@ pub mod winit_placeholder {
     /// Returns whether the winit window config translation scaffold is available.
     pub const fn winit_window_config_translation_available() -> bool {
         true
+    }
+
+    /// Returns whether the winit event translation scaffold is available.
+    pub const fn winit_event_translation_available() -> bool {
+        true
+    }
+
+    /// Translate a winit close request into the Semantic UI input event surface.
+    pub fn translate_winit_close_requested() -> prom_ui_runtime::InputEvent {
+        prom_ui_runtime::InputEvent::new(prom_ui_runtime::InputEventKind::CloseRequested)
+    }
+
+    /// Translate a selected winit physical key into the current Semantic key code space.
+    ///
+    /// This is intentionally small. It is not a full keyboard layout or text-input model.
+    pub const fn translate_winit_key_code(key_code: KeyCode) -> Option<u32> {
+        match key_code {
+            KeyCode::KeyA => Some(65),
+            KeyCode::KeyB => Some(66),
+            KeyCode::KeyC => Some(67),
+            KeyCode::KeyD => Some(68),
+            KeyCode::KeyW => Some(87),
+            KeyCode::KeyS => Some(83),
+            KeyCode::Digit0 => Some(48),
+            KeyCode::Digit1 => Some(49),
+            KeyCode::Digit2 => Some(50),
+            KeyCode::Enter => Some(13),
+            KeyCode::Escape => Some(27),
+            KeyCode::Space => Some(32),
+            _ => None,
+        }
+    }
+
+    /// Translate a winit physical key state into a Semantic UI input event.
+    ///
+    /// Unsupported keys return `None`.
+    pub fn translate_winit_physical_key(
+        state: ElementState,
+        physical_key: PhysicalKey,
+    ) -> Option<prom_ui_runtime::InputEvent> {
+        let key_code = match physical_key {
+            PhysicalKey::Code(code) => translate_winit_key_code(code)?,
+            PhysicalKey::Unidentified(_) => return None,
+        };
+
+        let kind = match state {
+            ElementState::Pressed => prom_ui_runtime::InputEventKind::KeyDown { key_code },
+            ElementState::Released => prom_ui_runtime::InputEventKind::KeyUp { key_code },
+        };
+
+        Some(prom_ui_runtime::InputEvent::new(kind))
+    }
+
+    /// Translate selected winit `WindowEvent` variants into the Semantic UI input surface.
+    ///
+    /// This function does not run an event loop and does not mutate backend state.
+    pub fn translate_winit_window_event(
+        event: &WindowEvent,
+    ) -> Option<prom_ui_runtime::InputEvent> {
+        match event {
+            WindowEvent::CloseRequested => Some(translate_winit_close_requested()),
+            WindowEvent::KeyboardInput { event, .. } => {
+                translate_winit_physical_key(event.state, event.physical_key)
+            }
+            _ => None,
+        }
     }
 
     /// Type-level scaffold for future winit event-loop integration.

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_event_translation_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_event_translation_contract.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::{
+    translate_winit_close_requested, translate_winit_key_code, translate_winit_physical_key,
+    translate_winit_window_event, winit_event_translation_available,
+};
+use prom_ui_runtime::InputEventKind;
+use winit::{
+    event::{ElementState, WindowEvent},
+    keyboard::{KeyCode, PhysicalKey},
+};
+
+#[test]
+fn winit_event_translation_scaffold_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_event_translation_available());
+}
+
+#[test]
+fn close_requested_translates_to_close_requested_input_event() {
+    let event = translate_winit_close_requested();
+
+    assert_eq!(event.kind, InputEventKind::CloseRequested);
+}
+
+#[test]
+fn key_code_translation_maps_selected_keys() {
+    assert_eq!(translate_winit_key_code(KeyCode::KeyA), Some(65));
+    assert_eq!(translate_winit_key_code(KeyCode::KeyW), Some(87));
+    assert_eq!(translate_winit_key_code(KeyCode::Digit1), Some(49));
+    assert_eq!(translate_winit_key_code(KeyCode::Enter), Some(13));
+    assert_eq!(translate_winit_key_code(KeyCode::Escape), Some(27));
+    assert_eq!(translate_winit_key_code(KeyCode::Space), Some(32));
+}
+
+#[test]
+fn pressed_physical_key_translates_to_key_down() {
+    let event =
+        translate_winit_physical_key(ElementState::Pressed, PhysicalKey::Code(KeyCode::KeyA))
+            .expect("KeyA must be supported");
+
+    assert_eq!(event.kind, InputEventKind::KeyDown { key_code: 65 });
+}
+
+#[test]
+fn released_physical_key_translates_to_key_up() {
+    let event =
+        translate_winit_physical_key(ElementState::Released, PhysicalKey::Code(KeyCode::KeyA))
+            .expect("KeyA must be supported");
+
+    assert_eq!(event.kind, InputEventKind::KeyUp { key_code: 65 });
+}
+
+#[test]
+fn unsupported_physical_key_returns_none() {
+    let event =
+        translate_winit_physical_key(ElementState::Pressed, PhysicalKey::Code(KeyCode::F12));
+
+    assert!(event.is_none());
+}
+
+#[test]
+fn window_event_close_requested_translates() {
+    let event = translate_winit_window_event(&WindowEvent::CloseRequested)
+        .expect("CloseRequested must translate");
+
+    assert_eq!(event.kind, InputEventKind::CloseRequested);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated winit event translation scaffold.
- Adds pure helpers for selected keyboard and close-event translation.
- Maps selected `winit::keyboard::KeyCode` values into the current `InputEventKind` key-code surface.
- Adds tests for close, key down, key up, and unsupported keys.

## Boundary

This PR only adds pure translation helpers.

No:
- `EventLoop::new`
- `run_app`
- `ActiveEventLoop::create_window`
- native window creation
- real event loop
- backend state mutation
- renderer
- backend trait changes
- runtime API changes

## Translation

```text
CloseRequested -> InputEventKind::CloseRequested

ElementState::Pressed  + supported PhysicalKey::Code -> KeyDown { key_code }
ElementState::Released + supported PhysicalKey::Code -> KeyUp   { key_code }
unsupported key                                    -> None
```

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`
