### PR TITLE
docs(ui): define UI implementation gate and boundary index

### DIFF
--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -1,0 +1,146 @@
+# Semantic UI Boundary Index
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: provide the canonical index of admitted Semantic UI architecture boundaries
+
+## 1. Goal
+
+This document is the canonical index for Semantic UI architecture boundaries.
+
+It exists so implementation PRs do not search through scattered documents or accidentally bypass earlier decisions.
+
+Every future Semantic UI implementation PR must identify which boundary documents it depends on.
+
+## 2. Boundary stack
+
+Current admitted UI boundary stack:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+  -> component admission boundary
+  -> interaction/input semantic boundary
+  -> focus/selection semantic boundary
+  -> semantic action boundary
+  -> effect request / UI capability boundary
+  -> trace/audit visual boundary
+  -> error/denial/quarantine visual boundary
+  -> recovery/rollback visual boundary
+  -> renderer transcript / presentation status boundary
+  -> Workbench UI consumption boundary
+  -> simulation/snapshot UI boundary
+  -> implementation gate
+```
+
+## 3. Canonical documents
+
+| Boundary                          | Document                                                            |
+| --------------------------------- | ------------------------------------------------------------------- |
+| visual doctrine                   | `docs/architecture/ui_visual_design_doctrine.md`                    |
+| visual token system               | `docs/architecture/ui_visual_token_system_boundary.md`              |
+| layout primitives                 | `docs/architecture/ui_layout_primitive_boundary.md`                 |
+| component admission               | `docs/architecture/ui_component_admission_boundary.md`              |
+| interaction/input semantics       | `docs/architecture/ui_interaction_input_semantic_boundary.md`       |
+| focus/selection semantics         | `docs/architecture/ui_focus_selection_semantic_boundary.md`         |
+| semantic actions                  | `docs/architecture/ui_semantic_action_boundary.md`                  |
+| effect requests / UI capabilities | `docs/architecture/ui_effect_request_capability_boundary.md`        |
+| trace/audit visual projection     | `docs/architecture/ui_trace_audit_visual_boundary.md`               |
+| error/denial/quarantine visuals   | `docs/architecture/ui_error_denial_quarantine_visual_boundary.md`   |
+| recovery/rollback visuals         | `docs/architecture/ui_recovery_rollback_visual_boundary.md`         |
+| renderer transcript/presentation  | `docs/architecture/ui_renderer_transcript_presentation_boundary.md` |
+| Workbench consumption             | `docs/architecture/ui_workbench_consumption_boundary.md`            |
+| simulation/snapshot UI            | `docs/architecture/ui_simulation_snapshot_boundary.md`              |
+| implementation gate               | `docs/architecture/ui_implementation_gate.md`                       |
+| ownership map                     | `docs/architecture/ui_ownership_map.md`                             |
+| renderer admission                | `docs/architecture/ui_renderer_admission_boundary.md`               |
+| native backend boundary           | `docs/architecture/ui_native_backend_boundary.md`                   |
+
+## 4. Non-negotiable invariants
+
+Future UI code must preserve:
+
+```text
+meaning first
+tokens second
+layout third
+components fourth
+interaction fifth
+actions/effects only after admission
+trace/audit source of truth remains outside visual projection
+renderer output is not semantic authority
+Workbench consumes contracts, does not define them
+non-live views are not authority
+```
+
+## 5. First implementation families
+
+Allowed implementation families after this index:
+
+| Family              | Allowed first step                                              |
+| ------------------- | --------------------------------------------------------------- |
+| visual tokens       | type/enum scaffold or docs-backed token map, no renderer        |
+| layout primitives   | type scaffold, no rendering                                     |
+| components          | admitted component metadata scaffold, no widgets                |
+| interaction         | intent enum scaffold, no effect execution                       |
+| focus/selection     | state scaffold, no pointer/hit-test                             |
+| actions             | action descriptor scaffold, no effect bridge                    |
+| renderer transcript | transcript type scaffold, no renderer                           |
+| Workbench           | consumption map docs or local projection scaffold, no authority |
+| simulation/snapshot | mode enum scaffold, no replay engine                            |
+
+Renderer implementation is not the first recommended step.
+
+## 6. Recommended first code PR
+
+The recommended first implementation PR is:
+
+```text
+PR-UI-I1 — feat(ui): add UI boundary registry scaffold
+```
+
+It should add a small registry/metadata layer that lists admitted boundaries and exposes them to tests or docs tooling.
+
+It should not implement renderer, components, actions, effects, Workbench, or simulation.
+
+## 7. Forbidden implementation shortcuts
+
+Future UI implementation must not:
+
+* start with renderer pixels;
+* start with Workbench dashboard;
+* start with component library;
+* add buttons before action/admission model;
+* treat visual tokens as arbitrary theme values;
+* treat Workbench command as semantic action;
+* treat submitted frames as presented frames;
+* treat preview/simulation as live authority;
+* treat trace display as audit authority;
+* hide denial/failure/quarantine as no-op.
+
+## 8. Change policy
+
+If implementation reveals that a boundary is incomplete, do not patch code around it.
+
+Correct order:
+
+```text
+boundary correction PR
+  -> implementation PR
+```
+
+Emergency exceptions require explicit note in PR body.
+
+## 9. Current decision
+
+The H-series boundary phase is complete after `ui_implementation_gate.md` is admitted.
+
+After H15:
+
+```text
+docs freeze
+  -> implementation PRs
+  -> small scoped code changes
+  -> tests before expansion
+```

--- a/docs/architecture/ui_implementation_gate.md
+++ b/docs/architecture/ui_implementation_gate.md
@@ -1,0 +1,256 @@
+# Semantic UI Implementation Gate
+
+Status: Draft
+Track: POST-UI / H-series
+Purpose: define the gate for moving from UI boundary documentation into implementation
+
+## 1. Goal
+
+This document defines when Semantic UI implementation may begin and what constraints every implementation PR must follow.
+
+H-series documentation has established the semantic boundaries required to avoid architecture drift.
+
+Implementation may begin only through small, boundary-backed PRs.
+
+## 2. Gate statement
+
+The UI documentation phase is considered sufficient after this gate is merged.
+
+The next phase is implementation.
+
+However, implementation is allowed only if it preserves the admitted boundary stack:
+
+```text
+visual doctrine
+  -> visual token boundary
+  -> layout primitive boundary
+  -> component admission boundary
+  -> interaction/input semantic boundary
+  -> focus/selection semantic boundary
+  -> semantic action boundary
+  -> effect request / UI capability boundary
+  -> trace/audit visual boundary
+  -> error/denial/quarantine visual boundary
+  -> recovery/rollback visual boundary
+  -> renderer transcript / presentation status boundary
+  -> Workbench UI consumption boundary
+  -> simulation/snapshot UI boundary
+```
+
+## 3. Required PR declaration
+
+Every future UI implementation PR must declare:
+
+1. touched layer;
+2. boundary documents used;
+3. explicitly out-of-scope layers;
+4. authority ownership;
+5. trace/audit relationship if any;
+6. renderer/native relationship if any;
+7. Workbench relationship if any;
+8. tests added or updated.
+
+A PR without boundary declaration is not admitted.
+
+## 4. Implementation order
+
+Preferred implementation order:
+
+```text
+I1 boundary registry scaffold
+I2 visual token type scaffold
+I3 layout primitive type scaffold
+I4 component metadata scaffold
+I5 interaction intent descriptor scaffold
+I6 focus/selection state scaffold
+I7 semantic action descriptor scaffold
+I8 renderer transcript type scaffold
+I9 Workbench consumption map scaffold
+```
+
+Renderer pixels come later.
+
+## 5. First allowed implementation PR
+
+The first allowed implementation PR:
+
+```text
+PR-UI-I1 — feat(ui): add UI boundary registry scaffold
+```
+
+Allowed:
+
+* a tiny docs-backed registry;
+* names/paths of admitted boundary documents;
+* tests that ensure all required boundary docs exist;
+* no runtime behavior;
+* no renderer;
+* no Workbench UI;
+* no components.
+
+Forbidden:
+
+* rendering;
+* `wgpu` / `pixels` / `softbuffer`;
+* native surface ownership;
+* buttons/widgets;
+* action execution;
+* effect execution;
+* command palette;
+* snapshot/replay engine.
+
+## 6. Renderer implementation gate
+
+Renderer implementation is not admitted by H15.
+
+Before renderer code, the project must have at minimum:
+
+* visual token scaffold;
+* layout primitive scaffold;
+* renderer transcript scaffold;
+* presentation status scaffold;
+* tests proving draw staging is not presentation;
+* explicit renderer admission PR.
+
+Renderer must not be the first implementation step.
+
+## 7. Workbench implementation gate
+
+Workbench UI implementation is not admitted directly by H15.
+
+Before Workbench UI code, the project must have at minimum:
+
+* Workbench consumption map;
+* source-of-truth rules;
+* stale/snapshot/simulation mode handling or explicit non-support;
+* action/effect admission path if commands are added.
+
+Workbench must consume core contracts, not define them.
+
+## 8. Component implementation gate
+
+Component implementation is not admitted directly by H15.
+
+Before components:
+
+* visual token scaffold must exist;
+* layout primitive scaffold must exist;
+* component metadata/admission scaffold must exist;
+* each component must cite semantic purpose and boundary.
+
+No arbitrary widget library is admitted.
+
+## 9. Interaction/action implementation gate
+
+Interaction/action implementation must preserve:
+
+```text
+native event
+  -> InputEvent
+  -> interaction intent
+  -> admission
+  -> semantic action
+  -> trace/effect if applicable
+```
+
+No callback may directly perform semantic effects.
+
+Workbench shortcuts must not bypass this chain.
+
+## 10. Effect/capability implementation gate
+
+Effect/capability implementation must preserve:
+
+```text
+semantic UI action
+  -> effect request
+  -> UI capability admission
+  -> runtime capability mapping if admitted
+  -> prepared effect
+  -> commit boundary
+```
+
+UI capability display is not capability grant.
+
+## 11. Trace/audit implementation gate
+
+Trace/audit UI implementation must preserve:
+
+```text
+trace/audit record
+  -> visual projection
+  -> inspection UI
+```
+
+Visual trace is not source of truth.
+
+Renderer transcript is not audit authority by default.
+
+## 12. Simulation/snapshot implementation gate
+
+Simulation/snapshot implementation must preserve:
+
+```text
+live source
+  -> snapshot / replay / simulation / preview
+  -> explicit mode label
+  -> no authority unless re-admitted
+```
+
+Non-live views must not look authoritative.
+
+## 13. Required tests
+
+Every implementation PR must include at least one of:
+
+* contract test;
+* compile-time shape test;
+* docs index test;
+* snapshot test;
+* no-op/fail-closed test.
+
+No implementation PR should land without a test unless it is docs-only.
+
+## 14. Stop conditions
+
+Stop implementation if a PR requires:
+
+* bypassing admission;
+* treating renderer output as semantic authority;
+* treating Workbench command as semantic action;
+* treating trace view as audit authority;
+* using visual state as capability grant;
+* treating simulation/snapshot as live state;
+* hiding denial/failure/quarantine;
+* adding global UI state without ownership.
+
+If a stop condition appears, write a boundary correction PR first.
+
+## 15. Documentation freeze
+
+After H15, the UI boundary docs are frozen for initial implementation.
+
+Allowed docs changes after freeze:
+
+* typo fixes;
+* link fixes;
+* boundary correction PRs caused by implementation discovery;
+* implementation-specific docs for admitted code.
+
+Not allowed:
+
+* adding new H-series boundary docs without explicit reason;
+* expanding architecture instead of implementing;
+* delaying code with speculative UI doctrine.
+
+## 16. Current decision
+
+H15 closes the H-series boundary phase.
+
+Next step:
+
+```text
+PR-UI-I1 — feat(ui): add UI boundary registry scaffold
+```
+
+This starts code carefully, without renderer, without Workbench UI, without components, and without effectful behavior.

--- a/docs/architecture/ui_ownership_map.md
+++ b/docs/architecture/ui_ownership_map.md
@@ -524,3 +524,28 @@ Preview is not admitted action.
 Replay is not current trace.
 Stale view is not authority.
 ```
