### PR TITLE
docs(ui): define component admission boundary

### DIFF
--- a/docs/architecture/ui_component_admission_boundary.md
+++ b/docs/architecture/ui_component_admission_boundary.md
@@ -1,0 +1,381 @@
+# Semantic UI Component Admission Boundary
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: define the component admission boundary before implementation
+
+## 1. Goal
+
+This document defines the boundary for Semantic UI components.
+
+Components are not arbitrary widgets.
+
+Components are reusable semantic UI units that combine:
+
+- semantic purpose;
+- layout primitives;
+- visual tokens;
+- state interpretation;
+- capability/admission meaning;
+- trace relationship;
+- failure/denial visibility.
+
+A component must exist because it represents a meaningful Semantic UI concept.
+
+A component must not be added only because it is visually convenient.
+
+## 2. Relationship to doctrine, tokens, and layout
+
+The component layer follows:
+
+```text
+docs/architecture/ui_visual_design_doctrine.md
+docs/architecture/ui_visual_token_system_boundary.md
+docs/architecture/ui_layout_primitive_boundary.md
+```
+
+Ownership chain:
+
+```text
+visual doctrine
+  -> visual token system
+  -> layout primitives
+  -> semantic components
+  -> renderer
+```
+
+The doctrine owns meaning.
+Tokens own reusable visual vocabulary.
+Layout primitives own spatial grammar.
+Components own reusable semantic UI behavior and composition.
+Renderer executes admitted component/layout output.
+
+The renderer must not invent component meaning.
+
+## 3. Component ownership
+
+Components are owned by the UI architecture layer.
+
+| Layer | Component role |
+| --- | --- |
+| `prom-ui-runtime` | exposes state/lifecycle data, does not own components |
+| `prom-ui-backend-native` | exposes native facade/transcripts, does not own components |
+| visual doctrine | owns meaning and rules |
+| visual token system | supplies visual vocabulary |
+| layout primitive system | supplies spatial grammar |
+| component system | owns reusable semantic UI units |
+| renderer | consumes resolved component/layout output |
+
+This preserves:
+
+```text
+Meaning first.
+Tokens second.
+Layout third.
+Components fourth.
+Renderer fifth.
+```
+
+## 4. Component vs layout primitive
+
+Layout primitives define spatial grammar.
+
+Components define reusable semantic UI units.
+
+Example distinction:
+
+| Concept | Layout primitive | Component |
+| --- | --- | --- |
+| visual region | `ModuleRegion` | `ModuleStatusCard` |
+| ordered trace space | `TraceLane` | `TraceEventRow` |
+| admission area | `CapabilityGate` | `CapabilityDecisionView` |
+| state surface | `StatePanel` | `LifecycleStateCard` |
+| inspection area | `InspectorPane` | `SemanticObjectInspector` |
+
+A component may use layout primitives.
+A layout primitive must not own component semantics.
+
+## 5. Component vs widget
+
+A widget is a generic interactive UI element.
+
+A Semantic UI component is not generic.
+
+Examples:
+
+| Generic widget | Semantic UI component |
+| --- | --- |
+| button | `AdmitActionButton` |
+| badge | `CapabilityStatusBadge` |
+| card | `LifecycleStateCard` |
+| list row | `TraceEventRow` |
+| modal | `DenialReasonOverlay` |
+| sidebar | `TraceInspectorPane` |
+
+Widgets may appear later as implementation details.
+They are not admitted in H4.
+
+## 6. Allowed component domains
+
+Allowed future component domains:
+
+| Domain | Purpose |
+| --- | --- |
+| lifecycle components | created/running/closed/failed visual units |
+| capability components | admitted/denied/missing/quarantined capability units |
+| trace components | trace rows, trace summaries, causal path units |
+| admission components | operation request/result/denial units |
+| effect components | prepared/committed/rolled-back effect units |
+| error components | structured failure and recovery units |
+| conflict components | conflict/quarantine/merge/inspection units |
+| renderer transcript components | staging/render/presentation distinction units |
+| module components | module identity/state/ownership units |
+| inspector components | structured semantic object inspection units |
+
+Concrete component implementation is out of scope for H4.
+
+## 7. Candidate component names
+
+H4 reserves candidate component names without implementing them:
+
+```text
+LifecycleStateCard
+CapabilityStatusBadge
+CapabilityDecisionView
+TraceEventRow
+TraceSummaryPanel
+AdmissionGateView
+EffectCommitView
+RollbackTraceView
+SemanticObjectInspector
+ModuleStatusCard
+ConflictBoundaryView
+QuarantineNotice
+RendererTranscriptView
+DrawStagingStatusView
+DenialReasonOverlay
+```
+
+These names are not API commitments yet.
+They define conceptual vocabulary for future implementation.
+
+## 8. Lifecycle components
+
+Lifecycle components must show:
+
+- current lifecycle state;
+- allowed transitions;
+- denied transitions;
+- trace link for transitions;
+- closed/final state clearly;
+- failure state explicitly.
+
+Lifecycle components must not hide invalid lifecycle operations behind generic disabled controls.
+
+## 9. Capability components
+
+Capability components must show:
+
+- required capability;
+- current capability status;
+- admission result;
+- denial reason;
+- quarantine/conflict state if applicable;
+- trace link if available.
+
+Generic badges are insufficient unless they carry Semantic capability meaning.
+
+## 10. Trace components
+
+Trace components must preserve causality.
+
+A trace component should be able to expose:
+
+1. requested action;
+2. admission context;
+3. state before;
+4. state after;
+5. effect or refusal;
+6. error if present;
+7. transcript link.
+
+Trace components must not become decorative timelines.
+
+## 11. Admission components
+
+Admission components visualize decision boundaries.
+
+They must show:
+
+- requested operation;
+- required preconditions;
+- granted/denied result;
+- reason;
+- capability/lifecycle relation;
+- trace/audit relation.
+
+Admission UI must be explicit and inspectable.
+
+## 12. Renderer transcript components
+
+Renderer transcript components must preserve distinction between:
+
+```text
+draw staging
+render attempted
+render succeeded
+frame presented
+```
+
+They must not collapse submitted frame accounting into presentation success.
+
+Candidate components:
+
+```text
+DrawStagingStatusView
+RendererAttemptView
+FramePresentationStatusView
+RendererTranscriptView
+```
+
+These are not implemented in H4.
+
+## 13. Component-token relationship
+
+Components consume visual tokens.
+
+Example:
+
+```text
+CapabilityStatusBadge
+  -> capability.status.admitted
+  -> color.admission.granted
+  -> border.capability.available
+  -> type.capability.label
+
+LifecycleStateCard
+  -> color.state.running
+  -> border.lifecycle.active
+  -> type.state.label
+  -> motion.lifecycle.transition
+```
+
+Components must not define raw colors, spacing, typography, motion, or renderer behavior.
+
+## 14. Component-layout relationship
+
+Components consume layout primitives.
+
+Example:
+
+```text
+SemanticObjectInspector
+  -> InspectorPane
+  -> panel.inspector
+  -> trace/detail rows
+
+CapabilityDecisionView
+  -> CapabilityGate
+  -> admission/result layout
+```
+
+Components may compose layout primitives.
+Components must not redefine layout ownership rules.
+
+## 15. Renderer relationship
+
+Renderer consumes resolved component/layout output.
+
+Renderer must not decide:
+
+- which components exist;
+- what components mean;
+- how admission/capability meaning is interpreted;
+- whether draw staging equals rendering;
+- whether hidden state may be omitted.
+
+Renderer executes admitted UI grammar.
+Renderer does not own component meaning.
+
+## 16. Forbidden component behavior
+
+The component system must not:
+
+- introduce arbitrary widgets without semantic purpose;
+- copy generic dashboard component libraries;
+- hide denial/failure behind generic disabled states;
+- make visual appeal the reason for admission;
+- bypass layout primitive boundary;
+- bypass token boundary;
+- let renderer define component semantics;
+- introduce Workbench-specific components as core UI semantics;
+- treat transcripts as decorative logs;
+- collapse lifecycle/capability/admission distinctions.
+
+## 17. Required component admission rule
+
+A future component implementation PR must define:
+
+1. component name;
+2. semantic purpose;
+3. consumed layout primitives;
+4. consumed token categories;
+5. accepted state inputs;
+6. denied/failed/quarantined behavior;
+7. trace/transcript relationship;
+8. allowed consumers;
+9. forbidden consumers;
+10. tests or snapshots where applicable.
+
+No component should be added only because it looks useful.
+
+## 18. Future implementation shape
+
+H4 does not mandate implementation.
+
+Possible future shapes:
+
+```text
+docs/spec/ui_components.md
+crates/prom-ui-components/
+crates/prom-ui-layout/
+apps/workbench component map
+renderer-local component resolver
+```
+
+Any implementation must preserve:
+
+```text
+meaning first
+tokens second
+layout third
+components fourth
+renderer fifth
+```
+
+## 19. Current decision
+
+Components are not implemented in H4.
+
+H4 only defines the admission boundary.
+
+Current admitted visual architecture:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+  -> component admission boundary
+```
+
+Not yet admitted:
+
+```text
+component structs
+component rendering
+widget system
+CSS component classes
+Workbench visual components
+renderer component resolver
+interactive component behavior
+```

--- a/docs/architecture/ui_layout_primitive_boundary.md
+++ b/docs/architecture/ui_layout_primitive_boundary.md
@@ -400,3 +400,16 @@ CSS layout maps
 renderer layout resolver
 Workbench visual layout implementation
 ```
