### PR TITLE
feat(ui-backend-native): add facade run summary transcript contract

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -628,6 +628,11 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the NativeBackend winit app facade transcript contract is available.
+    pub const fn native_backend_winit_app_facade_transcript_available() -> bool {
+        true
+    }
+
     /// Error returned by the separate NativeBackend winit app facade.
     #[derive(Debug)]
     pub enum NativeBackendWinitAppError {
@@ -638,6 +643,112 @@ pub mod winit_placeholder {
     impl From<winit::error::EventLoopError> for NativeBackendWinitAppError {
         fn from(err: winit::error::EventLoopError) -> Self {
             Self::EventLoop(err)
+        }
+    }
+
+    /// High-level status of the NativeBackend winit facade run transcript.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitAppRunTranscriptStatus {
+        /// Facade exists but native run has not been executed.
+        Planned,
+
+        /// Native run completed and returned a summary.
+        Completed,
+
+        /// Native run was attempted but failed before a completed summary.
+        Failed,
+    }
+
+    /// Transcript of the NativeBackend winit app facade run path.
+    ///
+    /// This is a compact contract object, not a full event log.
+    /// It captures the externally relevant milestones of the native facade path.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitAppRunTranscript {
+        pub status: NativeBackendWinitAppRunTranscriptStatus,
+
+        pub staged_window_config: bool,
+        pub event_loop_requested: bool,
+        pub app_state_created: bool,
+        pub run_app_requested: bool,
+
+        pub resumed_calls: usize,
+        pub window_event_calls: usize,
+        pub create_attempts: usize,
+        pub create_failures: usize,
+        pub window_created: bool,
+        pub close_requested: bool,
+        pub staged_event_count: usize,
+    }
+
+    impl NativeBackendWinitAppRunTranscript {
+        pub const fn planned(staged_window_config: bool) -> Self {
+            Self {
+                status: NativeBackendWinitAppRunTranscriptStatus::Planned,
+
+                staged_window_config,
+                event_loop_requested: false,
+                app_state_created: false,
+                run_app_requested: false,
+
+                resumed_calls: 0,
+                window_event_calls: 0,
+                create_attempts: 0,
+                create_failures: 0,
+                window_created: false,
+                close_requested: false,
+                staged_event_count: 0,
+            }
+        }
+
+        pub const fn completed_from_summary(
+            summary: NativeBackendWinitAppStateSummary,
+        ) -> Self {
+            Self {
+                status: NativeBackendWinitAppRunTranscriptStatus::Completed,
+
+                staged_window_config: true,
+                event_loop_requested: true,
+                app_state_created: true,
+                run_app_requested: true,
+
+                resumed_calls: summary.resumed_calls,
+                window_event_calls: summary.window_event_calls,
+                create_attempts: summary.create_attempts,
+                create_failures: summary.create_failures,
+                window_created: summary.window_created,
+                close_requested: summary.close_requested,
+                staged_event_count: summary.staged_event_count,
+            }
+        }
+
+        pub const fn failed_after_request(staged_window_config: bool) -> Self {
+            Self {
+                status: NativeBackendWinitAppRunTranscriptStatus::Failed,
+
+                staged_window_config,
+                event_loop_requested: staged_window_config,
+                app_state_created: false,
+                run_app_requested: false,
+
+                resumed_calls: 0,
+                window_event_calls: 0,
+                create_attempts: 0,
+                create_failures: 0,
+                window_created: false,
+                close_requested: false,
+                staged_event_count: 0,
+            }
+        }
+
+        pub fn completed_cleanly(&self) -> bool {
+            matches!(self.status, NativeBackendWinitAppRunTranscriptStatus::Completed)
+                && self.staged_window_config
+                && self.event_loop_requested
+                && self.app_state_created
+                && self.run_app_requested
+                && self.window_created
+                && self.create_failures == 0
         }
     }
 
@@ -667,6 +778,18 @@ pub mod winit_placeholder {
             self.backend
         }
 
+        /// Return the planned transcript before native execution.
+        pub fn planned_transcript(&self) -> NativeBackendWinitAppRunTranscript {
+            NativeBackendWinitAppRunTranscript::planned(self.backend.window_config().is_some())
+        }
+
+        /// Build a completed transcript from a run summary.
+        pub const fn transcript_from_summary(
+            summary: NativeBackendWinitAppStateSummary,
+        ) -> NativeBackendWinitAppRunTranscript {
+            NativeBackendWinitAppRunTranscript::completed_from_summary(summary)
+        }
+
         /// Run the separate NativeBackend-backed winit app facade until the native window closes.
         ///
         /// This consumes the facade and returns a summary.
@@ -680,6 +803,16 @@ pub mod winit_placeholder {
             event_loop.run_app(&mut app_state)?;
 
             Ok(app_state.summary())
+        }
+
+        /// Run until close and return a transcript instead of raw summary.
+        pub fn run_until_close_transcript(
+            self,
+        ) -> Result<NativeBackendWinitAppRunTranscript, NativeBackendWinitAppError> {
+            let summary = self.run_until_close()?;
+            Ok(NativeBackendWinitAppRunTranscript::completed_from_summary(
+                summary,
+            ))
         }
     }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_transcript_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_transcript_contract.rs
