### PR TITLE
feat(ui-backend-native): add native window creation scaffold behind winit-backend

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -31,6 +31,7 @@ pub mod winit_placeholder {
     use core::marker::PhantomData;
 
     use prom_ui_runtime::WindowConfig;
+    use winit::error::OsError;
     use winit::{
         application::ApplicationHandler,
         dpi::LogicalSize,
@@ -76,6 +77,11 @@ pub mod winit_placeholder {
         builder.build()
     }
 
+    /// Returns whether the winit native window creation scaffold is available.
+    pub const fn winit_window_creation_scaffold_available() -> bool {
+        true
+    }
+
     /// Translate Semantic UI `WindowConfig` into winit `WindowAttributes`.
     ///
     /// This function does not create a native window.
@@ -91,6 +97,20 @@ pub mod winit_placeholder {
     /// Returns whether the winit window config translation scaffold is available.
     pub const fn winit_window_config_translation_available() -> bool {
         true
+    }
+
+    /// Create a native winit `Window` from Semantic `WindowConfig`.
+    ///
+    /// This must only be called from a valid winit event-loop lifecycle callback,
+    /// such as `ApplicationHandler::resumed(...)`.
+    ///
+    /// This function does not run the event loop and does not render.
+    pub fn create_winit_window_from_config(
+        event_loop: &ActiveEventLoop,
+        config: &WindowConfig,
+    ) -> Result<Window, OsError> {
+        let attributes = window_config_to_winit_attributes(config);
+        event_loop.create_window(attributes)
     }
 
     /// Returns whether the winit event translation scaffold is available.
@@ -210,6 +230,88 @@ pub mod winit_placeholder {
 
             if matches!(event, WindowEvent::CloseRequested) {
                 self.close_requested = true;
+                event_loop.exit();
+            }
+        }
+    }
+
+    /// ApplicationHandler scaffold that creates one native window on `resumed(...)`.
+    ///
+    /// This is a controlled native-window creation scaffold.
+    /// It does not render, does not submit frames, and does not integrate with
+    /// `NativeBackend::run_event_loop(...)` yet.
+    #[derive(Debug)]
+    pub struct WinitWindowCreationScaffold {
+        config: WindowConfig,
+        window_id: Option<WindowId>,
+        window: Option<Window>,
+        create_attempts: usize,
+        create_failures: usize,
+    }
+
+    impl WinitWindowCreationScaffold {
+        pub fn new(config: WindowConfig) -> Self {
+            Self {
+                config,
+                window_id: None,
+                window: None,
+                create_attempts: 0,
+                create_failures: 0,
+            }
+        }
+
+        pub fn config(&self) -> &WindowConfig {
+            &self.config
+        }
+
+        pub const fn window_id(&self) -> Option<WindowId> {
+            self.window_id
+        }
+
+        pub const fn has_window(&self) -> bool {
+            self.window_id.is_some()
+        }
+
+        pub const fn create_attempts(&self) -> usize {
+            self.create_attempts
+        }
+
+        pub const fn create_failures(&self) -> usize {
+            self.create_failures
+        }
+    }
+
+    impl ApplicationHandler for WinitWindowCreationScaffold {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            if self.window.is_some() {
+                return;
+            }
+
+            self.create_attempts = self.create_attempts.saturating_add(1);
+
+            match create_winit_window_from_config(event_loop, &self.config) {
+                Ok(window) => {
+                    self.window_id = Some(window.id());
+                    self.window = Some(window);
+                }
+                Err(_err) => {
+                    self.create_failures = self.create_failures.saturating_add(1);
+                    event_loop.exit();
+                }
+            }
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            if Some(window_id) != self.window_id {
+                return;
+            }
+
+            if matches!(event, WindowEvent::CloseRequested) {
                 event_loop.exit();
             }
         }

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_window_creation_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_window_creation_contract.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::{
+    create_winit_window_from_config, winit_window_creation_scaffold_available,
+    WinitWindowCreationScaffold,
+};
+use prom_ui_runtime::WindowConfig;
+
+#[test]
+fn winit_window_creation_scaffold_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_window_creation_scaffold_available());
+}
+
+#[test]
+fn window_creation_scaffold_starts_without_window() {
+    let config = WindowConfig::new("Native Window Scaffold", 800, 600);
+    let scaffold = WinitWindowCreationScaffold::new(config);
+
+    assert!(!scaffold.has_window());
+    assert!(scaffold.window_id().is_none());
+    assert_eq!(scaffold.create_attempts(), 0);
+    assert_eq!(scaffold.create_failures(), 0);
+    assert_eq!(scaffold.config().title, "Native Window Scaffold");
+    assert_eq!(scaffold.config().width, 800);
+    assert_eq!(scaffold.config().height, 600);
+}
+
+#[test]
+fn window_creation_scaffold_implements_application_handler() {
+    fn assert_handler<T: winit::application::ApplicationHandler>() {}
+
+    assert_handler::<WinitWindowCreationScaffold>();
+}
+
+#[test]
+fn create_winit_window_from_config_has_expected_function_shape() {
+    let _f: fn(
+        &winit::event_loop::ActiveEventLoop,
+        &WindowConfig,
+    ) -> Result<winit::window::Window, winit::error::OsError> = create_winit_window_from_config;
+}


### PR DESCRIPTION
## Summary\n\n- Adds a feature-gated native window creation scaffold behind winit-backend.\n- Adds create_winit_window_from_config(...), which calls ActiveEventLoop::create_window(...).\n- Adds WinitWindowCreationScaffold, an ApplicationHandler that creates one window on resumed(...).\n- Adds compile/contract tests for scaffold availability, initial state, handler implementation, and creation function shape.\n\n## Boundary\n\nThis PR introduces native window creation code, but does not run the native event loop.\n\nAllowed:\n- ActiveEventLoop::create_window(...)\n\nStill out of scope:\n- EventLoop::run_app\n- renderer\n- frame presentation\n- NativeBackend run-loop integration\n- prom-ui-runtime changes\n- UiBackendAdapter changes\n- VM/verifier/SemCode changes\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check