+
+## Component dependency
+
+Component admission depends on the layout primitive boundary.
+
+```text
+visual doctrine
+  -> visual token system
+  -> layout primitives
+  -> semantic components
+```
+
+Components must compose admitted layout primitives rather than redefining spatial grammar.

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -14,6 +14,7 @@ Related:
 - `docs/architecture/ui_visual_design_doctrine.md`
 - `docs/architecture/ui_visual_token_system_boundary.md`
 - `docs/architecture/ui_layout_primitive_boundary.md`
+- `docs/architecture/ui_component_admission_boundary.md`
 
 ## 1. Purpose
 
@@ -241,4 +242,28 @@ Meaning first.
 Tokens second.
 Layout third.
 Renderer fourth.
+```
+
+### Component ownership
+
+Components are owned by the UI architecture layer.
+
+| Component | Component role |
+|---|---|
+| visual doctrine | owns meaning |
+| visual token system | supplies visual vocabulary |
+| layout primitive system | supplies spatial grammar |
+| component system | owns reusable semantic UI units |
+| renderer | consumes resolved component/layout output |
+| native backend | does not own components |
+| `prom-ui-runtime` | does not own components |
+
+This preserves:
+
+```text
+Meaning first.
+Tokens second.
+Layout third.
+Components fourth.
+Renderer fifth.
 ```

--- a/docs/architecture/ui_renderer_admission_boundary.md
+++ b/docs/architecture/ui_renderer_admission_boundary.md
@@ -255,4 +255,16 @@ Renderer implementation must consume admitted layout output.
 
 Renderer implementation must not invent layout semantics.
 
+## Component dependency
+
+Renderer admission depends on the component admission boundary:
+
+```text
+docs/architecture/ui_component_admission_boundary.md
+```
+
+Renderer implementation must consume admitted component/layout output.
+
+Renderer implementation must not invent component semantics.
+
 Renderer admission starts only after this boundary is accepted.

--- a/docs/architecture/ui_visual_design_doctrine.md
+++ b/docs/architecture/ui_visual_design_doctrine.md
@@ -394,3 +394,17 @@ Layout primitives are the spatial grammar of Semantic UI.
 They must follow this doctrine and consume admitted visual tokens.
 
 Layout primitives must not introduce arbitrary widgets or renderer-owned layout meaning.
+
+## Component admission boundary
+
+The component admission boundary is defined separately in:
+
+```text
+docs/architecture/ui_component_admission_boundary.md
+```
+
+Components are reusable semantic UI units.
+
+They must follow this doctrine, consume admitted visual tokens, and compose admitted layout primitives.
+
+Components must not introduce arbitrary widgets or renderer-owned component meaning.

--- a/docs/architecture/ui_visual_token_system_boundary.md
+++ b/docs/architecture/ui_visual_token_system_boundary.md
@@ -354,3 +354,16 @@ visual doctrine
 ```
 
 Layout primitives must consume semantic tokens rather than raw colors, spacing, typography, or motion values.
