### PR TITLE
feat(ui-backend-native): add manual run_app for NativeBackendWinitAppState

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -337,6 +337,11 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the NativeBackend winit app-state run_app helper is available.
+    pub const fn native_backend_winit_app_state_run_app_available() -> bool {
+        true
+    }
+
     /// Result summary for the native run_app smoke path.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct WinitRunAppSmokeResult {
@@ -344,6 +349,19 @@ pub mod winit_placeholder {
         pub create_attempts: usize,
         pub create_failures: usize,
         pub window_created: bool,
+    }
+
+    /// Error returned by the manual NativeBackend app-state run_app helper.
+    #[derive(Debug)]
+    pub enum NativeBackendWinitAppStateRunError {
+        MissingWindowConfig,
+        EventLoop(winit::error::EventLoopError),
+    }
+
+    impl From<winit::error::EventLoopError> for NativeBackendWinitAppStateRunError {
+        fn from(err: winit::error::EventLoopError) -> Self {
+            Self::EventLoop(err)
+        }
     }
 
     /// Manual smoke scaffold for `EventLoop::run_app(...)`.
@@ -429,6 +447,16 @@ pub mod winit_placeholder {
         }
     }
 
+    fn ensure_native_backend_has_window_config(
+        backend: &NativeBackend,
+    ) -> Result<(), NativeBackendWinitAppStateRunError> {
+        if backend.window_config().is_some() {
+            Ok(())
+        } else {
+            Err(NativeBackendWinitAppStateRunError::MissingWindowConfig)
+        }
+    }
+
     /// Run a manual native smoke using winit `EventLoop::run_app(...)`.
     ///
     /// This creates a real event loop and attempts to create one native window,
@@ -444,6 +472,25 @@ pub mod winit_placeholder {
         event_loop.run_app(&mut app)?;
 
         Ok(app.result())
+    }
+
+    /// Run a manual native winit app loop using `NativeBackendWinitAppState`.
+    ///
+    /// This opens a real native window and returns after the window is closed.
+    /// It is intended for ignored/manual smoke tests only.
+    ///
+    /// This does not modify `NativeBackend::run_event_loop(...)`.
+    pub fn run_native_backend_winit_app_state_until_close(
+        backend: NativeBackend,
+    ) -> Result<NativeBackendWinitAppStateSummary, NativeBackendWinitAppStateRunError> {
+        ensure_native_backend_has_window_config(&backend)?;
+
+        let event_loop = create_winit_event_loop()?;
+        let mut app = NativeBackendWinitAppState::new(backend);
+
+        event_loop.run_app(&mut app)?;
+
+        Ok(app.summary())
     }
 
     /// Returns whether the NativeBackend winit app state scaffold is available.

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_state_run_app.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_state_run_app.rs
@@ -1,0 +1,78 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_state_run_app_available,
+        run_native_backend_winit_app_state_until_close,
+        NativeBackendWinitAppStateRunError,
+        NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_state_run_app_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_state_run_app_available());
+}
+
+#[test]
+fn native_backend_winit_app_state_run_app_requires_staged_config() {
+    let backend = NativeBackend::new();
+
+    let err = run_native_backend_winit_app_state_until_close(backend)
+        .expect_err("run_app helper must require staged WindowConfig");
+
+    assert!(matches!(
+        err,
+        NativeBackendWinitAppStateRunError::MissingWindowConfig
+    ));
+}
+
+#[test]
+fn native_backend_winit_app_state_run_app_has_expected_function_shape() {
+    let _f: fn(
+        NativeBackend,
+    ) -> Result<
+        NativeBackendWinitAppStateSummary,
+        NativeBackendWinitAppStateRunError,
+    > = run_native_backend_winit_app_state_until_close;
+}
+
+#[test]
+fn native_backend_can_prepare_config_for_app_state_run_app() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic AppState RunApp", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let staged = backend
+        .window_config()
+        .expect("WindowConfig must be staged");
+
+    assert_eq!(staged.title, "Semantic AppState RunApp");
+    assert_eq!(staged.width, 800);
+    assert_eq!(staged.height, 600);
+    assert!(!backend.is_platform_wired());
+}
+
+#[test]
+#[ignore = "manual NativeBackendWinitAppState run_app smoke; opens a native window"]
+fn manual_native_backend_winit_app_state_runs_until_window_close() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic Native AppState", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let summary = run_native_backend_winit_app_state_until_close(backend)
+        .expect("manual NativeBackendWinitAppState run_app should complete");
+
+    assert!(summary.resumed_calls >= 1);
+    assert_eq!(summary.create_attempts, 1);
+    assert_eq!(summary.create_failures, 0);
+    assert!(summary.window_created);
+    assert!(summary.close_requested);
+    assert!(summary.window_event_calls >= 1);
+    assert!(summary.staged_event_count >= 1);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated manual `run_app(...)` helper for `NativeBackendWinitAppState`.
- Adds `NativeBackendWinitAppStateRunError`.
- Adds `run_native_backend_winit_app_state_until_close(...)`.
- Requires staged `WindowConfig` before creating the event loop.
- Adds non-ignored contract tests and an ignored manual native smoke test.

## Boundary

This PR runs the NativeBackend-backed app state manually, but does not integrate it with normal runtime behavior.

Allowed:
- `EventLoop::run_app(...)` in a manual helper
- `NativeBackendWinitAppState` as the `ApplicationHandler`
- native window creation through the existing G14 app state

Still out of scope:
- `NativeBackend::run_event_loop(...)` winit integration
- renderer
- frame presentation
- `prom-ui-runtime` changes
- `UiBackendAdapter` changes
- VM/verifier/SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`