### PR TITLE
docs(ui): define committed effect boundary

### DIFF
--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -61,6 +61,7 @@ visual doctrine
 | UI capability admission          | `docs/architecture/ui_capability_admission_boundary.md`            |
 | runtime capability mapping      | `docs/architecture/ui_runtime_capability_mapping_boundary.md`      |
 | prepared effect                 | `docs/architecture/ui_prepared_effect_boundary.md`                 |
+| committed effect                | `docs/architecture/ui_committed_effect_boundary.md`                 |
 | effect requests / UI capabilities | `docs/architecture/ui_effect_request_capability_boundary.md`        |
 | trace/audit visual projection     | `docs/architecture/ui_trace_audit_visual_boundary.md`               |
 | error/denial/quarantine visuals   | `docs/architecture/ui_error_denial_quarantine_visual_boundary.md`   |

--- a/docs/architecture/ui_committed_effect_boundary.md
+++ b/docs/architecture/ui_committed_effect_boundary.md
@@ -1,0 +1,250 @@
+# Semantic UI Committed Effect Boundary
+
+Status: Draft  
+Track: POST-UI / I-series  
+Purpose: define the boundary for future committed effects before Host ABI calls, VM calls, effect execution, or runtime mutation exist
+
+## 1. Goal
+
+This document defines the boundary for future Semantic UI committed effects.
+
+A committed effect is a future explicit post-commit record derived from a prepared
+effect result that has passed the required commit boundary.
+
+It is not arbitrary Host ABI execution.
+It is not VM authority.
+It is not unbounded runtime mutation.
+It is not renderer authority.
+It is not Workbench command execution.
+
+Any future runtime mutation must be explicit, capability-gated, auditable, and
+separately bounded.
+
+## 2. Position in the ladder
+
+The current implemented scaffold reaches:
+
+```text
+InteractionPreparedEffectDescriptor
+  -> InteractionPreparedEffectResult
+```
+
+The next future boundary is:
+
+```text
+InteractionPreparedEffectResult::Prepared
+  -> future CommitBoundary
+  -> future CommittedEffect
+  -> future HostRuntimeEffectPath if separately admitted
+```
+
+Only the committed effect boundary is defined here.
+
+## 3. Core separation
+
+```text
+prepared effect result is not commit boundary
+prepared effect denial is not commit boundary
+commit boundary is not committed effect by itself
+committed effect is not arbitrary Host ABI authority
+committed effect is not VM authority
+committed effect is not unbounded runtime mutation
+committed effect requires explicit audit visibility
+Host ABI path requires separate boundary
+```
+
+## 4. Commit input rule
+
+A future commit boundary may only consume:
+
+```text
+InteractionPreparedEffectResult::Prepared
+```
+
+or a future narrowed equivalent derived from it.
+
+It must not consume directly:
+
+* raw input;
+* interaction intent;
+* effect request descriptor;
+* effect request trace;
+* effect request summary;
+* UI capability admission descriptor;
+* UI capability admission result alone;
+* UI capability denial trace;
+* runtime capability mapping descriptor;
+* runtime capability mapping result alone if denied;
+* prepared effect descriptor alone;
+* denied prepared effect result;
+* renderer affordance;
+* Workbench command;
+* component callback.
+
+## 5. Required future commit boundary descriptor fields
+
+A future commit boundary descriptor must preserve:
+
+1. prepared effect result id;
+2. prepared effect descriptor id;
+3. runtime capability mapping result id;
+4. runtime capability mapping descriptor id;
+5. UI capability admission result id;
+6. UI capability admission descriptor id;
+7. effect request descriptor id;
+8. source admitted action id;
+9. dispatch record id;
+10. dispatch route id;
+11. requested effect kind;
+12. declared UI capability;
+13. declared runtime capability requirement;
+14. runtime capability namespace;
+15. lifecycle precondition;
+16. target policy;
+17. trace requirement;
+18. policy gate namespace;
+19. scope;
+20. audit requirement;
+21. future committed effect shape.
+
+## 6. Required future commit statuses
+
+A future commit boundary result must distinguish at minimum:
+
+```text
+committed
+denied_missing_prepared_effect
+denied_lifecycle
+denied_target
+denied_policy
+denied_audit_required
+denied_host_boundary
+denied_unknown
+```
+
+A committed result still does not mean arbitrary Host ABI access.
+
+## 7. Committed effect vs Host ABI
+
+Committed effect is not arbitrary Host ABI execution.
+
+Required future order:
+
+```text
+CommittedEffect
+  -> future HostRuntimeEffectBoundary
+  -> future HostRuntimeEffectPath
+```
+
+No committed effect PR may directly add Host ABI calls unless a separate Host
+runtime effect boundary already exists and explicitly admits that path.
+
+## 8. Committed effect vs VM
+
+Committed effect is not VM authority.
+
+The UI layer must not call VM directly during commit.
+
+Any future VM relationship must be explicit and separately bounded.
+
+## 9. Committed effect vs runtime mutation
+
+Committed effect is not unbounded runtime mutation.
+
+A committed effect may represent that an effect has passed the UI-side commit
+boundary, but actual runtime mutation must remain capability-gated, auditable,
+and separately controlled.
+
+## 10. Audit requirement
+
+Committed effects must be visible to audit.
+
+Future committed effect records must preserve:
+
+* source action identity;
+* effect request identity;
+* capability mapping identity;
+* prepared effect identity;
+* commit decision identity;
+* denial reason if denied;
+* target policy;
+* runtime capability namespace.
+
+No committed effect should become hidden mutation.
+
+## 11. Workbench and renderer relationship
+
+Workbench may display future committed effect data only through explicit
+consumption boundaries.
+
+Renderer may display committed effect state only as presentation.
+
+Neither Workbench nor renderer may define:
+
+* commit authority;
+* Host ABI authority;
+* VM authority;
+* effect execution;
+* runtime mutation;
+* audit finality.
+
+## 12. Forbidden shortcuts
+
+Future PRs must not:
+
+* treat prepared effect result as committed effect;
+* consume denied prepared effect result for commit;
+* create committed effect from renderer affordance;
+* create committed effect from Workbench command;
+* call VM/Host ABI from commit boundary docs/scaffold PR;
+* mutate runtime state from committed effect scaffold;
+* collapse committed effect, Host ABI, audit backend, and runtime mutation into one PR;
+* hide denied commit as no-op;
+* bypass audit visibility.
+
+## 13. Required implementation order
+
+Future implementation must proceed in separate PRs:
+
+```text
+docs committed effect boundary
+  -> commit boundary descriptor scaffold
+  -> commit boundary result scaffold
+  -> committed effect descriptor scaffold
+  -> committed effect record scaffold
+  -> committed effect denial trace scaffold if needed
+  -> Host runtime effect boundary docs
+  -> Host runtime effect scaffold
+```
+
+No PR should combine commit, Host ABI, VM, audit backend, and runtime mutation.
+
+## 14. Relationship to prepared effect boundary
+
+The prepared effect boundary is defined in:
+
+```text
+docs/architecture/ui_prepared_effect_boundary.md
+```
+
+This document starts the next stage after prepared effect result scaffolding.
+
+## 15. Relationship to H8 effect/capability boundary
+
+The general effect request and capability boundary is defined in:
+
+```text
+docs/architecture/ui_effect_request_capability_boundary.md
+```
+
+This document narrows the I-series committed effect step.
+
+## 16. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.

