### PR TITLE
feat(ui-backend-native): add draw-frame staging bridge without renderer

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -638,6 +638,11 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the NativeBackend winit app draw staging bridge is available.
+    pub const fn native_backend_winit_app_draw_staging_available() -> bool {
+        true
+    }
+
     /// Error returned by the separate NativeBackend winit app facade.
     #[derive(Debug)]
     pub enum NativeBackendWinitAppError {
@@ -825,6 +830,53 @@ pub mod winit_placeholder {
         }
     }
 
+    /// Status of a draw-frame staging operation.
+    ///
+    /// This is not renderer status. It only describes backend-side staging/accounting.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitAppDrawStagingStatus {
+        NotSubmitted,
+        Submitted,
+    }
+
+    /// Transcript for staged draw-frame submission through the native facade path.
+    ///
+    /// This does not imply rendering or presentation. It only records that a
+    /// `DrawFrame` was accepted into backend-side accounting.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitAppDrawTranscript {
+        pub status: NativeBackendWinitAppDrawStagingStatus,
+        pub submitted_before: usize,
+        pub submitted_after: usize,
+        pub submitted_delta: usize,
+    }
+
+    impl NativeBackendWinitAppDrawTranscript {
+        pub const fn not_submitted(current_submitted_frames: usize) -> Self {
+            Self {
+                status: NativeBackendWinitAppDrawStagingStatus::NotSubmitted,
+                submitted_before: current_submitted_frames,
+                submitted_after: current_submitted_frames,
+                submitted_delta: 0,
+            }
+        }
+
+        pub const fn submitted(before: usize, after: usize) -> Self {
+            Self {
+                status: NativeBackendWinitAppDrawStagingStatus::Submitted,
+                submitted_before: before,
+                submitted_after: after,
+                submitted_delta: after.saturating_sub(before),
+            }
+        }
+
+        pub fn accepted_one_frame(&self) -> bool {
+            matches!(self.status, NativeBackendWinitAppDrawStagingStatus::Submitted)
+                && self.submitted_delta == 1
+                && self.submitted_after == self.submitted_before.saturating_add(1)
+        }
+    }
+
     /// Separate native app facade for running NativeBackend through winit.
     ///
     /// This facade intentionally lives outside `UiBackendAdapter`.
@@ -845,6 +897,10 @@ pub mod winit_placeholder {
 
         pub fn backend(&self) -> &NativeBackend {
             &self.backend
+        }
+
+        pub fn backend_mut(&mut self) -> &mut NativeBackend {
+            &mut self.backend
         }
 
         pub fn into_backend(self) -> NativeBackend {
@@ -911,6 +967,31 @@ pub mod winit_placeholder {
                 transcript,
             ))
         }
