### PR TITLE
feat(ui-backend-native): add facade run transcript with draw facts

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -643,6 +643,11 @@ pub mod winit_placeholder {
         true
     }
 
+    /// Returns whether the combined facade run transcript with draw facts is available.
+    pub const fn native_backend_winit_app_facade_draw_run_transcript_available() -> bool {
+        true
+    }
+
     /// Error returned by the separate NativeBackend winit app facade.
     #[derive(Debug)]
     pub enum NativeBackendWinitAppError {
@@ -877,6 +882,102 @@ pub mod winit_placeholder {
         }
     }
 
+    /// High-level status for the combined facade transcript.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum NativeBackendWinitAppFacadeTranscriptStatus {
+        Planned,
+        Completed,
+        Failed,
+    }
+
+    /// Combined transcript for the NativeBackend winit app facade.
+    ///
+    /// This combines run, event, and draw-staging facts.
+    /// It does not imply rendering or frame presentation.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NativeBackendWinitAppFacadeTranscript {
+        pub status: NativeBackendWinitAppFacadeTranscriptStatus,
+
+        pub run: NativeBackendWinitAppRunTranscript,
+        pub events: NativeBackendWinitAppEventTranscript,
+        pub draw: NativeBackendWinitAppDrawTranscript,
+
+        pub submitted_frames_before_run: usize,
+        pub renderer_used: bool,
+        pub frame_presented: bool,
+    }
+
+    impl NativeBackendWinitAppFacadeTranscript {
+        pub const fn planned(
+            run: NativeBackendWinitAppRunTranscript,
+            draw: NativeBackendWinitAppDrawTranscript,
+        ) -> Self {
+            Self {
+                status: NativeBackendWinitAppFacadeTranscriptStatus::Planned,
+                events: NativeBackendWinitAppEventTranscript {
+                    status: NativeBackendWinitAppEventTranscriptStatus::NoWindowEventsObserved,
+                    window_event_calls: 0,
+                    staged_event_count: 0,
+                    close_observed: false,
+                },
+                submitted_frames_before_run: draw.submitted_after,
+                run,
+                draw,
+                renderer_used: false,
+                frame_presented: false,
+            }
+        }
+
+        pub const fn completed(
+            run: NativeBackendWinitAppRunTranscript,
+            events: NativeBackendWinitAppEventTranscript,
+            draw: NativeBackendWinitAppDrawTranscript,
+        ) -> Self {
+            Self {
+                status: NativeBackendWinitAppFacadeTranscriptStatus::Completed,
+                submitted_frames_before_run: draw.submitted_after,
+                run,
+                events,
+                draw,
+                renderer_used: false,
+                frame_presented: false,
+            }
+        }
+
+        pub const fn failed(
+            run: NativeBackendWinitAppRunTranscript,
+            draw: NativeBackendWinitAppDrawTranscript,
+        ) -> Self {
+            Self {
+                status: NativeBackendWinitAppFacadeTranscriptStatus::Failed,
+                events: NativeBackendWinitAppEventTranscript {
+                    status: NativeBackendWinitAppEventTranscriptStatus::NoWindowEventsObserved,
+                    window_event_calls: 0,
+                    staged_event_count: 0,
+                    close_observed: false,
+                },
+                submitted_frames_before_run: draw.submitted_after,
+                run,
+                draw,
+                renderer_used: false,
+                frame_presented: false,
+            }
+        }
+
+        pub const fn has_draw_staging(&self) -> bool {
+            self.draw.submitted_after > 0 || self.draw.submitted_delta > 0
+        }
+
+        pub const fn rendered_or_presented(&self) -> bool {
+            self.renderer_used || self.frame_presented
+        }
+
+        pub fn completed_without_renderer(&self) -> bool {
+            matches!(self.status, NativeBackendWinitAppFacadeTranscriptStatus::Completed)
+                && !self.rendered_or_presented()
+        }
+    }
+
     /// Separate native app facade for running NativeBackend through winit.
     ///
     /// This facade intentionally lives outside `UiBackendAdapter`.
@@ -933,6 +1034,24 @@ pub mod winit_placeholder {
             NativeBackendWinitAppEventTranscript::from_run_transcript(transcript)
         }
 