@@ -1,0 +1,160 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_facade_transcript_available,
+        NativeBackendWinitApp,
+        NativeBackendWinitAppRunTranscript,
+        NativeBackendWinitAppRunTranscriptStatus,
+        NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_facade_transcript_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_facade_transcript_available());
+}
+
+#[test]
+fn facade_planned_transcript_records_staged_config_without_running() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Transcript", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+    let transcript = facade.planned_transcript();
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Planned
+    );
+    assert!(transcript.staged_window_config);
+    assert!(!transcript.event_loop_requested);
+    assert!(!transcript.app_state_created);
+    assert!(!transcript.run_app_requested);
+    assert_eq!(transcript.resumed_calls, 0);
+    assert_eq!(transcript.window_event_calls, 0);
+}
+
+#[test]
+fn planned_transcript_can_record_missing_config() {
+    let transcript = NativeBackendWinitAppRunTranscript::planned(false);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Planned
+    );
+    assert!(!transcript.staged_window_config);
+    assert!(!transcript.event_loop_requested);
+    assert!(!transcript.app_state_created);
+    assert!(!transcript.run_app_requested);
+    assert!(!transcript.completed_cleanly());
+}
+
+#[test]
+fn completed_transcript_maps_summary_exactly() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 1,
+        window_event_calls: 2,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 1,
+    };
+
+    let transcript = NativeBackendWinitAppRunTranscript::completed_from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Completed
+    );
+    assert!(transcript.staged_window_config);
+    assert!(transcript.event_loop_requested);
+    assert!(transcript.app_state_created);
+    assert!(transcript.run_app_requested);
+
+    assert_eq!(transcript.resumed_calls, 1);
+    assert_eq!(transcript.window_event_calls, 2);
+    assert_eq!(transcript.create_attempts, 1);
+    assert_eq!(transcript.create_failures, 0);
+    assert!(transcript.window_created);
+    assert!(transcript.close_requested);
+    assert_eq!(transcript.staged_event_count, 1);
+    assert!(transcript.completed_cleanly());
+}
+
+#[test]
+fn facade_transcript_from_summary_maps_summary() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 3,
+        window_event_calls: 4,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 2,
+    };
+
+    let transcript = NativeBackendWinitApp::transcript_from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Completed
+    );
+    assert_eq!(transcript.resumed_calls, 3);
+    assert_eq!(transcript.window_event_calls, 4);
+    assert_eq!(transcript.staged_event_count, 2);
+}
+
+#[test]
+fn failed_transcript_is_explicit() {
+    let transcript = NativeBackendWinitAppRunTranscript::failed_after_request(true);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Failed
+    );
+    assert!(transcript.staged_window_config);
+    assert!(transcript.event_loop_requested);
+    assert!(!transcript.app_state_created);
+    assert!(!transcript.run_app_requested);
+    assert!(!transcript.completed_cleanly());
+}
+
+#[test]
+fn facade_run_until_close_transcript_has_expected_shape() {
+    let _f: fn(
+        NativeBackendWinitApp,
+    ) -> Result<
+        NativeBackendWinitAppRunTranscript,
+        prom_ui_backend_native::winit_placeholder::NativeBackendWinitAppError,
+    > = NativeBackendWinitApp::run_until_close_transcript;
+}
+
+#[test]
+#[ignore = "manual NativeBackendWinitApp transcript smoke; opens a native window"]
+fn manual_native_backend_winit_app_facade_returns_transcript() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic Native Transcript", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+
+    let transcript = facade
+        .run_until_close_transcript()
+        .expect("manual NativeBackendWinitApp transcript run should complete");
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppRunTranscriptStatus::Completed
+    );
+    assert!(transcript.completed_cleanly());
+    assert!(transcript.close_requested);
+    assert!(transcript.staged_event_count >= 1);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated facade run transcript contract.
- Adds `NativeBackendWinitAppRunTranscriptStatus`.
- Adds `NativeBackendWinitAppRunTranscript`.
- Adds planned/completed/failed transcript constructors.
- Adds `NativeBackendWinitApp::planned_transcript(...)`.
- Adds `NativeBackendWinitApp::transcript_from_summary(...)`.
- Adds `NativeBackendWinitApp::run_until_close_transcript(...)`.
- Adds contract tests and an ignored manual transcript smoke test.

## Boundary

This PR adds transcript contracts for the existing facade path.

Still out of scope:
- `NativeBackend::run_event_loop(...)` winit integration
- `UiBackendAdapter` changes
- `prom-ui-runtime` changes
- renderer
- frame presentation
- VM/verifier/SemCode changes
- Workbench integration

No new native ownership model is introduced.

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`

Manual smoke:

```bash
cargo test -p prom-ui-backend-native \
  --features winit-backend \
  --test native_backend_winit_app_facade_transcript_contract \
  -- --ignored --nocapture
```