### PR TITLE
feat(ui): add visual token type scaffold

### DIFF
--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -30,6 +30,7 @@
 extern crate alloc;
 
 pub mod boundary_registry;
+pub mod visual_tokens;
 
 use prom_ui::{UiCapabilityKind, UiOperationId};
 

--- a/crates/prom-ui-runtime/src/visual_tokens.rs
+++ b/crates/prom-ui-runtime/src/visual_tokens.rs
@@ -1,0 +1,239 @@
+//! Semantic UI visual token type scaffold.
+//!
+//! This module defines semantic visual token roles.
+//! It does not implement a renderer, theme engine, CSS, Workbench UI,
+//! components, widgets, or runtime presentation.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiVisualToken {
+    pub id: &'static str,
+    pub role: UiVisualTokenRole,
+    pub domain: UiVisualTokenDomain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiVisualTokenDomain {
+    Surface,
+    Border,
+    Text,
+    Accent,
+    State,
+    Trace,
+    Capability,
+    Effect,
+    Renderer,
+    Workbench,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiVisualTokenRole {
+    SurfaceBase,
+    SurfaceRaised,
+    SurfaceOverlay,
+    BorderSubtle,
+    BorderStrong,
+    TextPrimary,
+    TextSecondary,
+    AccentPrimary,
+    StateAdmitted,
+    StateDenied,
+    StateFailed,
+    StateQuarantined,
+    StateConflict,
+    StateStale,
+    StatePreview,
+    StateSimulation,
+    TraceSource,
+    TraceAdmission,
+    TraceAction,
+    TraceEffect,
+    TraceAudit,
+    CapabilityAvailable,
+    CapabilityMissing,
+    CapabilityDenied,
+    EffectRequested,
+    EffectPrepared,
+    EffectCommitted,
+    EffectRolledBack,
+    RendererStaged,
+    RendererAttempted,
+    RendererPresented,
+    WorkbenchLocal,
+    WorkbenchProjection,
+}
+
+pub const UI_VISUAL_TOKENS: &[UiVisualToken] = &[
+    UiVisualToken {
+        id: "ui.token.surface.base",
+        role: UiVisualTokenRole::SurfaceBase,
+        domain: UiVisualTokenDomain::Surface,
+    },
+    UiVisualToken {
+        id: "ui.token.surface.raised",
+        role: UiVisualTokenRole::SurfaceRaised,
+        domain: UiVisualTokenDomain::Surface,
+    },
+    UiVisualToken {
+        id: "ui.token.surface.overlay",
+        role: UiVisualTokenRole::SurfaceOverlay,
+        domain: UiVisualTokenDomain::Surface,
+    },
+    UiVisualToken {
+        id: "ui.token.border.subtle",
+        role: UiVisualTokenRole::BorderSubtle,
+        domain: UiVisualTokenDomain::Border,
+    },
+    UiVisualToken {
+        id: "ui.token.border.strong",
+        role: UiVisualTokenRole::BorderStrong,
+        domain: UiVisualTokenDomain::Border,
+    },
+    UiVisualToken {
+        id: "ui.token.text.primary",
+        role: UiVisualTokenRole::TextPrimary,
+        domain: UiVisualTokenDomain::Text,
+    },
+    UiVisualToken {
+        id: "ui.token.text.secondary",
+        role: UiVisualTokenRole::TextSecondary,
+        domain: UiVisualTokenDomain::Text,
+    },
+    UiVisualToken {
+        id: "ui.token.accent.primary",
+        role: UiVisualTokenRole::AccentPrimary,
+        domain: UiVisualTokenDomain::Accent,
+    },
+    UiVisualToken {
+        id: "ui.token.state.admitted",
+        role: UiVisualTokenRole::StateAdmitted,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.denied",
+        role: UiVisualTokenRole::StateDenied,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.failed",
+        role: UiVisualTokenRole::StateFailed,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.quarantined",
+        role: UiVisualTokenRole::StateQuarantined,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.conflict",
+        role: UiVisualTokenRole::StateConflict,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.stale",
+        role: UiVisualTokenRole::StateStale,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.preview",
+        role: UiVisualTokenRole::StatePreview,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.state.simulation",
+        role: UiVisualTokenRole::StateSimulation,
+        domain: UiVisualTokenDomain::State,
+    },
+    UiVisualToken {
+        id: "ui.token.trace.source",
+        role: UiVisualTokenRole::TraceSource,
+        domain: UiVisualTokenDomain::Trace,
+    },
+    UiVisualToken {
+        id: "ui.token.trace.admission",
+        role: UiVisualTokenRole::TraceAdmission,
+        domain: UiVisualTokenDomain::Trace,
+    },
+    UiVisualToken {
+        id: "ui.token.trace.action",
+        role: UiVisualTokenRole::TraceAction,
+        domain: UiVisualTokenDomain::Trace,
+    },
+    UiVisualToken {
+        id: "ui.token.trace.effect",
+        role: UiVisualTokenRole::TraceEffect,
+        domain: UiVisualTokenDomain::Trace,
+    },
+    UiVisualToken {
+        id: "ui.token.trace.audit",
+        role: UiVisualTokenRole::TraceAudit,
+        domain: UiVisualTokenDomain::Trace,
+    },
+    UiVisualToken {
+        id: "ui.token.capability.available",
+        role: UiVisualTokenRole::CapabilityAvailable,
+        domain: UiVisualTokenDomain::Capability,
+    },
+    UiVisualToken {
+        id: "ui.token.capability.missing",
+        role: UiVisualTokenRole::CapabilityMissing,
+        domain: UiVisualTokenDomain::Capability,
+    },
+    UiVisualToken {
+        id: "ui.token.capability.denied",
+        role: UiVisualTokenRole::CapabilityDenied,
+        domain: UiVisualTokenDomain::Capability,
+    },
+    UiVisualToken {
+        id: "ui.token.effect.requested",
+        role: UiVisualTokenRole::EffectRequested,
+        domain: UiVisualTokenDomain::Effect,
+    },
+    UiVisualToken {
+        id: "ui.token.effect.prepared",
+        role: UiVisualTokenRole::EffectPrepared,
+        domain: UiVisualTokenDomain::Effect,
+    },
+    UiVisualToken {
+        id: "ui.token.effect.committed",
+        role: UiVisualTokenRole::EffectCommitted,
+        domain: UiVisualTokenDomain::Effect,
+    },
+    UiVisualToken {
+        id: "ui.token.effect.rolled_back",
+        role: UiVisualTokenRole::EffectRolledBack,
+        domain: UiVisualTokenDomain::Effect,
+    },
+    UiVisualToken {
+        id: "ui.token.renderer.staged",
+        role: UiVisualTokenRole::RendererStaged,
+        domain: UiVisualTokenDomain::Renderer,
+    },
+    UiVisualToken {
+        id: "ui.token.renderer.attempted",
+        role: UiVisualTokenRole::RendererAttempted,
+        domain: UiVisualTokenDomain::Renderer,
+    },
+    UiVisualToken {
+        id: "ui.token.renderer.presented",
+        role: UiVisualTokenRole::RendererPresented,
+        domain: UiVisualTokenDomain::Renderer,
+    },
+    UiVisualToken {
+        id: "ui.token.workbench.local",
+        role: UiVisualTokenRole::WorkbenchLocal,
+        domain: UiVisualTokenDomain::Workbench,
+    },
+    UiVisualToken {
+        id: "ui.token.workbench.projection",
+        role: UiVisualTokenRole::WorkbenchProjection,
+        domain: UiVisualTokenDomain::Workbench,
+    },
+];
+
+pub fn ui_visual_tokens() -> &'static [UiVisualToken] {
+    UI_VISUAL_TOKENS
+}
+
+pub fn find_ui_visual_token(id: &str) -> Option<&'static UiVisualToken> {
+    UI_VISUAL_TOKENS.iter().find(|token| token.id == id)
+}

