### PR TITLE
docs(ui): document full UI effect trace ladder

### DIFF
--- a/docs/architecture/ui_boundary_index.md
+++ b/docs/architecture/ui_boundary_index.md
@@ -24,6 +24,7 @@ visual doctrine
   -> interaction/input semantic boundary
   -> focus/selection semantic boundary
   -> semantic action boundary
+  -> interaction-action trace ladder
   -> action admission descriptor
   -> action admission result / denial trace
   -> admitted semantic action object
@@ -31,6 +32,7 @@ visual doctrine
   -> effect request descriptor
   -> UI capability admission
   -> runtime capability mapping
+  -> full UI effect trace ladder
   -> effect request / UI capability boundary
   -> trace/audit visual boundary
   -> error/denial/quarantine visual boundary
@@ -53,6 +55,7 @@ visual doctrine
 | focus/selection semantics         | `docs/architecture/ui_focus_selection_semantic_boundary.md`         |
 | semantic actions                  | `docs/architecture/ui_semantic_action_boundary.md`                  |
 | interaction-action trace ladder   | `docs/architecture/ui_interaction_action_trace_ladder.md`           |
+| full UI effect trace ladder       | `docs/architecture/ui_full_effect_trace_ladder.md`                  |
 | action admission descriptor       | `docs/architecture/ui_action_admission_descriptor_boundary.md`      |
 | action admission result / denial trace | `docs/architecture/ui_action_admission_result_denial_boundary.md` |
 | admitted semantic action object   | `docs/architecture/ui_admitted_semantic_action_boundary.md`         |

