### PR TITLE
docs(ui): define UI capability admission boundary

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -35,6 +35,7 @@ pub mod action_dispatch_summary;
 pub mod effect_request;
 pub mod effect_request_trace;
 pub mod effect_request_summary;
+pub mod ui_capability_admission;
 pub mod intent_stream;
 pub mod raw_event;
 pub mod trace;
@@ -131,6 +132,13 @@ pub use effect_request_summary::{
     summarize_interaction_effect_requests, InteractionEffectRequestKindCount,
     InteractionEffectRequestRuntimeCapabilityCount, InteractionEffectRequestSummary,
     InteractionEffectRequestUiCapabilityCount,
+};
+pub use ui_capability_admission::{
+    describe_interaction_ui_capability_admission,
+    InteractionUiCapabilityAdmissionDescriptor,
+    InteractionUiCapabilityAdmissionDescriptorId,
+    InteractionUiCapabilityAdmissionFutureResultShape,
+    InteractionUiCapabilityAdmissionRuntimeMappingRequirement,
 };
 pub use intent_stream::{
     trace_interaction_intent_stream, InteractionIntentStreamModel,

--- a/crates/prom-ui/src/ui_capability_admission.rs
+++ b/crates/prom-ui/src/ui_capability_admission.rs
@@ -1,0 +1,303 @@
+//! Semantic UI capability admission descriptor scaffold.
+//!
+//! This module records what a future UI capability admission layer must
+//! evaluate before runtime capability mapping or prepared effect construction.
+//! It does not implement an admission result, capability grant, runtime
+//! capability mapping, prepared effects, committed effects, VM/Host ABI calls,
+//! or runtime mutation.
+
+use crate::action_admission::{
+    InteractionActionAdmissionPolicyGateNamespace, InteractionActionAdmissionTraceRequirement,
+};
+use crate::action_dispatch_record::InteractionSemanticActionDispatchRecordId;
+use crate::action_dispatch_route::InteractionSemanticActionDispatchRouteId;
+use crate::admitted_action::InteractionAdmittedSemanticActionId;
+use crate::effect_request::{
+    InteractionEffectRequestDenialBehavior, InteractionEffectRequestDescriptor,
+    InteractionEffectRequestDescriptorId, InteractionEffectRequestKind,
+    InteractionEffectRequestLifecyclePrecondition, InteractionEffectRequestRuntimeCapability,
+    InteractionEffectRequestScope, InteractionEffectRequestTargetPolicy,
+    InteractionEffectRequestUiCapability,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InteractionUiCapabilityAdmissionDescriptorId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionUiCapabilityAdmissionRuntimeMappingRequirement {
+    Required,
+    NotRequired,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionUiCapabilityAdmissionFutureResultShape {
+    AdmitOrDenyWithReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InteractionUiCapabilityAdmissionDescriptor {
+    pub id: InteractionUiCapabilityAdmissionDescriptorId,
+    pub effect_request_descriptor_id: InteractionEffectRequestDescriptorId,
+    pub source_admitted_action_id: InteractionAdmittedSemanticActionId,
+    pub dispatch_record_id: InteractionSemanticActionDispatchRecordId,
+    pub dispatch_route_id: InteractionSemanticActionDispatchRouteId,
+    pub requested_effect: InteractionEffectRequestKind,
+    pub declared_ui_capability: InteractionEffectRequestUiCapability,
+    pub declared_runtime_capability_requirement: InteractionEffectRequestRuntimeCapability,
+    pub lifecycle_precondition: InteractionEffectRequestLifecyclePrecondition,
+    pub target_policy: InteractionEffectRequestTargetPolicy,
+    pub denial_behavior: InteractionEffectRequestDenialBehavior,
+    pub trace_requirement: InteractionActionAdmissionTraceRequirement,
+    pub policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace,
+    pub scope: InteractionEffectRequestScope,
+    pub runtime_mapping_requirement: InteractionUiCapabilityAdmissionRuntimeMappingRequirement,
+    pub future_result_shape: InteractionUiCapabilityAdmissionFutureResultShape,
+}
+
+pub fn describe_interaction_ui_capability_admission(
+    effect_request: &InteractionEffectRequestDescriptor,
+) -> InteractionUiCapabilityAdmissionDescriptor {
+    InteractionUiCapabilityAdmissionDescriptor {
+        id: InteractionUiCapabilityAdmissionDescriptorId(effect_request.id.0),
+        effect_request_descriptor_id: effect_request.id,
+        source_admitted_action_id: effect_request.source_admitted_action_id,
+        dispatch_record_id: effect_request.dispatch_record_id,
+        dispatch_route_id: effect_request.dispatch_route_id,
+        requested_effect: effect_request.requested_effect,
+        declared_ui_capability: effect_request.required_ui_capability,
+        declared_runtime_capability_requirement: effect_request.required_runtime_capability,
+        lifecycle_precondition: effect_request.lifecycle_precondition,
+        target_policy: effect_request.target_policy,
+        denial_behavior: effect_request.denial_behavior,
+        trace_requirement: effect_request.trace_requirement,
+        policy_gate_namespace: effect_request.policy_gate_namespace,
+        scope: effect_request.scope,
+        runtime_mapping_requirement: map_runtime_mapping_requirement(
+            effect_request.required_runtime_capability,
+        ),
+        future_result_shape: InteractionUiCapabilityAdmissionFutureResultShape::AdmitOrDenyWithReason,
+    }
+}
+
+const fn map_runtime_mapping_requirement(
+    runtime_capability: InteractionEffectRequestRuntimeCapability,
+) -> InteractionUiCapabilityAdmissionRuntimeMappingRequirement {
+    match runtime_capability {
+        InteractionEffectRequestRuntimeCapability::Unknown => {
+            InteractionUiCapabilityAdmissionRuntimeMappingRequirement::Unknown
+        }
+        InteractionEffectRequestRuntimeCapability::WindowLifecycle
+        | InteractionEffectRequestRuntimeCapability::EffectControl
+        | InteractionEffectRequestRuntimeCapability::TargetQuarantine => {
+            InteractionUiCapabilityAdmissionRuntimeMappingRequirement::Required
+        }
+    }
+}
+
+impl InteractionUiCapabilityAdmissionDescriptor {
+    pub const fn is_admission_result(&self) -> bool {
+        false
+    }
+
+    pub const fn grants_ui_capability(&self) -> bool {
+        false
+    }
+
+    pub const fn grants_runtime_capability(&self) -> bool {
+        false
+    }
+
+    pub const fn is_runtime_mapping(&self) -> bool {
+        false
+    }
+
+    pub const fn is_prepared_effect(&self) -> bool {
+        false
+    }
+
+    pub const fn is_committed_effect(&self) -> bool {
+        false
+    }
+
+    pub const fn is_execution_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_runtime_mutation(&self) -> bool {
+        false
+    }
+
+    pub const fn calls_vm_or_host_abi(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::effect_request::{
+        describe_interaction_effect_request, InteractionEffectRequestDescriptor,
+    };
+    use crate::action_admission::{
+        InteractionActionAdmissionPolicyGateNamespace, InteractionActionAdmissionTraceRequirement,
+    };
+    use crate::action_binding::{InteractionActionBindingId, InteractionActionName};
+    use crate::action_dispatch_record::{
+        InteractionSemanticActionDispatchBlockReason, InteractionSemanticActionDispatchRecordId,
+        InteractionSemanticActionDispatchRecordStatus,
+    };
+    use crate::action_dispatch_route::{
+        InteractionSemanticActionDispatchEffectEligibility,
+        InteractionSemanticActionDispatchRouteId, InteractionSemanticActionDispatchRouteKind,
+    };
+    use crate::action_dispatch_trace::{
+        InteractionSemanticActionDispatchTraceReason, InteractionSemanticActionDispatchTraceReport,
+        InteractionSemanticActionDispatchTraceStatus,
+    };
+    use crate::admitted_action::InteractionAdmittedSemanticActionId;
+    use crate::interaction::InteractionIntentKind;
+
+    fn effect_request_descriptor() -> InteractionEffectRequestDescriptor {
+        let dispatch_trace = InteractionSemanticActionDispatchTraceReport {
+            record_id: InteractionSemanticActionDispatchRecordId(21),
+            route_id: InteractionSemanticActionDispatchRouteId(21),
+            admitted_action_id: InteractionAdmittedSemanticActionId(21),
+            action: InteractionActionName::PrepareEffect,
+            source_intent: InteractionIntentKind::Submit,
+            binding_id: InteractionActionBindingId(21),
+            route: InteractionSemanticActionDispatchRouteKind::EffectRequestCandidate,
+            record_status: InteractionSemanticActionDispatchRecordStatus::Recorded,
+            trace_status: InteractionSemanticActionDispatchTraceStatus::Recorded,
+            block_reason: InteractionSemanticActionDispatchBlockReason::None,
+            trace_reason: InteractionSemanticActionDispatchTraceReason::RouteRecorded,
+            trace_requirement: InteractionActionAdmissionTraceRequirement::Required,
+            effect_relationship:
+                crate::action_admission::InteractionActionAdmissionEffectRelationship::MayRequestEffectAfterAdmission,
+            policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace::CoreUi,
+            effect_eligibility:
+                InteractionSemanticActionDispatchEffectEligibility::RequiresFutureEffectBoundary,
+        };
+
+        describe_interaction_effect_request(&dispatch_trace)
+            .expect("effect candidate trace should produce descriptor")
+    }
+
+    fn unknown_runtime_capability_descriptor() -> InteractionEffectRequestDescriptor {
+        let dispatch_trace = InteractionSemanticActionDispatchTraceReport {
+            record_id: InteractionSemanticActionDispatchRecordId(22),
+            route_id: InteractionSemanticActionDispatchRouteId(22),
+            admitted_action_id: InteractionAdmittedSemanticActionId(22),
+            action: InteractionActionName::OpenInspector,
+            source_intent: InteractionIntentKind::Submit,
+            binding_id: InteractionActionBindingId(22),
+            route: InteractionSemanticActionDispatchRouteKind::EffectRequestCandidate,
+            record_status: InteractionSemanticActionDispatchRecordStatus::Recorded,
+            trace_status: InteractionSemanticActionDispatchTraceStatus::Recorded,
+            block_reason: InteractionSemanticActionDispatchBlockReason::None,
+            trace_reason: InteractionSemanticActionDispatchTraceReason::RouteRecorded,
+            trace_requirement: InteractionActionAdmissionTraceRequirement::Required,
+            effect_relationship: crate::action_admission::InteractionActionAdmissionEffectRelationship::NoEffect,
+            policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace::WorkbenchLocal,
+            effect_eligibility:
+                InteractionSemanticActionDispatchEffectEligibility::RequiresFutureEffectBoundary,
+        };
+
+        describe_interaction_effect_request(&dispatch_trace)
+            .expect("effect candidate trace should produce descriptor")
+    }
+
+    #[test]
+    fn descriptor_is_built_from_effect_request_descriptor() {
+        let effect_request = effect_request_descriptor();
+
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert_eq!(
+            admission.effect_request_descriptor_id,
+            effect_request.id
+        );
+        assert_eq!(admission.id, InteractionUiCapabilityAdmissionDescriptorId(21));
+    }
+
+    #[test]
+    fn descriptor_preserves_source_and_capability_metadata() {
+        let effect_request = effect_request_descriptor();
+
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert_eq!(
+            admission.source_admitted_action_id,
+            effect_request.source_admitted_action_id
+        );
+        assert_eq!(admission.dispatch_record_id, effect_request.dispatch_record_id);
+        assert_eq!(admission.dispatch_route_id, effect_request.dispatch_route_id);
+        assert_eq!(admission.requested_effect, effect_request.requested_effect);
+        assert_eq!(admission.declared_ui_capability, effect_request.required_ui_capability);
+        assert_eq!(
+            admission.declared_runtime_capability_requirement,
+            effect_request.required_runtime_capability
+        );
+        assert_eq!(admission.lifecycle_precondition, effect_request.lifecycle_precondition);
+        assert_eq!(admission.target_policy, effect_request.target_policy);
+        assert_eq!(admission.denial_behavior, effect_request.denial_behavior);
+        assert_eq!(admission.trace_requirement, effect_request.trace_requirement);
+        assert_eq!(admission.policy_gate_namespace, effect_request.policy_gate_namespace);
+        assert_eq!(admission.scope, effect_request.scope);
+    }
+
+    #[test]
+    fn runtime_capability_maps_to_runtime_mapping_requirement() {
+        let effect_request = effect_request_descriptor();
+
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert_eq!(
+            admission.runtime_mapping_requirement,
+            InteractionUiCapabilityAdmissionRuntimeMappingRequirement::Required
+        );
+        assert_eq!(
+            admission.future_result_shape,
+            InteractionUiCapabilityAdmissionFutureResultShape::AdmitOrDenyWithReason
+        );
+    }
+
+    #[test]
+    fn unknown_runtime_capability_maps_to_unknown() {
+        let effect_request = unknown_runtime_capability_descriptor();
+
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert_eq!(
+            admission.runtime_mapping_requirement,
+            InteractionUiCapabilityAdmissionRuntimeMappingRequirement::Unknown
+        );
+    }
+
+    #[test]
+    fn descriptor_is_not_authority() {
+        let effect_request = effect_request_descriptor();
+
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert!(!admission.is_admission_result());
+        assert!(!admission.grants_ui_capability());
+        assert!(!admission.grants_runtime_capability());
+        assert!(!admission.is_runtime_mapping());
+        assert!(!admission.is_prepared_effect());
+        assert!(!admission.is_committed_effect());
+        assert!(!admission.is_execution_authority());
+        assert!(!admission.is_runtime_mutation());
+        assert!(!admission.calls_vm_or_host_abi());
+    }
+
+    #[test]
+    fn descriptor_generation_is_deterministic() {
+        let effect_request = effect_request_descriptor();
+
+        let first = describe_interaction_ui_capability_admission(&effect_request);
+        let second = describe_interaction_ui_capability_admission(&effect_request);
+
+        assert_eq!(first, second);
+    }
+}

--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -29,6 +29,7 @@ visual doctrine
   -> admitted semantic action object
   -> semantic action dispatcher
   -> effect request descriptor
+  -> UI capability admission
   -> effect request / UI capability boundary
   -> trace/audit visual boundary
   -> error/denial/quarantine visual boundary
@@ -56,6 +57,7 @@ visual doctrine
 | admitted semantic action object   | `docs/architecture/ui_admitted_semantic_action_boundary.md`         |
 | semantic action dispatcher        | `docs/architecture/ui_semantic_action_dispatcher_boundary.md`      |
 | effect request descriptor         | `docs/architecture/ui_effect_request_descriptor_boundary.md`       |
+| UI capability admission          | `docs/architecture/ui_capability_admission_boundary.md`            |
 | effect requests / UI capabilities | `docs/architecture/ui_effect_request_capability_boundary.md`        |
 | trace/audit visual projection     | `docs/architecture/ui_trace_audit_visual_boundary.md`               |
 | error/denial/quarantine visuals   | `docs/architecture/ui_error_denial_quarantine_visual_boundary.md`   |

--- a/docs/architecture/ui_capability_admission_boundary.md
+++ b/docs/architecture/ui_capability_admission_boundary.md
@@ -1,0 +1,273 @@
+# Semantic UI Capability Admission Boundary
+
+Status: Draft
+Track: POST-UI / I-series
+Purpose: define the boundary for future UI capability admission before runtime capability mapping, prepared effects, or committed effects exist
+
+## 1. Goal
+
+This document defines the boundary for future Semantic UI capability admission.
+
+UI capability admission is the future decision layer that determines whether an
+effect request descriptor may proceed toward runtime capability mapping and
+prepared effect construction.
+
+It is not runtime capability grant.
+It is not prepared effect construction.
+It is not committed effect execution.
+It is not a VM operation.
+It is not a Host ABI operation.
+It must not mutate runtime state.
+
+## 2. Position in the ladder
+
+The current implemented scaffold reaches:
+
+```text
+InteractionEffectRequestDescriptor
+  -> InteractionEffectRequestTraceReport
+  -> InteractionEffectRequestSummary
+```
+
+The next future boundary is:
+
+```text
+InteractionEffectRequestDescriptor / InteractionEffectRequestTraceReport
+  -> future UiCapabilityAdmissionDescriptor
+  -> future UiCapabilityAdmissionResult
+  -> future RuntimeCapabilityMapping
+  -> future PreparedEffect
+  -> future CommitBoundary
+  -> future CommittedEffect
+```
+
+Only the UI capability admission boundary is defined here.
+
+## 3. Core separation
+
+```text
+effect request descriptor is not capability admission
+effect request trace is not capability admission
+effect request summary is not capability admission
+declared UI capability is not capability grant
+UI capability admission is not runtime capability grant
+runtime capability mapping requires separate boundary
+capability admission is not prepared effect
+prepared effect is not committed effect
+committed effect requires separate boundary
+```
+
+## 4. Admission input rule
+
+A future UI capability admission layer may only consume explicit effect request metadata:
+
+```text
+InteractionEffectRequestDescriptor
+```
+
+or a future narrowed equivalent derived from it.
+
+It must not consume directly:
+
+* raw input;
+* interaction intent;
+* action binding trace;
+* action candidate summary;
+* admitted action object;
+* dispatch route descriptor;
+* dispatch summary alone;
+* renderer affordance;
+* Workbench command;
+* component callback.
+
+## 5. Required future admission descriptor fields
+
+A future UI capability admission descriptor must preserve:
+
+1. effect request descriptor id;
+2. source admitted action id;
+3. dispatch record id;
+4. dispatch route id;
+5. requested effect kind;
+6. declared UI capability;
+7. declared runtime capability requirement;
+8. lifecycle precondition;
+9. target policy;
+10. denial behavior;
+11. trace requirement;
+12. policy gate namespace;
+13. scope;
+14. runtime mapping requirement;
+15. future admission result shape.
+
+## 6. Required future admission result statuses
+
+A future UI capability admission result must distinguish at minimum:
+
+```text
+admitted
+denied_missing_ui_capability
+denied_lifecycle
+denied_target
+denied_policy
+denied_runtime_mapping_required
+denied_unknown
+```
+
+An admitted result still does not grant runtime capability by itself.
+
+## 7. UI capability declaration vs admission
+
+Effect request descriptors may declare required UI capability.
+
+Declaration is not admission.
+
+```text
+required_ui_capability
+  -> UI capability admission
+  -> UI capability admission result
+```
+
+A descriptor field must never be treated as permission.
+
+## 8. UI capability vs runtime capability
+
+UI capability admission is still not runtime capability grant.
+
+Required future order:
+
+```text
+UI capability admission result
+  -> runtime capability mapping descriptor
+  -> runtime capability mapping admission
+  -> prepared effect
+```
+
+Runtime capability mapping must be explicit.
+
+No UI capability admission PR may silently map to Host ABI or runtime authority.
+
+## 9. Prepared effect separation
+
+UI capability admission is not prepared effect construction.
+
+Required future order:
+
+```text
+EffectRequestDescriptor
+  -> UI capability admission
+  -> runtime capability mapping
+  -> PreparedEffect
+```
+
+Prepared effect remains inert until commit boundary.
+
+## 10. Commit separation
+
+Prepared effect is not committed effect.
+
+Required future order:
+
+```text
+PreparedEffect
+  -> CommitBoundary
+  -> CommittedEffect
+```
+
+No capability admission PR may collapse admission, preparation, and commit.
+
+## 11. Denial and trace requirements
+
+Denied UI capability admission must be visible when it affects user expectation or semantic UI state.
+
+Future denial reasons may include:
+
+* missing UI capability;
+* lifecycle blocked;
+* target unavailable;
+* target invalid;
+* policy denied;
+* runtime mapping required;
+* unknown denial.
+
+Denied capability admission must not become hidden no-op.
+
+## 12. Workbench and renderer relationship
+
+Workbench may display future capability admission data only through explicit consumption boundaries.
+
+Renderer may display capability state only as presentation.
+
+Neither Workbench nor renderer may define:
+
+* capability grant;
+* runtime authority;
+* effect permission;
+* prepare authority;
+* commit authority;
+* audit finality.
+
+## 13. Forbidden shortcuts
+
+Future PRs must not:
+
+* treat declared UI capability as admitted capability;
+* treat effect request summary as admission input by itself;
+* admit capability from renderer affordance;
+* admit capability from Workbench command;
+* map UI capability to runtime capability implicitly;
+* create prepared effect in capability admission PR;
+* create committed effect in capability admission PR;
+* call VM/Host ABI from capability admission;
+* mutate runtime state from capability admission;
+* hide denied capability admission as no-op;
+* collapse capability admission, runtime mapping, prepare, and commit into one PR.
+
+## 14. Required implementation order
+
+Future implementation must proceed in separate PRs:
+
+```text
+docs UI capability admission boundary
+  -> UI capability admission descriptor scaffold
+  -> UI capability admission result scaffold
+  -> UI capability denial trace scaffold
+  -> runtime capability mapping boundary docs
+  -> runtime capability mapping descriptor scaffold
+  -> prepared effect boundary docs
+  -> prepared effect scaffold
+  -> commit boundary docs
+  -> committed effect scaffold
+```
+
+No PR should combine capability admission, runtime mapping, prepared effect, commit, and runtime mutation.
+
+## 15. Relationship to effect request descriptor boundary
+
+The effect request descriptor boundary is defined in:
+
+```text
+docs/architecture/ui_effect_request_descriptor_boundary.md
+```
+
+This document starts the next stage after descriptor/trace/summary scaffolding.
+
+## 16. Relationship to H8 effect/capability boundary
+
+The general effect request and capability boundary is defined in:
+
+```text
+docs/architecture/ui_effect_request_capability_boundary.md
+```
+
+This document narrows the I-series UI capability admission step.
+
+## 17. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.

--- a/docs/architecture/ui_effect_request_capability_boundary.md
+++ b/docs/architecture/ui_effect_request_capability_boundary.md
@@ -446,6 +446,26 @@ A future effect request implementation PR must define:
 
 No effect request should be added only because it is convenient for UI wiring.
 
+## UI capability admission dependency
+
+The I-series UI capability admission boundary is defined separately in:
+
+```text
+docs/architecture/ui_capability_admission_boundary.md
+```
+
+This document narrows the admission stage after effect request descriptors.
+
+```text
+EffectRequestDescriptor
+  -> future UiCapabilityAdmissionDescriptor
+  -> future UiCapabilityAdmissionResult
+  -> future RuntimeCapabilityMapping
+```
+
+UI capability admission is not runtime capability grant.
+Runtime capability mapping requires a separate boundary.
+
 ## 20. Future implementation shape
 
 H8 does not mandate implementation.

--- a/docs/architecture/ui_effect_request_descriptor_boundary.md
+++ b/docs/architecture/ui_effect_request_descriptor_boundary.md
@@ -256,6 +256,26 @@ docs/architecture/ui_effect_request_capability_boundary.md
 
 This document narrows that general boundary for the I-series effect request descriptor step.
 
+## UI capability admission dependency
+
+UI capability admission boundary is defined separately in:
+
+```text
+docs/architecture/ui_capability_admission_boundary.md
+```
+
+The effect request descriptor/trace/summary layer stops before admission.
+
+```text
+InteractionEffectRequestDescriptor
+  -> future UiCapabilityAdmissionDescriptor
+  -> future UiCapabilityAdmissionResult
+```
+
+Effect request descriptor is not capability admission.
+Declared UI capability is not capability grant.
+UI capability admission is not runtime capability grant.
+
 ## 15. Validation expectation
 
 Docs-only PR validation:


### PR DESCRIPTION
## Summary

Defines the Semantic UI capability admission boundary.

This docs-only PR records the next boundary after effect request descriptor,
trace, and summary scaffolding. It clarifies that effect request descriptors are
not capability admission, declared UI capabilities are not capability grants, UI
capability admission is not runtime capability grant, and prepared/committed
effects require separate boundaries.

## Scope

- Add `docs/architecture/ui_capability_admission_boundary.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the boundary from
  `docs/architecture/ui_effect_request_descriptor_boundary.md`
- Reference the boundary from
  `docs/architecture/ui_effect_request_capability_boundary.md`
- Define admission input rule and required future descriptor fields
- Define future admission result statuses
- Document UI/runtime capability separation
- Document prepared/committed effect separation
- Document forbidden shortcuts and implementation order

## Out of scope

- Rust code changes
- TypeScript code changes
- `Cargo.toml` changes
- dependency changes
- tests
- capability admission implementation
- capability checker
- runtime capability grant
- runtime capability mapping
- prepared effect
- committed effect
- effect execution
- VM / Host ABI bridge
- Workbench command bridge
- renderer affordance map
- runtime mutation

## Validation

- [x] `git diff --check`