### PR TITLE
feat(ui-backend-native): wire NativeBackend pending events into run_event_loop stub

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -12,9 +12,9 @@
 
 extern crate alloc;
 
-use prom_ui::UiOperationId;
 use prom_ui_runtime::{
-    DrawFrame, InputEvent, LoopControl, UiBackendAdapter, UiRuntimeError, WindowConfig,
+    DrawFrame, InputEvent, InputEventKind, LoopControl, UiBackendAdapter, UiRuntimeError,
+    WindowConfig,
 };
 
 /// Returns whether this crate was compiled with the `winit-backend` feature.
@@ -206,6 +206,8 @@ pub struct NativeBackend {
     pending_events: alloc::vec::Vec<InputEvent>,
     submitted_frames: usize,
     closed: bool,
+    run_loop_calls: usize,
+    run_loop_ticks: usize,
 }
 
 impl NativeBackend {
@@ -217,6 +219,8 @@ impl NativeBackend {
             pending_events: alloc::vec::Vec::new(),
             submitted_frames: 0,
             closed: false,
+            run_loop_calls: 0,
+            run_loop_ticks: 0,
         }
     }
 
@@ -245,6 +249,14 @@ impl NativeBackend {
 
     pub const fn is_closed(&self) -> bool {
         self.closed
+    }
+
+    pub const fn run_loop_calls(&self) -> usize {
+        self.run_loop_calls
+    }
+
+    pub const fn run_loop_ticks(&self) -> usize {
+        self.run_loop_ticks
     }
 
     pub fn push_pending_event(&mut self, event: InputEvent) {
@@ -322,9 +334,25 @@ impl UiBackendAdapter for NativeBackend {
 
     fn run_event_loop<F: FnMut(LoopControl)>(
         &mut self,
-        _on_event: F,
+        mut on_event: F,
     ) -> Result<(), UiRuntimeError> {
-        Err(UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun))
+        self.run_loop_calls = self.run_loop_calls.saturating_add(1);
+
+        let events = self.drain_pending_events();
+
+        for event in events {
+            self.run_loop_ticks = self.run_loop_ticks.saturating_add(1);
+
+            match event.kind {
+                InputEventKind::CloseRequested => {
+                    on_event(LoopControl::ExitRequested);
+                    break;
+                }
+                _ => on_event(LoopControl::Continue),
+            }
+        }
+
+        Ok(())
     }
 
     fn draw_frame(&mut self, _frame: &DrawFrame) -> Result<(), UiRuntimeError> {

--- a/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
@@ -1,7 +1,6 @@
-use prom_ui::UiOperationId;
 use prom_ui_backend_native::NativeBackend;
 use prom_ui_runtime::{
-    DesktopSession, DrawFrame, UiBackendAdapter, UiRuntimeError, WindowConfig,
+    DesktopSession, DrawFrame, UiBackendAdapter, WindowConfig,
 };
 
 #[test]
@@ -31,17 +30,16 @@ fn native_backend_create_window_stages_config_without_platform_window() {
 }
 
 #[test]
-fn native_backend_run_event_loop_fails_closed() {
+fn native_backend_run_event_loop_is_staged_not_platform_wired() {
     let mut backend = NativeBackend::new();
+    let mut controls = Vec::new();
 
-    let err = backend
-        .run_event_loop(|_| {})
-        .expect_err("unwired native backend must reject run_event_loop");
+    backend.run_event_loop(|control| controls.push(control)).unwrap();
 
-    assert_eq!(
-        err,
-        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun)
-    );
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 0);
+    assert!(controls.is_empty());
+    assert!(!backend.is_platform_wired());
 }
 
 #[test]

--- a/crates/prom-ui-backend-native/tests/native_backend_staged_run_loop_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_staged_run_loop_contract.rs
@@ -1,0 +1,140 @@
+use prom_ui_backend_native::NativeBackend;
+use prom_ui_runtime::{
+    DesktopSession, InputEvent, InputEventKind, LoopControl, SessionState, UiBackendAdapter,
+    WindowConfig,
+};
+
+#[test]
+fn run_loop_starts_with_zero_counters() {
+    let backend = NativeBackend::new();
+
+    assert_eq!(backend.run_loop_calls(), 0);
+    assert_eq!(backend.run_loop_ticks(), 0);
+}
+
+#[test]
+fn run_loop_with_no_pending_events_calls_no_ticks() {
+    let mut backend = NativeBackend::new();
+    let mut controls = Vec::new();
+
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
+
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 0);
+    assert!(controls.is_empty());
+}
+
+#[test]
+fn run_loop_drains_pending_key_events_as_continue_ticks() {
+    let mut backend = NativeBackend::new();
+
+    backend.extend_pending_events([
+        InputEvent::new(InputEventKind::KeyDown { key_code: 65 }),
+        InputEvent::new(InputEventKind::KeyUp { key_code: 65 }),
+    ]);
+
+    let mut controls = Vec::new();
+
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
+
+    assert_eq!(
+        controls,
+        vec![LoopControl::Continue, LoopControl::Continue]
+    );
+
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 2);
+    assert_eq!(backend.pending_event_count(), 0);
+}
+
+#[test]
+fn run_loop_emits_exit_requested_for_close_event() {
+    let mut backend = NativeBackend::new();
+
+    backend.push_pending_event(InputEvent::new(InputEventKind::CloseRequested));
+
+    let mut controls = Vec::new();
+
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
+
+    assert_eq!(controls, vec![LoopControl::ExitRequested]);
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 1);
+    assert_eq!(backend.pending_event_count(), 0);
+}
+
+#[test]
+fn run_loop_stops_after_close_requested() {
+    let mut backend = NativeBackend::new();
+
+    backend.extend_pending_events([
+        InputEvent::new(InputEventKind::KeyDown { key_code: 65 }),
+        InputEvent::new(InputEventKind::CloseRequested),
+        InputEvent::new(InputEventKind::KeyDown { key_code: 66 }),
+    ]);
+
+    let mut controls = Vec::new();
+
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
+
+    assert_eq!(
+        controls,
+        vec![LoopControl::Continue, LoopControl::ExitRequested]
+    );
+
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 2);
+    assert_eq!(backend.pending_event_count(), 0);
+}
+
+#[test]
+fn run_loop_accumulates_counters_across_runs() {
+    let mut backend = NativeBackend::new();
+
+    backend.push_pending_event(InputEvent::new(InputEventKind::KeyDown { key_code: 1 }));
+
+    backend.run_event_loop(|_| {}).unwrap();
+
+    backend.push_pending_event(InputEvent::new(InputEventKind::KeyDown { key_code: 2 }));
+
+    backend.run_event_loop(|_| {}).unwrap();
+
+    assert_eq!(backend.run_loop_calls(), 2);
+    assert_eq!(backend.run_loop_ticks(), 2);
+}
+
+#[test]
+fn desktop_session_run_works_with_staged_native_backend() {
+    let mut backend = NativeBackend::new();
+
+    backend.extend_pending_events([
+        InputEvent::new(InputEventKind::KeyDown { key_code: 65 }),
+        InputEvent::new(InputEventKind::CloseRequested),
+    ]);
+
+    let config = WindowConfig::new("Staged Native", 640, 480);
+    let mut session = DesktopSession::create(backend, config).unwrap();
+
+    let mut frame_ticks = 0usize;
+
+    session
+        .run(|_buffer| {
+            frame_ticks += 1;
+            LoopControl::Continue
+        })
+        .unwrap();
+
+    assert_eq!(session.state(), SessionState::Running);
+    assert_eq!(frame_ticks, 2);
+    assert_eq!(session.backend().run_loop_calls(), 1);
+    assert_eq!(session.backend().run_loop_ticks(), 2);
+    assert_eq!(session.backend().pending_event_count(), 0);
+}

