### PR TITLE
docs(ui): define focus and selection semantic boundary

### DIFF
--- a/docs/architecture/ui_component_admission_boundary.md
+++ b/docs/architecture/ui_component_admission_boundary.md
@@ -396,3 +396,15 @@ Components may expose interaction surfaces, but must not directly mutate semanti
 
 Components produce interaction intent candidates.
 Admission decides whether an intent becomes an action.
+
+## Focus and selection dependency
+
+Components may expose focusable and selectable surfaces.
+
+Focus and selection semantics are defined separately in:
+
+```text
+docs/architecture/ui_focus_selection_semantic_boundary.md
+```
+
+Components must not directly mutate global focus or selection from raw input.

--- a/docs/architecture/ui_focus_selection_semantic_boundary.md
+++ b/docs/architecture/ui_focus_selection_semantic_boundary.md
@@ -1,0 +1,449 @@
+# Semantic UI Focus and Selection Boundary
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: define focus and selection semantics before implementation
+
+## 1. Goal
+
+This document defines the Semantic UI boundary for focus and selection.
+
+Focus and selection are semantic UI states.
+
+They are not raw input states.
+
+The project must distinguish:
+
+```text
+hover != focus
+focus != selection
+selection != active action target
+native pointer target != semantic target
+component-local focus != system focus
+```
+
+Focus and selection must be admitted, traceable, and inspectable where they affect behavior.
+
+## 2. Relationship to interaction/input boundary
+
+Focus and selection depend on the interaction/input semantic boundary:
+
+```text
+docs/architecture/ui_interaction_input_semantic_boundary.md
+```
+
+Current interaction chain:
+
+```text
+native host event
+  -> InputEvent
+  -> interaction intent
+  -> admission check
+  -> semantic UI action
+  -> trace/effect
+```
+
+Focus/selection-specific chain:
+
+```text
+input signal
+  -> interaction intent
+  -> focus/selection request
+  -> admission
+  -> semantic focus/selection state
+  -> trace
+```
+
+H6 does not implement this chain.
+It defines the boundary.
+
+## 3. Layer separation
+
+| Layer | Meaning | Owner |
+| --- | --- | --- |
+| native pointer/key target | host/platform location or key event | native backend / renderer plumbing |
+| `InputEvent` | normalized input signal | `prom-ui-runtime` |
+| interaction intent | interpreted request | future interaction layer |
+| focus request | request to make something the active inspection/keyboard target | future focus layer |
+| selection request | request to mark an object/range/entity as selected | future selection layer |
+| active action target | admitted target for operation | future action/admission layer |
+| trace | observable causality | audit/runtime boundary |
+
+This preserves:
+
+```text
+Pointer target is not semantic target.
+Focus is not selection.
+Selection is not action.
+Action requires admission.
+```
+
+## 4. Focus definition
+
+Focus is the current semantic attention target for UI operation routing.
+
+Focus may answer:
+
+- where keyboard-like intent routes;
+- which inspector context is active;
+- which trace lane is active;
+- which component receives semantic interaction first;
+- which object is currently being inspected.
+
+Focus must not imply:
+
+- object selected;
+- action admitted;
+- capability available;
+- effect prepared;
+- state mutation.
+
+## 5. Selection definition
+
+Selection is the current semantic chosen object, range, trace item, module, or capability target.
+
+Selection may answer:
+
+- what object is selected?
+- what trace event is selected?
+- what module is selected?
+- what capability is selected?
+- what range or set is selected?
+
+Selection must not imply:
+
+- keyboard focus;
+- active action target;
+- capability admission;
+- effect commitment;
+- mutation.
+
+## 6. Active action target definition
+
+Active action target is the admitted target for a semantic action.
+
+It is downstream from focus/selection and admission.
+
+Example:
+
+```text
+selected trace event
+  -> request.rollback_effect
+  -> admission check
+  -> active action target
+  -> rollback action
+```
+
+Selection alone is not permission to act.
+
+## 7. Hover and pointer target boundary
+
+Hover and pointer target are low-level input/plumbing facts.
+
+They may support future interaction intent derivation.
+
+They must not be treated as semantic focus or selection without admission.
+
+Out of scope for H6:
+
+```text
+mouse hover model
+pointer capture
+drag selection
+touch focus
+hit-test implementation
+coordinate routing
+```
+
+These require separate implementation PRs.
+
+## 8. Component relationship
+
+Components may expose focusable or selectable semantic surfaces.
+
+Examples:
+
+```text
+TraceEventRow
+  -> selectable trace event
+
+CapabilityDecisionView
+  -> focusable capability decision
+
+SemanticObjectInspector
+  -> focusable inspector context
+
+ModuleStatusCard
+  -> selectable module
+```
+
+Components must not directly mutate global focus or selection from raw input.
+
+They may produce interaction intents:
+
+```text
+request.focus_component
+request.select_object
+request.select_trace_event
+request.focus_inspector
+```
+
+Admission decides whether focus/selection state changes.
+
+## 9. Layout relationship
+
+Layout primitives provide target regions.
+
+Examples:
+
+```text
+TraceLane
+  -> trace event target context
+
+InspectorPane
+  -> inspector focus context
+
+ModuleRegion
+  -> module selection context
+
+SystemMap
+  -> graph/node selection context
+```
+
+Layout primitives do not own focus/selection meaning.
+
+They provide spatial context and identity boundaries.
+
+## 10. Renderer relationship
+
+Renderer may support hit-testing or visual focus indication after admission.
+
+Renderer must not decide:
+
+- semantic focus;
+- semantic selection;
+- active action target;
+- admission result;
+- trace result.
+
+Renderer may report low-level target facts only after a renderer/input model is admitted.
+
+Renderer output must not be treated as semantic focus automatically.
+
+## 11. Native backend relationship
+
+Native backend may capture host events.
+
+Native backend may translate:
+
+```text
+host event -> InputEvent
+```
+
+Native backend must not own:
+
+```text
+semantic focus
+semantic selection
+active action target
+component focus rules
+selection policy
+```
+
+Native backend is not the focus model.
+
+## 12. Focus admission rule
+
+Changing focus may require admission if it affects operation routing, inspection, or action target context.
+
+Admission may check:
+
+- lifecycle state;
+- component existence;
+- target ownership;
+- target visibility;
+- quarantine/conflict state;
+- capability requirement;
+- current interaction mode;
+- traceability requirement.
+
+A denied focus request must not silently mutate focus.
+
+## 13. Selection admission rule
+
+Changing selection may require admission if it affects action target, operation scope, or trace context.
+
+Admission may check:
+
+- target type;
+- target ownership;
+- target lifecycle state;
+- target visibility;
+- multi-selection policy;
+- quarantine/conflict state;
+- operation mode;
+- traceability requirement.
+
+A denied selection request must remain visible or inspectable if it affects user action.
+
+## 14. Focus vs selection examples
+
+| Scenario | Focus | Selection |
+| --- | --- | --- |
+| keyboard routing to trace lane | `TraceLane` | none |
+| object selected in system map | maybe `SystemMap` | selected object |
+| inspector active | `InspectorPane` | inspected object |
+| capability gate opened | `CapabilityGate` | capability item |
+| denial overlay open | `DenialReasonOverlay` | original denied target |
+
+Focus and selection may coincide, but they are not the same state.
+
+## 15. Multi-selection boundary
+
+Multi-selection is not admitted in H6.
+
+Future multi-selection must define:
+
+- allowed target types;
+- ordering;
+- range semantics;
+- conflict/quarantine behavior;
+- admission checks;
+- trace behavior;
+- action target derivation.
+
+H6 only reserves the boundary.
+
+## 16. Focus history and trace
+
+Focus/selection changes may be trace-relevant when they affect:
+
+- admitted action target;
+- capability decision context;
+- rollback target;
+- committed effect target;
+- inspection result.
+
+Future implementation must define when focus/selection changes produce trace records.
+
+Decorative focus movement should not flood trace.
+
+Semantic focus/selection changes that affect behavior must be explainable.
+
+## 17. Visual representation
+
+Visual focus and visual selection must be distinct.
+
+Visual representation must not rely on color alone.
+
+Candidate visual distinctions:
+
+```text
+focus
+  -> active routing boundary
+  -> keyboard/inspection target
+  -> subtle but clear outline/region emphasis
+
+selection
+  -> chosen object/entity/range
+  -> stronger object identity mark
+  -> traceable target indicator
+
+active action target
+  -> admitted operation target
+  -> explicit action context marker
+```
+
+Concrete visual tokens are not implemented in H6.
+
+## 18. Forbidden shortcuts
+
+The system must not:
+
+- treat hover as focus;
+- treat focus as selection;
+- treat selection as action permission;
+- treat renderer hit-test as semantic target;
+- mutate focus/selection directly from raw input;
+- hide denied focus/selection requests;
+- let native backend own focus semantics;
+- let renderer own selection semantics;
+- collapse focus, selection, and active action target into one field;
+- add Workbench-specific focus semantics to core UI contracts.
+
+## 19. Required focus/selection admission rule
+
+A future focus/selection implementation PR must define:
+
+1. focus/selection state type;
+2. source interaction intent;
+3. target identity model;
+4. target ownership;
+5. admitted/denied behavior;
+6. lifecycle/capability constraints;
+7. visual representation boundary;
+8. trace behavior;
+9. tests/snapshots where applicable.
+
+No focus/selection rule should be added only because it is convenient for UI wiring.
+
+## 20. Future implementation shape
+
+H6 does not mandate implementation.
+
+Possible future shapes:
+
+```text
+docs/spec/ui_focus_selection.md
+crates/prom-ui-interaction/
+crates/prom-ui-focus/
+crates/prom-ui-selection/
+prom-ui-runtime focus module
+Workbench focus/selection map
+renderer hit-test adapter
+```
+
+Any implementation must preserve:
+
+```text
+hover/pointer target
+  -> input signal
+  -> interaction intent
+  -> focus/selection request
+  -> admission
+  -> semantic focus/selection state
+  -> trace if behavior-relevant
+```
+
+## 21. Current decision
+
+Focus and selection are not implemented in H6.
+
+H6 only defines the boundary.
+
+Current admitted visual/interaction architecture:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+  -> component admission boundary
+  -> interaction/input semantic boundary
+  -> focus/selection semantic boundary
+```
+
+Not yet admitted:
+
+```text
+focus structs
+selection structs
+multi-selection
+hover model
+hit testing
+pointer capture
+drag selection
+focus traversal
+selection actions
+Workbench focus/selection implementation
+renderer-owned focus/selection semantics
+```

--- a/docs/architecture/ui_interaction_input_semantic_boundary.md
+++ b/docs/architecture/ui_interaction_input_semantic_boundary.md
@@ -444,3 +444,23 @@ selection model
 Workbench interaction implementation
 renderer-owned input semantics
 ```
