### PR TITLE
feat(ui): add component metadata scaffold

### DIFF
--- a/crates/prom-ui-runtime/src/component_metadata.rs
+++ b/crates/prom-ui-runtime/src/component_metadata.rs
@@ -1,0 +1,188 @@
+//! Semantic UI component metadata scaffold.
+//!
+//! This module defines component descriptors and semantic component roles.
+//! It does not implement widgets, renderer output, Workbench UI,
+//! interaction callbacks, actions, effects, or runtime presentation.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiComponentDescriptor {
+    pub id: &'static str,
+    pub kind: UiComponentKind,
+    pub domain: UiComponentDomain,
+    pub admission: UiComponentAdmission,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiComponentDomain {
+    State,
+    Trace,
+    Capability,
+    Effect,
+    Error,
+    Recovery,
+    Renderer,
+    Workbench,
+    Simulation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiComponentKind {
+    StateBadge,
+    StateSummary,
+    TraceEventRow,
+    TraceSummaryPanel,
+    CapabilityDecisionView,
+    CapabilityMissingBadge,
+    EffectRequestView,
+    EffectCommitView,
+    DenialReasonOverlay,
+    ErrorDetailPanel,
+    FailureStageView,
+    QuarantineNotice,
+    ConflictBoundaryView,
+    RecoveryOptionPanel,
+    RollbackTraceView,
+    RendererTranscriptView,
+    FramePresentationStatusView,
+    WorkbenchProjectionView,
+    SnapshotModeBadge,
+    SimulationModeBadge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiComponentAdmission {
+    CoreCandidate,
+    WorkbenchLocal,
+    DiagnosticOnly,
+}
+
+pub const UI_COMPONENTS: &[UiComponentDescriptor] = &[
+    UiComponentDescriptor {
+        id: "ui.component.state_badge",
+        kind: UiComponentKind::StateBadge,
+        domain: UiComponentDomain::State,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.state_summary",
+        kind: UiComponentKind::StateSummary,
+        domain: UiComponentDomain::State,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.trace_event_row",
+        kind: UiComponentKind::TraceEventRow,
+        domain: UiComponentDomain::Trace,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.trace_summary_panel",
+        kind: UiComponentKind::TraceSummaryPanel,
+        domain: UiComponentDomain::Trace,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.capability_decision_view",
+        kind: UiComponentKind::CapabilityDecisionView,
+        domain: UiComponentDomain::Capability,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.capability_missing_badge",
+        kind: UiComponentKind::CapabilityMissingBadge,
+        domain: UiComponentDomain::Capability,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.effect_request_view",
+        kind: UiComponentKind::EffectRequestView,
+        domain: UiComponentDomain::Effect,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.effect_commit_view",
+        kind: UiComponentKind::EffectCommitView,
+        domain: UiComponentDomain::Effect,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.denial_reason_overlay",
+        kind: UiComponentKind::DenialReasonOverlay,
+        domain: UiComponentDomain::Error,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.error_detail_panel",
+        kind: UiComponentKind::ErrorDetailPanel,
+        domain: UiComponentDomain::Error,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.failure_stage_view",
+        kind: UiComponentKind::FailureStageView,
+        domain: UiComponentDomain::Error,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.quarantine_notice",
+        kind: UiComponentKind::QuarantineNotice,
+        domain: UiComponentDomain::Error,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.conflict_boundary_view",
+        kind: UiComponentKind::ConflictBoundaryView,
+        domain: UiComponentDomain::Error,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.recovery_option_panel",
+        kind: UiComponentKind::RecoveryOptionPanel,
+        domain: UiComponentDomain::Recovery,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.rollback_trace_view",
+        kind: UiComponentKind::RollbackTraceView,
+        domain: UiComponentDomain::Recovery,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.renderer_transcript_view",
+        kind: UiComponentKind::RendererTranscriptView,
+        domain: UiComponentDomain::Renderer,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.frame_presentation_status_view",
+        kind: UiComponentKind::FramePresentationStatusView,
+        domain: UiComponentDomain::Renderer,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.workbench_projection_view",
+        kind: UiComponentKind::WorkbenchProjectionView,
+        domain: UiComponentDomain::Workbench,
+        admission: UiComponentAdmission::WorkbenchLocal,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.snapshot_mode_badge",
+        kind: UiComponentKind::SnapshotModeBadge,
+        domain: UiComponentDomain::Simulation,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+    UiComponentDescriptor {
+        id: "ui.component.simulation_mode_badge",
+        kind: UiComponentKind::SimulationModeBadge,
+        domain: UiComponentDomain::Simulation,
+        admission: UiComponentAdmission::CoreCandidate,
+    },
+];
+
+pub fn ui_components() -> &'static [UiComponentDescriptor] {
+    UI_COMPONENTS
+}
+
+pub fn find_ui_component(id: &str) -> Option<&'static UiComponentDescriptor> {
+    UI_COMPONENTS.iter().find(|component| component.id == id)
+}

--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -32,6 +32,7 @@ extern crate alloc;
 pub mod boundary_registry;
 pub mod visual_tokens;
 pub mod layout_primitives;
+pub mod component_metadata;
 
 use prom_ui::{UiCapabilityKind, UiOperationId};
 

--- a/crates/prom-ui-runtime/tests/ui_component_metadata_contract.rs
+++ b/crates/prom-ui-runtime/tests/ui_component_metadata_contract.rs
@@ -1,0 +1,86 @@
+use prom_ui_runtime::component_metadata::{
+    find_ui_component, ui_components, UiComponentAdmission, UiComponentDomain,
+    UiComponentKind,
+};
+
+#[test]
+fn ui_component_registry_is_not_empty() {
+    assert!(!ui_components().is_empty());
+}
+
+#[test]
+fn ui_component_registry_contains_required_metadata_roles() {
+    let required = [
+        "ui.component.state_badge",
+        "ui.component.trace_event_row",
+        "ui.component.capability_decision_view",
+        "ui.component.effect_request_view",
+        "ui.component.denial_reason_overlay",
+        "ui.component.quarantine_notice",
+        "ui.component.conflict_boundary_view",
+        "ui.component.recovery_option_panel",
+        "ui.component.renderer_transcript_view",
+        "ui.component.workbench_projection_view",
+        "ui.component.snapshot_mode_badge",
+        "ui.component.simulation_mode_badge",
+    ];
+
+    for id in required {
+        assert!(find_ui_component(id).is_some(), "missing component metadata: {id}");
+    }
+}
+
+#[test]
+fn ui_component_ids_are_unique() {
+    let components = ui_components();
+
+    for (index, left) in components.iter().enumerate() {
+        for right in components.iter().skip(index + 1) {
+            assert_ne!(left.id, right.id, "duplicate component id: {}", left.id);
+        }
+    }
+}
+
+#[test]
+fn ui_component_ids_use_canonical_prefix() {
+    for component in ui_components() {
+        assert!(
+            component.id.starts_with("ui.component."),
+            "component id must use ui.component. prefix: {}",
+            component.id
+        );
+    }
+}
+
+#[test]
+fn ui_component_domains_are_semantic_not_renderer_types() {
+    let trace = find_ui_component("ui.component.trace_event_row").unwrap();
+    let capability = find_ui_component("ui.component.capability_decision_view").unwrap();
+    let renderer = find_ui_component("ui.component.renderer_transcript_view").unwrap();
+
+    assert_eq!(trace.domain, UiComponentDomain::Trace);
+    assert_eq!(capability.domain, UiComponentDomain::Capability);
+    assert_eq!(renderer.domain, UiComponentDomain::Renderer);
+}
+
+#[test]
+fn workbench_component_is_marked_workbench_local() {
+    let component = find_ui_component("ui.component.workbench_projection_view").unwrap();
+
+    assert_eq!(component.admission, UiComponentAdmission::WorkbenchLocal);
+}
+
+#[test]
+fn error_denial_quarantine_components_are_distinct_roles() {
+    let denial = find_ui_component("ui.component.denial_reason_overlay").unwrap();
+    let failure = find_ui_component("ui.component.failure_stage_view").unwrap();
+    let quarantine = find_ui_component("ui.component.quarantine_notice").unwrap();
+
+    assert_eq!(denial.kind, UiComponentKind::DenialReasonOverlay);
+    assert_eq!(failure.kind, UiComponentKind::FailureStageView);
+    assert_eq!(quarantine.kind, UiComponentKind::QuarantineNotice);
+
+    assert_ne!(denial.kind, failure.kind);
+    assert_ne!(failure.kind, quarantine.kind);
+    assert_ne!(denial.kind, quarantine.kind);
+}


### PR DESCRIPTION
## Summary

- Adds a small Semantic UI component metadata scaffold to `prom-ui-runtime`.
- Defines component domains, kinds, and admission markers.
- Adds a static component metadata registry with canonical `ui.component.*` IDs.
- Exposes `ui_components()` and `find_ui_component(...)`.
- Adds contract tests for required metadata roles, ID uniqueness, canonical prefix, semantic domains, Workbench-local admission, and distinct denial/failure/quarantine surfaces.

## Boundary

Fourth implementation PR after H-series docs freeze.

Allowed by:
- `docs/architecture/ui_component_admission_boundary.md`
- `docs/architecture/ui_layout_primitive_boundary.md`
- `docs/architecture/ui_visual_token_system_boundary.md`
- `docs/architecture/ui_implementation_gate.md`
- `docs/architecture/ui_boundary_index.md`

No:
- renderer implementation
- layout engine
- widget implementation
- component rendering
- component state machine
- interaction callbacks
- actions/effects
- Workbench UI
- TypeScript
- CSS
- runtime behavior
- dependency changes
- `Cargo.toml` changes
- native backend changes

## Validation

- [x] `cargo test -q -p prom-ui-runtime`
- [x] `git diff --check`