+        /// Return a planned facade transcript including current draw-staging facts.
+        pub fn planned_facade_transcript(&self) -> NativeBackendWinitAppFacadeTranscript {
+            let run = self.planned_transcript();
+            let submitted = self.backend.submitted_frames();
+            let draw = NativeBackendWinitAppDrawTranscript::not_submitted(submitted);
+
+            NativeBackendWinitAppFacadeTranscript::planned(run, draw)
+        }
+
+        /// Build a completed facade transcript from run summary and pre-run draw facts.
+        pub const fn facade_transcript_from_parts(
+            run: NativeBackendWinitAppRunTranscript,
+            events: NativeBackendWinitAppEventTranscript,
+            draw: NativeBackendWinitAppDrawTranscript,
+        ) -> NativeBackendWinitAppFacadeTranscript {
+            NativeBackendWinitAppFacadeTranscript::completed(run, events, draw)
+        }
+
         /// Run the separate NativeBackend-backed winit app facade until the native window closes.
         ///
         /// This consumes the facade and returns a summary.
@@ -965,6 +1084,25 @@ pub mod winit_placeholder {
             let transcript = self.run_until_close_transcript()?;
             Ok(NativeBackendWinitAppEventTranscript::from_run_transcript(
                 transcript,
+            ))
+        }
+
+        /// Run until close and return a combined facade transcript.
+        ///
+        /// Draw facts are captured from the inner backend's submitted frame counter
+        /// before native run. This does not render or present frames.
+        pub fn run_until_close_facade_transcript(
+            self,
+        ) -> Result<NativeBackendWinitAppFacadeTranscript, NativeBackendWinitAppError> {
+            let submitted_before_run = self.backend.submitted_frames();
+
+            let draw = NativeBackendWinitAppDrawTranscript::not_submitted(submitted_before_run);
+
+            let run = self.run_until_close_transcript()?;
+            let events = NativeBackendWinitAppEventTranscript::from_run_transcript(run);
+
+            Ok(NativeBackendWinitAppFacadeTranscript::completed(
+                run, events, draw,
             ))
         }
 

