### PR TITLE
feat(ui-backend-native): add NativeBackend winit app scaffold state

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -30,6 +30,7 @@ pub mod winit_placeholder {
 
     use core::marker::PhantomData;
 
+    use super::NativeBackend;
     use prom_ui_runtime::WindowConfig;
     use winit::error::OsError;
     use winit::{
@@ -429,6 +430,171 @@ pub mod winit_placeholder {
         event_loop.run_app(&mut app)?;
 
         Ok(app.result())
+    }
+
+    /// Returns whether the NativeBackend winit app state scaffold is available.
+    pub const fn native_backend_winit_app_state_available() -> bool {
+        true
+    }
+
+    /// Read-only summary of the NativeBackend winit app scaffold.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitAppStateSummary {
+        pub resumed_calls: usize,
+        pub window_event_calls: usize,
+        pub create_attempts: usize,
+        pub create_failures: usize,
+        pub window_created: bool,
+        pub close_requested: bool,
+        pub staged_event_count: usize,
+    }
+
+    /// Winit ApplicationHandler scaffold backed by `NativeBackend`.
+    ///
+    /// This is a state scaffold for future native runtime integration.
+    /// It can create one native window and stage translated winit events into
+    /// the inner `NativeBackend`, but it is not wired into
+    /// `NativeBackend::run_event_loop(...)` yet.
+    #[derive(Debug)]
+    pub struct NativeBackendWinitAppState {
+        backend: NativeBackend,
+        window: Option<Window>,
+        window_id: Option<WindowId>,
+        resumed_calls: usize,
+        window_event_calls: usize,
+        create_attempts: usize,
+        create_failures: usize,
+        window_created: bool,
+        close_requested: bool,
+    }
+
+    impl NativeBackendWinitAppState {
+        pub fn new(backend: NativeBackend) -> Self {
+            Self {
+                backend,
+                window: None,
+                window_id: None,
+                resumed_calls: 0,
+                window_event_calls: 0,
+                create_attempts: 0,
+                create_failures: 0,
+                window_created: false,
+                close_requested: false,
+            }
+        }
+
+        pub fn backend(&self) -> &NativeBackend {
+            &self.backend
+        }
+
+        pub fn backend_mut(&mut self) -> &mut NativeBackend {
+            &mut self.backend
+        }
+
+        pub const fn window_id(&self) -> Option<WindowId> {
+            self.window_id
+        }
+
+        pub const fn has_window(&self) -> bool {
+            self.window_id.is_some()
+        }
+
+        pub const fn resumed_calls(&self) -> usize {
+            self.resumed_calls
+        }
+
+        pub const fn window_event_calls(&self) -> usize {
+            self.window_event_calls
+        }
+
+        pub const fn create_attempts(&self) -> usize {
+            self.create_attempts
+        }
+
+        pub const fn create_failures(&self) -> usize {
+            self.create_failures
+        }
+
+        pub const fn window_created(&self) -> bool {
+            self.window_created
+        }
+
+        pub const fn close_requested(&self) -> bool {
+            self.close_requested
+        }
+
+        pub fn summary(&self) -> NativeBackendWinitAppStateSummary {
+            NativeBackendWinitAppStateSummary {
+                resumed_calls: self.resumed_calls,
+                window_event_calls: self.window_event_calls,
+                create_attempts: self.create_attempts,
+                create_failures: self.create_failures,
+                window_created: self.window_created,
+                close_requested: self.close_requested,
+                staged_event_count: self.backend.pending_event_count(),
+            }
+        }
+
+        fn staged_config(&self) -> Option<&WindowConfig> {
+            self.backend.window_config()
+        }
+    }
+
+    impl ApplicationHandler for NativeBackendWinitAppState {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            self.resumed_calls = self.resumed_calls.saturating_add(1);
+
+            if self.window.is_some() {
+                return;
+            }
+
+            self.create_attempts = self.create_attempts.saturating_add(1);
+
+            let Some(config) = self.staged_config().cloned() else {
+                self.create_failures = self.create_failures.saturating_add(1);
+                event_loop.exit();
+                return;
+            };
+
+            match create_winit_window_from_config(event_loop, &config) {
+                Ok(window) => {
+                    self.window_id = Some(window.id());
+                    self.window = Some(window);
+                    self.window_created = true;
+                }
+                Err(_err) => {
+                    self.create_failures = self.create_failures.saturating_add(1);
+                    event_loop.exit();
+                }
+            }
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            if Some(window_id) != self.window_id {
+                return;
+            }
+
+            self.window_event_calls = self.window_event_calls.saturating_add(1);
+
+            if let Some(input) = translate_winit_window_event(&event) {
+                if matches!(
+                    &input.kind,
+                    prom_ui_runtime::InputEventKind::CloseRequested
+                ) {
+                    self.close_requested = true;
+                    self.backend.push_pending_event(input);
+                    event_loop.exit();
+                    return;
+                }
+
+                self.backend.push_pending_event(input);
+            }
+        }
     }
 }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_state_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_state_contract.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_state_available, NativeBackendWinitAppState,
