### PR TITLE
feat(ui-backend-native): add separate NativeBackend winit app facade

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -623,6 +623,66 @@ pub mod winit_placeholder {
         }
     }
 
+    /// Returns whether the separate NativeBackend winit app facade is available.
+    pub const fn native_backend_winit_app_facade_available() -> bool {
+        true
+    }
+
+    /// Error returned by the separate NativeBackend winit app facade.
+    #[derive(Debug)]
+    pub enum NativeBackendWinitAppError {
+        MissingWindowConfig,
+        EventLoop(winit::error::EventLoopError),
+    }
+
+    impl From<winit::error::EventLoopError> for NativeBackendWinitAppError {
+        fn from(err: winit::error::EventLoopError) -> Self {
+            Self::EventLoop(err)
+        }
+    }
+
+    /// Separate native app facade for running NativeBackend through winit.
+    ///
+    /// This facade intentionally lives outside `UiBackendAdapter`.
+    /// It owns the native event-loop path and keeps `prom-ui-runtime` platform-neutral.
+    #[derive(Debug)]
+    pub struct NativeBackendWinitApp {
+        backend: NativeBackend,
+    }
+
+    impl NativeBackendWinitApp {
+        pub fn new(backend: NativeBackend) -> Result<Self, NativeBackendWinitAppError> {
+            if backend.window_config().is_none() {
+                return Err(NativeBackendWinitAppError::MissingWindowConfig);
+            }
+
+            Ok(Self { backend })
+        }
+
+        pub fn backend(&self) -> &NativeBackend {
+            &self.backend
+        }
+
+        pub fn into_backend(self) -> NativeBackend {
+            self.backend
+        }
+
+        /// Run the separate NativeBackend-backed winit app facade until the native window closes.
+        ///
+        /// This consumes the facade and returns a summary.
+        /// It does not modify `NativeBackend::run_event_loop(...)`.
+        pub fn run_until_close(
+            self,
+        ) -> Result<NativeBackendWinitAppStateSummary, NativeBackendWinitAppError> {
+            let event_loop = create_winit_event_loop()?;
+            let mut app_state = NativeBackendWinitAppState::new(self.backend);
+
+            event_loop.run_app(&mut app_state)?;
+
+            Ok(app_state.summary())
+        }
+    }
+
     /// Read-only summary of the NativeBackend winit app scaffold.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct NativeBackendWinitAppStateSummary {

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_contract.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_facade_available, NativeBackendWinitApp,
+        NativeBackendWinitAppError, NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_facade_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_facade_available());
+}
+
+#[test]
+fn native_backend_winit_app_facade_requires_staged_window_config() {
+    let backend = NativeBackend::new();
+
+    let err = NativeBackendWinitApp::new(backend)
+        .expect_err("facade must require staged WindowConfig");
+
+    assert!(matches!(err, NativeBackendWinitAppError::MissingWindowConfig));
+}
+
+#[test]
+fn native_backend_winit_app_facade_accepts_staged_window_config() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Facade", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend)
+        .expect("facade must accept staged WindowConfig");
+
+    let staged = facade
+        .backend()
+        .window_config()
+        .expect("WindowConfig must remain staged");
+
+    assert_eq!(staged.title, "Facade");
+    assert_eq!(staged.width, 800);
+    assert_eq!(staged.height, 600);
+    assert!(!facade.backend().is_platform_wired());
+}
+
+#[test]
+fn native_backend_winit_app_facade_can_return_backend_before_run() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Return Backend", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+    let backend = facade.into_backend();
+
+    let staged = backend
+        .window_config()
+        .expect("WindowConfig must survive facade roundtrip");
+
+    assert_eq!(staged.title, "Return Backend");
+    assert_eq!(staged.width, 640);
+    assert_eq!(staged.height, 480);
+    assert!(!backend.is_platform_wired());
+}
+
+#[test]
+fn native_backend_winit_app_facade_run_until_close_has_expected_shape() {
+    let _f: fn(
+        NativeBackendWinitApp,
+    ) -> Result<NativeBackendWinitAppStateSummary, NativeBackendWinitAppError> =
+        NativeBackendWinitApp::run_until_close;
+}
+
+#[test]
+#[ignore = "manual NativeBackendWinitApp facade smoke; opens a native window"]
+fn manual_native_backend_winit_app_facade_runs_until_close() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic Native App Facade", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+
+    let summary = facade
+        .run_until_close()
+        .expect("manual NativeBackendWinitApp facade run should complete");
+
+    assert!(summary.resumed_calls >= 1);
+    assert_eq!(summary.create_attempts, 1);
+    assert_eq!(summary.create_failures, 0);
+    assert!(summary.window_created);
+    assert!(summary.close_requested);
+    assert!(summary.window_event_calls >= 1);
+    assert!(summary.staged_event_count >= 1);
+}


### PR DESCRIPTION
## Summary

- Adds a separate feature-gated `NativeBackendWinitApp` facade.
- Keeps the native winit app path outside `UiBackendAdapter`.
- Requires staged `WindowConfig` before facade creation.
- Runs `NativeBackendWinitAppState` through `EventLoop::run_app(...)`.
- Returns `NativeBackendWinitAppStateSummary`.
- Adds non-ignored contract tests and an ignored manual native smoke test.

## Boundary

This PR creates a separate native app facade, not runtime integration.

Allowed:
- `NativeBackendWinitApp`
- `EventLoop::run_app(...)` inside facade method
- `NativeBackendWinitAppState` as the native app handler

Still out of scope:
- `NativeBackend::run_event_loop(...)` winit integration
- `UiBackendAdapter` changes
- `prom-ui-runtime` changes
- renderer
- frame presentation
- VM/verifier/SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`

Manual smoke:

```bash
cargo test -p prom-ui-backend-native \
  --features winit-backend \
  --test native_backend_winit_app_facade_contract \
  -- --ignored --nocapture
```