### PR TITLE
docs(ui): define simulation and snapshot UI boundary

### DIFF
--- a/docs/architecture/ui_effect_request_capability_boundary.md
+++ b/docs/architecture/ui_effect_request_capability_boundary.md
@@ -538,3 +538,16 @@ docs/architecture/ui_renderer_transcript_presentation_boundary.md
 ```
 
 Effect success remains owned by the effect/capability boundary.
+
+## Simulation and snapshot dependency
+
+Previewed or simulated capability/effect state is not capability/effect authority.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+A simulated capability is not a grant.
+A previewed effect is not prepared or committed.

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -498,3 +498,29 @@ Workbench convenience is not architecture rule.
 Workbench view is not source of truth.
 Workbench command is not semantic action by default.
 ```
+
+### Simulation and snapshot UI ownership
+
+Simulation and snapshot UI meaning is owned by the UI architecture layer.
+
+| Component | Simulation/snapshot role |
+|---|---|
+| live source | owns current authority |
+| snapshot view | preserves captured state, not live authority |
+| replay view | projects prior trace/event sequence |
+| simulation view | projects hypothetical state |
+| preview view | projects possible result before admission |
+| Workbench | may display these modes, does not make them authoritative |
+| trace/audit layer | owns original trace/audit facts |
+| capability/effect boundary | owns real admission/effect authority |
+| renderer | renders projections, does not define authority |
+
+This preserves:
+
+```text
+Snapshot is not live state.
+Simulation is not runtime state.
+Preview is not admitted action.
+Replay is not current trace.
+Stale view is not authority.
+```

--- a/docs/architecture/ui_renderer_transcript_presentation_boundary.md
+++ b/docs/architecture/ui_renderer_transcript_presentation_boundary.md
@@ -504,3 +504,15 @@ renderer audit mapping
 Workbench renderer transcript UI
 native backend presentation authority
 ```
+
+## Simulation and snapshot dependency
+
+Renderer replay, preview, and snapshot views must not be treated as current presentation state.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+A replayed presented frame is not current frame presentation.

--- a/docs/architecture/ui_semantic_action_boundary.md
+++ b/docs/architecture/ui_semantic_action_boundary.md
@@ -499,3 +499,15 @@ docs/architecture/ui_recovery_rollback_visual_boundary.md
 ```
 
 A recovery option is not action permission.
+
+## Simulation and snapshot dependency
+
+Previewed, simulated, or replayed actions are not admitted semantic actions.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+Preview is not admitted action.