--- a/crates/prom-ui-runtime/tests/ui_visual_token_contract.rs
+++ b/crates/prom-ui-runtime/tests/ui_visual_token_contract.rs
@@ -1,0 +1,68 @@
+use prom_ui_runtime::visual_tokens::{find_ui_visual_token, ui_visual_tokens, UiVisualTokenRole};
+
+#[test]
+fn ui_visual_token_registry_is_not_empty() {
+    assert!(!ui_visual_tokens().is_empty());
+}
+
+#[test]
+fn ui_visual_token_registry_contains_required_semantic_roles() {
+    let required = [
+        "ui.token.surface.base",
+        "ui.token.surface.raised",
+        "ui.token.text.primary",
+        "ui.token.state.denied",
+        "ui.token.state.failed",
+        "ui.token.state.quarantined",
+        "ui.token.state.stale",
+        "ui.token.state.preview",
+        "ui.token.state.simulation",
+        "ui.token.trace.audit",
+        "ui.token.capability.denied",
+        "ui.token.effect.committed",
+        "ui.token.renderer.staged",
+        "ui.token.renderer.presented",
+        "ui.token.workbench.projection",
+    ];
+
+    for id in required {
+        assert!(find_ui_visual_token(id).is_some(), "missing visual token: {id}");
+    }
+}
+
+#[test]
+fn ui_visual_token_ids_are_unique() {
+    let tokens = ui_visual_tokens();
+
+    for (index, left) in tokens.iter().enumerate() {
+        for right in tokens.iter().skip(index + 1) {
+            assert_ne!(left.id, right.id, "duplicate visual token id: {}", left.id);
+        }
+    }
+}
+
+#[test]
+fn ui_visual_token_ids_use_canonical_prefix() {
+    for token in ui_visual_tokens() {
+        assert!(
+            token.id.starts_with("ui.token."),
+            "visual token id must use ui.token. prefix: {}",
+            token.id
+        );
+    }
+}
+
+#[test]
+fn ui_visual_state_tokens_are_distinct_semantic_roles() {
+    let denied = find_ui_visual_token("ui.token.state.denied").unwrap();
+    let failed = find_ui_visual_token("ui.token.state.failed").unwrap();
+    let quarantined = find_ui_visual_token("ui.token.state.quarantined").unwrap();
+
+    assert_eq!(denied.role, UiVisualTokenRole::StateDenied);
+    assert_eq!(failed.role, UiVisualTokenRole::StateFailed);
+    assert_eq!(quarantined.role, UiVisualTokenRole::StateQuarantined);
+
+    assert_ne!(denied.role, failed.role);
+    assert_ne!(failed.role, quarantined.role);
+    assert_ne!(denied.role, quarantined.role);
+}


### PR DESCRIPTION
## Summary

- Adds a small Semantic UI visual token type scaffold to `prom-ui-runtime`.
- Defines semantic visual token domains and roles.
- Adds a static visual token registry with canonical `ui.token.*` IDs.
- Exposes `ui_visual_tokens()` and `find_ui_visual_token(...)`.
- Adds contract tests for required token roles, ID uniqueness, canonical prefix, and distinct semantic state roles.

## Boundary

Second implementation PR after H-series docs freeze.

Allowed by:
- `docs/architecture/ui_visual_token_system_boundary.md`
- `docs/architecture/ui_visual_design_doctrine.md`
- `docs/architecture/ui_implementation_gate.md`
- `docs/architecture/ui_boundary_index.md`

No:
- renderer implementation
- theme engine
- color/hex values
- CSS
- TypeScript
- Workbench UI
- components/widgets
- actions/effects
- runtime behavior
- dependency changes
- `Cargo.toml` changes
- native backend changes

## Validation

- [x] `cargo test -q -p prom-ui-runtime`
- [x] `git diff --check`
