### PR TITLE
docs(ui): document full UI effect trace ladder

### DIFF
--- a/crates/prom-ui/src/committed_effect_record.rs
+++ b/crates/prom-ui/src/committed_effect_record.rs
@@ -1,0 +1,323 @@
+//! Semantic UI committed effect record scaffold.
+//!
+//! This module records an inert UI-side committed-effect record derived from a
+//! committed effect descriptor. It does not implement Host ABI calls, VM
+//! calls, effect execution, runtime mutation, an audit backend, or any host
+//! runtime path.
+
+use crate::action_admission::{
+    InteractionActionAdmissionPolicyGateNamespace, InteractionActionAdmissionTraceRequirement,
+};
+use crate::action_dispatch_record::InteractionSemanticActionDispatchRecordId;
+use crate::action_dispatch_route::InteractionSemanticActionDispatchRouteId;
+use crate::admitted_action::InteractionAdmittedSemanticActionId;
+use crate::commit_boundary::InteractionCommitAuditRequirement;
+use crate::commit_boundary_result::InteractionCommitBoundaryResultId;
+use crate::committed_effect::{
+    InteractionCommittedEffectAuditVisibility, InteractionCommittedEffectDescriptor,
+    InteractionCommittedEffectDescriptorId,
+    InteractionCommittedEffectHostPathRequirement,
+    InteractionCommittedEffectRuntimeMutationRequirement,
+};
+use crate::effect_request::{
+    InteractionEffectRequestDescriptorId, InteractionEffectRequestKind,
+    InteractionEffectRequestLifecyclePrecondition, InteractionEffectRequestRuntimeCapability,
+    InteractionEffectRequestScope, InteractionEffectRequestTargetPolicy,
+    InteractionEffectRequestUiCapability,
+};
+use crate::prepared_effect::InteractionPreparedEffectDescriptorId;
+use crate::prepared_effect_result::InteractionPreparedEffectResultId;
+use crate::runtime_capability_mapping::{
+    InteractionRuntimeCapabilityMappingDescriptorId, InteractionRuntimeCapabilityNamespace,
+};
+use crate::runtime_capability_mapping_result::InteractionRuntimeCapabilityMappingResultId;
+use crate::ui_capability_admission::InteractionUiCapabilityAdmissionDescriptorId;
+use crate::ui_capability_admission_result::InteractionUiCapabilityAdmissionResultId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InteractionCommittedEffectRecordId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionCommittedEffectRecordStatus {
+    Recorded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionCommittedEffectRuntimeMutationStatus {
+    NotPerformed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionCommittedEffectHostPathStatus {
+    NotEntered,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InteractionCommittedEffectRecord {
+    pub id: InteractionCommittedEffectRecordId,
+    pub descriptor_id: InteractionCommittedEffectDescriptorId,
+    pub commit_boundary_result_id: InteractionCommitBoundaryResultId,
+    pub commit_boundary_descriptor_id: crate::commit_boundary::InteractionCommitBoundaryDescriptorId,
+    pub prepared_effect_result_id: InteractionPreparedEffectResultId,
+    pub prepared_effect_descriptor_id: InteractionPreparedEffectDescriptorId,
+    pub runtime_capability_mapping_result_id: InteractionRuntimeCapabilityMappingResultId,
+    pub runtime_capability_mapping_descriptor_id: InteractionRuntimeCapabilityMappingDescriptorId,
+    pub ui_capability_admission_result_id: InteractionUiCapabilityAdmissionResultId,
+    pub ui_capability_admission_descriptor_id: InteractionUiCapabilityAdmissionDescriptorId,
+    pub effect_request_descriptor_id: InteractionEffectRequestDescriptorId,
+    pub source_admitted_action_id: InteractionAdmittedSemanticActionId,
+    pub dispatch_record_id: InteractionSemanticActionDispatchRecordId,
+    pub dispatch_route_id: InteractionSemanticActionDispatchRouteId,
+    pub requested_effect: InteractionEffectRequestKind,
+    pub declared_ui_capability: InteractionEffectRequestUiCapability,
+    pub declared_runtime_capability_requirement: InteractionEffectRequestRuntimeCapability,
+    pub runtime_capability_namespace: InteractionRuntimeCapabilityNamespace,
+    pub lifecycle_precondition: InteractionEffectRequestLifecyclePrecondition,
+    pub target_policy: InteractionEffectRequestTargetPolicy,
+    pub trace_requirement: InteractionActionAdmissionTraceRequirement,
+    pub policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace,
+    pub scope: InteractionEffectRequestScope,
+    pub audit_requirement: InteractionCommitAuditRequirement,
+    pub audit_visibility: InteractionCommittedEffectAuditVisibility,
+    pub runtime_mutation_requirement: InteractionCommittedEffectRuntimeMutationRequirement,
+    pub host_path_requirement: InteractionCommittedEffectHostPathRequirement,
+    pub record_status: InteractionCommittedEffectRecordStatus,
+    pub runtime_mutation_status: InteractionCommittedEffectRuntimeMutationStatus,
+    pub host_path_status: InteractionCommittedEffectHostPathStatus,
+}
+
+pub fn record_interaction_committed_effect(
+    descriptor: &InteractionCommittedEffectDescriptor,
+) -> InteractionCommittedEffectRecord {
+    InteractionCommittedEffectRecord {
+        id: InteractionCommittedEffectRecordId(descriptor.id.0),
+        descriptor_id: descriptor.id,
+        commit_boundary_result_id: descriptor.commit_boundary_result_id,
+        commit_boundary_descriptor_id: descriptor.commit_boundary_descriptor_id,
+        prepared_effect_result_id: descriptor.prepared_effect_result_id,
+        prepared_effect_descriptor_id: descriptor.prepared_effect_descriptor_id,
+        runtime_capability_mapping_result_id: descriptor.runtime_capability_mapping_result_id,
+        runtime_capability_mapping_descriptor_id: descriptor
+            .runtime_capability_mapping_descriptor_id,
+        ui_capability_admission_result_id: descriptor.ui_capability_admission_result_id,
+        ui_capability_admission_descriptor_id: descriptor.ui_capability_admission_descriptor_id,
+        effect_request_descriptor_id: descriptor.effect_request_descriptor_id,
+        source_admitted_action_id: descriptor.source_admitted_action_id,
+        dispatch_record_id: descriptor.dispatch_record_id,
+        dispatch_route_id: descriptor.dispatch_route_id,
+        requested_effect: descriptor.requested_effect,
+        declared_ui_capability: descriptor.declared_ui_capability,
+        declared_runtime_capability_requirement: descriptor
+            .declared_runtime_capability_requirement,
+        runtime_capability_namespace: descriptor.runtime_capability_namespace,
+        lifecycle_precondition: descriptor.lifecycle_precondition,
+        target_policy: descriptor.target_policy,
+        trace_requirement: descriptor.trace_requirement,
+        policy_gate_namespace: descriptor.policy_gate_namespace,
+        scope: descriptor.scope,
+        audit_requirement: descriptor.audit_requirement,
+        audit_visibility: descriptor.audit_visibility,
+        runtime_mutation_requirement: descriptor.runtime_mutation_requirement,
+        host_path_requirement: descriptor.host_path_requirement,
+        record_status: InteractionCommittedEffectRecordStatus::Recorded,
+        runtime_mutation_status: InteractionCommittedEffectRuntimeMutationStatus::NotPerformed,
+        host_path_status: InteractionCommittedEffectHostPathStatus::NotEntered,
+    }
+}
+
+impl InteractionCommittedEffectRecord {
+    pub const fn is_host_abi_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_vm_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_execution_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_runtime_mutation(&self) -> bool {
+        false
+    }
+
+    pub const fn is_audit_backend(&self) -> bool {
+        false
+    }
+
+    pub const fn is_host_runtime_path(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::action_admission::InteractionActionAdmissionEffectRelationship;
+    use crate::action_binding::{InteractionActionBindingId, InteractionActionName};
+    use crate::action_dispatch_record::{
+        InteractionSemanticActionDispatchBlockReason, InteractionSemanticActionDispatchRecordId,
+        InteractionSemanticActionDispatchRecordStatus,
+    };
+    use crate::action_dispatch_route::{
+        InteractionSemanticActionDispatchEffectEligibility,
+        InteractionSemanticActionDispatchRouteId, InteractionSemanticActionDispatchRouteKind,
+    };
+    use crate::action_dispatch_trace::{
+        InteractionSemanticActionDispatchTraceReason, InteractionSemanticActionDispatchTraceReport,
+        InteractionSemanticActionDispatchTraceStatus,
+    };
+    use crate::admitted_action::InteractionAdmittedSemanticActionId;
+    use crate::commit_boundary::describe_interaction_commit_boundary;
+    use crate::commit_boundary_result::record_interaction_commit_boundary_committed_result;
+    use crate::committed_effect::describe_interaction_committed_effect;
+    use crate::effect_request::describe_interaction_effect_request;
+    use crate::interaction::InteractionIntentKind;
+    use crate::prepared_effect::describe_interaction_prepared_effect;
+    use crate::prepared_effect_result::record_interaction_prepared_effect_result;
+    use crate::runtime_capability_mapping::describe_interaction_runtime_capability_mapping;
+    use crate::runtime_capability_mapping_result::record_interaction_runtime_capability_mapped_result;
+    use crate::ui_capability_admission::describe_interaction_ui_capability_admission;
+    use crate::ui_capability_admission_result::record_interaction_ui_capability_admitted_result;
+
+    fn effect_request_descriptor() -> crate::effect_request::InteractionEffectRequestDescriptor {
+        let dispatch_trace = InteractionSemanticActionDispatchTraceReport {
+            record_id: InteractionSemanticActionDispatchRecordId(151),
+            route_id: InteractionSemanticActionDispatchRouteId(151),
+            admitted_action_id: InteractionAdmittedSemanticActionId(151),
+            action: InteractionActionName::PrepareEffect,
+            source_intent: InteractionIntentKind::Submit,
+            binding_id: InteractionActionBindingId(151),
+            route: InteractionSemanticActionDispatchRouteKind::EffectRequestCandidate,
+            record_status: InteractionSemanticActionDispatchRecordStatus::Recorded,
+            trace_status: InteractionSemanticActionDispatchTraceStatus::Recorded,
+            block_reason: InteractionSemanticActionDispatchBlockReason::None,
+            trace_reason: InteractionSemanticActionDispatchTraceReason::RouteRecorded,
+            trace_requirement: InteractionActionAdmissionTraceRequirement::Required,
+            effect_relationship:
+                InteractionActionAdmissionEffectRelationship::MayRequestEffectAfterAdmission,
+            policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace::CoreUi,
+            effect_eligibility:
+                InteractionSemanticActionDispatchEffectEligibility::RequiresFutureEffectBoundary,
+        };
+
+        describe_interaction_effect_request(&dispatch_trace)
+            .expect("effect candidate trace should produce descriptor")
+    }
+
+    fn committed_effect_descriptor() -> InteractionCommittedEffectDescriptor {
+        let effect_request = effect_request_descriptor();
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+        let ui_result = record_interaction_ui_capability_admitted_result(&admission);
+        let mapping_descriptor = describe_interaction_runtime_capability_mapping(&ui_result)
+            .expect("admitted result should produce mapping descriptor");
+        let mapping_result = record_interaction_runtime_capability_mapped_result(&mapping_descriptor);
+        let prepared_descriptor = describe_interaction_prepared_effect(&mapping_result)
+            .expect("mapped result should produce prepared effect descriptor");
+        let prepared_result = record_interaction_prepared_effect_result(&prepared_descriptor);
+        let commit_descriptor = describe_interaction_commit_boundary(&prepared_result)
+            .expect("prepared result should produce commit boundary descriptor");
+        let commit_result = record_interaction_commit_boundary_committed_result(&commit_descriptor);
+
+        describe_interaction_committed_effect(&commit_result)
+            .expect("committed result should produce committed effect descriptor")
+    }
+
+    #[test]
+    fn committed_effect_descriptor_creates_committed_effect_record() {
+        let descriptor = committed_effect_descriptor();
+        let record = record_interaction_committed_effect(&descriptor);
+
+        assert_eq!(record.id, InteractionCommittedEffectRecordId(descriptor.id.0));
+        assert_eq!(record.descriptor_id, descriptor.id);
+    }
+
+    #[test]
+    fn record_preserves_source_capability_audit_metadata() {
+        let descriptor = committed_effect_descriptor();
+        let record = record_interaction_committed_effect(&descriptor);
+
+        assert_eq!(record.commit_boundary_result_id, descriptor.commit_boundary_result_id);
+        assert_eq!(record.commit_boundary_descriptor_id, descriptor.commit_boundary_descriptor_id);
+        assert_eq!(record.prepared_effect_result_id, descriptor.prepared_effect_result_id);
+        assert_eq!(record.prepared_effect_descriptor_id, descriptor.prepared_effect_descriptor_id);
+        assert_eq!(
+            record.runtime_capability_mapping_result_id,
+            descriptor.runtime_capability_mapping_result_id
+        );
+        assert_eq!(
+            record.runtime_capability_mapping_descriptor_id,
+            descriptor.runtime_capability_mapping_descriptor_id
+        );
+        assert_eq!(record.ui_capability_admission_result_id, descriptor.ui_capability_admission_result_id);
+        assert_eq!(
+            record.ui_capability_admission_descriptor_id,
+            descriptor.ui_capability_admission_descriptor_id
+        );
+        assert_eq!(record.effect_request_descriptor_id, descriptor.effect_request_descriptor_id);
+        assert_eq!(record.source_admitted_action_id, descriptor.source_admitted_action_id);
+        assert_eq!(record.dispatch_record_id, descriptor.dispatch_record_id);
+        assert_eq!(record.dispatch_route_id, descriptor.dispatch_route_id);
+        assert_eq!(record.requested_effect, descriptor.requested_effect);
+        assert_eq!(record.declared_ui_capability, descriptor.declared_ui_capability);
+        assert_eq!(
+            record.declared_runtime_capability_requirement,
+            descriptor.declared_runtime_capability_requirement
+        );
+        assert_eq!(record.runtime_capability_namespace, descriptor.runtime_capability_namespace);
+        assert_eq!(record.lifecycle_precondition, descriptor.lifecycle_precondition);
+        assert_eq!(record.target_policy, descriptor.target_policy);
+        assert_eq!(record.trace_requirement, descriptor.trace_requirement);
+        assert_eq!(record.policy_gate_namespace, descriptor.policy_gate_namespace);
+        assert_eq!(record.scope, descriptor.scope);
+        assert_eq!(record.audit_requirement, descriptor.audit_requirement);
+        assert_eq!(record.audit_visibility, descriptor.audit_visibility);
+    }
+
+    #[test]
+    fn record_preserves_separate_runtime_mutation_and_host_path_requirements() {
+        let descriptor = committed_effect_descriptor();
+        let record = record_interaction_committed_effect(&descriptor);
+
+        assert_eq!(record.runtime_mutation_requirement, descriptor.runtime_mutation_requirement);
+        assert_eq!(record.host_path_requirement, descriptor.host_path_requirement);
+    }
+
+    #[test]
+    fn record_status_fields_are_inert() {
+        let descriptor = committed_effect_descriptor();
+        let record = record_interaction_committed_effect(&descriptor);
+
+        assert_eq!(record.record_status, InteractionCommittedEffectRecordStatus::Recorded);
+        assert_eq!(
+            record.runtime_mutation_status,
+            InteractionCommittedEffectRuntimeMutationStatus::NotPerformed
+        );
+        assert_eq!(
+            record.host_path_status,
+            InteractionCommittedEffectHostPathStatus::NotEntered
+        );
+    }
+
+    #[test]
+    fn record_is_not_authority() {
+        let descriptor = committed_effect_descriptor();
+        let record = record_interaction_committed_effect(&descriptor);
+
+        assert!(!record.is_host_abi_authority());
+        assert!(!record.is_vm_authority());
+        assert!(!record.is_execution_authority());
+        assert!(!record.is_runtime_mutation());
+        assert!(!record.is_audit_backend());
+        assert!(!record.is_host_runtime_path());
+    }
+
+    #[test]
+    fn generation_is_deterministic() {
+        let left = record_interaction_committed_effect(&committed_effect_descriptor());
+        let right = record_interaction_committed_effect(&committed_effect_descriptor());
+
+        assert_eq!(left, right);
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -45,6 +45,7 @@ pub mod prepared_effect_result;
 pub mod commit_boundary;
 pub mod commit_boundary_result;
 pub mod committed_effect;
+pub mod committed_effect_record;
 pub mod intent_stream;
 pub mod raw_event;
 pub mod trace;
@@ -218,6 +219,11 @@ pub use committed_effect::{
     InteractionCommittedEffectDescriptor, InteractionCommittedEffectDescriptorId,
     InteractionCommittedEffectHostPathRequirement,
     InteractionCommittedEffectRuntimeMutationRequirement,
+};
+pub use committed_effect_record::{
+    record_interaction_committed_effect, InteractionCommittedEffectHostPathStatus,
+    InteractionCommittedEffectRecord, InteractionCommittedEffectRecordId,
+    InteractionCommittedEffectRecordStatus, InteractionCommittedEffectRuntimeMutationStatus,
 };
 pub use intent_stream::{
     trace_interaction_intent_stream, InteractionIntentStreamModel,

--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -24,6 +24,7 @@ visual doctrine
   -> interaction/input semantic boundary
   -> focus/selection semantic boundary
   -> semantic action boundary
+  -> interaction-action trace ladder
   -> action admission descriptor
   -> action admission result / denial trace
   -> admitted semantic action object
@@ -31,6 +32,7 @@ visual doctrine
   -> effect request descriptor
   -> UI capability admission
   -> runtime capability mapping
+  -> full UI effect trace ladder
   -> effect request / UI capability boundary
   -> trace/audit visual boundary
   -> error/denial/quarantine visual boundary
@@ -53,6 +55,7 @@ visual doctrine
 | focus/selection semantics         | `docs/architecture/ui_focus_selection_semantic_boundary.md`         |
 | semantic actions                  | `docs/architecture/ui_semantic_action_boundary.md`                  |
 | interaction-action trace ladder   | `docs/architecture/ui_interaction_action_trace_ladder.md`           |
+| full UI effect trace ladder       | `docs/architecture/ui_full_effect_trace_ladder.md`                  |
 | action admission descriptor       | `docs/architecture/ui_action_admission_descriptor_boundary.md`      |
 | action admission result / denial trace | `docs/architecture/ui_action_admission_result_denial_boundary.md` |
 | admitted semantic action object   | `docs/architecture/ui_admitted_semantic_action_boundary.md`         |

--- a/docs/architecture/ui_committed_effect_boundary.md
+++ b/docs/architecture/ui_committed_effect_boundary.md
@@ -248,3 +248,21 @@ git diff --check
 ```
 
 No Rust tests are required for this PR.
+
+## 17. Relationship to full effect trace ladder
+
+The full UI-side effect trace ladder is documented in:
+
+```text
+docs/architecture/ui_full_effect_trace_ladder.md
+```
+
+The committed effect boundary is the final currently documented UI-side effect stage:
+
+```text
+InteractionCommitBoundaryResult::Committed
+  -> InteractionCommittedEffectDescriptor
+  -> InteractionCommittedEffectRecord
+```
+
+The committed effect record is still not Host ABI authority, VM authority, effect execution, runtime mutation, audit backend, or host runtime path.

--- a/docs/architecture/ui_full_effect_trace_ladder.md
+++ b/docs/architecture/ui_full_effect_trace_ladder.md
@@ -1,0 +1,263 @@
+# Semantic UI Full Effect Trace Ladder
+
+Status: Draft
+Track: POST-UI / I-series
+Purpose: document the complete inert UI-side trace ladder from raw input to committed effect record
+
+## 1. Goal
+
+This document records the full UI-side effect trace ladder introduced across the I-series.
+
+The ladder exists to make every transition from user interaction to committed
+effect record explicit, observable, deterministic, and bounded.
+
+It does not define new runtime behavior.
+
+It does not execute effects.
+It does not call Host ABI.
+It does not call VM.
+It does not mutate runtime state.
+It does not implement an audit backend.
+It does not enter a host runtime effect path.
+
+## 2. Full ladder
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> InteractionIntentTraceReport
+  -> InteractionIntentStreamReport
+  -> InteractionActionBindingDescriptor
+  -> InteractionActionBindingTraceReport
+  -> InteractionActionBindingTraceStreamReport
+  -> InteractionActionCandidateSummary
+  -> InteractionActionAdmissionDescriptor
+  -> InteractionActionAdmissionResult
+  -> InteractionActionDenialTrace
+  -> InteractionAdmittedSemanticAction
+  -> InteractionSemanticActionDispatchRoute
+  -> InteractionSemanticActionDispatchRecord
+  -> InteractionSemanticActionDispatchTraceReport
+  -> InteractionSemanticActionDispatchSummary
+  -> InteractionEffectRequestDescriptor
+  -> InteractionEffectRequestTraceReport
+  -> InteractionEffectRequestSummary
+  -> InteractionUiCapabilityAdmissionDescriptor
+  -> InteractionUiCapabilityAdmissionResult
+  -> InteractionUiCapabilityDenialTrace
+  -> InteractionRuntimeCapabilityMappingDescriptor
+  -> InteractionRuntimeCapabilityMappingResult
+  -> InteractionPreparedEffectDescriptor
+  -> InteractionPreparedEffectResult
+  -> InteractionCommitBoundaryDescriptor
+  -> InteractionCommitBoundaryResult
+  -> InteractionCommittedEffectDescriptor
+  -> InteractionCommittedEffectRecord
+```
+
+## 3. Reduced conceptual ladder
+
+```text
+raw input
+  -> intent
+  -> binding candidate
+  -> admission
+  -> admitted action
+  -> dispatch
+  -> effect request
+  -> UI capability admission
+  -> runtime capability mapping
+  -> prepared effect
+  -> commit boundary
+  -> committed effect record
+```
+
+## 4. Layer table
+
+| Stage | Main type | Meaning | Explicitly not |
+| --- | --- | --- | --- |
+| Raw input | `RawUiEvent` | Platform-neutral input sample | event loop, native backend |
+| Intent | `InteractionIntentDescriptor` | Classified UI intent | action |
+| Intent trace | `InteractionIntentTraceReport` | Raw event -> intent explanation | dispatcher |
+| Intent stream | `InteractionIntentStreamReport` | Ordered batch trace | async queue |
+| Binding | `InteractionActionBindingDescriptor` | Candidate intent -> action name binding | admission |
+| Binding trace | `InteractionActionBindingTraceReport` | Binding visibility | admitted action |
+| Binding trace stream | `InteractionActionBindingTraceStreamReport` | Ordered binding trace batch | runtime queue |
+| Candidate summary | `InteractionActionCandidateSummary` | Compact diagnostic summary | dispatcher, admission |
+| Action admission descriptor | `InteractionActionAdmissionDescriptor` | Future admission request | admission decision |
+| Action admission result | `InteractionActionAdmissionResult` | Admit/deny metadata | execution |
+| Action denial trace | `InteractionActionDenialTrace` | Denial visibility | retry execution |
+| Admitted action | `InteractionAdmittedSemanticAction` | Inert admitted semantic action object | effect |
+| Dispatch route | `InteractionSemanticActionDispatchRoute` | Candidate route | dispatch execution |
+| Dispatch record | `InteractionSemanticActionDispatchRecord` | Dispatch record metadata | effect |
+| Dispatch trace | `InteractionSemanticActionDispatchTraceReport` | Dispatch visibility | Host ABI |
+| Dispatch summary | `InteractionSemanticActionDispatchSummary` | Dispatch diagnostics | scheduler |
+| Effect request descriptor | `InteractionEffectRequestDescriptor` | Future effect request metadata | effect execution |
+| Effect request trace | `InteractionEffectRequestTraceReport` | Effect request visibility | prepared effect |
+| Effect request summary | `InteractionEffectRequestSummary` | Effect request diagnostics | capability grant |
+| UI capability admission descriptor | `InteractionUiCapabilityAdmissionDescriptor` | UI capability admission request | grant |
+| UI capability admission result | `InteractionUiCapabilityAdmissionResult` | Admit/deny UI capability metadata | runtime grant |
+| UI capability denial trace | `InteractionUiCapabilityDenialTrace` | UI capability denial visibility | runtime mapping |
+| Runtime mapping descriptor | `InteractionRuntimeCapabilityMappingDescriptor` | Runtime capability mapping request | runtime grant |
+| Runtime mapping result | `InteractionRuntimeCapabilityMappingResult` | Mapped/denied metadata | Host ABI |
+| Prepared effect descriptor | `InteractionPreparedEffectDescriptor` | Future prepared effect descriptor | execution |
+| Prepared effect result | `InteractionPreparedEffectResult` | Prepared/denied metadata | commit |
+| Commit boundary descriptor | `InteractionCommitBoundaryDescriptor` | Future commit boundary request | commit decision |
+| Commit boundary result | `InteractionCommitBoundaryResult` | Committed/denied metadata | committed effect |
+| Committed effect descriptor | `InteractionCommittedEffectDescriptor` | UI-side committed effect descriptor | Host ABI path |
+| Committed effect record | `InteractionCommittedEffectRecord` | Final inert UI-side committed effect record | runtime mutation |
+
+## 5. Global invariants
+
+```text
+raw event is not intent
+intent is not action
+binding is not admission
+admission descriptor is not decision
+admission result is not execution
+admitted action is not effect
+dispatch is not Host ABI
+effect request is not effect execution
+UI capability admission is not runtime capability grant
+runtime capability mapping is not Host ABI
+prepared effect is not committed effect
+commit boundary result is not Host ABI authority
+committed effect record is not runtime mutation
+```
+
+## 6. Authority separation
+
+No current UI ladder layer is allowed to act as:
+
+* Host ABI authority;
+* VM authority;
+* effect execution authority;
+* runtime mutation authority;
+* audit backend;
+* renderer authority;
+* Workbench command authority;
+* host runtime effect path.
+
+## 7. Determinism rule
+
+Each layer must preserve deterministic identity propagation.
+
+The current scaffold pattern is:
+
+```text
+next_id = source_id
+```
+
+unless a future boundary explicitly defines another deterministic mapping.
+
+No layer may introduce nondeterministic ordering, hidden filtering, hidden deduplication, or time-dependent identifiers.
+
+## 8. Denial visibility rule
+
+Denied states must be visible.
+
+The ladder must not hide denial as no-op.
+
+Denied states currently appear or are expected around:
+
+* action admission;
+* UI capability admission;
+* runtime capability mapping;
+* prepared effect;
+* commit boundary.
+
+Future denial trace documents may refine presentation, but denial must remain explicit.
+
+## 9. Effect execution separation
+
+The ladder stops at:
+
+```text
+InteractionCommittedEffectRecord
+```
+
+This is still not:
+
+* Host ABI call;
+* VM call;
+* effect execution;
+* runtime mutation;
+* host runtime effect path;
+* audit backend write.
+
+Future Host runtime effect work requires a separate boundary document.
+
+## 10. Relationship to early interaction-action ladder
+
+The early interaction-action ladder is defined in:
+
+```text
+docs/architecture/ui_interaction_action_trace_ladder.md
+```
+
+That document covers the early segment:
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> InteractionActionCandidateSummary
+```
+
+This document extends the view across the full effect-side chain.
+
+## 11. Relationship to capability and effect boundaries
+
+Capability/effect boundaries are defined in:
+
+```text
+docs/architecture/ui_effect_request_capability_boundary.md
+docs/architecture/ui_capability_admission_boundary.md
+docs/architecture/ui_runtime_capability_mapping_boundary.md
+docs/architecture/ui_prepared_effect_boundary.md
+docs/architecture/ui_committed_effect_boundary.md
+```
+
+This document does not replace them.
+
+It is an index/trace ladder overview.
+
+## 12. Forbidden shortcuts
+
+Future PRs must not:
+
+* jump from raw input to action;
+* jump from intent to effect request;
+* treat binding as admission;
+* treat admitted action as effect execution;
+* treat dispatch as Host ABI;
+* treat effect request as capability grant;
+* treat UI capability admission as runtime grant;
+* treat runtime mapping as Host ABI;
+* treat prepared effect as committed effect;
+* treat commit boundary result as runtime mutation;
+* treat committed effect record as host runtime path;
+* hide denial as no-op;
+* let renderer or Workbench define semantic authority.
+
+## 13. Future allowed next steps
+
+Allowed next PR families after this document:
+
+| Family | Allowed | Still forbidden |
+| --- | --- | --- |
+| docs | refine full ladder / add diagrams | behavior changes |
+| committed effect trace | denial/record trace docs | Host ABI |
+| host runtime boundary | boundary docs only | runtime mutation |
+| audit visibility | docs or inert descriptors | audit backend writes |
+| renderer consumption | presentation contract | renderer authority |
+| Workbench consumption | read-only consumption docs | command execution |
+
+## 14. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.

--- a/docs/architecture/ui_interaction_action_trace_ladder.md
+++ b/docs/architecture/ui_interaction_action_trace_ladder.md
@@ -208,3 +208,32 @@ git diff --check
 ```
 
 No Rust tests are required for this PR.
+
+## 14. Full effect trace ladder dependency
+
+The complete UI-side effect trace ladder is documented separately in:
+
+```text
+docs/architecture/ui_full_effect_trace_ladder.md
+```
+
+This document covers the early interaction/action segment.
+
+The full ladder continues through:
+
+```text
+InteractionActionCandidateSummary
+  -> InteractionActionAdmissionDescriptor
+  -> InteractionActionAdmissionResult
+  -> InteractionAdmittedSemanticAction
+  -> InteractionSemanticActionDispatchRoute
+  -> InteractionSemanticActionDispatchRecord
+  -> InteractionEffectRequestDescriptor
+  -> InteractionUiCapabilityAdmissionResult
+  -> InteractionRuntimeCapabilityMappingResult
+  -> InteractionPreparedEffectResult
+  -> InteractionCommitBoundaryResult
+  -> InteractionCommittedEffectRecord
+```
+
+The full ladder is still inert and does not define Host ABI, VM calls, effect execution, runtime mutation, or audit backend behavior.


### PR DESCRIPTION
## Summary

Documents the full Semantic UI effect trace ladder.

This docs-only PR adds a single overview document that connects the inert UI-side chain from raw input through intent, action binding, admission, dispatch, effect request, UI capability admission, runtime capability mapping, prepared effect, commit boundary, and committed effect record.

It clarifies that the ladder remains inert: no Host ABI calls, no VM calls, no effect execution, no runtime mutation, no audit backend, and no host runtime effect path.

## Scope

- Add `docs/architecture/ui_full_effect_trace_ladder.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the full ladder from `docs/architecture/ui_interaction_action_trace_ladder.md`
- Reference the full ladder from `docs/architecture/ui_committed_effect_boundary.md`
- Document the full ladder from `RawUiEvent` to `InteractionCommittedEffectRecord`
- Document reduced conceptual ladder
- Document layer ownership / non-authority table
- Document determinism and denial visibility rules
- Document forbidden shortcuts

## Out of scope

- Rust code changes
- TypeScript changes
- `Cargo.toml` changes
- dependency changes
- tests
- new UI behavior
- renderer logic
- Workbench command bridge
- Host ABI calls
- VM calls
- effect execution
- runtime state mutation
- audit backend implementation
- HostRuntimeEffectBoundary
- HostRuntimeEffectPath

## Validation

- `git diff --check`