### PR TITLE
feat(ui-backend-native): add native run_app smoke behind ignored/manual test

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -316,6 +316,120 @@ pub mod winit_placeholder {
             }
         }
     }
+
+    /// Returns whether the native run_app smoke scaffold is available.
+    pub const fn winit_run_app_smoke_available() -> bool {
+        true
+    }
+
+    /// Result summary for the native run_app smoke path.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct WinitRunAppSmokeResult {
+        pub resumed_calls: usize,
+        pub create_attempts: usize,
+        pub create_failures: usize,
+        pub window_created: bool,
+    }
+
+    /// Manual smoke scaffold for `EventLoop::run_app(...)`.
+    ///
+    /// This creates one native window on `resumed(...)` and exits immediately.
+    /// It is intended for manual smoke tests only.
+    #[derive(Debug)]
+    pub struct WinitRunAppSmokeScaffold {
+        config: WindowConfig,
+        resumed_calls: usize,
+        create_attempts: usize,
+        create_failures: usize,
+        window_created: bool,
+        window_id: Option<WindowId>,
+        window: Option<Window>,
+    }
+
+    impl WinitRunAppSmokeScaffold {
+        pub fn new(config: WindowConfig) -> Self {
+            Self {
+                config,
+                resumed_calls: 0,
+                create_attempts: 0,
+                create_failures: 0,
+                window_created: false,
+                window_id: None,
+                window: None,
+            }
+        }
+
+        pub fn result(&self) -> WinitRunAppSmokeResult {
+            WinitRunAppSmokeResult {
+                resumed_calls: self.resumed_calls,
+                create_attempts: self.create_attempts,
+                create_failures: self.create_failures,
+                window_created: self.window_created,
+            }
+        }
+
+        pub const fn has_window(&self) -> bool {
+            self.window_id.is_some()
+        }
+    }
+
+    impl ApplicationHandler for WinitRunAppSmokeScaffold {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            self.resumed_calls = self.resumed_calls.saturating_add(1);
+
+            if self.window.is_some() {
+                event_loop.exit();
+                return;
+            }
+
+            self.create_attempts = self.create_attempts.saturating_add(1);
+
+            match create_winit_window_from_config(event_loop, &self.config) {
+                Ok(window) => {
+                    self.window_id = Some(window.id());
+                    self.window = Some(window);
+                    self.window_created = true;
+                    event_loop.exit();
+                }
+                Err(_err) => {
+                    self.create_failures = self.create_failures.saturating_add(1);
+                    event_loop.exit();
+                }
+            }
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            if Some(window_id) != self.window_id {
+                return;
+            }
+
+            if matches!(event, WindowEvent::CloseRequested) {
+                event_loop.exit();
+            }
+        }
+    }
+
+    /// Run a manual native smoke using winit `EventLoop::run_app(...)`.
+    ///
+    /// This creates a real event loop and attempts to create one native window,
+    /// then exits immediately.
+    ///
+    /// This function is not used by `NativeBackend::run_event_loop(...)`.
+    pub fn run_winit_window_creation_smoke(
+        config: WindowConfig,
+    ) -> Result<WinitRunAppSmokeResult, winit::error::EventLoopError> {
+        let event_loop = create_winit_event_loop()?;
+        let mut app = WinitRunAppSmokeScaffold::new(config);
+
+        event_loop.run_app(&mut app)?;
+
+        Ok(app.result())
+    }
 }
 
 /// Skeleton native backend.

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_run_app_smoke.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_run_app_smoke.rs
@@ -1,0 +1,59 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::{
+    run_winit_window_creation_smoke, winit_run_app_smoke_available, WinitRunAppSmokeResult,
+    WinitRunAppSmokeScaffold,
+};
+use prom_ui_runtime::WindowConfig;
+
+#[test]
+fn winit_run_app_smoke_scaffold_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(winit_run_app_smoke_available());
+}
+
+#[test]
+fn run_app_smoke_scaffold_starts_empty() {
+    let config = WindowConfig::new("RunApp Smoke", 640, 480);
+    let scaffold = WinitRunAppSmokeScaffold::new(config);
+
+    let result = scaffold.result();
+
+    assert_eq!(
+        result,
+        WinitRunAppSmokeResult {
+            resumed_calls: 0,
+            create_attempts: 0,
+            create_failures: 0,
+            window_created: false,
+        }
+    );
+    assert!(!scaffold.has_window());
+}
+
+#[test]
+fn run_app_smoke_scaffold_implements_application_handler() {
+    fn assert_handler<T: winit::application::ApplicationHandler>() {}
+
+    assert_handler::<WinitRunAppSmokeScaffold>();
+}
+
+#[test]
+fn run_winit_window_creation_smoke_has_expected_function_shape() {
+    let _f: fn(WindowConfig) -> Result<WinitRunAppSmokeResult, winit::error::EventLoopError> =
+        run_winit_window_creation_smoke;
+}
+
+#[test]
+#[ignore = "manual native window smoke; may require desktop session"]
+fn manual_run_app_creates_window_and_exits() {
+    let config = WindowConfig::new("Semantic Native Smoke", 640, 480);
+
+    let result = run_winit_window_creation_smoke(config)
+        .expect("manual native run_app smoke should complete");
+
+    assert!(result.resumed_calls >= 1);
+    assert_eq!(result.create_attempts, 1);
+    assert_eq!(result.create_failures, 0);
+    assert!(result.window_created);
+}


### PR DESCRIPTION
## Summary\n\n- Adds a feature-gated manual native run_app smoke scaffold.\n- Adds WinitRunAppSmokeScaffold, an ApplicationHandler that creates one native window and exits immediately.\n- Adds run_winit_window_creation_smoke(...) helper.\n- Adds non-ignored compile/contract tests.\n- Adds one ignored manual smoke test for real desktop environments.\n\n## Boundary\n\nThis PR introduces controlled EventLoop::run_app(...) usage, but does not integrate it with runtime behavior.\n\nAllowed:\n- EventLoop::run_app(...)\n- one native window creation inside manual smoke scaffold\n\nStill out of scope:\n- NativeBackend::run_event_loop(...) winit integration\n- renderer\n- frame presentation\n- prom-ui-runtime changes\n- UiBackendAdapter changes\n- VM/verifier/SemCode changes\n- Workbench integration\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check\n\nManual smoke:\n\ncargo test -p prom-ui-backend-native --features winit-backend --test native_backend_winit_run_app_smoke -- --ignored --nocapture