### PR TITLE
feat(ui): add layout primitive type scaffold

### DIFF
--- a/crates/prom-ui-runtime/src/layout_primitives.rs
+++ b/crates/prom-ui-runtime/src/layout_primitives.rs
@@ -1,0 +1,150 @@
+//! Semantic UI layout primitive type scaffold.
+//!
+//! This module defines semantic layout primitive roles.
+//! It does not implement a renderer, layout engine, geometry solver,
+//! Workbench UI, components, widgets, or runtime presentation.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiLayoutPrimitive {
+    pub id: &'static str,
+    pub kind: UiLayoutPrimitiveKind,
+    pub domain: UiLayoutPrimitiveDomain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiLayoutPrimitiveDomain {
+    Root,
+    Structure,
+    Content,
+    Trace,
+    Inspector,
+    Boundary,
+    Overlay,
+    Map,
+    Workbench,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiLayoutPrimitiveKind {
+    Root,
+    Pane,
+    Panel,
+    Lane,
+    Region,
+    Slot,
+    Stack,
+    Split,
+    Overlay,
+    InspectorPane,
+    TraceLane,
+    EffectLane,
+    CapabilityGateRegion,
+    ConflictBoundary,
+    QuarantineRegion,
+    SystemMap,
+    WorkbenchSurface,
+    WorkbenchPanel,
+}
+
+pub const UI_LAYOUT_PRIMITIVES: &[UiLayoutPrimitive] = &[
+    UiLayoutPrimitive {
+        id: "ui.layout.root",
+        kind: UiLayoutPrimitiveKind::Root,
+        domain: UiLayoutPrimitiveDomain::Root,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.pane",
+        kind: UiLayoutPrimitiveKind::Pane,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.panel",
+        kind: UiLayoutPrimitiveKind::Panel,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.lane",
+        kind: UiLayoutPrimitiveKind::Lane,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.region",
+        kind: UiLayoutPrimitiveKind::Region,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.slot",
+        kind: UiLayoutPrimitiveKind::Slot,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.stack",
+        kind: UiLayoutPrimitiveKind::Stack,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.split",
+        kind: UiLayoutPrimitiveKind::Split,
+        domain: UiLayoutPrimitiveDomain::Structure,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.overlay",
+        kind: UiLayoutPrimitiveKind::Overlay,
+        domain: UiLayoutPrimitiveDomain::Overlay,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.inspector_pane",
+        kind: UiLayoutPrimitiveKind::InspectorPane,
+        domain: UiLayoutPrimitiveDomain::Inspector,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.trace_lane",
+        kind: UiLayoutPrimitiveKind::TraceLane,
+        domain: UiLayoutPrimitiveDomain::Trace,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.effect_lane",
+        kind: UiLayoutPrimitiveKind::EffectLane,
+        domain: UiLayoutPrimitiveDomain::Trace,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.capability_gate_region",
+        kind: UiLayoutPrimitiveKind::CapabilityGateRegion,
+        domain: UiLayoutPrimitiveDomain::Boundary,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.conflict_boundary",
+        kind: UiLayoutPrimitiveKind::ConflictBoundary,
+        domain: UiLayoutPrimitiveDomain::Boundary,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.quarantine_region",
+        kind: UiLayoutPrimitiveKind::QuarantineRegion,
+        domain: UiLayoutPrimitiveDomain::Boundary,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.system_map",
+        kind: UiLayoutPrimitiveKind::SystemMap,
+        domain: UiLayoutPrimitiveDomain::Map,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.workbench_surface",
+        kind: UiLayoutPrimitiveKind::WorkbenchSurface,
+        domain: UiLayoutPrimitiveDomain::Workbench,
+    },
+    UiLayoutPrimitive {
+        id: "ui.layout.workbench_panel",
+        kind: UiLayoutPrimitiveKind::WorkbenchPanel,
+        domain: UiLayoutPrimitiveDomain::Workbench,
+    },
+];
+
+pub fn ui_layout_primitives() -> &'static [UiLayoutPrimitive] {
+    UI_LAYOUT_PRIMITIVES
+}
+
+pub fn find_ui_layout_primitive(id: &str) -> Option<&'static UiLayoutPrimitive> {
+    UI_LAYOUT_PRIMITIVES
+        .iter()
+        .find(|primitive| primitive.id == id)
+}

--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -31,6 +31,7 @@ extern crate alloc;
 
 pub mod boundary_registry;
 pub mod visual_tokens;
+pub mod layout_primitives;
 
 use prom_ui::{UiCapabilityKind, UiOperationId};
 

