### PR TITLE
feat(ui-backend-native): add event transcript extraction from facade summary

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -633,6 +633,11 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the NativeBackend winit app event transcript extraction is available.
+    pub const fn native_backend_winit_app_event_transcript_available() -> bool {
+        true
+    }
+
     /// Error returned by the separate NativeBackend winit app facade.
     #[derive(Debug)]
     pub enum NativeBackendWinitAppError {
@@ -752,6 +757,74 @@ pub mod winit_placeholder {
         }
     }
 
+    /// Derived event status for the NativeBackend winit app facade path.
+    ///
+    /// This is derived from summary counters, not from a full raw event log.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitAppEventTranscriptStatus {
+        NoWindowEventsObserved,
+        WindowEventsObserved,
+        CloseObserved,
+    }
+
+    /// Derived event transcript extracted from facade summary/transcript.
+    ///
+    /// This is not a raw event log. It records event-level facts available from
+    /// `NativeBackendWinitAppStateSummary`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitAppEventTranscript {
+        pub status: NativeBackendWinitAppEventTranscriptStatus,
+        pub window_event_calls: usize,
+        pub staged_event_count: usize,
+        pub close_observed: bool,
+    }
+
+    impl NativeBackendWinitAppEventTranscript {
+        pub const fn from_summary(summary: NativeBackendWinitAppStateSummary) -> Self {
+            let status = if summary.close_requested {
+                NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+            } else if summary.window_event_calls > 0 || summary.staged_event_count > 0 {
+                NativeBackendWinitAppEventTranscriptStatus::WindowEventsObserved
+            } else {
+                NativeBackendWinitAppEventTranscriptStatus::NoWindowEventsObserved
+            };
+
+            Self {
+                status,
+                window_event_calls: summary.window_event_calls,
+                staged_event_count: summary.staged_event_count,
+                close_observed: summary.close_requested,
+            }
+        }
+
+        pub const fn from_run_transcript(
+            transcript: NativeBackendWinitAppRunTranscript,
+        ) -> Self {
+            let status = if transcript.close_requested {
+                NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+            } else if transcript.window_event_calls > 0 || transcript.staged_event_count > 0 {
+                NativeBackendWinitAppEventTranscriptStatus::WindowEventsObserved
+            } else {
+                NativeBackendWinitAppEventTranscriptStatus::NoWindowEventsObserved
+            };
+
+            Self {
+                status,
+                window_event_calls: transcript.window_event_calls,
+                staged_event_count: transcript.staged_event_count,
+                close_observed: transcript.close_requested,
+            }
+        }
+
+        pub const fn observed_any_event(&self) -> bool {
+            self.window_event_calls > 0 || self.staged_event_count > 0 || self.close_observed
+        }
+
+        pub const fn observed_close(&self) -> bool {
+            self.close_observed
+        }
+    }
+
     /// Separate native app facade for running NativeBackend through winit.
     ///
     /// This facade intentionally lives outside `UiBackendAdapter`.
@@ -790,6 +863,20 @@ pub mod winit_placeholder {
             NativeBackendWinitAppRunTranscript::completed_from_summary(summary)
         }
 
+        /// Build an event transcript from a completed app-state summary.
+        pub const fn event_transcript_from_summary(
+            summary: NativeBackendWinitAppStateSummary,
+        ) -> NativeBackendWinitAppEventTranscript {
+            NativeBackendWinitAppEventTranscript::from_summary(summary)
+        }
+
+        /// Build an event transcript from a facade run transcript.
+        pub const fn event_transcript_from_run_transcript(
+            transcript: NativeBackendWinitAppRunTranscript,
+        ) -> NativeBackendWinitAppEventTranscript {
+            NativeBackendWinitAppEventTranscript::from_run_transcript(transcript)
+        }
+
         /// Run the separate NativeBackend-backed winit app facade until the native window closes.
         ///
         /// This consumes the facade and returns a summary.