--- a/docs/architecture/ui_committed_effect_boundary.md
+++ b/docs/architecture/ui_committed_effect_boundary.md
@@ -248,3 +248,21 @@ git diff --check
 ```
 
 No Rust tests are required for this PR.
+
+## 17. Relationship to full effect trace ladder
+
+The full UI-side effect trace ladder is documented in:
+
+```text
+docs/architecture/ui_full_effect_trace_ladder.md
+```
+
+The committed effect boundary is the final currently documented UI-side effect stage:
+
+```text
+InteractionCommitBoundaryResult::Committed
+  -> InteractionCommittedEffectDescriptor
+  -> InteractionCommittedEffectRecord
+```
+
+The committed effect record is still not Host ABI authority, VM authority, effect execution, runtime mutation, audit backend, or host runtime path.

--- a/docs/architecture/ui_full_effect_trace_ladder.md
+++ b/docs/architecture/ui_full_effect_trace_ladder.md
@@ -1,0 +1,263 @@
+# Semantic UI Full Effect Trace Ladder
+
+Status: Draft
+Track: POST-UI / I-series
+Purpose: document the complete inert UI-side trace ladder from raw input to committed effect record
+
+## 1. Goal
+
+This document records the full UI-side effect trace ladder introduced across the I-series.
+
+The ladder exists to make every transition from user interaction to committed
+effect record explicit, observable, deterministic, and bounded.
+
+It does not define new runtime behavior.
+
+It does not execute effects.
+It does not call Host ABI.
+It does not call VM.
+It does not mutate runtime state.
+It does not implement an audit backend.
+It does not enter a host runtime effect path.
+
+## 2. Full ladder
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> InteractionIntentTraceReport
+  -> InteractionIntentStreamReport
+  -> InteractionActionBindingDescriptor
+  -> InteractionActionBindingTraceReport
+  -> InteractionActionBindingTraceStreamReport
+  -> InteractionActionCandidateSummary
+  -> InteractionActionAdmissionDescriptor
+  -> InteractionActionAdmissionResult
+  -> InteractionActionDenialTrace
+  -> InteractionAdmittedSemanticAction
+  -> InteractionSemanticActionDispatchRoute
+  -> InteractionSemanticActionDispatchRecord
+  -> InteractionSemanticActionDispatchTraceReport
+  -> InteractionSemanticActionDispatchSummary
+  -> InteractionEffectRequestDescriptor
+  -> InteractionEffectRequestTraceReport
+  -> InteractionEffectRequestSummary
+  -> InteractionUiCapabilityAdmissionDescriptor
+  -> InteractionUiCapabilityAdmissionResult
+  -> InteractionUiCapabilityDenialTrace
+  -> InteractionRuntimeCapabilityMappingDescriptor
+  -> InteractionRuntimeCapabilityMappingResult
+  -> InteractionPreparedEffectDescriptor
+  -> InteractionPreparedEffectResult
+  -> InteractionCommitBoundaryDescriptor
+  -> InteractionCommitBoundaryResult
+  -> InteractionCommittedEffectDescriptor
+  -> InteractionCommittedEffectRecord
+```
+
+## 3. Reduced conceptual ladder
+
+```text
+raw input
+  -> intent
+  -> binding candidate
+  -> admission
+  -> admitted action
+  -> dispatch
+  -> effect request
+  -> UI capability admission
+  -> runtime capability mapping
+  -> prepared effect
+  -> commit boundary
+  -> committed effect record
+```
+
+## 4. Layer table
+
+| Stage | Main type | Meaning | Explicitly not |
+| --- | --- | --- | --- |
+| Raw input | `RawUiEvent` | Platform-neutral input sample | event loop, native backend |
+| Intent | `InteractionIntentDescriptor` | Classified UI intent | action |
+| Intent trace | `InteractionIntentTraceReport` | Raw event -> intent explanation | dispatcher |
+| Intent stream | `InteractionIntentStreamReport` | Ordered batch trace | async queue |
+| Binding | `InteractionActionBindingDescriptor` | Candidate intent -> action name binding | admission |
+| Binding trace | `InteractionActionBindingTraceReport` | Binding visibility | admitted action |
+| Binding trace stream | `InteractionActionBindingTraceStreamReport` | Ordered binding trace batch | runtime queue |
+| Candidate summary | `InteractionActionCandidateSummary` | Compact diagnostic summary | dispatcher, admission |
+| Action admission descriptor | `InteractionActionAdmissionDescriptor` | Future admission request | admission decision |
+| Action admission result | `InteractionActionAdmissionResult` | Admit/deny metadata | execution |
+| Action denial trace | `InteractionActionDenialTrace` | Denial visibility | retry execution |
+| Admitted action | `InteractionAdmittedSemanticAction` | Inert admitted semantic action object | effect |
+| Dispatch route | `InteractionSemanticActionDispatchRoute` | Candidate route | dispatch execution |
+| Dispatch record | `InteractionSemanticActionDispatchRecord` | Dispatch record metadata | effect |
+| Dispatch trace | `InteractionSemanticActionDispatchTraceReport` | Dispatch visibility | Host ABI |
+| Dispatch summary | `InteractionSemanticActionDispatchSummary` | Dispatch diagnostics | scheduler |
+| Effect request descriptor | `InteractionEffectRequestDescriptor` | Future effect request metadata | effect execution |
+| Effect request trace | `InteractionEffectRequestTraceReport` | Effect request visibility | prepared effect |
+| Effect request summary | `InteractionEffectRequestSummary` | Effect request diagnostics | capability grant |
+| UI capability admission descriptor | `InteractionUiCapabilityAdmissionDescriptor` | UI capability admission request | grant |
+| UI capability admission result | `InteractionUiCapabilityAdmissionResult` | Admit/deny UI capability metadata | runtime grant |
+| UI capability denial trace | `InteractionUiCapabilityDenialTrace` | UI capability denial visibility | runtime mapping |
+| Runtime mapping descriptor | `InteractionRuntimeCapabilityMappingDescriptor` | Runtime capability mapping request | runtime grant |
+| Runtime mapping result | `InteractionRuntimeCapabilityMappingResult` | Mapped/denied metadata | Host ABI |
+| Prepared effect descriptor | `InteractionPreparedEffectDescriptor` | Future prepared effect descriptor | execution |
+| Prepared effect result | `InteractionPreparedEffectResult` | Prepared/denied metadata | commit |
+| Commit boundary descriptor | `InteractionCommitBoundaryDescriptor` | Future commit boundary request | commit decision |
+| Commit boundary result | `InteractionCommitBoundaryResult` | Committed/denied metadata | committed effect |
+| Committed effect descriptor | `InteractionCommittedEffectDescriptor` | UI-side committed effect descriptor | Host ABI path |
+| Committed effect record | `InteractionCommittedEffectRecord` | Final inert UI-side committed effect record | runtime mutation |
+
+## 5. Global invariants
+
+```text
+raw event is not intent
+intent is not action
+binding is not admission
+admission descriptor is not decision
+admission result is not execution
+admitted action is not effect
+dispatch is not Host ABI
+effect request is not effect execution
+UI capability admission is not runtime capability grant
+runtime capability mapping is not Host ABI
+prepared effect is not committed effect
+commit boundary result is not Host ABI authority
+committed effect record is not runtime mutation
+```
+
+## 6. Authority separation
+
+No current UI ladder layer is allowed to act as:
+
+* Host ABI authority;
+* VM authority;
+* effect execution authority;
+* runtime mutation authority;
+* audit backend;
+* renderer authority;
+* Workbench command authority;
+* host runtime effect path.
+
+## 7. Determinism rule
+
+Each layer must preserve deterministic identity propagation.
+
+The current scaffold pattern is:
+
+```text
+next_id = source_id
+```
+
+unless a future boundary explicitly defines another deterministic mapping.
+
+No layer may introduce nondeterministic ordering, hidden filtering, hidden deduplication, or time-dependent identifiers.
+
+## 8. Denial visibility rule
+
+Denied states must be visible.
+
+The ladder must not hide denial as no-op.
+
+Denied states currently appear or are expected around:
+
+* action admission;
+* UI capability admission;
+* runtime capability mapping;
+* prepared effect;
+* commit boundary.
+
+Future denial trace documents may refine presentation, but denial must remain explicit.
+
+## 9. Effect execution separation
+
+The ladder stops at:
+
+```text
+InteractionCommittedEffectRecord
+```
+
+This is still not:
+
+* Host ABI call;
+* VM call;
+* effect execution;
+* runtime mutation;
+* host runtime effect path;
+* audit backend write.
+
+Future Host runtime effect work requires a separate boundary document.
+
+## 10. Relationship to early interaction-action ladder
+
+The early interaction-action ladder is defined in:
+
+```text
+docs/architecture/ui_interaction_action_trace_ladder.md
+```
+
+That document covers the early segment:
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> InteractionActionCandidateSummary
+```
+
+This document extends the view across the full effect-side chain.
+
+## 11. Relationship to capability and effect boundaries
+
+Capability/effect boundaries are defined in:
+
+```text
+docs/architecture/ui_effect_request_capability_boundary.md
+docs/architecture/ui_capability_admission_boundary.md
+docs/architecture/ui_runtime_capability_mapping_boundary.md
+docs/architecture/ui_prepared_effect_boundary.md
+docs/architecture/ui_committed_effect_boundary.md
+```
+
+This document does not replace them.
+
+It is an index/trace ladder overview.
+
+## 12. Forbidden shortcuts
+
+Future PRs must not:
+
+* jump from raw input to action;
+* jump from intent to effect request;
+* treat binding as admission;
+* treat admitted action as effect execution;
+* treat dispatch as Host ABI;
+* treat effect request as capability grant;
+* treat UI capability admission as runtime grant;
+* treat runtime mapping as Host ABI;
+* treat prepared effect as committed effect;
+* treat commit boundary result as runtime mutation;
+* treat committed effect record as host runtime path;
+* hide denial as no-op;
+* let renderer or Workbench define semantic authority.
+
+## 13. Future allowed next steps
+
+Allowed next PR families after this document:
+
+| Family | Allowed | Still forbidden |
+| --- | --- | --- |
+| docs | refine full ladder / add diagrams | behavior changes |
+| committed effect trace | denial/record trace docs | Host ABI |
+| host runtime boundary | boundary docs only | runtime mutation |
+| audit visibility | docs or inert descriptors | audit backend writes |
+| renderer consumption | presentation contract | renderer authority |
+| Workbench consumption | read-only consumption docs | command execution |
+
+## 14. Validation expectation
+
+Docs-only PR validation:
+
+```text
+git diff --check
+```
+
+No Rust tests are required for this PR.

--- a/docs/architecture/ui_interaction_action_trace_ladder.md
+++ b/docs/architecture/ui_interaction_action_trace_ladder.md
@@ -208,3 +208,32 @@ git diff --check
 ```
 
 No Rust tests are required for this PR.
