### PR TITLE
docs(ui-backend-native): document native facade transcript boundary

### DIFF
--- a/docs/architecture/ui_native_backend_boundary.md
+++ b/docs/architecture/ui_native_backend_boundary.md
@@ -1,0 +1,314 @@
+# Native UI Backend Boundary
+
+Status: Draft
+Track: POST-UI
+Purpose: define the implementation boundary before adding a native backend
+
+## 1. Goal
+
+This document defines the boundary for the first native UI backend implementation.
+
+The native backend must plug into the existing `UiBackendAdapter` seam and must not move
+platform-specific behavior into `prom-ui-runtime`.
+
+Current reference path:
+
+```text
+DesktopSession<InMemoryBackend>
+  -> lifecycle gate
+  -> injected events
+  -> tick_in_memory_frame(...)
+  -> DrawFrame
+  -> captured frame transcript
+```
+
+Future native path:
+
+```text
+DesktopSession<NativeBackend>
+  -> lifecycle gate
+  -> native event loop
+  -> DrawFrame
+  -> native draw submission
+```
+
+## 2. Current runtime ownership
+
+`prom-ui-runtime` owns:
+
+* `DesktopSession`
+* `UiLifecycleGate`
+* `SessionState`
+* `EventBuffer`
+* `InputEvent`
+* `InputEventKind`
+* `DrawFrame`
+* `DrawCommand`
+* `Color`
+* `Rect`
+* `UiBackendAdapter`
+* `InMemoryBackend`
+
+`prom-ui-runtime` must remain platform-neutral.
+
+## 3. Native backend ownership
+
+The native backend owns:
+
+* native window creation;
+* native event loop integration;
+* platform event translation into `InputEvent`;
+* platform draw submission from `DrawFrame`;
+* native close/window lifecycle interaction.
+
+The native backend must not own:
+
+* Semantic lifecycle rules;
+* UI capability admission;
+* verifier admission;
+* SemCode format;
+* VM dispatch;
+* Workbench policy.
+
+## 4. First native backend target
+
+The first native backend should be introduced as a separate crate:
+
+```text
+crates/prom-ui-backend-native/
+```
+
+Preferred public type:
+
+```rust
+NativeBackend
+```
+
+The crate must implement:
+
+```rust
+UiBackendAdapter for NativeBackend
+```
+
+The native backend crate may depend on platform/window libraries.
+`prom-ui-runtime` must not.
+
+## 5. Dependency boundary
+
+Allowed:
+
+```text
+prom-ui-backend-native -> prom-ui-runtime
+prom-ui-backend-native -> native window/event crates
+```
+
+Forbidden:
+
+```text
+prom-ui-runtime -> winit
+prom-ui-runtime -> tao
+prom-ui-runtime -> wgpu
+prom-ui-runtime -> platform-specific APIs
+sm-vm -> native UI backend
+sm-verify -> native UI backend
+prom-ui -> native UI backend
+prom-cap -> native UI backend
+```
+
+## 6. Adapter contract
+
+The native backend must implement the existing adapter:
+
+```rust
+create_window(&WindowConfig) -> Result<(), UiRuntimeError>
+run_event_loop(on_event) -> Result<(), UiRuntimeError>
+draw_frame(&DrawFrame) -> Result<(), UiRuntimeError>
+close_window()
+```
+
+No trait changes are allowed in the first native backend PR unless a separate contract PR justifies them.
+
+## 7. Event translation
+
+The first native backend may translate only the current first-wave event set:
+
+```text
+KeyDown { key_code }
+KeyUp { key_code }
+CloseRequested
+```
+
+Out of scope for the first native backend:
+
+```text
+mouse
+touch
+gamepad
+IME
+clipboard
+drag/drop
+multi-window
+browser target
+mobile target
+```
+
+## 8. Draw translation
+
+The first native backend may translate only the current first-wave draw set:
+
+```text
+Clear
+FillRect
+DrawText
+```
+
+Out of scope for the first native backend:
+
+```text
+images
+paths
+fonts API
+layout engine
+widgets
+GPU pipeline abstraction
+animation system
+```
+
+## 9. Lifecycle rule
+
+The native backend must not bypass `DesktopSession`.
+
+All native UI behavior must still pass through:
+
+```text
+DesktopSession
+  -> UiLifecycleGate
+  -> UiBackendAdapter
+```
+
+Invalid lifecycle operations must fail before backend calls.
+
+## 10. Determinism rule
+
+The native backend itself is host-bound and not deterministic by default.
+
+The deterministic reference remains:
+
+```text
+InMemoryBackend
+```
+
+Native backend tests must compare against reference behavior where possible, but native timing and OS event ordering are outside the deterministic core.
+
+## 11. Native facade transcript boundary
+
+`prom-ui-backend-native` exposes a separate native facade path for winit-backed execution:
+
+```text
+NativeBackend
+  -> NativeBackendWinitApp
+  -> NativeBackendWinitAppState
+  -> winit EventLoop::run_app(...)
+  -> NativeBackendWinitAppFacadeTranscript
+```
+
+This path is intentionally separate from `UiBackendAdapter`.
+
+`NativeBackend::run_event_loop(...)` remains a staged deterministic seam and is not the winit app runner.
+
+### Ownership split
+
+| Layer | Ownership | Status |
+|---|---|---|
+| `prom-ui-runtime` | platform-neutral session/lifecycle contracts | stable boundary |
+| `UiBackendAdapter` | staged backend adapter seam | unchanged |
+| `NativeBackend` | staged native backend state and accounting | no persistent native window ownership |
+| `NativeBackendWinitApp` | native facade ownership | owns the winit app path |
+| `NativeBackendWinitAppState` | `ApplicationHandler` state | owns native window during run |
+| renderer | not implemented | out of scope |
+
+### Transcript hierarchy
+
+The native facade path exposes transcript objects for different levels of observation:
+
+| Transcript | Meaning | Renderer implication |
+|---|---|---|
+| `NativeBackendWinitAppRunTranscript` | event-loop/window lifecycle facts | none |
+| `NativeBackendWinitAppEventTranscript` | derived event facts from summary counters | none |
+| `NativeBackendWinitAppDrawTranscript` | staged draw-frame accounting facts | none |
+| `NativeBackendWinitAppFacadeTranscript` | combined run/event/draw facts | none |
+
+Draw transcript facts are staging/accounting only. They do not mean that a frame was rendered or presented.
+
+### Current admitted path
+
+The currently admitted native path is:
+
+```text
+staged WindowConfig
+  -> NativeBackendWinitApp::new(...)
+  -> NativeBackendWinitAppState
+  -> EventLoop::run_app(...)
+  -> summary/transcript
+```
+
+The currently admitted draw path is:
+
+```text
+DrawFrame
+  -> NativeBackendWinitApp::stage_draw_frame(...)
+  -> NativeBackend submitted_frames accounting
+  -> NativeBackendWinitAppDrawTranscript
+```
+
+The draw path is not a renderer path.
+
+## 12. First implementation PR boundary
+
+The first implementation PR after this document should only add:
+
+```text
+crates/prom-ui-backend-native/
+Cargo.toml
+src/lib.rs
+basic NativeBackend skeleton
+compile tests
+```
+
+It should not add:
+
+```text
+Workbench integration
+VM integration
+SemCode integration
+verifier changes
+capability changes
+new UI operations
+new draw commands
+new input event kinds
+```
+
+## 13. Explicit non-goals
+
+The native facade transcript boundary does not introduce:
+
+* renderer ownership;
+* surface/pixels/wgpu integration;
+* native drawing calls;
+* frame presentation;
+* changes to `UiBackendAdapter`;
+* changes to `prom-ui-runtime`;
+* integration of winit into `NativeBackend::run_event_loop(...)`;
+* Workbench integration.
+
+## 14. Stop rules
+
+Stop the native backend implementation if it requires:
+
+* changing `UiBackendAdapter` immediately;
+* adding platform dependencies to `prom-ui-runtime`;
+* storing native handles in `DesktopSession`;
+* changing lifecycle semantics;
+* adding VM/verifier/SemCode coupling;
+* making Workbench the owner of runtime UI semantics.
+

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -9,6 +9,7 @@ Related:
 - `docs/spec/ui_contract_map.md`
 - `docs/spec/ui_abi_capability_admission.md`
 - `docs/roadmap/post_ui/ui_admission_checklist.md`
