### PR TITLE
feat(ui-backend-native): add real winit EventLoop creation behind feature

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -12,9 +12,9 @@
 
 extern crate alloc;
 
-use prom_ui::UiOperationId;
 use prom_ui_runtime::{
-    DrawFrame, InputEvent, LoopControl, UiBackendAdapter, UiRuntimeError, WindowConfig,
+    DrawFrame, InputEvent, InputEventKind, LoopControl, UiBackendAdapter, UiRuntimeError,
+    WindowConfig,
 };
 
 /// Returns whether this crate was compiled with the `winit-backend` feature.
@@ -35,7 +35,7 @@ pub mod winit_placeholder {
         application::ApplicationHandler,
         dpi::LogicalSize,
         event::{ElementState, WindowEvent},
-        event_loop::ActiveEventLoop,
+        event_loop::{ActiveEventLoop, EventLoop},
         keyboard::{KeyCode, PhysicalKey},
         window::{Window, WindowAttributes, WindowId},
     };
@@ -43,9 +43,7 @@ pub mod winit_placeholder {
     /// Compile-time marker proving the `winit` crate is available behind the feature.
     pub const WINIT_BACKEND_PLACEHOLDER: bool = true;
 
-    /// Return the winit crate version selected by Cargo.
-    ///
-    /// Kept as a simple static marker to avoid touching native APIs in G3.
+    /// Returns whether the winit placeholder feature marker is available.
     pub const fn winit_backend_placeholder_enabled() -> bool {
         true
     }
@@ -53,6 +51,29 @@ pub mod winit_placeholder {
     /// Returns a marker that anchors the current winit ApplicationHandler scaffold.
     pub const fn winit_event_loop_scaffold_available() -> bool {
         true
+    }
+
+    /// Returns whether the winit event-loop creation scaffold is available.
+    pub const fn winit_event_loop_creation_available() -> bool {
+        true
+    }
+
+    /// Create a real winit `EventLoop`.
+    ///
+    /// This does not run the loop and does not create a window.
+    /// It only verifies that the native backend crate can construct the platform event loop
+    /// behind the `winit-backend` feature.
+    pub fn create_winit_event_loop() -> Result<EventLoop<()>, winit::error::EventLoopError> {
+        let mut builder = EventLoop::builder();
+
+        #[cfg(target_os = "windows")]
+        {
+            use winit::platform::windows::EventLoopBuilderExtWindows;
+
+            builder.with_any_thread(true);
+        }
+
+        builder.build()
     }
 
     /// Translate Semantic UI `WindowConfig` into winit `WindowAttributes`.
@@ -195,139 +216,6 @@ pub mod winit_placeholder {
     }
 }
 
-/// Returns whether this crate was compiled with the `winit-backend` feature.
-pub const fn winit_backend_feature_enabled() -> bool {
-    cfg!(feature = "winit-backend")
-}
-
-#[cfg(feature = "winit-backend")]
-pub mod winit_placeholder {
-    //! Feature-gated placeholder for future winit integration.
-    //!
-    //! This module intentionally does not create windows or run an event loop yet.
-
-    /// Compile-time marker proving the `winit` crate is available behind the feature.
-    pub const WINIT_BACKEND_PLACEHOLDER: bool = true;
-
-    /// Return the winit crate version selected by Cargo.
-    ///
-    /// Kept as a simple static marker to avoid touching native APIs in G3.
-    pub const fn winit_backend_placeholder_enabled() -> bool {
-        true
-    }
-}
-
-/// Returns whether this crate was compiled with the `winit-backend` feature.
-pub const fn winit_backend_feature_enabled() -> bool {
-    cfg!(feature = "winit-backend")
-}
-
-#[cfg(feature = "winit-backend")]
-pub mod winit_placeholder {
-    //! Feature-gated placeholder for future winit integration.
-    //!
-    //! This module intentionally does not create windows or run an event loop yet.
-
-    use core::marker::PhantomData;
-
-    use prom_ui_runtime::WindowConfig;
-    use winit::{
-        application::ApplicationHandler,
-        dpi::LogicalSize,
-        event::WindowEvent,
-        event_loop::ActiveEventLoop,
-        window::{Window, WindowAttributes, WindowId},
-    };
-
-    /// Compile-time marker proving the `winit` crate is available behind the feature.
-    pub const WINIT_BACKEND_PLACEHOLDER: bool = true;
-
-    /// Return the winit crate version selected by Cargo.
-    ///
-    /// Kept as a simple static marker to avoid touching native APIs in G3.
-    pub const fn winit_backend_placeholder_enabled() -> bool {
-        true
-    }
-
-    /// Returns a marker that anchors the current winit ApplicationHandler scaffold.
-    pub const fn winit_event_loop_scaffold_available() -> bool {
-        true
-    }
-
-    /// Translate Semantic UI `WindowConfig` into winit `WindowAttributes`.
-    ///
-    /// This function does not create a native window.
-    /// It only prepares attributes for a future `ActiveEventLoop::create_window(...)` call.
-    pub fn window_config_to_winit_attributes(config: &WindowConfig) -> WindowAttributes {
-        Window::default_attributes()
-            .with_title(config.title.clone())
-            .with_inner_size(LogicalSize::new(config.width as f64, config.height as f64))
-            .with_visible(true)
-            .with_resizable(true)
-    }
-
-    /// Returns whether the winit window config translation scaffold is available.
-    pub const fn winit_window_config_translation_available() -> bool {
-        true
-    }
-
-    /// Type-level scaffold for future winit event-loop integration.
-    ///
-    /// This struct intentionally owns no `EventLoop`, no `Window`, and no OS handle.
-    /// It only proves that the native backend crate can compile against the
-    /// `winit` 0.30 ApplicationHandler surface behind the `winit-backend` feature.
-    #[derive(Debug, Default)]
-    pub struct WinitEventLoopScaffold {
-        resumed_calls: usize,
-        window_event_calls: usize,
-        close_requested: bool,
-        _not_send_sync_runtime: PhantomData<*const ()>,
-    }
-
-    impl WinitEventLoopScaffold {
-        pub const fn new() -> Self {
-            Self {
-                resumed_calls: 0,
-                window_event_calls: 0,
-                close_requested: false,
-                _not_send_sync_runtime: PhantomData,
-            }
-        }
-
-        pub const fn resumed_calls(&self) -> usize {
-            self.resumed_calls
-        }
-
-        pub const fn window_event_calls(&self) -> usize {
-            self.window_event_calls
-        }
-
-        pub const fn close_requested(&self) -> bool {
-            self.close_requested
-        }
-    }
-
-    impl ApplicationHandler for WinitEventLoopScaffold {
-        fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
-            self.resumed_calls = self.resumed_calls.saturating_add(1);
-        }
-
-        fn window_event(
-            &mut self,
-            event_loop: &ActiveEventLoop,
-            _window_id: WindowId,
-            event: WindowEvent,
-        ) {
-            self.window_event_calls = self.window_event_calls.saturating_add(1);
-
-            if matches!(event, WindowEvent::CloseRequested) {
-                self.close_requested = true;
-                event_loop.exit();
-            }
-        }
-    }
-}
-
 /// Skeleton native backend.
 ///
 /// This type is intentionally not wired to a platform windowing library yet.