+
+## 14. Full effect trace ladder dependency
+
+The complete UI-side effect trace ladder is documented separately in:
+
+```text
+docs/architecture/ui_full_effect_trace_ladder.md
+```
+
+This document covers the early interaction/action segment.
+
+The full ladder continues through:
+
+```text
+InteractionActionCandidateSummary
+  -> InteractionActionAdmissionDescriptor
+  -> InteractionActionAdmissionResult
+  -> InteractionAdmittedSemanticAction
+  -> InteractionSemanticActionDispatchRoute
+  -> InteractionSemanticActionDispatchRecord
+  -> InteractionEffectRequestDescriptor
+  -> InteractionUiCapabilityAdmissionResult
+  -> InteractionRuntimeCapabilityMappingResult
+  -> InteractionPreparedEffectResult
+  -> InteractionCommitBoundaryResult
+  -> InteractionCommittedEffectRecord
+```
+
+The full ladder is still inert and does not define Host ABI, VM calls, effect execution, runtime mutation, or audit backend behavior.


### PR DESCRIPTION
## Summary

Documents the full Semantic UI effect trace ladder.

This docs-only PR adds a single overview document that connects the inert UI-side chain from raw input through intent, action binding, admission, dispatch, effect request, UI capability admission, runtime capability mapping, prepared effect, commit boundary, and committed effect record.

It clarifies that the ladder remains inert: no Host ABI calls, no VM calls, no effect execution, no runtime mutation, no audit backend, and no host runtime effect path.

## Scope

- Add `docs/architecture/ui_full_effect_trace_ladder.md`
- Link the new document from `docs/architecture/ui_boundary_index.md`
- Reference the full ladder from `docs/architecture/ui_interaction_action_trace_ladder.md`
- Reference the full ladder from `docs/architecture/ui_committed_effect_boundary.md`
- Document the full ladder from `RawUiEvent` to `InteractionCommittedEffectRecord`
- Document reduced conceptual ladder
- Document layer ownership / non-authority table
- Document determinism and denial visibility rules
- Document forbidden shortcuts

## Out of scope

- Rust code changes
- TypeScript changes
- `Cargo.toml` changes
- dependency changes
- tests
- new UI behavior
- renderer logic
- Workbench command bridge
- Host ABI calls
- VM calls
- effect execution
- runtime state mutation
- audit backend implementation
- HostRuntimeEffectBoundary
- HostRuntimeEffectPath

## Validation

- `git diff --check`