### PR TITLE
docs(ui): define layout primitive boundary

### DIFF
--- a/docs/architecture/ui_layout_primitive_boundary.md
+++ b/docs/architecture/ui_layout_primitive_boundary.md
@@ -1,0 +1,402 @@
+# Semantic UI Layout Primitive Boundary
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: define the layout primitive boundary before implementation
+
+## 1. Goal
+
+This document defines the boundary for Semantic UI layout primitives.
+
+Layout primitives are not widgets.
+
+Layout primitives are controlled spatial structures that express Semantic UI architecture.
+
+They must support:
+
+- ownership boundaries;
+- semantic state hierarchy;
+- trace inspection;
+- capability admission;
+- lifecycle visibility;
+- module grouping;
+- effect/result separation;
+- conflict/quarantine isolation;
+- renderer-independent structure.
+
+Layout primitives must not be introduced as arbitrary UI components.
+
+## 2. Relationship to doctrine and tokens
+
+The layout primitive system follows:
+
+```text
+docs/architecture/ui_visual_design_doctrine.md
+docs/architecture/ui_visual_token_system_boundary.md
+```
+
+Ownership chain:
+
+```text
+visual doctrine
+  -> visual token system
+  -> layout primitives
+  -> renderer
+```
+
+The doctrine owns meaning.
+Tokens own reusable visual vocabulary.
+Layout primitives own spatial grammar.
+Renderer executes admitted layout instructions.
+
+The renderer must not invent layout meaning.
+
+## 3. Layout primitive ownership
+
+Layout primitives are owned by the UI architecture layer.
+
+| Layer | Layout primitive role |
+| --- | --- |
+| `prom-ui-runtime` | none |
+| `prom-ui-backend-native` | none |
+| renderer | consumes resolved layout output |
+| visual token system | supplies visual roles |
+| layout primitive system | owns spatial grammar |
+| visual doctrine | owns meaning and rules |
+
+This preserves:
+
+```text
+Meaning first.
+Tokens second.
+Layout third.
+Renderer fourth.
+```
+
+## 4. Primitive categories
+
+Allowed primitive categories:
+
+| Category | Purpose |
+| --- | --- |
+| root surfaces | whole UI frame / app shell |
+| module regions | module ownership grouping |
+| panels | stable inspection/control surfaces |
+| lanes | ordered trace/event/result flows |
+| inspectors | structured object introspection |
+| state cards | compact semantic state surfaces |
+| gates | admission/capability decision surfaces |
+| boundaries | ownership/conflict/quarantine separators |
+| timelines | ordered lifecycle/trace visualization |
+| maps | architecture/system/module maps |
+| overlays | temporary inspection or refusal details |
+| split regions | stable multi-pane working layout |
+
+Concrete layout implementation is out of scope for H3.
+
+## 5. Core primitive candidates
+
+H3 reserves the following candidate names without implementing them:
+
+```text
+LayoutRoot
+ModuleRegion
+StatePanel
+TraceLane
+CapabilityGate
+LifecycleStrip
+InspectorPane
+EffectLane
+ConflictBoundary
+QuarantineRegion
+SystemMap
+TimelineRail
+SplitRegion
+OverlaySurface
+```
+
+These names are not API commitments yet.
+They define the conceptual vocabulary for future implementation.
+
+## 6. Root and shell primitives
+
+Root primitives define the highest visible boundary.
+
+They must answer:
+
+- what system is being viewed?
+- what mode is active?
+- what lifecycle state is active?
+- what capabilities are globally available?
+- what trace context is selected?
+
+Forbidden root behavior:
+
+- decorative full-screen shells;
+- hidden global state;
+- random dashboard grids;
+- renderer-owned layout policy.
+
+## 7. Module region primitives
+
+Module regions represent ownership.
+
+A module region should make clear:
+
+- module identity;
+- module state;
+- module boundary;
+- active/inactive status;
+- failure/quarantine state;
+- trace relation.
+
+Module regions must not become generic cards without ownership meaning.
+
+## 8. Panel primitives
+
+Panels are stable inspection/control surfaces.
+
+Allowed panel types:
+
+```text
+panel.state
+panel.trace
+panel.capability
+panel.effect
+panel.error
+panel.inspector
+panel.runtime
+```
+
+Panels must have a reason to exist.
+Decorative panels are forbidden.
+
+## 9. Lane primitives
+
+Lanes represent ordered flows.
+
+Allowed lanes:
+
+```text
+lane.trace
+lane.effect
+lane.event
+lane.rollback
+lane.admission
+lane.lifecycle
+```
+
+A lane must preserve ordering and causal direction.
+
+A lane must not hide denied, failed, or quarantined states.
+
+## 10. Gate primitives
+
+Gate primitives visualize admission and capability decisions.
+
+Examples:
+
+```text
+gate.capability
+gate.lifecycle
+gate.effect
+gate.verifier
+gate.renderer_admission
+```
+
+A gate must show:
+
+1. requested operation;
+2. required condition;
+3. admission result;
+4. denial reason if denied;
+5. trace link if available.
+
+Generic disabled controls are insufficient.
+
+## 11. Inspector primitives
+
+Inspectors expose structured state.
+
+Inspectors may display:
+
+- semantic object identity;
+- type/category;
+- lifecycle state;
+- capability requirements;
+- trace references;
+- errors/denials;
+- transcript facts;
+- renderer/staging distinction.
+
+Inspectors must not mutate hidden state without explicit action and trace.
+
+## 12. Boundary primitives
+
+Boundaries express separation.
+
+Allowed boundaries:
+
+```text
+boundary.ownership
+boundary.lifecycle
+boundary.capability
+boundary.conflict
+boundary.quarantine
+boundary.runtime
+boundary.renderer
+```
+
+Boundary primitives are not ornamental.
+They indicate where meaning, authority, or lifecycle changes.
+
+## 13. Map primitives
+
+Map primitives visualize architecture.
+
+Allowed maps:
+
+```text
+map.system
+map.module
+map.trace
+map.capability
+map.effect
+map.runtime
+```
+
+Map primitives must preserve semantic relationships.
+They must not become decorative node graphs.
+
+## 14. Overlay primitives
+
+Overlays are temporary inspection or refusal surfaces.
+
+Allowed overlays:
+
+```text
+overlay.error_detail
+overlay.denial_reason
+overlay.trace_detail
+overlay.capability_detail
+overlay.conflict_detail
+overlay.renderer_detail
+```
+
+Overlays must not hide base state.
+They must be dismissible and traceable.
+
+## 15. Layout-token relationship
+
+Layout primitives consume visual tokens.
+
+Examples:
+
+```text
+ModuleRegion
+  -> surface.panel.primary
+  -> border.lifecycle.active
+  -> type.module.name
+  -> space.panel.padding
+
+CapabilityGate
+  -> color.admission.denied
+  -> border.capability.missing
+  -> type.capability.label
+  -> motion.admission.denied
+```
+
+Layout primitives must not define their own raw colors, spacing, typography, or motion.
+
+## 16. Renderer relationship
+
+Renderer implementation must consume resolved layout output.
+
+Renderer must not decide:
+
+- which primitives exist;
+- what they mean;
+- which state is important;
+- how capability/admission meaning is encoded;
+- whether draw staging equals rendering.
+
+Renderer executes admitted spatial grammar.
+Renderer does not own layout meaning.
+
+## 17. Forbidden layout behavior
+
+The layout system must not:
+
+- introduce arbitrary widgets without semantic role;
+- copy generic dashboard layouts;
+- hide ownership boundaries;
+- hide trace path;
+- collapse denied/failed states into generic disabled controls;
+- let renderer determine layout semantics;
+- treat visual grouping as decoration;
+- introduce layout engine before primitive boundary is admitted;
+- bind layout meaning to platform/native backend.
+
+## 18. Required primitive admission rule
+
+A future layout primitive implementation PR must define:
+
+1. primitive name;
+2. semantic purpose;
+3. owner;
+4. allowed states;
+5. required tokens;
+6. allowed consumers;
+7. forbidden consumers;
+8. transcript/trace relationship if applicable;
+9. tests or snapshots where applicable.
+
+No primitive should be added only because it is visually convenient.
+
+## 19. Future implementation shape
+
+H3 does not mandate implementation.
+
+Possible future shapes:
+
+```text
+docs/spec/ui_layout_primitives.md
+crates/prom-ui-layout/
+crates/prom-ui-style/
+apps/workbench layout maps
+renderer-local layout resolver
+```
+
+Any implementation must preserve:
+
+```text
+meaning first
+tokens second
+layout third
+renderer fourth
+```
+
+## 20. Current decision
+
+Layout primitives are not implemented in H3.
+
+H3 only defines the boundary.
+
+Current admitted visual architecture:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+```
+
+Not yet admitted:
+
+```text
+layout engine
+layout structs
+component system
+CSS layout maps
+renderer layout resolver
+Workbench visual layout implementation
+```

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -13,6 +13,7 @@ Related:
 - `docs/architecture/ui_renderer_admission_boundary.md`
 - `docs/architecture/ui_visual_design_doctrine.md`
 - `docs/architecture/ui_visual_token_system_boundary.md`
+- `docs/architecture/ui_layout_primitive_boundary.md`
 
 ## 1. Purpose
 
@@ -218,4 +219,26 @@ This preserves:
 Meaning first.
 Tokens second.
 Renderer third.
+```
+
+### Layout primitive ownership
+
+Layout primitives are owned by the UI architecture layer.
+
+| Component | Layout role |
+|---|---|
+| visual doctrine | owns meaning |
+| visual token system | owns reusable visual vocabulary |
+| layout primitive system | owns spatial grammar |
+| renderer | consumes resolved layout output |
+| native backend | does not own layout |
+| `prom-ui-runtime` | does not own layout |
+
+This preserves:
+
+```text
+Meaning first.
+Tokens second.
+Layout third.
+Renderer fourth.
 ```

