### PR TITLE
feat(ui-backend-native): add staged event pump from translated winit events

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -269,6 +269,46 @@ impl Default for NativeBackend {
     }
 }
 
+#[cfg(feature = "winit-backend")]
+impl NativeBackend {
+    /// Stage a translated winit `WindowEvent` into the backend pending-event queue.
+    ///
+    /// Returns `true` if the event was translated and staged.
+    /// Returns `false` for unsupported events.
+    ///
+    /// This does not run a native event loop and does not mutate platform state.
+    pub fn stage_winit_window_event(&mut self, event: &winit::event::WindowEvent) -> bool {
+        if let Some(input) = winit_placeholder::translate_winit_window_event(event) {
+            self.push_pending_event(input);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Stage a translated winit physical key event into the backend pending-event queue.
+    ///
+    /// Returns `true` if the key was supported and staged.
+    /// Returns `false` for unsupported or unidentified keys.
+    pub fn stage_winit_physical_key(
+        &mut self,
+        state: winit::event::ElementState,
+        physical_key: winit::keyboard::PhysicalKey,
+    ) -> bool {
+        if let Some(input) = winit_placeholder::translate_winit_physical_key(state, physical_key) {
+            self.push_pending_event(input);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Stage a close request into the backend pending-event queue.
+    pub fn stage_winit_close_requested(&mut self) {
+        self.push_pending_event(winit_placeholder::translate_winit_close_requested());
+    }
+}
+
 impl UiBackendAdapter for NativeBackend {
     fn create_window(&mut self, _config: &WindowConfig) -> Result<(), UiRuntimeError> {
         self.window_config = Some(_config.clone());

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_event_pump_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_event_pump_contract.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::NativeBackend;
+use prom_ui_runtime::InputEventKind;
+use winit::{
+    event::{ElementState, WindowEvent},
+    keyboard::{KeyCode, PhysicalKey},
+};
+
+#[test]
+fn staged_winit_close_request_enters_pending_queue() {
+    let mut backend = NativeBackend::new();
+
+    backend.stage_winit_close_requested();
+
+    assert_eq!(backend.pending_event_count(), 1);
+    assert_eq!(
+        backend.pending_events()[0].kind,
+        InputEventKind::CloseRequested
+    );
+}
+
+#[test]
+fn staged_window_event_close_requested_enters_pending_queue() {
+    let mut backend = NativeBackend::new();
+
+    let staged = backend.stage_winit_window_event(&WindowEvent::CloseRequested);
+
+    assert!(staged);
+    assert_eq!(backend.pending_event_count(), 1);
+    assert_eq!(
+        backend.pending_events()[0].kind,
+        InputEventKind::CloseRequested
+    );
+}
+
+#[test]
+fn staged_pressed_physical_key_enters_pending_queue_as_key_down() {
+    let mut backend = NativeBackend::new();
+
+    let staged =
+        backend.stage_winit_physical_key(ElementState::Pressed, PhysicalKey::Code(KeyCode::KeyA));
+
+    assert!(staged);
+    assert_eq!(backend.pending_event_count(), 1);
+    assert_eq!(
+        backend.pending_events()[0].kind,
+        InputEventKind::KeyDown { key_code: 65 }
+    );
+}
+
+#[test]
+fn staged_released_physical_key_enters_pending_queue_as_key_up() {
+    let mut backend = NativeBackend::new();
+
+    let staged = backend
+        .stage_winit_physical_key(ElementState::Released, PhysicalKey::Code(KeyCode::KeyA));
+
+    assert!(staged);
+    assert_eq!(backend.pending_event_count(), 1);
+    assert_eq!(
+        backend.pending_events()[0].kind,
+        InputEventKind::KeyUp { key_code: 65 }
+    );
+}
+
+#[test]
+fn unsupported_winit_key_is_not_staged() {
+    let mut backend = NativeBackend::new();
+
+    let staged =
+        backend.stage_winit_physical_key(ElementState::Pressed, PhysicalKey::Code(KeyCode::F12));
+
+    assert!(!staged);
+    assert_eq!(backend.pending_event_count(), 0);
+    assert!(backend.pending_events().is_empty());
+}
+
+#[test]
+fn multiple_staged_winit_events_preserve_order() {
+    let mut backend = NativeBackend::new();
+
+    assert!(backend.stage_winit_physical_key(
+        ElementState::Pressed,
+        PhysicalKey::Code(KeyCode::KeyA),
+    ));
+
+    assert!(backend.stage_winit_physical_key(
+        ElementState::Released,
+        PhysicalKey::Code(KeyCode::KeyA),
+    ));
+
+    backend.stage_winit_close_requested();
+
+    assert_eq!(backend.pending_event_count(), 3);
+
+    assert_eq!(
+        backend.pending_events()[0].kind,
+        InputEventKind::KeyDown { key_code: 65 }
+    );
+    assert_eq!(
+        backend.pending_events()[1].kind,
+        InputEventKind::KeyUp { key_code: 65 }
+    );
+    assert_eq!(
+        backend.pending_events()[2].kind,
+        InputEventKind::CloseRequested
+    );
+}
+
+#[test]
+fn staged_winit_events_can_be_drained() {
+    let mut backend = NativeBackend::new();
+
+    backend.stage_winit_physical_key(
+        ElementState::Pressed,
+        PhysicalKey::Code(KeyCode::KeyA),
+    );
+    backend.stage_winit_close_requested();
+
+    let drained = backend.drain_pending_events();
+
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0].kind, InputEventKind::KeyDown { key_code: 65 });
+    assert_eq!(drained[1].kind, InputEventKind::CloseRequested);
+
+    assert_eq!(backend.pending_event_count(), 0);
+}


### PR DESCRIPTION
## Summary\n\n- Adds feature-gated staged winit event pump helpers to NativeBackend.\n- Stages translated winit close/key events into NativeBackend pending-event queue.\n- Reuses existing winit translation helpers.\n- Adds tests for close, key down, key up, unsupported key, ordering, and drain behavior.\n\n## Boundary\n\nThis PR stages translated events only.\n\nNo:\n- EventLoop::new\n- run_app\n- ActiveEventLoop::create_window\n- native window creation\n- real event loop\n- rendering\n- backend trait changes\n- runtime API changes\n\n## Behavior\n\nBehind winit-backend:\n\nWindowEvent::CloseRequested -> pending InputEvent::CloseRequested\n\nElementState::Pressed + supported PhysicalKey -> pending InputEventKind::KeyDown\n\nElementState::Released + supported PhysicalKey -> pending InputEventKind::KeyUp\n\nunsupported key -> not staged\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check