--- a/crates/prom-ui-runtime/tests/ui_layout_primitive_contract.rs
+++ b/crates/prom-ui-runtime/tests/ui_layout_primitive_contract.rs
@@ -1,0 +1,88 @@
+use prom_ui_runtime::layout_primitives::{
+    find_ui_layout_primitive, ui_layout_primitives, UiLayoutPrimitiveDomain,
+    UiLayoutPrimitiveKind,
+};
+
+#[test]
+fn ui_layout_primitive_registry_is_not_empty() {
+    assert!(!ui_layout_primitives().is_empty());
+}
+
+#[test]
+fn ui_layout_primitive_registry_contains_required_roles() {
+    let required = [
+        "ui.layout.root",
+        "ui.layout.pane",
+        "ui.layout.panel",
+        "ui.layout.lane",
+        "ui.layout.region",
+        "ui.layout.overlay",
+        "ui.layout.inspector_pane",
+        "ui.layout.trace_lane",
+        "ui.layout.effect_lane",
+        "ui.layout.capability_gate_region",
+        "ui.layout.conflict_boundary",
+        "ui.layout.quarantine_region",
+        "ui.layout.system_map",
+        "ui.layout.workbench_surface",
+    ];
+
+    for id in required {
+        assert!(
+            find_ui_layout_primitive(id).is_some(),
+            "missing layout primitive: {id}"
+        );
+    }
+}
+
+#[test]
+fn ui_layout_primitive_ids_are_unique() {
+    let primitives = ui_layout_primitives();
+
+    for (index, left) in primitives.iter().enumerate() {
+        for right in primitives.iter().skip(index + 1) {
+            assert_ne!(
+                left.id, right.id,
+                "duplicate layout primitive id: {}",
+                left.id
+            );
+        }
+    }
+}
+
+#[test]
+fn ui_layout_primitive_ids_use_canonical_prefix() {
+    for primitive in ui_layout_primitives() {
+        assert!(
+            primitive.id.starts_with("ui.layout."),
+            "layout primitive id must use ui.layout. prefix: {}",
+            primitive.id
+        );
+    }
+}
+
+#[test]
+fn ui_layout_boundary_primitives_are_distinct_semantic_roles() {
+    let conflict = find_ui_layout_primitive("ui.layout.conflict_boundary").unwrap();
+    let quarantine = find_ui_layout_primitive("ui.layout.quarantine_region").unwrap();
+    let capability = find_ui_layout_primitive("ui.layout.capability_gate_region").unwrap();
+
+    assert_eq!(conflict.kind, UiLayoutPrimitiveKind::ConflictBoundary);
+    assert_eq!(quarantine.kind, UiLayoutPrimitiveKind::QuarantineRegion);
+    assert_eq!(capability.kind, UiLayoutPrimitiveKind::CapabilityGateRegion);
+
+    assert_ne!(conflict.kind, quarantine.kind);
+    assert_ne!(quarantine.kind, capability.kind);
+    assert_ne!(conflict.kind, capability.kind);
+}
+
+#[test]
+fn ui_layout_primitives_are_spatial_roles_not_components() {
+    let trace_lane = find_ui_layout_primitive("ui.layout.trace_lane").unwrap();
+    let inspector = find_ui_layout_primitive("ui.layout.inspector_pane").unwrap();
+    let system_map = find_ui_layout_primitive("ui.layout.system_map").unwrap();
+
+    assert_eq!(trace_lane.domain, UiLayoutPrimitiveDomain::Trace);
+    assert_eq!(inspector.domain, UiLayoutPrimitiveDomain::Inspector);
+    assert_eq!(system_map.domain, UiLayoutPrimitiveDomain::Map);
+}


### PR DESCRIPTION
## Summary

- Adds a small Semantic UI layout primitive type scaffold to `prom-ui-runtime`.
- Defines semantic layout primitive domains and kinds.
- Adds a static layout primitive registry with canonical `ui.layout.*` IDs.
- Exposes `ui_layout_primitives()` and `find_ui_layout_primitive(...)`.
- Adds contract tests for required layout roles, ID uniqueness, canonical prefix, boundary role distinction, and spatial-role semantics.

## Boundary

Third implementation PR after H-series docs freeze.

Allowed by:
- `docs/architecture/ui_layout_primitive_boundary.md`
- `docs/architecture/ui_visual_token_system_boundary.md`
- `docs/architecture/ui_implementation_gate.md`
- `docs/architecture/ui_boundary_index.md`

No:
- renderer implementation
- layout engine
- geometry solver
- size/position/pixel structs
- CSS
- TypeScript
- Workbench UI
- components/widgets
- actions/effects
- runtime behavior
- dependency changes
- `Cargo.toml` changes
- native backend changes

## Validation

- [x] `cargo test -q -p prom-ui-runtime`
- [x] `git diff --check`