@@ -339,6 +227,8 @@ pub struct NativeBackend {
     pending_events: alloc::vec::Vec<InputEvent>,
     submitted_frames: usize,
     closed: bool,
+    run_loop_calls: usize,
+    run_loop_ticks: usize,
 }
 
 impl NativeBackend {
@@ -350,6 +240,8 @@ impl NativeBackend {
             pending_events: alloc::vec::Vec::new(),
             submitted_frames: 0,
             closed: false,
+            run_loop_calls: 0,
+            run_loop_ticks: 0,
         }
     }
 
@@ -380,6 +272,14 @@ impl NativeBackend {
         self.closed
     }
 
+    pub const fn run_loop_calls(&self) -> usize {
+        self.run_loop_calls
+    }
+
+    pub const fn run_loop_ticks(&self) -> usize {
+        self.run_loop_ticks
+    }
+
     pub fn push_pending_event(&mut self, event: InputEvent) {
         self.pending_events.push(event);
     }
@@ -402,9 +302,49 @@ impl Default for NativeBackend {
     }
 }
 
+#[cfg(feature = "winit-backend")]
+impl NativeBackend {
+    /// Stage a translated winit `WindowEvent` into the backend pending-event queue.
+    ///
+    /// Returns `true` if the event was translated and staged.
+    /// Returns `false` for unsupported events.
+    ///
+    /// This does not run a native event loop and does not mutate platform state.
+    pub fn stage_winit_window_event(&mut self, event: &winit::event::WindowEvent) -> bool {
+        if let Some(input) = winit_placeholder::translate_winit_window_event(event) {
+            self.push_pending_event(input);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Stage a translated winit physical key event into the backend pending-event queue.
+    ///
+    /// Returns `true` if the key was supported and staged.
+    /// Returns `false` for unsupported or unidentified keys.
+    pub fn stage_winit_physical_key(
+        &mut self,
+        state: winit::event::ElementState,
+        physical_key: winit::keyboard::PhysicalKey,
+    ) -> bool {
+        if let Some(input) = winit_placeholder::translate_winit_physical_key(state, physical_key) {
+            self.push_pending_event(input);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Stage a close request into the backend pending-event queue.
+    pub fn stage_winit_close_requested(&mut self) {
+        self.push_pending_event(winit_placeholder::translate_winit_close_requested());
+    }
+}
+
 impl UiBackendAdapter for NativeBackend {
-    fn create_window(&mut self, _config: &WindowConfig) -> Result<(), UiRuntimeError> {
-        self.window_config = Some(_config.clone());
+    fn create_window(&mut self, config: &WindowConfig) -> Result<(), UiRuntimeError> {
+        self.window_config = Some(config.clone());
         self.closed = false;
         Ok(())
     }
@@ -415,9 +355,25 @@ impl UiBackendAdapter for NativeBackend {
 
     fn run_event_loop<F: FnMut(LoopControl)>(
         &mut self,
-        _on_event: F,
+        mut on_event: F,
     ) -> Result<(), UiRuntimeError> {
-        Err(UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun))
+        self.run_loop_calls = self.run_loop_calls.saturating_add(1);
+
+        let events = self.drain_pending_events();
+
+        for event in events {
+            self.run_loop_ticks = self.run_loop_ticks.saturating_add(1);
+
+            match event.kind {
+                InputEventKind::CloseRequested => {
+                    on_event(LoopControl::ExitRequested);
+                    break;
+                }
+                _ => on_event(LoopControl::Continue),
+            }
+        }
+
+        Ok(())
     }
 
     fn draw_frame(&mut self, _frame: &DrawFrame) -> Result<(), UiRuntimeError> {

--- a/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_skeleton_contract.rs
@@ -1,7 +1,6 @@
-use prom_ui::UiOperationId;
 use prom_ui_backend_native::NativeBackend;
 use prom_ui_runtime::{
-    DesktopSession, DrawFrame, UiBackendAdapter, UiRuntimeError, WindowConfig,
+    DesktopSession, DrawFrame, UiBackendAdapter, WindowConfig,
 };
 
 #[test]
@@ -31,17 +30,16 @@ fn native_backend_create_window_stages_config_without_platform_window() {
 }
 
 #[test]
-fn native_backend_run_event_loop_fails_closed() {
+fn native_backend_run_event_loop_is_staged_not_platform_wired() {
     let mut backend = NativeBackend::new();
+    let mut controls = Vec::new();
 
-    let err = backend
-        .run_event_loop(|_| {})
-        .expect_err("unwired native backend must reject run_event_loop");
+    backend.run_event_loop(|control| controls.push(control)).unwrap();
 
-    assert_eq!(
-        err,
-        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun)
-    );
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 0);
+    assert!(controls.is_empty());
+    assert!(!backend.is_platform_wired());
 }
 
 #[test]

--- a/crates/prom-ui-backend-native/tests/native_backend_staged_state_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_staged_state_contract.rs
@@ -1,8 +1,6 @@
-use prom_ui::UiOperationId;
 use prom_ui_backend_native::NativeBackend;
 use prom_ui_runtime::{
-    DesktopSession, DrawFrame, InputEvent, InputEventKind, UiBackendAdapter, UiRuntimeError,
-    WindowConfig,
+    DesktopSession, DrawFrame, InputEvent, InputEventKind, UiBackendAdapter, WindowConfig,
 };
 
 #[test]
@@ -107,17 +105,18 @@ fn draw_frame_counts_submitted_frames_without_rendering() {
 }
 
 #[test]
-fn run_event_loop_remains_not_admitted_until_winit_wiring() {
+fn run_event_loop_is_staged_until_winit_wiring() {
     let mut backend = NativeBackend::new();
+    let mut controls = Vec::new();
 
-    let err = backend
-        .run_event_loop(|_| {})
-        .unwrap_err();
+    backend
+        .run_event_loop(|control| controls.push(control))
+        .unwrap();
 
-    assert_eq!(
-        err,
-        UiRuntimeError::OperationNotAdmitted(UiOperationId::WindowRun)
-    );
+    assert_eq!(backend.run_loop_calls(), 1);
+    assert_eq!(backend.run_loop_ticks(), 0);
+    assert!(controls.is_empty());
+    assert!(!backend.is_platform_wired());
 }
 
 #[test]

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_event_loop_creation_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_event_loop_creation_contract.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::{
+    create_winit_event_loop, winit_event_loop_creation_available,
+};
+
+#[test]
+fn winit_event_loop_creation_scaffold_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_event_loop_creation_available());
+}
+
+#[test]
+fn can_call_winit_event_loop_creation_helper_without_panicking() {
+    let _ = create_winit_event_loop();
+}


### PR DESCRIPTION
## Summary\n\n- Adds a feature-gated helper to create a real winit EventLoop inside prom-ui-backend-native.\n- Keeps the helper behind winit-backend so default builds remain platform-free.\n- Adds contract tests for feature-gated availability and non-panicking creation helper behavior.\n\nNote: this PR also carries the staged run-loop consolidation required because the prior G9 chain was merged through stacked native-backend branches.\n\n## Boundary\n\nThis PR only creates the event loop object.\n\nNo:\n- run_app\n- ActiveEventLoop::create_window\n- native window creation\n- rendering\n- prom-ui-runtime changes\n- UiBackendAdapter changes\n- lifecycle rule changes\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check