+
+## Focus and selection dependency
+
+Focus and selection semantics are defined separately in:
+
+```text
+docs/architecture/ui_focus_selection_semantic_boundary.md
+```
+
+Focus and selection are downstream from input and interaction intent.
+
+```text
+input signal
+  -> interaction intent
+  -> focus/selection request
+  -> admission
+  -> semantic focus/selection state
+```
+
+Raw input must not directly mutate focus or selection.

--- a/docs/architecture/ui_layout_primitive_boundary.md
+++ b/docs/architecture/ui_layout_primitive_boundary.md
@@ -409,6 +409,18 @@ Layout primitives provide spatial structure and target regions.
 
 They must not own interaction meaning.
 
+## Focus and selection target dependency
+
+Layout primitives may provide target context for focus and selection.
+
+They must not own focus or selection semantics.
+
+Focus and selection are defined separately in:
+
+```text
+docs/architecture/ui_focus_selection_semantic_boundary.md
+```
+
 ## Component dependency
 
 Component admission depends on the layout primitive boundary.

--- a/docs/architecture/ui_native_backend_boundary.md
+++ b/docs/architecture/ui_native_backend_boundary.md
@@ -353,6 +353,18 @@ Interaction semantics are defined separately in:
 docs/architecture/ui_interaction_input_semantic_boundary.md
 ```
 
+## Focus and selection boundary
+
+Native backend must not own semantic focus or semantic selection.
+
+Native backend may translate host events into `InputEvent`.
+
+Focus and selection semantics are defined separately in:
+
+```text
+docs/architecture/ui_focus_selection_semantic_boundary.md
+```
+
 ## 14. Stop rules
 
 Stop the native backend implementation if it requires:

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -16,6 +16,7 @@ Related:
 - `docs/architecture/ui_layout_primitive_boundary.md`
 - `docs/architecture/ui_component_admission_boundary.md`
 - `docs/architecture/ui_interaction_input_semantic_boundary.md`
+- `docs/architecture/ui_focus_selection_semantic_boundary.md`
 
 ## 1. Purpose
 
@@ -292,4 +293,28 @@ Interaction intent third.
 Admission fourth.
 Semantic action fifth.
 Trace/effect sixth.
+```
+
+### Focus and selection semantic ownership
+
+Focus and selection are owned by the UI architecture layer.
+
+| Component | Focus/selection role |
+|---|---|
+| native backend | captures/translates host events only |
+| `prom-ui-runtime` | may own normalized `InputEvent` contracts later, not raw semantics |
+| component system | exposes focusable/selectable surfaces |
+| layout primitive system | provides target context |
+| interaction semantic layer | produces focus/selection requests |
+| focus/selection semantic layer | owns focus/selection meaning |
+| admission/policy layer | decides whether focus/selection changes are allowed |
+| renderer | may display admitted focus/selection state, does not own meaning |
+
+This preserves:
+
+```text
+Hover is not focus.
+Focus is not selection.
+Selection is not action.
+Action requires admission.
 ```