+
+### UI implementation gate ownership
+
+Implementation authority is constrained by the admitted UI boundaries.
+
+| Component | Implementation role |
+|---|---|
+| boundary index | lists admitted boundary documents |
+| implementation gate | controls transition into code |
+| UI implementation PRs | must cite touched boundary documents |
+| renderer implementation | remains gated |
+| Workbench implementation | remains gated |
+| component implementation | remains gated |
+| action/effect implementation | remains gated by admission |
+| tests | enforce contract shape |
+
+This preserves:
+
+```text
+Docs freeze before code.
+Implementation follows boundaries.
+Renderer is not first.
+Workbench does not define semantics.
+Every code PR cites its boundary.
+```

--- a/docs/architecture/ui_renderer_admission_boundary.md
+++ b/docs/architecture/ui_renderer_admission_boundary.md
@@ -371,3 +371,14 @@ render attempted != render succeeded
 render succeeded != frame presented
 frame presented != semantic success
 ```
+
+## Implementation gate dependency
+
+Renderer implementation remains gated by:
+
+```text
+docs/architecture/ui_implementation_gate.md
+docs/architecture/ui_boundary_index.md
+```
+
+Renderer must not be the first implementation step.

--- a/docs/architecture/ui_visual_design_doctrine.md
+++ b/docs/architecture/ui_visual_design_doctrine.md
@@ -379,6 +379,17 @@ docs/architecture/ui_workbench_consumption_boundary.md
 
 Workbench views must not become source of truth.
 
+## Implementation gate
+
+UI implementation is governed by:
+
+```text
+docs/architecture/ui_implementation_gate.md
+docs/architecture/ui_boundary_index.md
+```
+
+Visual implementation must cite admitted boundaries before adding code.
+
 ## Visual token system boundary
 
 The visual token system is defined separately in:

--- a/docs/architecture/ui_workbench_consumption_boundary.md
+++ b/docs/architecture/ui_workbench_consumption_boundary.md
@@ -506,3 +506,14 @@ docs/architecture/ui_simulation_snapshot_boundary.md
 ```
 
 Workbench must not let non-live views look authoritative.
