### PR TITLE
docs(ui): define semantic action dispatcher boundary

### DIFF
--- a/docs/architecture/ui_admitted_semantic_action_boundary.md
+++ b/docs/architecture/ui_admitted_semantic_action_boundary.md
@@ -192,7 +192,26 @@ docs admitted action boundary
   -> effect request scaffold
 ```
 
-## 13. Validation expectation
+## 14. Semantic action dispatcher dependency
+
+Semantic action dispatcher boundary is defined separately in:
+
+```text
+docs/architecture/ui_semantic_action_dispatcher_boundary.md
+```
+
+The admitted action object layer stops before dispatch.
+
+```text
+InteractionAdmittedSemanticAction
+  -> future SemanticActionDispatcher
+```
+
+The action object is not dispatcher.
+The dispatcher is not effect bridge.
+Effect requires separate admission.
+
+## 15. Validation expectation
 
 Docs-only PR validation:
 

--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -23,10 +23,11 @@ visual doctrine
   -> component admission boundary
   -> interaction/input semantic boundary
   -> focus/selection semantic boundary
- -> semantic action boundary
+  -> semantic action boundary
   -> action admission descriptor
   -> action admission result / denial trace
   -> admitted semantic action object
+  -> semantic action dispatcher
   -> effect request / UI capability boundary
   -> trace/audit visual boundary
   -> error/denial/quarantine visual boundary
@@ -52,6 +53,7 @@ visual doctrine
 | action admission descriptor       | `docs/architecture/ui_action_admission_descriptor_boundary.md`      |
 | action admission result / denial trace | `docs/architecture/ui_action_admission_result_denial_boundary.md` |
 | admitted semantic action object   | `docs/architecture/ui_admitted_semantic_action_boundary.md`         |
+| semantic action dispatcher        | `docs/architecture/ui_semantic_action_dispatcher_boundary.md`      |
 | effect requests / UI capabilities | `docs/architecture/ui_effect_request_capability_boundary.md`        |
 | trace/audit visual projection     | `docs/architecture/ui_trace_audit_visual_boundary.md`               |
 | error/denial/quarantine visuals   | `docs/architecture/ui_error_denial_quarantine_visual_boundary.md`   |

--- a/docs/architecture/ui_semantic_action_dispatcher_boundary.md
+++ b/docs/architecture/ui_semantic_action_dispatcher_boundary.md
@@ -1,0 +1,227 @@
+# Semantic UI Action Dispatcher Boundary
+
+Status: Draft
+Track: POST-UI / I-series
+Purpose: define the boundary for a future Semantic UI action dispatcher before execution or effect bridges exist
+
+## 1. Goal
+
+This document defines the boundary for a future Semantic UI action dispatcher.
+
+A Semantic UI action dispatcher is a future layer that may consume admitted Semantic UI action objects and route them to future handling paths.
+
+The dispatcher is not the admitted action object.
+The dispatcher is not effect execution.
+The dispatcher is not a VM operation.
+The dispatcher is not a Host ABI operation.
+The dispatcher must not silently mutate runtime state.
+The dispatcher must not bypass effect/capability admission.
+
+## 2. Position in the ladder
+
+The current implemented scaffold reaches:
+
+```text
+InteractionActionAdmissionResult::Admitted
+  -> InteractionAdmittedSemanticAction
+```
+
+The next future boundary is:
+
+```text
+InteractionAdmittedSemanticAction
+  -> future SemanticActionDispatcher
+  -> future dispatch record
+  -> future effect request descriptor if needed
+```
+
+Only the dispatcher boundary is defined here.
+
+## 3. Core separation
+
+```text
+admitted action object is not dispatcher
+dispatcher is not effect bridge
+dispatcher is not VM bridge
+dispatcher is not Host ABI bridge
+dispatch record is not effect execution
+effect requires separate admission
+```
+
+## 4. Dispatcher input rule
+
+A future dispatcher may only consume:
+
+```text
+InteractionAdmittedSemanticAction
+```
+
+It must not consume directly:
+
+* raw input;
+* interaction intent;
+* binding descriptor;
+* binding trace;
+* candidate summary;
+* admission descriptor;
+* denied admission result;
+* denial trace;
+* renderer affordance;
+* Workbench command;
+* component callback.
+
+## 5. Dispatcher output rule
+
+A future dispatcher may produce only explicit dispatch metadata, such as:
+
+1. dispatch id;
+2. admitted action id;
+3. action name;
+4. dispatch route;
+5. trace requirement;
+6. effect relationship;
+7. policy gate namespace;
+8. dispatch status;
+9. future effect request eligibility.
+
+It must not directly produce:
+
+* external effects;
+* VM calls;
+* Host ABI calls;
+* runtime mutation;
+* renderer commands;
+* Workbench commands.
+
+## 6. Dispatch route classes
+
+Future dispatch routes may include:
+
+| Route                     | Meaning                                    |
+| ------------------------- | ------------------------------------------ |
+| `NoopSemanticRecord`      | record-only semantic action, no effect     |
+| `LocalUiStateCandidate`   | future local UI state transition candidate |
+| `EffectRequestCandidate`  | future explicit effect request path        |
+| `WorkbenchLocalCandidate` | future Workbench-local handling path       |
+| `DiagnosticOnlyCandidate` | diagnostic route only                      |
+| `Unknown`                 | unresolved route                           |
+
+These routes are not execution authority.
+
+## 7. Dispatch result classes
+
+Future dispatch result/status must distinguish:
+
+```text
+routed
+blocked_missing_route
+blocked_policy
+blocked_effect_boundary
+blocked_unknown
+```
+
+A blocked dispatch must be visible if it affects user expectation or semantic UI state.
+
+## 8. Effect relationship
+
+A dispatcher may identify that an admitted action requires an effect path.
+
+It must not execute that effect.
+
+Required future order:
+
+```text
+InteractionAdmittedSemanticAction
+  -> SemanticActionDispatcher
+  -> EffectRequestDescriptor
+  -> effect/capability admission
+  -> effect execution
+```
+
+No dispatcher PR may silently produce external effects.
+
+## 9. Runtime mutation relationship
+
+Dispatcher construction and dispatch metadata are not runtime mutation.
+
+Any future runtime mutation must pass through a separate boundary.
+
+Required future order:
+
+```text
+dispatch metadata
+  -> future state transition descriptor
+  -> future state transition admission
+  -> future runtime mutation
+```
+
+No dispatcher should mutate runtime state directly.
+
+## 10. Trace relationship
+
+A future dispatcher must preserve traceability when dispatch affects:
+
+* semantic UI state;
+* lifecycle state;
+* capability/effect path;
+* denial/recovery path;
+* user-visible semantic result.
+
+Trace display is not audit authority by itself.
+
+## 11. Workbench and renderer relationship
+
+Workbench may consume future dispatch metadata only through a Workbench consumption boundary.
+
+Renderer may display dispatch state or affordances only as presentation.
+
+Neither Workbench nor renderer may define:
+
+* dispatch permission;
+* action meaning;
+* effect permission;
+* runtime mutation;
+* audit finality.
+
+## 12. Forbidden shortcuts
+
+Future PRs must not:
+
+* dispatch directly from interaction intent;
+* dispatch directly from binding trace;
+* dispatch directly from candidate summary;
+* dispatch denied results;
+* treat denial trace as fallback action;
+* perform effects inside dispatcher;
+* call VM/Host ABI from dispatcher;
+* mutate runtime state from dispatcher;
+* treat renderer affordance as dispatch permission;
+* treat Workbench command as dispatch permission;
+* combine dispatcher and effect bridge in one PR;
+* combine dispatcher and runtime mutation in one PR.
+
+## 13. Required implementation order
+
+Future implementation must proceed in separate PRs:
+
+```text
+docs dispatcher boundary
+  -> dispatcher route enum scaffold
+  -> dispatch record scaffold
+  -> dispatch trace/summary scaffold if needed
+  -> effect request boundary docs
+  -> effect request descriptor scaffold
+  -> effect/capability admission boundary
+```
+
+No PR should combine dispatcher, effect request, capability admission, and execution.
+
+## 14. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.


### PR DESCRIPTION
## Summary

Defines the Semantic UI action dispatcher boundary.

This docs-only PR records the next boundary after the admitted semantic action object scaffold. It clarifies that admitted action objects are not dispatchers, dispatchers are not effect bridges, dispatchers are not VM/Host ABI bridges, and runtime mutation requires a separate boundary.

## Scope

- Add `docs/architecture/ui_semantic_action_dispatcher_boundary.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the dispatcher boundary from
  `docs/architecture/ui_admitted_semantic_action_boundary.md`
- Define dispatcher input/output rules
- Define future route/status classes
- Document effect/runtime separation
- Document forbidden shortcuts and implementation order

## Out of scope

- Rust code changes
- TypeScript code changes
- `Cargo.toml` changes
- dependency changes
- tests
- dispatcher implementation
- action execution
- effect request bridge
- capability checker
- lifecycle checker
- VM / Host ABI bridge
- Workbench command bridge
- renderer affordance map
- runtime mutation

## Validation

- [x] `git diff --check`