+
+        /// Stage a DrawFrame through the facade's inner NativeBackend.
+        ///
+        /// This only updates backend accounting through the existing `draw_frame(...)`
+        /// adapter method. It does not render and does not present anything.
+        pub fn stage_draw_frame(
+            &mut self,
+            frame: &prom_ui_runtime::DrawFrame,
+        ) -> Result<NativeBackendWinitAppDrawTranscript, prom_ui_runtime::UiRuntimeError> {
+            let before = self.backend.submitted_frames();
+
+            prom_ui_runtime::UiBackendAdapter::draw_frame(&mut self.backend, frame)?;
+
+            let after = self.backend.submitted_frames();
+
+            Ok(NativeBackendWinitAppDrawTranscript::submitted(before, after))
+        }
+    }
+
+    /// Return a staged draw transcript from frame counters.
+    pub const fn draw_transcript_from_counts(
+        before: usize,
+        after: usize,
+    ) -> NativeBackendWinitAppDrawTranscript {
+        NativeBackendWinitAppDrawTranscript::submitted(before, after)
     }
 
     /// Read-only summary of the NativeBackend winit app scaffold.

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_draw_staging_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_draw_staging_contract.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_draw_staging_available, NativeBackendWinitApp,
+        NativeBackendWinitAppDrawStagingStatus, NativeBackendWinitAppDrawTranscript,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{DrawFrame, UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_draw_staging_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_draw_staging_available());
+}
+
+#[test]
+fn draw_transcript_can_represent_not_submitted() {
+    let transcript = NativeBackendWinitAppDrawTranscript::not_submitted(3);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppDrawStagingStatus::NotSubmitted
+    );
+    assert_eq!(transcript.submitted_before, 3);
+    assert_eq!(transcript.submitted_after, 3);
+    assert_eq!(transcript.submitted_delta, 0);
+    assert!(!transcript.accepted_one_frame());
+}
+
+#[test]
+fn draw_transcript_can_represent_one_submitted_frame() {
+    let transcript = NativeBackendWinitAppDrawTranscript::submitted(2, 3);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppDrawStagingStatus::Submitted
+    );
+    assert_eq!(transcript.submitted_before, 2);
+    assert_eq!(transcript.submitted_after, 3);
+    assert_eq!(transcript.submitted_delta, 1);
+    assert!(transcript.accepted_one_frame());
+}
+
+#[test]
+fn native_backend_winit_app_facade_exposes_mutable_backend_for_staging() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Draw Staging", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+
+    facade.backend_mut().stage_winit_close_requested();
+
+    assert_eq!(facade.backend().pending_event_count(), 1);
+}
+
+#[test]
+fn stage_draw_frame_increments_backend_submitted_frame_count() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Draw Staging", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+    let frame = DrawFrame::new();
+
+    let transcript = facade
+        .stage_draw_frame(&frame)
+        .expect("draw staging should succeed");
+
+    assert!(transcript.accepted_one_frame());
+    assert_eq!(transcript.submitted_before, 0);
+    assert_eq!(transcript.submitted_after, 1);
+    assert_eq!(facade.backend().submitted_frames(), 1);
+}
+
+#[test]
+fn multiple_staged_draw_frames_accumulate() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Draw Accumulate", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+    let frame = DrawFrame::new();
+
+    let first = facade.stage_draw_frame(&frame).unwrap();
+    let second = facade.stage_draw_frame(&frame).unwrap();
+
+    assert_eq!(first.submitted_before, 0);
+    assert_eq!(first.submitted_after, 1);
+    assert_eq!(second.submitted_before, 1);
+    assert_eq!(second.submitted_after, 2);
+    assert_eq!(facade.backend().submitted_frames(), 2);
+}
+
+#[test]
+fn staging_draw_frame_does_not_mark_backend_platform_wired() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("No Platform Wiring", 640, 480);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+    let frame = DrawFrame::new();
+
+    facade.stage_draw_frame(&frame).unwrap();
+
+    assert!(!facade.backend().is_platform_wired());
+}
+
+#[test]
+fn facade_stage_draw_frame_has_expected_shape() {
+    let _f: fn(
+        &mut NativeBackendWinitApp,
+        &DrawFrame,
+    ) -> Result<NativeBackendWinitAppDrawTranscript, prom_ui_runtime::UiRuntimeError> =
+        NativeBackendWinitApp::stage_draw_frame;
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated draw-frame staging bridge for the NativeBackend winit app facade.
- Adds `NativeBackendWinitAppDrawStagingStatus`.
- Adds `NativeBackendWinitAppDrawTranscript`.
- Adds `NativeBackendWinitApp::backend_mut()`.
- Adds `NativeBackendWinitApp::stage_draw_frame(...)`.
- Locks that draw staging updates backend accounting but does not render or present frames.
- Adds contract tests for transcript shape and submitted frame accounting.

## Boundary

This PR stages draw-frame intent only.

Still out of scope:
- renderer
- surface/pixels/wgpu
- native drawing APIs
- frame presentation
- `NativeBackend::run_event_loop(...)` winit integration
- `UiBackendAdapter` changes
- `prom-ui-runtime` changes
- VM/verifier/SemCode changes
- Workbench integration

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`