### PR TITLE
docs(ui): define action admission descriptor boundary

### DIFF
--- a/docs/architecture/ui_action_admission_descriptor_boundary.md
+++ b/docs/architecture/ui_action_admission_descriptor_boundary.md
@@ -1,0 +1,235 @@
+# Semantic UI Action Admission Descriptor Boundary
+
+Status: Draft
+Track: POST-UI / I-series
+Purpose: define the boundary for future action admission descriptor scaffolding before any admission engine or action execution exists
+
+## 1. Goal
+
+This document defines the boundary for future Semantic UI action admission descriptors.
+
+An action admission descriptor is not an admission result.
+
+It is a static or inert description of what must be checked before an action candidate may become an admitted Semantic UI action.
+
+It does not execute actions.
+It does not admit actions.
+It does not deny actions.
+It does not request effects.
+It does not call the VM.
+It does not call Host ABI.
+It does not mutate runtime state.
+
+## 2. Position in the ladder
+
+The current interaction-action trace ladder ends at candidate summary:
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> InteractionIntentTraceReport
+  -> InteractionIntentStreamReport
+  -> InteractionActionBindingDescriptor
+  -> InteractionActionBindingTraceReport
+  -> InteractionActionBindingTraceStreamReport
+  -> InteractionActionCandidateSummary
+```
+
+The next boundary is:
+
+```text
+InteractionActionCandidateSummary / InteractionActionBindingTraceReport
+  -> ActionAdmissionDescriptor
+  -> future ActionAdmissionResult
+  -> future AdmittedSemanticUiAction
+```
+
+Only the descriptor boundary is defined here.
+
+## 3. Definitions
+
+| Term                 | Meaning                                         | Not allowed      |
+| -------------------- | ----------------------------------------------- | ---------------- |
+| action candidate     | future action name found through binding trace  | permission       |
+| admission descriptor | inert description of required checks            | decision         |
+| admission result     | future decision: admitted or denied             | execution        |
+| admitted action      | future action object after successful admission | effect by itself |
+| denial trace         | future visible denial explanation               | hidden no-op     |
+
+## 4. Core invariant
+
+```text
+candidate is not permission
+descriptor is not decision
+decision is not execution
+action is not effect
+effect requires separate admission
+```
+
+No implementation may treat a bound candidate as admitted simply because a binding exists.
+
+## 5. Required descriptor fields
+
+A future action admission descriptor must identify:
+
+1. action name;
+2. source intent kind;
+3. binding identity;
+4. target requirement;
+5. target ownership requirement;
+6. lifecycle requirement;
+7. capability requirement;
+8. trace requirement;
+9. effect relationship;
+10. denial visibility requirement;
+11. policy gate namespace;
+12. future admission result shape.
+
+The descriptor must be explicit about missing target behavior.
+
+## 6. Target admission rules
+
+A target may be:
+
+```text
+required
+optional / may be resolved later
+ignored
+```
+
+If target is required and missing:
+
+```text
+candidate
+  -> admission descriptor
+  -> future denial result
+  -> denial trace
+  -> no admitted action
+```
+
+The system must not convert missing target into silent no-op.
+
+## 7. Lifecycle admission rules
+
+A descriptor may require lifecycle state such as:
+
+```text
+session active
+window alive
+surface ready
+frame open
+frame not submitted
+runtime not quarantined
+```
+
+Lifecycle requirement is a descriptor field only.
+
+I14 does not implement lifecycle checking.
+
+## 8. Capability admission rules
+
+A descriptor may require UI capability state such as:
+
+```text
+DesktopSession
+InputPoll
+FrameEmit
+future action-specific capability
+future effect capability
+```
+
+Capability requirement is declarative only.
+
+I14 does not implement capability checks.
+
+## 9. Trace requirement
+
+Admission decisions must be traceable when they affect semantic UI behavior.
+
+Future admission results must distinguish:
+
+```text
+admitted
+denied_missing_target
+denied_lifecycle
+denied_capability
+denied_policy
+denied_effect_boundary
+denied_unknown
+```
+
+I14 does not implement result types.
+
+It only defines that future result types must preserve denial reason visibility.
+
+## 10. Effect relationship
+
+An admitted semantic UI action may later request an effect.
+
+The action is still not the effect.
+
+Required separation:
+
+```text
+action admission
+  -> admitted semantic UI action
+  -> optional effect request
+  -> effect/capability admission
+  -> effect execution
+```
+
+No descriptor may authorize external effects directly.
+
+## 11. Relationship to existing I-series types
+
+| Existing type                               | Relationship to admission                 |
+| ------------------------------------------- | ----------------------------------------- |
+| `InteractionActionBindingDescriptor`        | candidate vocabulary only                 |
+| `InteractionActionBindingTraceReport`       | explains candidate presence/absence       |
+| `InteractionActionBindingTraceStreamReport` | batch diagnostic data                     |
+| `InteractionActionCandidateSummary`         | aggregate diagnostic summary              |
+| future `ActionAdmissionDescriptor`          | describes required checks                 |
+| future `ActionAdmissionResult`              | performs decision reporting               |
+| future `AdmittedSemanticUiAction`           | represents admitted action after decision |
+
+## 12. Forbidden shortcuts
+
+Future PRs must not:
+
+* treat `InteractionActionBindingDescriptor` as admission;
+* treat `InteractionActionBindingTraceReport` as admitted action;
+* treat `InteractionActionCandidateSummary` as action queue;
+* skip target ownership checks;
+* skip lifecycle checks;
+* skip capability checks;
+* hide denied candidates as no-op;
+* merge admission result and dispatcher in one PR;
+* merge action execution and effect request in one PR;
+* let Workbench command define core action admission;
+* let renderer affordance define permission;
+* call VM/Host ABI from admission descriptor layer.
+
+## 13. Required implementation order
+
+Future implementation must proceed in separate PRs:
+
+```text
+docs admission boundary
+  -> admission descriptor scaffold
+  -> admission result / denial trace scaffold
+  -> admitted action object scaffold
+  -> dispatcher scaffold
+  -> effect request bridge
+```
+
+No PR should combine descriptor, decision, action object, dispatcher, and effect bridge.
+
+## 14. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.

--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -46,6 +46,7 @@ visual doctrine
 | focus/selection semantics         | `docs/architecture/ui_focus_selection_semantic_boundary.md`         |
 | semantic actions                  | `docs/architecture/ui_semantic_action_boundary.md`                  |
 | interaction-action trace ladder   | `docs/architecture/ui_interaction_action_trace_ladder.md`           |
+| action admission descriptor       | `docs/architecture/ui_action_admission_descriptor_boundary.md`      |
 | effect requests / UI capabilities | `docs/architecture/ui_effect_request_capability_boundary.md`        |
 | trace/audit visual projection     | `docs/architecture/ui_trace_audit_visual_boundary.md`               |
 | error/denial/quarantine visuals   | `docs/architecture/ui_error_denial_quarantine_visual_boundary.md`   |

--- a/docs/architecture/ui_interaction_action_trace_ladder.md
+++ b/docs/architecture/ui_interaction_action_trace_ladder.md
@@ -145,7 +145,28 @@ in separate PRs.
 
 No PR should combine these steps.
 
-## 10. Forbidden shortcuts
+## 10. Action admission descriptor dependency
+
+Action admission descriptor boundary is defined separately in:
+
+```text
+docs/architecture/ui_action_admission_descriptor_boundary.md
+```
+
+The trace ladder stops before admission.
+
+```text
+InteractionActionCandidateSummary
+  -> future ActionAdmissionDescriptor
+  -> future ActionAdmissionResult
+  -> future AdmittedSemanticUiAction
+```
+
+The descriptor is not the decision.
+The decision is not execution.
+The admitted action is not an effect.
+
+## 11. Forbidden shortcuts
 
 Future PRs must not:
 
@@ -159,7 +180,7 @@ Future PRs must not:
 * hide unbound candidates as no-op;
 * add VM/Host ABI bridge from this ladder directly.
 
-## 11. Validation expectation
+## 12. Validation expectation
 
 Docs-only PR validation:
 


### PR DESCRIPTION
## Summary

Defines the Semantic UI action admission descriptor boundary.

This docs-only PR records the next boundary after the inert interaction-action
trace ladder. It clarifies that action candidates are not permissions,
admission descriptors are not admission decisions, admitted actions are not
effects, and effects require a separate boundary.

## Scope

- Add `docs/architecture/ui_action_admission_descriptor_boundary.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the new boundary from `docs/architecture/ui_interaction_action_trace_ladder.md`
- Define required future descriptor fields and implementation order
- Document forbidden shortcuts before admission/result/action/dispatcher work

## Out of scope

- Rust code changes
- TypeScript code changes
- `Cargo.toml` changes
- dependency changes
- tests
- admission engine
- admitted action object
- dispatcher
- capability checker
- effect request bridge
- VM / Host ABI bridge
- Workbench command bridge
- renderer affordance map
- runtime mutation

## Validation

- [x] `git diff --check`