+
+## Component dependency
+
+Component admission depends on the visual token system boundary.
+
+Components must consume semantic tokens rather than raw colors, spacing, typography, or motion values.
+
+```text
+visual doctrine
+  -> visual token system
+  -> layout primitives
+  -> semantic components
+```

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -34,6 +34,7 @@ Current documents in this PR:
 - `../architecture/ui_visual_design_doctrine.md` - Semantic UI visual design doctrine before renderer implementation
 - `../architecture/ui_visual_token_system_boundary.md` - Semantic UI visual token system boundary before implementation
 - `../architecture/ui_layout_primitive_boundary.md` - Semantic UI layout primitive boundary before implementation
+- `../architecture/ui_component_admission_boundary.md` - Semantic UI component admission boundary before implementation
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/ui_component_admission_boundary.md`.
- Defines Semantic UI components as reusable semantic UI units, not arbitrary widgets.
- Documents component ownership, component-vs-layout-vs-widget separation, allowed component domains, candidate component names, and admission rules.
- Clarifies that components consume visual tokens and compose layout primitives.
- Updates visual doctrine, layout primitive boundary, token boundary, renderer admission boundary, ownership map, and docs index.

## Boundary

Docs-only PR.

No:
- Rust code changes
- `Cargo.toml` changes
- dependency changes
- component implementation
- CSS/component files
- renderer implementation
- widget system
- Workbench visual component implementation

## Validation

- [x] `git diff --check`