### PR TITLE
feat(ui-backend-native): add controlled NativeBackend winit run-loop integration plan

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -498,6 +498,131 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the controlled NativeBackend winit run-loop integration plan is available.
+    pub const fn native_backend_winit_run_loop_plan_available() -> bool {
+        true
+    }
+
+    /// Current planned stage for NativeBackend/winit run-loop integration.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitRunLoopStage {
+        /// Existing manual smoke path.
+        ManualSmoke,
+
+        /// Existing NativeBackendWinitAppState manual run_app path.
+        ManualAppStateRun,
+
+        /// Future step: adapter integration has not been admitted yet.
+        AdapterIntegrationDeferred,
+    }
+
+    /// Ownership model for the planned NativeBackend/winit run-loop path.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitRunLoopOwnership {
+        /// Manual helper consumes NativeBackend and returns summary only.
+        ConsumesBackendReturnsSummary,
+
+        /// Future persistent ownership model is intentionally unresolved.
+        PersistentBackendOwnershipDeferred,
+    }
+
+    /// Preflight readiness for running the NativeBackend-backed winit app state.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitRunLoopReadiness {
+        MissingWindowConfig,
+        ReadyForManualAppStateRun,
+    }
+
+    /// Controlled integration plan for NativeBackend-backed winit run-loop support.
+    ///
+    /// This is a code-level contract, not a runtime integration.
+    /// It records the currently admitted boundary before `NativeBackend::run_event_loop(...)`
+    /// is allowed to touch winit.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitRunLoopIntegrationPlan {
+        pub stage: NativeBackendWinitRunLoopStage,
+        pub ownership: NativeBackendWinitRunLoopOwnership,
+
+        pub requires_staged_window_config: bool,
+        pub uses_native_backend_app_state: bool,
+        pub creates_event_loop: bool,
+        pub may_create_native_window: bool,
+        pub may_call_run_app: bool,
+
+        pub integrates_with_backend_run_event_loop: bool,
+        pub mutates_prom_ui_runtime: bool,
+        pub changes_ui_backend_adapter: bool,
+        pub includes_renderer: bool,
+        pub presents_frames: bool,
+    }
+
+    impl NativeBackendWinitRunLoopIntegrationPlan {
+        /// Current G16-admitted plan.
+        ///
+        /// This reflects the existing manual `NativeBackendWinitAppState` path:
+        /// it can create an EventLoop, create one native window, and call run_app
+        /// only through manual/ignored smoke helpers.
+        ///
+        /// It does not admit normal runtime integration yet.
+        pub const fn current_manual_app_state_plan() -> Self {
+            Self {
+                stage: NativeBackendWinitRunLoopStage::ManualAppStateRun,
+                ownership: NativeBackendWinitRunLoopOwnership::ConsumesBackendReturnsSummary,
+
+                requires_staged_window_config: true,
+                uses_native_backend_app_state: true,
+                creates_event_loop: true,
+                may_create_native_window: true,
+                may_call_run_app: true,
+
+                integrates_with_backend_run_event_loop: false,
+                mutates_prom_ui_runtime: false,
+                changes_ui_backend_adapter: false,
+                includes_renderer: false,
+                presents_frames: false,
+            }
+        }
+
+        pub const fn keeps_runtime_boundary_clean(&self) -> bool {
+            !self.integrates_with_backend_run_event_loop
+                && !self.mutates_prom_ui_runtime
+                && !self.changes_ui_backend_adapter
+        }
+
+        pub const fn keeps_rendering_out_of_scope(&self) -> bool {
+            !self.includes_renderer && !self.presents_frames
+        }
+
+        pub const fn is_g16_admissible(&self) -> bool {
+            self.requires_staged_window_config
+                && self.uses_native_backend_app_state
+                && self.creates_event_loop
+                && self.may_create_native_window
+                && self.may_call_run_app
+                && self.keeps_runtime_boundary_clean()
+                && self.keeps_rendering_out_of_scope()
+        }
+    }
+
+    /// Return the current controlled integration plan.
+    pub const fn current_native_backend_winit_run_loop_plan(
+    ) -> NativeBackendWinitRunLoopIntegrationPlan {
+        NativeBackendWinitRunLoopIntegrationPlan::current_manual_app_state_plan()
+    }
+
+    /// Preflight the staged NativeBackend state for the current manual app-state run path.
+    ///
+    /// This does not create an EventLoop, does not create a Window, and does not call run_app.
+    pub fn native_backend_winit_run_loop_readiness(
+        backend: &NativeBackend,
+    ) -> NativeBackendWinitRunLoopReadiness {
+        if backend.window_config().is_some() {
+            NativeBackendWinitRunLoopReadiness::ReadyForManualAppStateRun
+        } else {
+            NativeBackendWinitRunLoopReadiness::MissingWindowConfig
+        }
+    }
+
     /// Read-only summary of the NativeBackend winit app scaffold.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct NativeBackendWinitAppStateSummary {

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_run_loop_plan_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_run_loop_plan_contract.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        current_native_backend_winit_run_loop_plan,
+        native_backend_winit_run_loop_plan_available,
+        native_backend_winit_run_loop_readiness,
+        NativeBackendWinitRunLoopOwnership,
+        NativeBackendWinitRunLoopReadiness,
+        NativeBackendWinitRunLoopStage,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_run_loop_plan_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_run_loop_plan_available());
+}
+
+#[test]
+fn current_plan_is_manual_app_state_run() {
+    let plan = current_native_backend_winit_run_loop_plan();
+
+    assert_eq!(plan.stage, NativeBackendWinitRunLoopStage::ManualAppStateRun);
+    assert_eq!(
+        plan.ownership,
+        NativeBackendWinitRunLoopOwnership::ConsumesBackendReturnsSummary
+    );
+
+    assert!(plan.requires_staged_window_config);
+    assert!(plan.uses_native_backend_app_state);
+    assert!(plan.creates_event_loop);
+    assert!(plan.may_create_native_window);
+    assert!(plan.may_call_run_app);
+}
+
+#[test]
+fn current_plan_does_not_integrate_backend_run_event_loop_yet() {
+    let plan = current_native_backend_winit_run_loop_plan();
+
+    assert!(!plan.integrates_with_backend_run_event_loop);
+    assert!(!plan.mutates_prom_ui_runtime);
+    assert!(!plan.changes_ui_backend_adapter);
+    assert!(plan.keeps_runtime_boundary_clean());
+}
+
+#[test]
+fn current_plan_excludes_renderer_and_frame_presentation() {
+    let plan = current_native_backend_winit_run_loop_plan();
+
+    assert!(!plan.includes_renderer);
+    assert!(!plan.presents_frames);
+    assert!(plan.keeps_rendering_out_of_scope());
+}
+
+#[test]
+fn current_plan_is_g16_admissible() {
+    let plan = current_native_backend_winit_run_loop_plan();
+
+    assert!(plan.is_g16_admissible());
+}
+
+#[test]
+fn run_loop_readiness_requires_staged_window_config() {
+    let backend = NativeBackend::new();
+
+    assert_eq!(
+        native_backend_winit_run_loop_readiness(&backend),
+        NativeBackendWinitRunLoopReadiness::MissingWindowConfig
+    );
+}
+
+#[test]
+fn run_loop_readiness_accepts_staged_window_config() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("RunLoop Plan", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    assert_eq!(
+        native_backend_winit_run_loop_readiness(&backend),
+        NativeBackendWinitRunLoopReadiness::ReadyForManualAppStateRun
+    );
+}
+
+#[test]
+fn run_loop_readiness_does_not_mutate_backend_state() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("No Mutation", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let before_pending = backend.pending_event_count();
+    let before_frames = backend.submitted_frames();
+    let before_run_calls = backend.run_loop_calls();
+
+    let readiness = native_backend_winit_run_loop_readiness(&backend);
+
+    assert_eq!(
+        readiness,
+        NativeBackendWinitRunLoopReadiness::ReadyForManualAppStateRun
+    );
+    assert_eq!(backend.pending_event_count(), before_pending);
+    assert_eq!(backend.submitted_frames(), before_frames);
+    assert_eq!(backend.run_loop_calls(), before_run_calls);
+    assert!(!backend.is_platform_wired());
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated controlled integration plan for NativeBackend/winit run-loop support.
- Adds `NativeBackendWinitRunLoopIntegrationPlan`.
- Adds stage, ownership, and readiness enums.
- Adds a readiness preflight for staged `WindowConfig`.
- Locks that current admitted state remains manual NativeBackendWinitAppState run path only.
- Adds contract tests for runtime boundary, renderer exclusion, and readiness behavior.

## Boundary

This PR is a code-level integration plan, not runtime integration.

Allowed:
- plan structs/enums
- readiness checks
- contract tests

Still out of scope:
- new `EventLoop::run_app(...)` calls
- new `ActiveEventLoop::create_window(...)` calls
- `NativeBackend::run_event_loop(...)` winit integration
- renderer
- frame presentation
- `prom-ui-runtime` changes
- `UiBackendAdapter` changes
- VM/verifier/SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`