--- a/docs/architecture/ui_simulation_snapshot_boundary.md
+++ b/docs/architecture/ui_simulation_snapshot_boundary.md
@@ -1,0 +1,433 @@
+# Semantic UI Simulation and Snapshot Boundary
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: define simulation, snapshot, replay, preview, and stale-state boundaries before implementation
+
+## 1. Goal
+
+This document defines the boundary between live UI state, snapshots, simulations, previews, replays, and stale projections.
+
+The project must distinguish:
+
+```text
+snapshot != live state
+simulation != runtime state
+preview != admitted action
+replay != current trace
+stale view != authority
+```
+
+A non-live view must never look authoritative.
+
+Simulation and snapshot UI must be explicit, inspectable, and separated from live runtime authority.
+
+## 2. Relationship to Workbench boundary
+
+Simulation and snapshot views are especially relevant to Workbench:
+
+```text
+docs/architecture/ui_workbench_consumption_boundary.md
+```
+
+Workbench may later consume:
+
+* live state;
+* snapshots;
+* trace replays;
+* simulated state;
+* previewed actions;
+* stale/disconnected projections.
+
+But Workbench must clearly label those modes.
+
+Workbench view is not source of truth.
+
+## 3. Layer separation
+
+| Mode         | Meaning                                           | Authority                     |
+| ------------ | ------------------------------------------------- | ----------------------------- |
+| live         | current admitted runtime/UI state                 | live runtime/source boundary  |
+| snapshot     | captured state at a point in time                 | historical/static only        |
+| replay       | playback of prior trace/event sequence            | historical/trace-derived only |
+| simulation   | hypothetical state evolution                      | sandbox/hypothesis only       |
+| preview      | possible result before admission/commit           | non-authoritative             |
+| stale        | previously valid view no longer confirmed current | no current authority          |
+| disconnected | no active source connection                       | no live authority             |
+
+This preserves:
+
+```text
+Live is not snapshot.
+Snapshot is not live.
+Simulation is not runtime.
+Preview is not action.
+Replay is not current trace.
+Stale is not authority.
+```
+
+## 4. Live state definition
+
+Live state is the currently authoritative state from an admitted source.
+
+Live state may include:
+
+* current UI state;
+* current capability state;
+* current lifecycle state;
+* current renderer transcript state;
+* current trace projection;
+* current Workbench-connected view.
+
+Live state must have a source/provenance.
+
+A view must not claim to be live unless the source is current and admitted.
+
+## 5. Snapshot definition
+
+Snapshot is captured state from a specific point.
+
+A snapshot must carry:
+
+* capture time or logical epoch if available;
+* source identity;
+* scope;
+* whether it is complete or partial;
+* whether it is safe for inspection only;
+* relation to trace/audit if available.
+
+Snapshot does not authorize current action.
+
+## 6. Replay definition
+
+Replay is playback of prior trace, event, or state sequence.
+
+Replay may help inspect causality.
+
+Replay must not be treated as current trace.
+
+Replay must show:
+
+* replay source;
+* replay range;
+* replay cursor;
+* original trace reference;
+* whether replay is complete or filtered;
+* whether effects are simulated or disabled.
+
+Replay must not re-execute effects unless a separate admitted boundary exists.
+
+## 7. Simulation definition
+
+Simulation is hypothetical state evolution.
+
+Simulation may be based on:
+
+* proposed action;
+* hypothetical capability;
+* sandbox state;
+* replay input;
+* altered target;
+* renderer/presentation assumption.
+
+Simulation must be visibly non-live.
+
+Simulation must not mutate runtime state without explicit admission.
+
+## 8. Preview definition
+
+Preview is a projected possible result before admission or commit.
+
+Examples:
+
+```text
+preview selection result
+preview layout change
+preview effect request
+preview renderer frame
+preview rollback path
+preview recovery path
+```
+
+Preview is not action.
+
+Preview is not effect.
+
+Preview is not commitment.
+
+A preview must not imply admission.
+
+## 9. Stale state definition
+
+Stale state is a view that was once based on a source but is no longer confirmed current.
+
+Stale state may occur when:
+
+* runtime disconnected;
+* source epoch changed;
+* trace moved forward;
+* capability state changed;
+* renderer state changed;
+* Workbench lost connection;
+* snapshot was opened from history.
+
+Stale state must be labeled.
+
+Stale state must not allow effectful actions without freshness checks and admission.
+
+## 10. Disconnected state definition
+
+Disconnected state means the UI no longer has a live source.
+
+Disconnected views may remain inspectable.
+
+They must not appear live.
+
+Disconnected view must show:
+
+* source lost;
+* last known state if available;
+* time/epoch if available;
+* unavailable actions;
+* safe inspection options.
+
+## 11. Authority boundary
+
+Only admitted live sources may provide authority.
+
+The following are not authority by default:
+
+```text
+snapshot
+simulation
+preview
+replay
+stale view
+disconnected view
+Workbench local cache
+renderer output
+visual trace projection
+```
+
+A non-live projection may inform the user.
+
+It must not authorize action or effect.
+
+## 12. Admission boundary
+
+Any action from non-live context requires explicit admission.
+
+Examples:
+
+```text
+snapshot -> inspect only
+snapshot -> restore request -> admission
+simulation -> commit proposal -> admission
+preview -> semantic action request -> admission
+replay -> rollback request -> admission
+stale view -> refresh required before effect
+```
+
+No non-live view may directly produce effectful operations.
+
+## 13. Trace/audit relationship
+
+Snapshot, replay, simulation, and preview may display trace/audit references.
+
+But they must not become trace/audit authority.
+
+Replay must preserve original trace meaning.
+
+Simulation must not invent audit records.
+
+Preview must not imply audit success.
+
+If a simulated or previewed path becomes real, it must produce its own admitted trace/audit path.
+
+## 14. Semantic action relationship
+
+A previewed action is not an admitted action.
+
+A simulated action is not an admitted action.
+
+A replayed action is not current action.
+
+Future implementation must distinguish:
+
+```text
+action.previewed
+action.simulated
+action.replayed
+action.admitted
+action.executed
+```
+
+H14 does not implement these states.
+
+## 15. Effect/capability relationship
+
+A simulated or previewed capability state is not a capability grant.
+
+Examples:
+
+```text
+preview capability available
+simulation assumes capability
+snapshot shows capability was available
+replay shows capability was admitted
+```
+
+None of these prove current capability availability.
+
+Effectful operations from non-live views require re-admission.
+
+## 16. Renderer transcript relationship
+
+Renderer replay or preview must distinguish:
+
+```text
+staged frame snapshot
+render preview
+presentation replay
+current presented frame
+```
+
+A rendered preview is not frame presentation.
+
+A replayed presented frame is not current presentation.
+
+Renderer transcript from replay/snapshot is not current renderer authority.
+
+## 17. Workbench relationship
+
+Workbench may support snapshot, replay, preview, simulation, and stale views.
+
+Workbench must clearly distinguish modes:
+
+```text
+LIVE
+SNAPSHOT
+REPLAY
+SIMULATION
+PREVIEW
+STALE
+DISCONNECTED
+```
+
+Workbench must not allow these modes to visually masquerade as live state.
+
+Workbench-local cache must not become source of truth.
+
+## 18. Visual grammar requirements
+
+Future visual implementation must distinguish:
+
+| Mode         | Must not look like  | Required visibility          |
+| ------------ | ------------------- | ---------------------------- |
+| live         | snapshot/simulation | source/current status        |
+| snapshot     | live                | capture source/time/epoch    |
+| replay       | current trace       | replay cursor/source         |
+| simulation   | runtime state       | hypothetical marker          |
+| preview      | admitted action     | preview/non-committed marker |
+| stale        | live authority      | stale marker/refresh path    |
+| disconnected | live                | source unavailable state     |
+
+Visual representation must not rely on color alone.
+
+## 19. Forbidden shortcuts
+
+The system must not:
+
+* treat snapshot as live state;
+* treat simulation as runtime state;
+* treat preview as admitted action;
+* treat replay as current trace;
+* treat stale view as authority;
+* allow effectful action from stale state without admission;
+* allow Workbench local cache to become source of truth;
+* hide disconnected state;
+* show simulated capability as granted capability;
+* show previewed effect as prepared or committed effect;
+* show replayed frame as current presented frame.
+
+## 20. Required admission rule
+
+A future simulation/snapshot UI implementation PR must define:
+
+1. mode name;
+2. source identity;
+3. authority level;
+4. stale/freshness behavior;
+5. allowed actions;
+6. forbidden actions;
+7. trace/audit relationship;
+8. capability/effect relationship;
+9. visual marker requirements;
+10. Workbench relationship if applicable;
+11. tests/snapshots where applicable.
+
+No snapshot/simulation mode should be added only because it is convenient for debugging.
+
+## 21. Future implementation shape
+
+H14 does not mandate implementation.
+
+Possible future shapes:
+
+```text
+docs/spec/ui_simulation_snapshot.md
+crates/prom-ui-snapshot/
+crates/prom-ui-simulation/
+crates/prom-ui-replay/
+apps/workbench snapshot/replay views
+apps/workbench simulation sandbox
+```
+
+Any implementation must preserve:
+
+```text
+live source
+  -> snapshot / replay / simulation / preview
+  -> explicit mode label
+  -> no authority unless re-admitted
+```
+
+## 22. Current decision
+
+Simulation and snapshot UI handling is not implemented in H14.
+
+H14 only defines the boundary.
+
+Current admitted visual/interaction/action architecture:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+  -> component admission boundary
+  -> interaction/input semantic boundary
+  -> focus/selection semantic boundary
+  -> semantic action boundary
+  -> effect request / UI capability boundary
+  -> trace/audit visual boundary
+  -> error/denial/quarantine visual boundary
+  -> recovery/rollback visual boundary
+  -> renderer transcript / presentation status boundary
+  -> Workbench UI consumption boundary
+  -> simulation/snapshot UI boundary
+```
+
+Not yet admitted:
+
+```text
+snapshot structs
+simulation structs
+replay engine
+preview action model
+stale-state model
+freshness checker
+Workbench simulation view
+Workbench replay timeline
+snapshot-to-action bridge
+simulation-to-effect bridge
+```

--- a/docs/architecture/ui_trace_audit_visual_boundary.md
+++ b/docs/architecture/ui_trace_audit_visual_boundary.md
@@ -480,3 +480,16 @@ docs/architecture/ui_workbench_consumption_boundary.md
 ```
 
 Workbench trace view is not audit authority.