--- a/crates/prom-ui-backend-native/tests/native_backend_staged_state_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_staged_state_contract.rs
@@ -1,8 +1,6 @@
-use prom_ui::UiOperationId;
 use prom_ui_backend_native::NativeBackend;
 use prom_ui_runtime::{
-    DesktopSession, DrawFrame, InputEvent, InputEventKind, UiBackendAdapter, UiRuntimeError,
-    WindowConfig,
+    DesktopSession, DrawFrame, InputEvent, InputEventKind, UiBackendAdapter, WindowConfig,
 };
 
 #[test]
@@ -107,17 +105,18 @@ fn draw_frame_counts_submitted_frames_without_rendering() {
 }
 
 #[test]
-fn run_event_loop_remains_not_admitted_until_winit_wiring() {
+fn run_event_loop_is_staged_until_winit_wiring() {
     let mut backend = NativeBackend::new();
+    let mut controls = Vec::new();
 
-    let err = backend
-        .run_event_loop(|_| {})
-        .unwrap_err();
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
 
-    assert_eq!(
-        err,
-        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun)
-    );
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 0);
+    assert!(controls.is_empty());
+    assert!(!backend.is_platform_wired());
 }
 
 #[test]


### PR DESCRIPTION
## Summary\n\n- Wires NativeBackend pending events into a staged deterministic run_event_loop stub.\n- Adds run-loop counters for calls and ticks.\n- Drains staged pending events during run_event_loop.\n- Emits LoopControl::Continue for key events.\n- Emits LoopControl::ExitRequested for close request and stops the loop.\n- Updates native backend skeleton/staged-state tests.\n\n## Boundary\n\nThis PR does not create or run native platform objects.\n\nNo:\n- EventLoop::new\n- run_app\n- ActiveEventLoop::create_window\n- native window creation\n- rendering\n- backend trait changes\n- runtime API changes\n\n## Behavior\n\npending KeyDown/KeyUp events -> run_event_loop(...) -> callback receives LoopControl::Continue\n\npending CloseRequested -> run_event_loop(...) -> callback receives LoopControl::ExitRequested -> loop stops\n\nNativeBackend remains not platform-wired:\n\nis_platform_wired() == false\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check