@@ -812,6 +899,16 @@ pub mod winit_placeholder {
             let summary = self.run_until_close()?;
             Ok(NativeBackendWinitAppRunTranscript::completed_from_summary(
                 summary,
+            ))
+        }
+
+        /// Run until close and return a derived event transcript.
+        pub fn run_until_close_event_transcript(
+            self,
+        ) -> Result<NativeBackendWinitAppEventTranscript, NativeBackendWinitAppError> {
+            let transcript = self.run_until_close_transcript()?;
+            Ok(NativeBackendWinitAppEventTranscript::from_run_transcript(
+                transcript,
             ))
         }
     }

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_event_transcript_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_event_transcript_contract.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_event_transcript_available, NativeBackendWinitApp,
+        NativeBackendWinitAppEventTranscript, NativeBackendWinitAppEventTranscriptStatus,
+        NativeBackendWinitAppRunTranscript, NativeBackendWinitAppRunTranscriptStatus,
+        NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_event_transcript_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_event_transcript_available());
+}
+
+#[test]
+fn event_transcript_from_empty_summary_records_no_events() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 0,
+        window_event_calls: 0,
+        create_attempts: 0,
+        create_failures: 0,
+        window_created: false,
+        close_requested: false,
+        staged_event_count: 0,
+    };
+
+    let transcript = NativeBackendWinitAppEventTranscript::from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::NoWindowEventsObserved
+    );
+    assert_eq!(transcript.window_event_calls, 0);
+    assert_eq!(transcript.staged_event_count, 0);
+    assert!(!transcript.close_observed);
+    assert!(!transcript.observed_any_event());
+}
+
+#[test]
+fn event_transcript_records_window_events_without_close() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 1,
+        window_event_calls: 2,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: false,
+        staged_event_count: 1,
+    };
+
+    let transcript = NativeBackendWinitAppEventTranscript::from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::WindowEventsObserved
+    );
+    assert_eq!(transcript.window_event_calls, 2);
+    assert_eq!(transcript.staged_event_count, 1);
+    assert!(!transcript.close_observed);
+    assert!(transcript.observed_any_event());
+}
+
+#[test]
+fn event_transcript_records_close_observed() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 1,
+        window_event_calls: 1,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 1,
+    };
+
+    let transcript = NativeBackendWinitAppEventTranscript::from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+    );
+    assert_eq!(transcript.window_event_calls, 1);
+    assert_eq!(transcript.staged_event_count, 1);
+    assert!(transcript.close_observed);
+    assert!(transcript.observed_any_event());
+    assert!(transcript.observed_close());
+}
+
+#[test]
+fn event_transcript_can_be_extracted_from_run_transcript() {
+    let run_transcript = NativeBackendWinitAppRunTranscript {
+        status: NativeBackendWinitAppRunTranscriptStatus::Completed,
+
+        staged_window_config: true,
+        event_loop_requested: true,
+        app_state_created: true,
+        run_app_requested: true,
+
+        resumed_calls: 1,
+        window_event_calls: 3,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 2,
+    };
+
+    let event_transcript =
+        NativeBackendWinitAppEventTranscript::from_run_transcript(run_transcript);
+
+    assert_eq!(
+        event_transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+    );
+    assert_eq!(event_transcript.window_event_calls, 3);
+    assert_eq!(event_transcript.staged_event_count, 2);
+    assert!(event_transcript.close_observed);
+}
+
+#[test]
+fn facade_event_transcript_from_summary_maps_summary() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 1,
+        window_event_calls: 4,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 2,
+    };
+
+    let transcript = NativeBackendWinitApp::event_transcript_from_summary(summary);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+    );
+    assert_eq!(transcript.window_event_calls, 4);
+    assert_eq!(transcript.staged_event_count, 2);
+}
+
+#[test]
+fn facade_run_until_close_event_transcript_has_expected_shape() {
+    let _f: fn(
+        NativeBackendWinitApp,
+    ) -> Result<
+        NativeBackendWinitAppEventTranscript,
+        prom_ui_backend_native::winit_placeholder::NativeBackendWinitAppError,
+    > = NativeBackendWinitApp::run_until_close_event_transcript;
+}
+
+#[test]
+#[ignore = "manual NativeBackendWinitApp event transcript smoke; opens a native window"]
+fn manual_native_backend_winit_app_facade_returns_event_transcript() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic Native Event Transcript", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+
+    let transcript = facade
+        .run_until_close_event_transcript()
+        .expect("manual NativeBackendWinitApp event transcript run should complete");
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+    );
+    assert!(transcript.observed_close());
+    assert!(transcript.observed_any_event());
+    assert!(transcript.staged_event_count >= 1);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated event transcript extraction contract for the NativeBackend winit app facade.
- Adds `NativeBackendWinitAppEventTranscriptStatus`.
- Adds `NativeBackendWinitAppEventTranscript`.
- Adds extraction from `NativeBackendWinitAppStateSummary`.
- Adds extraction from `NativeBackendWinitAppRunTranscript`.
- Adds facade helper methods for event transcript conversion.
- Adds contract tests and an ignored manual event-transcript smoke test.

## Boundary

This PR derives event transcript facts from existing facade summary/transcript data.

Still out of scope:
- raw event log storage
- `NativeBackend::run_event_loop(...)` winit integration
- `UiBackendAdapter` changes
- `prom-ui-runtime` changes
- renderer
- frame presentation
- VM/verifier/SemCode changes
- Workbench integration

No new native ownership model is introduced.

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`

Manual smoke:

```bash
cargo test -p prom-ui-backend-native \
  --features winit-backend \
  --test native_backend_winit_app_event_transcript_contract \
  -- --ignored --nocapture
```