+        NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_state_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_state_available());
+}
+
+#[test]
+fn native_backend_winit_app_state_starts_empty() {
+    let backend = NativeBackend::new();
+    let app = NativeBackendWinitAppState::new(backend);
+
+    assert!(!app.has_window());
+    assert!(app.window_id().is_none());
+    assert_eq!(app.resumed_calls(), 0);
+    assert_eq!(app.window_event_calls(), 0);
+    assert_eq!(app.create_attempts(), 0);
+    assert_eq!(app.create_failures(), 0);
+    assert!(!app.window_created());
+    assert!(!app.close_requested());
+    assert_eq!(app.backend().pending_event_count(), 0);
+}
+
+#[test]
+fn native_backend_winit_app_state_preserves_staged_config() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic App State", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let app = NativeBackendWinitAppState::new(backend);
+
+    let staged = app
+        .backend()
+        .window_config()
+        .expect("staged WindowConfig must remain available");
+
+    assert_eq!(staged.title, "Semantic App State");
+    assert_eq!(staged.width, 800);
+    assert_eq!(staged.height, 600);
+    assert!(!app.backend().is_platform_wired());
+}
+
+#[test]
+fn native_backend_winit_app_state_summary_starts_empty() {
+    let backend = NativeBackend::new();
+    let app = NativeBackendWinitAppState::new(backend);
+
+    assert_eq!(
+        app.summary(),
+        NativeBackendWinitAppStateSummary {
+            resumed_calls: 0,
+            window_event_calls: 0,
+            create_attempts: 0,
+            create_failures: 0,
+            window_created: false,
+            close_requested: false,
+            staged_event_count: 0,
+        }
+    );
+}
+
+#[test]
+fn native_backend_winit_app_state_implements_application_handler() {
+    fn assert_handler<T: winit::application::ApplicationHandler>() {}
+
+    assert_handler::<NativeBackendWinitAppState>();
+}
+
+#[test]
+fn native_backend_winit_app_state_backend_mut_can_stage_events() {
+    let backend = NativeBackend::new();
+    let mut app = NativeBackendWinitAppState::new(backend);
+
+    app.backend_mut().stage_winit_close_requested();
+
+    assert_eq!(app.backend().pending_event_count(), 1);
+    assert_eq!(app.summary().staged_event_count, 1);
+}


### PR DESCRIPTION
## Summary\n\n- Adds a feature-gated NativeBackend-backed winit app state scaffold.\n- Adds NativeBackendWinitAppState and NativeBackendWinitAppStateSummary.\n- Preserves staged NativeBackend config and pending event queue.\n- Implements ApplicationHandler for the app state scaffold.\n- Translates matching winit window events into the inner NativeBackend pending-event queue.\n- Adds contract tests for initial state, summary, staged config, handler shape, and backend mutation.\n\n## Boundary\n\nThis PR adds state for a future native app loop but does not run it.\n\nAllowed:\n- ApplicationHandler implementation\n- native window creation inside resumed(...)\n- translated event staging into inner NativeBackend\n\nStill out of scope:\n- EventLoop::run_app(...) in this PR\n- NativeBackend::run_event_loop(...) winit integration\n- renderer\n- frame presentation\n- persistent native window ownership in NativeBackend\n- prom-ui-runtime changes\n- UiBackendAdapter changes\n- VM/verifier/SemCode changes\n- Workbench integration\n\n## Validation\n\n- cargo test -q -p prom-ui-backend-native\n- cargo test -q -p prom-ui-backend-native --features winit-backend\n- cargo test -q -p prom-ui-runtime\n- git diff --check