+
+## Implementation gate dependency
+
+Workbench implementation remains gated by:
+
+```text
+docs/architecture/ui_implementation_gate.md
+docs/architecture/ui_boundary_index.md
+```
+
+Workbench must consume admitted contracts and must not define core semantics.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -45,6 +45,8 @@ Current documents in this PR:
 - `../architecture/ui_renderer_transcript_presentation_boundary.md` - Semantic UI renderer transcript and presentation status boundary before implementation
 - `../architecture/ui_workbench_consumption_boundary.md` - Workbench UI consumption boundary before implementation
 - `../architecture/ui_simulation_snapshot_boundary.md` - Semantic UI simulation and snapshot boundary before implementation
+- `../architecture/ui_boundary_index.md` - canonical Semantic UI boundary index
+- `../architecture/ui_implementation_gate.md` - Semantic UI implementation gate before code phase
 
 Adjacent source-surface documents also remain relevant:
 


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/ui_boundary_index.md`.
- Adds `docs/architecture/ui_implementation_gate.md`.
- Defines the canonical Semantic UI boundary index.
- Defines the gate for moving from H-series boundary documentation into implementation.
- Declares H-series boundary phase complete after H15.
- Defines the first allowed implementation PR as `PR-UI-I1 — feat(ui): add UI boundary registry scaffold`.
- Clarifies renderer, Workbench, component, action/effect implementation gates.

## Boundary

Docs-only PR.

No:
- Rust code changes
- TypeScript code changes
- `Cargo.toml` changes
- dependency changes
- test changes
- registry implementation
- renderer code
- Workbench code
- components
- actions/effects

## Validation

- [x] `git diff --check`