--- a/docs/architecture/ui_renderer_admission_boundary.md
+++ b/docs/architecture/ui_renderer_admission_boundary.md
@@ -243,4 +243,16 @@ Renderer implementation must consume admitted visual tokens.
 
 Renderer implementation must not invent token semantics.
 
+## Layout dependency
+
+Renderer admission depends on the layout primitive boundary:
+
+```text
+docs/architecture/ui_layout_primitive_boundary.md
+```
+
+Renderer implementation must consume admitted layout output.
+
+Renderer implementation must not invent layout semantics.
+
 Renderer admission starts only after this boundary is accepted.

--- a/docs/architecture/ui_visual_design_doctrine.md
+++ b/docs/architecture/ui_visual_design_doctrine.md
@@ -380,3 +380,17 @@ Visual tokens are the reusable vocabulary of Semantic UI visual meaning.
 Tokens must follow this doctrine.
 
 Tokens must not introduce arbitrary theme values or renderer-owned meaning.
+
+## Layout primitive boundary
+
+The layout primitive system is defined separately in:
+
+```text
+docs/architecture/ui_layout_primitive_boundary.md
+```
+
+Layout primitives are the spatial grammar of Semantic UI.
+
+They must follow this doctrine and consume admitted visual tokens.
+
+Layout primitives must not introduce arbitrary widgets or renderer-owned layout meaning.

