### PR TITLE
feat(ui-backend-native): add NativeBackend winit smoke adapter behind manual test

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -17,6 +17,20 @@ use prom_ui_runtime::{
     WindowConfig,
 };
 
+#[cfg(feature = "winit-backend")]
+#[derive(Debug)]
+pub enum NativeBackendWinitSmokeError {
+    MissingWindowConfig,
+    EventLoop(winit::error::EventLoopError),
+}
+
+#[cfg(feature = "winit-backend")]
+impl From<winit::error::EventLoopError> for NativeBackendWinitSmokeError {
+    fn from(err: winit::error::EventLoopError) -> Self {
+        Self::EventLoop(err)
+    }
+}
+
 /// Returns whether this crate was compiled with the `winit-backend` feature.
 pub const fn winit_backend_feature_enabled() -> bool {
     cfg!(feature = "winit-backend")
@@ -520,6 +534,10 @@ impl Default for NativeBackend {
 
 #[cfg(feature = "winit-backend")]
 impl NativeBackend {
+    pub const fn winit_smoke_adapter_available() -> bool {
+        true
+    }
+
     /// Stage a translated winit `WindowEvent` into the backend pending-event queue.
     ///
     /// Returns `true` if the event was translated and staged.
@@ -555,6 +573,29 @@ impl NativeBackend {
     /// Stage a close request into the backend pending-event queue.
     pub fn stage_winit_close_requested(&mut self) {
         self.push_pending_event(winit_placeholder::translate_winit_close_requested());
+    }
+
+    /// Run the manual winit window-creation smoke using the staged `WindowConfig`.
+    ///
+    /// This does not integrate winit with `NativeBackend::run_event_loop(...)`.
+    /// It creates a temporary native event loop/window through the G12 manual smoke path
+    /// and returns the smoke result.
+    ///
+    /// The created native window is not retained by `NativeBackend`.
+    pub fn run_winit_smoke_from_staged_config(
+        &self,
+    ) -> Result<
+        winit_placeholder::WinitRunAppSmokeResult,
+        NativeBackendWinitSmokeError,
+    > {
+        let config = self
+            .window_config
+            .clone()
+            .ok_or(NativeBackendWinitSmokeError::MissingWindowConfig)?;
+
+        let result = winit_placeholder::run_winit_window_creation_smoke(config)?;
+
+        Ok(result)
     }
 }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_smoke_adapter_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_smoke_adapter_contract.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{NativeBackend, NativeBackendWinitSmokeError};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_smoke_adapter_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(NativeBackend::winit_smoke_adapter_available());
+}
+
+#[test]
+fn native_backend_winit_smoke_requires_staged_window_config() {
+    let backend = NativeBackend::new();
+
+    let err = backend
+        .run_winit_smoke_from_staged_config()
+        .expect_err("smoke adapter must require staged WindowConfig");
+
+    assert!(matches!(
+        err,
+        NativeBackendWinitSmokeError::MissingWindowConfig
+    ));
+
+    assert!(!backend.is_platform_wired());
+}
+
+#[test]
+fn native_backend_can_stage_config_for_winit_smoke_adapter() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("NativeBackend Smoke", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let staged = backend
+        .window_config()
+        .expect("WindowConfig must be staged");
+
+    assert_eq!(staged.title, "NativeBackend Smoke");
+    assert_eq!(staged.width, 640);
+    assert_eq!(staged.height, 480);
+    assert!(!backend.is_platform_wired());
+}
+
+#[test]
+fn native_backend_winit_smoke_adapter_has_expected_method_shape() {
+    let _f: fn(
+        &NativeBackend,
+    ) -> Result<
+        prom_ui_backend_native::winit_placeholder::WinitRunAppSmokeResult,
+        NativeBackendWinitSmokeError,
+    > = NativeBackend::run_winit_smoke_from_staged_config;
+}
+
+#[test]
+#[ignore = "manual NativeBackend winit smoke; may require desktop session"]
+fn manual_native_backend_winit_smoke_from_staged_config() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic NativeBackend Smoke", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let result = backend
+        .run_winit_smoke_from_staged_config()
+        .expect("manual NativeBackend winit smoke should complete");
+
+    assert!(result.resumed_calls >= 1);
+    assert_eq!(result.create_attempts, 1);
+    assert_eq!(result.create_failures, 0);
+    assert!(result.window_created);
+
+    // G13 is still a manual smoke adapter, not persistent platform wiring.
+    assert!(!backend.is_platform_wired());
+}


### PR DESCRIPTION
## Summary\n\n- Adds a feature-gated NativeBackend adapter for the existing manual winit smoke path.\n- Adds NativeBackendWinitSmokeError.\n- Adds NativeBackend::run_winit_smoke_from_staged_config(...).\n- Requires staged WindowConfig before running the smoke adapter.\n- Adds non-ignored contract tests and an ignored manual NativeBackend smoke test.\n\n## Boundary\n\nThis PR does not integrate winit with runtime behavior.\n\nAllowed:\n- calling the existing G12 manual smoke helper through staged NativeBackend config\n\nStill out of scope:\n- NativeBackend::run_event_loop(...) winit integration\n- persistent native window ownership in NativeBackend\n- renderer\n- frame presentation\n- prom-ui-runtime changes\n- UiBackendAdapter changes\n- VM/verifier/SemCode changes\n- Workbench integration\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check\n\nManual smoke:\n\ncargo test -p prom-ui-backend-native --features winit-backend --test native_backend_winit_smoke_adapter_contract -- --ignored --nocapture