### PR TITLE
feat(ui): add host runtime effect boundary descriptor scaffold

### DIFF
--- a/crates/prom-ui/src/host_runtime_effect.rs
+++ b/crates/prom-ui/src/host_runtime_effect.rs
@@ -1,0 +1,384 @@
+//! Semantic UI host runtime effect boundary descriptor scaffold.
+//!
+//! This module records an inert descriptor for the future host runtime effect
+//! boundary. It does not implement Host ABI calls, VM calls, effect execution,
+//! runtime mutation, audit backend writes, or a host runtime effect path.
+
+use crate::action_admission::{
+    InteractionActionAdmissionPolicyGateNamespace, InteractionActionAdmissionTraceRequirement,
+};
+use crate::action_dispatch_record::InteractionSemanticActionDispatchRecordId;
+use crate::action_dispatch_route::InteractionSemanticActionDispatchRouteId;
+use crate::admitted_action::InteractionAdmittedSemanticActionId;
+use crate::commit_boundary::{
+    InteractionCommitAuditRequirement, InteractionCommitBoundaryDescriptorId,
+};
+use crate::commit_boundary_result::InteractionCommitBoundaryResultId;
+use crate::committed_effect::{
+    InteractionCommittedEffectAuditVisibility, InteractionCommittedEffectDescriptorId,
+    InteractionCommittedEffectHostPathRequirement,
+    InteractionCommittedEffectRuntimeMutationRequirement,
+};
+use crate::committed_effect_record::{
+    InteractionCommittedEffectHostPathStatus, InteractionCommittedEffectRecord,
+    InteractionCommittedEffectRecordId, InteractionCommittedEffectRecordStatus,
+    InteractionCommittedEffectRuntimeMutationStatus,
+};
+use crate::effect_request::{
+    InteractionEffectRequestDescriptorId, InteractionEffectRequestKind,
+    InteractionEffectRequestLifecyclePrecondition, InteractionEffectRequestRuntimeCapability,
+    InteractionEffectRequestScope, InteractionEffectRequestTargetPolicy,
+    InteractionEffectRequestUiCapability,
+};
+use crate::prepared_effect::InteractionPreparedEffectDescriptorId;
+use crate::prepared_effect_result::InteractionPreparedEffectResultId;
+use crate::runtime_capability_mapping::{
+    InteractionRuntimeCapabilityMappingDescriptorId, InteractionRuntimeCapabilityNamespace,
+};
+use crate::runtime_capability_mapping_result::InteractionRuntimeCapabilityMappingResultId;
+use crate::ui_capability_admission::InteractionUiCapabilityAdmissionDescriptorId;
+use crate::ui_capability_admission_result::InteractionUiCapabilityAdmissionResultId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InteractionHostRuntimeEffectBoundaryDescriptorId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionHostRuntimeEffectBoundaryDecisionShape {
+    AdmitOrDenyWithReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionHostRuntimeEffectPathRequirement {
+    SeparateBoundaryRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionHostRuntimeMutationRequirement {
+    SeparateBoundaryRequired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionHostRuntimeAuditWriteRequirement {
+    SeparateBoundaryRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InteractionHostRuntimeEffectBoundaryDescriptor {
+    pub id: InteractionHostRuntimeEffectBoundaryDescriptorId,
+    pub committed_effect_record_id: InteractionCommittedEffectRecordId,
+    pub committed_effect_descriptor_id: InteractionCommittedEffectDescriptorId,
+    pub commit_boundary_result_id: InteractionCommitBoundaryResultId,
+    pub commit_boundary_descriptor_id: InteractionCommitBoundaryDescriptorId,
+    pub prepared_effect_result_id: InteractionPreparedEffectResultId,
+    pub prepared_effect_descriptor_id: InteractionPreparedEffectDescriptorId,
+    pub runtime_capability_mapping_result_id: InteractionRuntimeCapabilityMappingResultId,
+    pub runtime_capability_mapping_descriptor_id: InteractionRuntimeCapabilityMappingDescriptorId,
+    pub ui_capability_admission_result_id: InteractionUiCapabilityAdmissionResultId,
+    pub ui_capability_admission_descriptor_id: InteractionUiCapabilityAdmissionDescriptorId,
+    pub effect_request_descriptor_id: InteractionEffectRequestDescriptorId,
+    pub source_admitted_action_id: InteractionAdmittedSemanticActionId,
+    pub dispatch_record_id: InteractionSemanticActionDispatchRecordId,
+    pub dispatch_route_id: InteractionSemanticActionDispatchRouteId,
+    pub requested_effect: InteractionEffectRequestKind,
+    pub declared_ui_capability: InteractionEffectRequestUiCapability,
+    pub declared_runtime_capability_requirement: InteractionEffectRequestRuntimeCapability,
+    pub runtime_capability_namespace: InteractionRuntimeCapabilityNamespace,
+    pub lifecycle_precondition: InteractionEffectRequestLifecyclePrecondition,
+    pub target_policy: InteractionEffectRequestTargetPolicy,
+    pub trace_requirement: InteractionActionAdmissionTraceRequirement,
+    pub policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace,
+    pub scope: InteractionEffectRequestScope,
+    pub audit_requirement: InteractionCommitAuditRequirement,
+    pub audit_visibility: InteractionCommittedEffectAuditVisibility,
+    pub runtime_mutation_requirement: InteractionCommittedEffectRuntimeMutationRequirement,
+    pub host_path_requirement: InteractionCommittedEffectHostPathRequirement,
+    pub record_status: InteractionCommittedEffectRecordStatus,
+    pub runtime_mutation_status: InteractionCommittedEffectRuntimeMutationStatus,
+    pub host_path_status: InteractionCommittedEffectHostPathStatus,
+    pub host_boundary_decision_shape: InteractionHostRuntimeEffectBoundaryDecisionShape,
+    pub future_host_path_requirement: InteractionHostRuntimeEffectPathRequirement,
+    pub future_runtime_mutation_requirement: InteractionHostRuntimeMutationRequirement,
+    pub future_audit_write_requirement: InteractionHostRuntimeAuditWriteRequirement,
+}
+
+pub fn describe_interaction_host_runtime_effect_boundary(
+    committed_record: &InteractionCommittedEffectRecord,
+) -> Option<InteractionHostRuntimeEffectBoundaryDescriptor> {
+    if !matches!(
+        committed_record.record_status,
+        InteractionCommittedEffectRecordStatus::Recorded
+    ) {
+        return None;
+    }
+
+    if !matches!(
+        committed_record.runtime_mutation_status,
+        InteractionCommittedEffectRuntimeMutationStatus::NotPerformed
+    ) {
+        return None;
+    }
+
+    if !matches!(
+        committed_record.host_path_status,
+        InteractionCommittedEffectHostPathStatus::NotEntered
+    ) {
+        return None;
+    }
+
+    Some(InteractionHostRuntimeEffectBoundaryDescriptor {
+        id: InteractionHostRuntimeEffectBoundaryDescriptorId(committed_record.id.0),
+        committed_effect_record_id: committed_record.id,
+        committed_effect_descriptor_id: committed_record.descriptor_id,
+        commit_boundary_result_id: committed_record.commit_boundary_result_id,
+        commit_boundary_descriptor_id: committed_record.commit_boundary_descriptor_id,
+        prepared_effect_result_id: committed_record.prepared_effect_result_id,
+        prepared_effect_descriptor_id: committed_record.prepared_effect_descriptor_id,
+        runtime_capability_mapping_result_id: committed_record.runtime_capability_mapping_result_id,
+        runtime_capability_mapping_descriptor_id: committed_record
+            .runtime_capability_mapping_descriptor_id,
+        ui_capability_admission_result_id: committed_record.ui_capability_admission_result_id,
+        ui_capability_admission_descriptor_id: committed_record.ui_capability_admission_descriptor_id,
+        effect_request_descriptor_id: committed_record.effect_request_descriptor_id,
+        source_admitted_action_id: committed_record.source_admitted_action_id,
+        dispatch_record_id: committed_record.dispatch_record_id,
+        dispatch_route_id: committed_record.dispatch_route_id,
+        requested_effect: committed_record.requested_effect,
+        declared_ui_capability: committed_record.declared_ui_capability,
+        declared_runtime_capability_requirement: committed_record
+            .declared_runtime_capability_requirement,
+        runtime_capability_namespace: committed_record.runtime_capability_namespace,
+        lifecycle_precondition: committed_record.lifecycle_precondition,
+        target_policy: committed_record.target_policy,
+        trace_requirement: committed_record.trace_requirement,
+        policy_gate_namespace: committed_record.policy_gate_namespace,
+        scope: committed_record.scope,
+        audit_requirement: committed_record.audit_requirement,
+        audit_visibility: committed_record.audit_visibility,
+        runtime_mutation_requirement: committed_record.runtime_mutation_requirement,
+        host_path_requirement: committed_record.host_path_requirement,
+        record_status: committed_record.record_status,
+        runtime_mutation_status: committed_record.runtime_mutation_status,
+        host_path_status: committed_record.host_path_status,
+        host_boundary_decision_shape:
+            InteractionHostRuntimeEffectBoundaryDecisionShape::AdmitOrDenyWithReason,
+        future_host_path_requirement:
+            InteractionHostRuntimeEffectPathRequirement::SeparateBoundaryRequired,
+        future_runtime_mutation_requirement:
+            InteractionHostRuntimeMutationRequirement::SeparateBoundaryRequired,
+        future_audit_write_requirement:
+            InteractionHostRuntimeAuditWriteRequirement::SeparateBoundaryRequired,
+    })
+}
+
+impl InteractionHostRuntimeEffectBoundaryDescriptor {
+    pub const fn is_host_abi_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_vm_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_execution_authority(&self) -> bool {
+        false
+    }
+
+    pub const fn is_runtime_mutation(&self) -> bool {
+        false
+    }
+
+    pub const fn is_audit_backend(&self) -> bool {
+        false
+    }
+
+    pub const fn is_host_runtime_path(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::action_admission::InteractionActionAdmissionEffectRelationship;
+    use crate::action_binding::{InteractionActionBindingId, InteractionActionName};
+    use crate::action_dispatch_record::{
+        InteractionSemanticActionDispatchBlockReason, InteractionSemanticActionDispatchRecordId,
+        InteractionSemanticActionDispatchRecordStatus,
+    };
+    use crate::action_dispatch_route::{
+        InteractionSemanticActionDispatchEffectEligibility,
+        InteractionSemanticActionDispatchRouteId, InteractionSemanticActionDispatchRouteKind,
+    };
+    use crate::action_dispatch_trace::{
+        InteractionSemanticActionDispatchTraceReason, InteractionSemanticActionDispatchTraceReport,
+        InteractionSemanticActionDispatchTraceStatus,
+    };
+    use crate::admitted_action::InteractionAdmittedSemanticActionId;
+    use crate::commit_boundary::describe_interaction_commit_boundary;
+    use crate::commit_boundary_result::record_interaction_commit_boundary_committed_result;
+    use crate::committed_effect::describe_interaction_committed_effect;
+    use crate::committed_effect_record::record_interaction_committed_effect;
+    use crate::effect_request::describe_interaction_effect_request;
+    use crate::interaction::InteractionIntentKind;
+    use crate::prepared_effect::describe_interaction_prepared_effect;
+    use crate::prepared_effect_result::record_interaction_prepared_effect_result;
+    use crate::runtime_capability_mapping::describe_interaction_runtime_capability_mapping;
+    use crate::runtime_capability_mapping_result::record_interaction_runtime_capability_mapped_result;
+    use crate::ui_capability_admission::describe_interaction_ui_capability_admission;
+    use crate::ui_capability_admission_result::record_interaction_ui_capability_admitted_result;
+
+    fn effect_request_descriptor() -> crate::effect_request::InteractionEffectRequestDescriptor {
+        let dispatch_trace = InteractionSemanticActionDispatchTraceReport {
+            record_id: InteractionSemanticActionDispatchRecordId(161),
+            route_id: InteractionSemanticActionDispatchRouteId(161),
+            admitted_action_id: InteractionAdmittedSemanticActionId(161),
+            action: InteractionActionName::PrepareEffect,
+            source_intent: InteractionIntentKind::Submit,
+            binding_id: InteractionActionBindingId(161),
+            route: InteractionSemanticActionDispatchRouteKind::EffectRequestCandidate,
+            record_status: InteractionSemanticActionDispatchRecordStatus::Recorded,
+            trace_status: InteractionSemanticActionDispatchTraceStatus::Recorded,
+            block_reason: InteractionSemanticActionDispatchBlockReason::None,
+            trace_reason: InteractionSemanticActionDispatchTraceReason::RouteRecorded,
+            trace_requirement: InteractionActionAdmissionTraceRequirement::Required,
+            effect_relationship:
+                InteractionActionAdmissionEffectRelationship::MayRequestEffectAfterAdmission,
+            policy_gate_namespace: InteractionActionAdmissionPolicyGateNamespace::CoreUi,
+            effect_eligibility:
+                InteractionSemanticActionDispatchEffectEligibility::RequiresFutureEffectBoundary,
+        };
+
+        describe_interaction_effect_request(&dispatch_trace)
+            .expect("effect candidate trace should produce descriptor")
+    }
+
+    fn committed_effect_record() -> InteractionCommittedEffectRecord {
+        let effect_request = effect_request_descriptor();
+        let admission = describe_interaction_ui_capability_admission(&effect_request);
+        let ui_result = record_interaction_ui_capability_admitted_result(&admission);
+        let mapping_descriptor = describe_interaction_runtime_capability_mapping(&ui_result)
+            .expect("admitted result should produce mapping descriptor");
+        let mapping_result = record_interaction_runtime_capability_mapped_result(&mapping_descriptor);
+        let prepared_descriptor = describe_interaction_prepared_effect(&mapping_result)
+            .expect("mapped result should produce prepared effect descriptor");
+        let prepared_result = record_interaction_prepared_effect_result(&prepared_descriptor);
+        let commit_descriptor = describe_interaction_commit_boundary(&prepared_result)
+            .expect("prepared result should produce commit boundary descriptor");
+        let commit_result = record_interaction_commit_boundary_committed_result(&commit_descriptor);
+        let committed_descriptor = describe_interaction_committed_effect(&commit_result)
+            .expect("committed result should produce committed effect descriptor");
+
+        record_interaction_committed_effect(&committed_descriptor)
+    }
+
+    #[test]
+    fn committed_effect_record_creates_host_runtime_effect_boundary_descriptor() {
+        let record = committed_effect_record();
+
+        let descriptor = describe_interaction_host_runtime_effect_boundary(&record)
+            .expect("committed record should produce host runtime effect boundary descriptor");
+
+        assert_eq!(
+            descriptor.id,
+            InteractionHostRuntimeEffectBoundaryDescriptorId(record.id.0)
+        );
+        assert_eq!(descriptor.committed_effect_record_id, record.id);
+    }
+
+    #[test]
+    fn descriptor_preserves_source_capability_audit_status_metadata() {
+        let record = committed_effect_record();
+        let descriptor = describe_interaction_host_runtime_effect_boundary(&record)
+            .expect("committed record should produce host runtime effect boundary descriptor");
+
+        assert_eq!(descriptor.committed_effect_descriptor_id, record.descriptor_id);
+        assert_eq!(descriptor.commit_boundary_result_id, record.commit_boundary_result_id);
+        assert_eq!(descriptor.commit_boundary_descriptor_id, record.commit_boundary_descriptor_id);
+        assert_eq!(descriptor.prepared_effect_result_id, record.prepared_effect_result_id);
+        assert_eq!(descriptor.prepared_effect_descriptor_id, record.prepared_effect_descriptor_id);
+        assert_eq!(
+            descriptor.runtime_capability_mapping_result_id,
+            record.runtime_capability_mapping_result_id
+        );
+        assert_eq!(
+            descriptor.runtime_capability_mapping_descriptor_id,
+            record.runtime_capability_mapping_descriptor_id
+        );
+        assert_eq!(descriptor.ui_capability_admission_result_id, record.ui_capability_admission_result_id);
+        assert_eq!(
+            descriptor.ui_capability_admission_descriptor_id,
+            record.ui_capability_admission_descriptor_id
+        );
+        assert_eq!(descriptor.effect_request_descriptor_id, record.effect_request_descriptor_id);
+        assert_eq!(descriptor.source_admitted_action_id, record.source_admitted_action_id);
+        assert_eq!(descriptor.dispatch_record_id, record.dispatch_record_id);
+        assert_eq!(descriptor.dispatch_route_id, record.dispatch_route_id);
+        assert_eq!(descriptor.requested_effect, record.requested_effect);
+        assert_eq!(descriptor.declared_ui_capability, record.declared_ui_capability);
+        assert_eq!(
+            descriptor.declared_runtime_capability_requirement,
+            record.declared_runtime_capability_requirement
+        );
+        assert_eq!(descriptor.runtime_capability_namespace, record.runtime_capability_namespace);
+        assert_eq!(descriptor.lifecycle_precondition, record.lifecycle_precondition);
+        assert_eq!(descriptor.target_policy, record.target_policy);
+        assert_eq!(descriptor.trace_requirement, record.trace_requirement);
+        assert_eq!(descriptor.policy_gate_namespace, record.policy_gate_namespace);
+        assert_eq!(descriptor.scope, record.scope);
+        assert_eq!(descriptor.audit_requirement, record.audit_requirement);
+        assert_eq!(descriptor.audit_visibility, record.audit_visibility);
+        assert_eq!(descriptor.runtime_mutation_requirement, record.runtime_mutation_requirement);
+        assert_eq!(descriptor.host_path_requirement, record.host_path_requirement);
+        assert_eq!(descriptor.record_status, record.record_status);
+        assert_eq!(descriptor.runtime_mutation_status, record.runtime_mutation_status);
+        assert_eq!(descriptor.host_path_status, record.host_path_status);
+    }
+
+    #[test]
+    fn descriptor_records_separate_requirements() {
+        let record = committed_effect_record();
+        let descriptor = describe_interaction_host_runtime_effect_boundary(&record)
+            .expect("committed record should produce host runtime effect boundary descriptor");
+
+        assert_eq!(
+            descriptor.host_boundary_decision_shape,
+            InteractionHostRuntimeEffectBoundaryDecisionShape::AdmitOrDenyWithReason
+        );
+        assert_eq!(
+            descriptor.future_host_path_requirement,
+            InteractionHostRuntimeEffectPathRequirement::SeparateBoundaryRequired
+        );
+        assert_eq!(
+            descriptor.future_runtime_mutation_requirement,
+            InteractionHostRuntimeMutationRequirement::SeparateBoundaryRequired
+        );
+        assert_eq!(
+            descriptor.future_audit_write_requirement,
+            InteractionHostRuntimeAuditWriteRequirement::SeparateBoundaryRequired
+        );
+    }
+
+    #[test]
+    fn descriptor_is_not_authority() {
+        let record = committed_effect_record();
+        let descriptor = describe_interaction_host_runtime_effect_boundary(&record)
+            .expect("committed record should produce host runtime effect boundary descriptor");
+
+        assert!(!descriptor.is_host_abi_authority());
+        assert!(!descriptor.is_vm_authority());
+        assert!(!descriptor.is_execution_authority());
+        assert!(!descriptor.is_runtime_mutation());
+        assert!(!descriptor.is_audit_backend());
+        assert!(!descriptor.is_host_runtime_path());
+    }
+
+    #[test]
+    fn generation_is_deterministic() {
+        let left = describe_interaction_host_runtime_effect_boundary(&committed_effect_record())
+            .expect("committed record should produce host runtime effect boundary descriptor");
+        let right = describe_interaction_host_runtime_effect_boundary(&committed_effect_record())
+            .expect("committed record should produce host runtime effect boundary descriptor");
+
+        assert_eq!(left, right);
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -46,6 +46,7 @@ pub mod commit_boundary;
 pub mod commit_boundary_result;
 pub mod committed_effect;
 pub mod committed_effect_record;
+pub mod host_runtime_effect;
 pub mod intent_stream;
 pub mod raw_event;
 pub mod trace;
@@ -224,6 +225,15 @@ pub use committed_effect_record::{
     record_interaction_committed_effect, InteractionCommittedEffectHostPathStatus,
     InteractionCommittedEffectRecord, InteractionCommittedEffectRecordId,
     InteractionCommittedEffectRecordStatus, InteractionCommittedEffectRuntimeMutationStatus,
+};
+pub use host_runtime_effect::{
+    describe_interaction_host_runtime_effect_boundary,
+    InteractionHostRuntimeAuditWriteRequirement,
+    InteractionHostRuntimeEffectBoundaryDecisionShape,
+    InteractionHostRuntimeEffectBoundaryDescriptor,
+    InteractionHostRuntimeEffectBoundaryDescriptorId,
+    InteractionHostRuntimeEffectPathRequirement,
+    InteractionHostRuntimeMutationRequirement,
 };
 pub use intent_stream::{
     trace_interaction_intent_stream, InteractionIntentStreamModel,


### PR DESCRIPTION
## Summary

Adds an inert Semantic UI host runtime effect boundary descriptor scaffold to `prom-ui`.

This PR builds on the host runtime effect boundary docs and creates a descriptor
from inert committed effect records.

The descriptor preserves committed effect record identity, committed effect
descriptor identity, commit boundary identity, prepared effect identity, runtime
capability mapping identity, UI capability admission identity, effect request
identity, source action identity, dispatch identity, requested effect, declared
capability requirements, runtime capability namespace, lifecycle/target/trace
/policy metadata, scope, audit requirement, audit visibility, runtime mutation
requirement, host path requirement, and committed record status fields.

It records that the future host path, runtime mutation, and audit write steps all
require separate boundaries.

It is not Host ABI authority, not VM authority, not effect execution, not runtime
mutation, not an audit backend, and not a host runtime effect path.

## Scope

- Add `InteractionHostRuntimeEffectBoundaryDescriptor`
- Add `InteractionHostRuntimeEffectBoundaryDescriptorId`
- Add `InteractionHostRuntimeEffectBoundaryDecisionShape`
- Add `InteractionHostRuntimeEffectPathRequirement`
- Add `InteractionHostRuntimeMutationRequirement`
- Add `InteractionHostRuntimeAuditWriteRequirement`
- Add `describe_interaction_host_runtime_effect_boundary(...)`
- Export host runtime effect boundary descriptor types from `prom-ui`
- Add unit tests for metadata preservation, non-authority invariants,
  separate-boundary requirements, status fields, and determinism

## Out of scope

- host runtime effect boundary result
- host runtime effect path descriptor
- Host ABI call
- VM call
- effect execution
- effect bridge
- verifier changes
- runtime state mutation
- audit backend write
- audit backend implementation
- capability grant implementation
- Workbench command bridge
- renderer affordance map
- async/event loop
- serde/JSON output

## Validation

- `cargo test -q -p prom-ui`
- `git diff --check`