--- a/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_draw_run_transcript_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_winit_app_facade_draw_run_transcript_contract.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::{
+    winit_placeholder::{
+        native_backend_winit_app_facade_draw_run_transcript_available,
+        NativeBackendWinitApp,
+        NativeBackendWinitAppDrawTranscript,
+        NativeBackendWinitAppEventTranscript,
+        NativeBackendWinitAppEventTranscriptStatus,
+        NativeBackendWinitAppFacadeTranscript,
+        NativeBackendWinitAppFacadeTranscriptStatus,
+        NativeBackendWinitAppRunTranscript,
+        NativeBackendWinitAppStateSummary,
+    },
+    NativeBackend,
+};
+use prom_ui_runtime::{DrawFrame, UiBackendAdapter, WindowConfig};
+
+#[test]
+fn native_backend_winit_app_facade_draw_run_transcript_is_available() {
+    assert!(prom_ui_backend_native::winit_backend_feature_enabled());
+    assert!(native_backend_winit_app_facade_draw_run_transcript_available());
+}
+
+#[test]
+fn planned_facade_transcript_records_no_renderer_or_presentation() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Facade Transcript", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let facade = NativeBackendWinitApp::new(backend).unwrap();
+    let transcript = facade.planned_facade_transcript();
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppFacadeTranscriptStatus::Planned
+    );
+    assert!(!transcript.renderer_used);
+    assert!(!transcript.frame_presented);
+    assert!(!transcript.rendered_or_presented());
+}
+
+#[test]
+fn planned_facade_transcript_records_existing_draw_staging_count() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Draw Count", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+    let frame = DrawFrame::new();
+
+    facade.stage_draw_frame(&frame).unwrap();
+    facade.stage_draw_frame(&frame).unwrap();
+
+    let transcript = facade.planned_facade_transcript();
+
+    assert_eq!(transcript.submitted_frames_before_run, 2);
+    assert_eq!(transcript.draw.submitted_before, 2);
+    assert_eq!(transcript.draw.submitted_after, 2);
+    assert_eq!(transcript.draw.submitted_delta, 0);
+    assert!(transcript.has_draw_staging());
+}
+
+#[test]
+fn completed_facade_transcript_combines_run_event_and_draw_facts() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 1,
+        window_event_calls: 2,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 1,
+    };
+
+    let run = NativeBackendWinitAppRunTranscript::completed_from_summary(summary);
+    let events = NativeBackendWinitAppEventTranscript::from_summary(summary);
+    let draw = NativeBackendWinitAppDrawTranscript::submitted(0, 1);
+
+    let transcript = NativeBackendWinitAppFacadeTranscript::completed(run, events, draw);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppFacadeTranscriptStatus::Completed
+    );
+    assert_eq!(transcript.run.resumed_calls, 1);
+    assert_eq!(
+        transcript.events.status,
+        NativeBackendWinitAppEventTranscriptStatus::CloseObserved
+    );
+    assert!(transcript.draw.accepted_one_frame());
+    assert!(transcript.completed_without_renderer());
+}
+
+#[test]
+fn failed_facade_transcript_remains_renderer_free() {
+    let run = NativeBackendWinitAppRunTranscript::failed_after_request(true);
+    let draw = NativeBackendWinitAppDrawTranscript::not_submitted(0);
+
+    let transcript = NativeBackendWinitAppFacadeTranscript::failed(run, draw);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppFacadeTranscriptStatus::Failed
+    );
+    assert!(!transcript.renderer_used);
+    assert!(!transcript.frame_presented);
+    assert!(!transcript.rendered_or_presented());
+}
+
+#[test]
+fn facade_helper_combines_transcript_parts() {
+    let summary = NativeBackendWinitAppStateSummary {
+        resumed_calls: 2,
+        window_event_calls: 3,
+        create_attempts: 1,
+        create_failures: 0,
+        window_created: true,
+        close_requested: true,
+        staged_event_count: 2,
+    };
+
+    let run = NativeBackendWinitApp::transcript_from_summary(summary);
+    let events = NativeBackendWinitApp::event_transcript_from_summary(summary);
+    let draw = NativeBackendWinitAppDrawTranscript::submitted(1, 2);
+
+    let transcript = NativeBackendWinitApp::facade_transcript_from_parts(run, events, draw);
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppFacadeTranscriptStatus::Completed
+    );
+    assert_eq!(transcript.run.window_event_calls, 3);
+    assert_eq!(transcript.events.staged_event_count, 2);
+    assert_eq!(transcript.draw.submitted_delta, 1);
+}
+
+#[test]
+fn facade_run_until_close_facade_transcript_has_expected_shape() {
+    let _f: fn(
+        NativeBackendWinitApp,
+    ) -> Result<
+        NativeBackendWinitAppFacadeTranscript,
+        prom_ui_backend_native::winit_placeholder::NativeBackendWinitAppError,
+    > = NativeBackendWinitApp::run_until_close_facade_transcript;
+}
+
+#[test]
+#[ignore = "manual NativeBackendWinitApp facade draw/run transcript smoke; opens a native window"]
+fn manual_native_backend_winit_app_facade_returns_draw_run_transcript() {
+    let mut backend = NativeBackend::new();
+    let config = WindowConfig::new("Semantic Native Facade Transcript", 800, 600);
+
+    backend.create_window(&config).unwrap();
+
+    let mut facade = NativeBackendWinitApp::new(backend).unwrap();
+    let frame = DrawFrame::new();
+
+    facade.stage_draw_frame(&frame).unwrap();
+
+    let transcript = facade
+        .run_until_close_facade_transcript()
+        .expect("manual NativeBackendWinitApp facade transcript run should complete");
+
+    assert_eq!(
+        transcript.status,
+        NativeBackendWinitAppFacadeTranscriptStatus::Completed
+    );
+    assert!(transcript.completed_without_renderer());
+    assert!(transcript.has_draw_staging());
+    assert!(transcript.events.observed_close());
+    assert_eq!(transcript.submitted_frames_before_run, 1);
+}


### PR DESCRIPTION
## Summary

- Adds a feature-gated combined facade transcript with draw-staging facts.
- Adds `NativeBackendWinitAppFacadeTranscriptStatus`.
- Adds `NativeBackendWinitAppFacadeTranscript`.
- Combines run transcript, event transcript, and draw transcript.
- Adds `NativeBackendWinitApp::planned_facade_transcript(...)`.
- Adds `NativeBackendWinitApp::facade_transcript_from_parts(...)`.
- Adds `NativeBackendWinitApp::run_until_close_facade_transcript(...)`.
- Locks that draw facts remain staging/accounting only, not rendering or presentation.

## Boundary

This PR combines existing transcript facts.

Still out of scope:
- renderer
- surface/pixels/wgpu
- native drawing APIs
- frame presentation
- `NativeBackend::run_event_loop(...)` winit integration
- `UiBackendAdapter` changes
- `prom-ui-runtime` changes
- VM/verifier/SemCode changes
- Workbench integration

No new native ownership model is introduced.

## Validation

- `cargo test -q -p prom-ui-backend-native`
- `cargo test -q -p prom-ui-backend-native --features winit-backend`
- `cargo test -q -p prom-ui-runtime`
- `git diff --check`

Manual smoke:

```bash
cargo test -p prom-ui-backend-native \
  --features winit-backend \
  --test native_backend_winit_app_facade_draw_run_transcript_contract \
  -- --ignored --nocapture
```