--- a/docs/architecture/ui_renderer_admission_boundary.md
+++ b/docs/architecture/ui_renderer_admission_boundary.md
@@ -279,4 +279,16 @@ docs/architecture/ui_interaction_input_semantic_boundary.md
 
 Renderer must not treat native input or hit-test output as admitted semantic action.
 
+## Focus and selection dependency
+
+Renderer hit-testing or visual focus indication must not define semantic focus or selection.
+
+Focus and selection semantics are defined separately in:
+
+```text
+docs/architecture/ui_focus_selection_semantic_boundary.md
+```
+
+Renderer must not treat hit-test output as semantic selection or admitted action target.
+
 Renderer admission starts only after this boundary is accepted.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -36,6 +36,7 @@ Current documents in this PR:
 - `../architecture/ui_layout_primitive_boundary.md` - Semantic UI layout primitive boundary before implementation
 - `../architecture/ui_component_admission_boundary.md` - Semantic UI component admission boundary before implementation
 - `../architecture/ui_interaction_input_semantic_boundary.md` - Semantic UI interaction and input semantic boundary before implementation
+- `../architecture/ui_focus_selection_semantic_boundary.md` - Semantic UI focus and selection semantic boundary before implementation
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/ui_focus_selection_semantic_boundary.md`.
- Defines focus and selection as semantic UI states, not raw input or hover states.
- Separates hover, focus, selection, active action target, admitted action, and effect.
- Clarifies that components/layouts may expose targets but do not own focus/selection meaning.
- Clarifies that renderer/native backend do not own focus or selection semantics.
- Updates interaction, component, layout, renderer, ownership, native backend, and docs index references.

## Boundary

Docs-only PR.

No:
- Rust code changes
- `Cargo.toml` changes
- dependency changes
- focus implementation
- selection implementation
- pointer/hit-test implementation
- focus traversal
- Workbench focus/selection behavior

## Validation

- [x] `git diff --check`