--- a/docs/architecture/ui_visual_token_system_boundary.md
+++ b/docs/architecture/ui_visual_token_system_boundary.md
@@ -342,3 +342,15 @@ renderer token resolver
 theme switching
 visual components
 ```
+
+## Layout primitive dependency
+
+Layout primitive admission depends on the visual token system boundary.
+
+```text
+visual doctrine
+  -> visual token system
+  -> layout primitives
+```
+
+Layout primitives must consume semantic tokens rather than raw colors, spacing, typography, or motion values.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -33,6 +33,7 @@ Current documents in this PR:
 - `../architecture/ui_renderer_admission_boundary.md` - renderer admission boundary before implementation
 - `../architecture/ui_visual_design_doctrine.md` - Semantic UI visual design doctrine before renderer implementation
 - `../architecture/ui_visual_token_system_boundary.md` - Semantic UI visual token system boundary before implementation
+- `../architecture/ui_layout_primitive_boundary.md` - Semantic UI layout primitive boundary before implementation
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/ui_layout_primitive_boundary.md`.
- Defines layout primitives as semantic spatial grammar, not arbitrary widgets.
- Documents primitive ownership, categories, candidate primitive names, and root/module/panel/lane/gate/inspector/boundary/map/overlay primitives.
- Clarifies that layout primitives consume visual tokens and renderer consumes resolved layout output.
- Updates visual doctrine, token boundary, renderer admission boundary, ownership map, and docs index.

## Boundary

Docs-only PR.

No:
- Rust code changes
- `Cargo.toml` changes
- dependency changes
- layout implementation
- CSS/layout files
- renderer implementation
- visual component implementation
- Workbench visual layout implementation

## Validation

- [x] `git diff --check`