+
+## Simulation and snapshot dependency
+
+Replay and snapshot views may project trace/audit facts.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+Replay is not current trace.
+Simulation is not audit authority.

--- a/docs/architecture/ui_visual_design_doctrine.md
+++ b/docs/architecture/ui_visual_design_doctrine.md
@@ -432,3 +432,15 @@ docs/architecture/ui_error_denial_quarantine_visual_boundary.md
 ```
 
 Visual refusal must not become hidden no-op.
+
+## Simulation and snapshot visual doctrine
+
+Simulation, snapshot, replay, preview, stale, and disconnected views must be visually distinct from live state.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+Non-live views must not look authoritative.

--- a/docs/architecture/ui_workbench_consumption_boundary.md
+++ b/docs/architecture/ui_workbench_consumption_boundary.md
@@ -494,3 +494,15 @@ Workbench stale-state model
 Workbench simulation model
 Workbench command palette semantics
 ```
+
+## Simulation and snapshot dependency
+
+Workbench may later display live, snapshot, replay, simulation, preview, stale, and disconnected views.
+
+Simulation and snapshot UI boundaries are defined separately in:
+
+```text
+docs/architecture/ui_simulation_snapshot_boundary.md
+```
+
+Workbench must not let non-live views look authoritative.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -44,6 +44,7 @@ Current documents in this PR:
 - `../architecture/ui_recovery_rollback_visual_boundary.md` - Semantic UI recovery and rollback visual boundary before implementation
 - `../architecture/ui_renderer_transcript_presentation_boundary.md` - Semantic UI renderer transcript and presentation status boundary before implementation
 - `../architecture/ui_workbench_consumption_boundary.md` - Workbench UI consumption boundary before implementation
+- `../architecture/ui_simulation_snapshot_boundary.md` - Semantic UI simulation and snapshot boundary before implementation
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/ui_simulation_snapshot_boundary.md`.
- Defines the boundary between live state, snapshots, simulations, previews, replays, stale views, and disconnected views.
- Clarifies that snapshot is not live state and simulation is not runtime state.
- Clarifies that preview is not admitted action and replay is not current trace.
- Clarifies that stale/non-live views are not authority.
- Updates Workbench, trace/audit, semantic action, effect/capability, renderer transcript, ownership, visual doctrine, and docs index references.

## Boundary

Docs-only PR.

No:
- Rust code changes
- TypeScript code changes
- `Cargo.toml` changes
- dependency changes
- test changes
- snapshot structs
- simulation structs
- replay engine
- preview action model
- stale-state model
- Workbench implementation changes

## Validation

- [x] `git diff --check`