--- a/docs/architecture/ui_effect_request_capability_boundary.md
+++ b/docs/architecture/ui_effect_request_capability_boundary.md
@@ -231,6 +231,27 @@ Prepared effect is not Host ABI authority.
 Prepared effect is not committed effect.
 Commit requires a separate boundary.
 
+## Committed effect dependency
+
+The I-series committed effect boundary is defined separately in:
+
+```text
+docs/architecture/ui_committed_effect_boundary.md
+```
+
+This document narrows the committed effect stage after prepared effect handling.
+
+```text
+PreparedEffectResult::Prepared
+  -> future CommitBoundary
+  -> future CommittedEffect
+  -> future HostRuntimeEffectBoundary
+```
+
+Committed effect is not arbitrary Host ABI authority.
+Committed effect is not VM authority.
+Runtime mutation requires explicit capability-gated and auditable boundaries.
+
 ## 7. Capability visibility vs capability grant
 
 Showing a capability in UI does not grant it.

--- a/docs/architecture/ui_prepared_effect_boundary.md
+++ b/docs/architecture/ui_prepared_effect_boundary.md
@@ -243,6 +243,26 @@ docs/architecture/ui_effect_request_capability_boundary.md
 
 This document narrows the I-series prepared effect step.
 
+## Committed effect dependency
+
+Committed effect boundary is defined separately in:
+
+```text
+docs/architecture/ui_committed_effect_boundary.md
+```
+
+The prepared effect layer stops before commit and committed effect construction.
+
+```text
+InteractionPreparedEffectResult::Prepared
+  -> future CommitBoundary
+  -> future CommittedEffect
+```
+
+Prepared effect result is not commit boundary.
+Commit boundary is not Host ABI authority.
+Committed effect still requires explicit audit/runtime boundaries.
+
 ## 17. Validation expectation
 
 Docs-only PR validation:


### PR DESCRIPTION
## Summary

Defines the Semantic UI committed effect boundary.

This docs-only PR records the next boundary after prepared effect result scaffolding. It clarifies that prepared effect results are not commit boundaries, commit boundaries are not committed effects by themselves, and committed effects are not arbitrary Host ABI authority, VM authority, or unbounded runtime mutation.

## Scope

- Add `docs/architecture/ui_committed_effect_boundary.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the boundary from `docs/architecture/ui_prepared_effect_boundary.md`
- Reference the boundary from `docs/architecture/ui_effect_request_capability_boundary.md`
- Define commit input rule and required future descriptor fields
- Define future commit statuses
- Document Host ABI / VM separation
- Document runtime mutation separation
- Document audit visibility requirement
- Document forbidden shortcuts and implementation order

## Out of scope

- Rust code changes
- TypeScript changes
- `Cargo.toml` changes
- dependency changes
- tests
- committed effect implementation
- commit boundary implementation
- Host ABI call
- VM call
- effect execution implementation
- runtime state mutation
- Workbench command bridge
- renderer affordance map
- audit backend implementation

## Validation

- `git diff --check`