+- `docs/architecture/ui_native_backend_boundary.md`
 
 ## 1. Purpose
 
@@ -140,3 +141,21 @@ This document is complete when:
 - forbidden ownership leaks are listed;
 - Workbench is separated from UI application boundary;
 - capability and ABI ownership are explicit.
+
+### Native backend facade ownership
+
+`prom-ui-backend-native` now separates three roles:
+
+| Role | Type | Responsibility |
+|---|---|---|
+| staged backend | `NativeBackend` | stores staged config/events/frame accounting |
+| native app facade | `NativeBackendWinitApp` | owns the native app run path outside `UiBackendAdapter` |
+| app state | `NativeBackendWinitAppState` | implements winit `ApplicationHandler` and owns native window state during run |
+
+This preserves the core invariant:
+
+```text
+prom-ui-runtime remains platform-neutral.
+UiBackendAdapter remains unchanged.
+Native-specific ownership stays inside prom-ui-backend-native.
+```

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -29,6 +29,7 @@ Current documents in this PR:
 - `ui_contract_map.md` - POST-UI Semantic UI contract sketch and ownership map
 - `ui_abi_capability_admission.md` - POST-UI ABI/capability admission checklist for future UI operations
 - `ui_verifier_admission_metadata.md` - POST-UI verifier-visible metadata plan for future UI operation admission
+- `../architecture/ui_native_backend_boundary.md` - native facade transcript boundary and ownership split
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Documents the native facade transcript boundary in `prom-ui-backend-native`.
- Clarifies the split between `NativeBackend`, `NativeBackendWinitApp`, and `NativeBackendWinitAppState`.
- Documents run/event/draw/facade transcript hierarchy.
- Locks that draw transcript facts are staging/accounting only, not rendering or presentation.
- Reaffirms that `NativeBackend::run_event_loop(...)` remains staged-only.
- Updates UI ownership/index documentation.

## Boundary

Docs-only PR.

No:
- Rust code changes
- `Cargo.toml` changes
- dependency changes
- renderer implementation
- frame presentation
- `prom-ui-runtime` changes
- `UiBackendAdapter` changes

## Validation

- `git diff --check`