### PR TITLE
PR-PCC-0B — docs(readiness): add live feature matrix audit scaffold

### DIFF
--- a/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
+++ b/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
@@ -1,0 +1,342 @@
+# Semantic Practical Core Feature Matrix Live Audit
+
+Status: active audit scaffold
+Track: PCC-0.5 Feature Matrix Live Audit
+Layer: language maturity / readiness discipline
+Scope: documentation only
+Implementation: out of scope
+Owner: language maturity stream
+
+Related:
+
+- `practical_core_truth_reset.md`
+- `practical_core_completion_v0_3.md`
+- `core_trust_freeze/index.md`
+
+## 1. Purpose
+
+This document defines the live audit scaffold for Semantic practical core
+readiness.
+
+The audit exists to replace optimistic, historical, or mixed-status assumptions
+with current evidence from `main`.
+
+Core question:
+
+```text
+What is actually true in the repository right now?
+```
+
+The answer must be recorded feature by feature before PCC-1 begins.
+
+## 2. Position in PCC
+
+Current ladder:
+
+```text
+PCC-0 Truth Reset
+  ↓
+PCC-0.5 Feature Matrix Live Audit
+  ↓
+PCC-0.6 7hell Skeleton Seed
+  ↓
+PCC language phases
+  ↕
+CTF Core Trust Freeze Lane
+```
+
+PCC-0.5 is a gate. It is not implementation work.
+
+The audit must not add new language features, runtime behavior, UI behavior, or
+Workbench code.
+
+## 3. Audit goals
+
+The audit must identify:
+
+```text
+what really works
+what partially works
+what is only documented
+what is experimental
+what is out of scope
+```
+
+For every audited item, the output must include:
+
+- feature name;
+- current status;
+- evidence source;
+- tested path;
+- missing edge if partial;
+- owning PCC phase if work remains;
+- CTF impact;
+- 7hell coverage need;
+- next action.
+
+## 4. Status vocabulary
+
+Only these statuses are allowed:
+
+| Status | Meaning |
+|---|---|
+| `confirmed-working` | Current `main` has code and evidence for the stated behavior. |
+| `confirmed-partial` | Behavior exists, but a missing edge or unsupported shape is explicit. |
+| `documented-only` | A document/spec/roadmap exists, but implementation evidence is absent. |
+| `experimental` | Exists as research, donor, legacy, or non-canonical substrate. |
+| `out-of-scope` | Explicitly excluded from PCC or this audit phase. |
+| `unknown` | Not yet audited. Temporary status only. |
+
+Temporary statuses that must be resolved:
+
+```text
+implemented / maybe partial
+closed but needs audit
+ready but not checked
+landed but unverified
+probably works
+assumed stable
+```
+
+Rule:
+
+```text
+No `unknown` item may be used as justification for starting PCC-1.
+```
+
+## 5. Evidence levels
+
+Evidence must be categorized.
+
+| Evidence level | Description |
+|---|---|
+| `E0-doc` | Documentation or roadmap only. |
+| `E1-code` | Code exists, but no direct test or full pipeline evidence is cited. |
+| `E2-test` | Unit/integration/golden test evidence exists. |
+| `E3-pipeline` | Source passes `check -> compile -> verify -> run-smc` or equivalent full path. |
+| `E4-release-gate` | Covered by stable qualification gate / 7hell / release-facing fixture. |
+
+Rules:
+
+- `confirmed-working` requires at least `E2-test`.
+- Practical language features should target `E3-pipeline` before PCC closure.
+- `E0-doc` cannot justify implementation readiness.
+- `E1-code` is not enough for stable readiness.
+
+## 6. Tested path vocabulary
+
+Use one or more of the following tested paths:
+
+```text
+parse
+parse -> typecheck
+parse -> typecheck -> lower
+parse -> typecheck -> lower -> emit
+check -> compile -> verify
+check -> compile -> verify -> run-smc
+check -> lint -> compile -> verify -> run-smc -> disasm
+unit test
+integration test
+golden fixture
+manual inspection only
+```
+
+If the tested path is manual inspection only, the status cannot be
+`confirmed-working` unless there is separate test evidence.
+
+## 7. Audit matrix schema
+
+Use this schema for every row:
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `id` | yes | Stable audit row id. |
+| `area` | yes | Language/runtime/tooling area. |
+| `feature` | yes | Feature or contract being audited. |
+| `status` | yes | One allowed status. |
+| `evidence` | yes | Evidence level and pointer. |
+| `tested_path` | yes | Tested path vocabulary. |
+| `missing_edge` | yes if partial | Exact gap. |
+| `pcc_owner` | yes | PCC phase or `none`. |
+| `ctf_impact` | yes | `none`, `value`, `trap`, `determinism`, `verifier`, `symbolid`, `capability`, `trace`. |
+| `seven_hell_stage` | yes | Target 7hell stage or `none`. |
+| `next_action` | yes | Audit, test, document, implement, exclude. |
+
+## 8. Initial audit areas
+
+The live audit should cover these areas first:
+
+```text
+A. Language surface
+B. Type system
+C. Control flow
+D. Numeric core
+E. Text core
+F. Records
+G. ADT / match
+H. Option / Result
+I. Collections
+J. Stdlib
+K. Modules / imports / exports
+L. SemCode / verifier / VM
+M. Runtime values / traps / determinism
+N. CLI / project model
+O. Examples / fixtures / golden tests
+P. UI boundary status
+Q. Experimental / legacy substrates
+```
+
+## 9. Starter matrix
+
+This starter matrix is intentionally conservative. `unknown` means the row must
+be audited against current `main` before it can support planning claims.
+
+| id | area | feature | status | evidence | tested_path | missing_edge | pcc_owner | ctf_impact | seven_hell_stage | next_action |
+|---|---|---|---|---|---|---|---|---|---|---|
+| FM-001 | Language surface | `.sm` source format | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
+| FM-002 | Language surface | `fn` declarations | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
+| FM-003 | Language surface | `let` bindings | unknown | TBD | TBD | TBD | PCC-0.5 | value | Type Hell | audit |
+| FM-004 | Language surface | `let mut` | unknown | TBD | TBD | TBD | PCC-0.5 / PCC-1 | value | Type Hell | audit |
+| FM-005 | Language surface | reassignment | unknown | TBD | TBD | TBD | PCC-0.5 / PCC-1 | value | Type Hell | audit |
+| FM-006 | Control flow | `if / else` | unknown | TBD | TBD | TBD | PCC-0.5 | determinism | Syntax Hell | audit |
+| FM-007 | Control flow | `while` | unknown | TBD | TBD | TBD | PCC-1 | determinism | VM Hell | audit |
+| FM-008 | Control flow | statement `loop` | unknown | TBD | TBD | TBD | PCC-1 | determinism | VM Hell | audit |
+| FM-009 | Control flow | `break` | unknown | TBD | TBD | TBD | PCC-1 | trap | VM Hell | audit |
+| FM-010 | Control flow | `continue` | unknown | TBD | TBD | TBD | PCC-1 | determinism | VM Hell | audit |
+| FM-011 | Type system | `quad` | unknown | TBD | TBD | TBD | PCC-0.5 | value | Type Hell | audit |
+| FM-012 | Type system | `bool` | unknown | TBD | TBD | TBD | PCC-0.5 | value | Type Hell | audit |
+| FM-013 | Numeric core | `i32` arithmetic | unknown | TBD | TBD | TBD | PCC-2 | value/trap | VM Hell | audit |
+| FM-014 | Numeric core | `u32` arithmetic | unknown | TBD | TBD | TBD | PCC-2 | value/trap | VM Hell | audit |
+| FM-015 | Numeric core | `fx` value behavior | unknown | TBD | TBD | TBD | PCC-2 | value/trap | VM Hell | audit |
+| FM-016 | Text core | text literal | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
+| FM-017 | Text core | text equality | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
+| FM-018 | Text core | text concat | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
+| FM-019 | Records | record declaration | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
+| FM-020 | Records | record construction | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
+| FM-021 | Records | field access | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
+| FM-022 | ADT / match | enum declaration | unknown | TBD | TBD | TBD | PCC-5 | value | Practical Hell | audit |
+| FM-023 | ADT / match | constructor expression | unknown | TBD | TBD | TBD | PCC-5 | value | Practical Hell | audit |
+| FM-024 | ADT / match | basic ADT match | unknown | TBD | TBD | TBD | PCC-5 | determinism | Practical Hell | audit |
+| FM-025 | Option / Result | `Option` shape | unknown | TBD | TBD | TBD | PCC-6 | value | Practical Hell | audit |
+| FM-026 | Option / Result | `Result` shape | unknown | TBD | TBD | TBD | PCC-6 | value | Practical Hell | audit |
+| FM-027 | Collections | `Sequence<T>` | unknown | TBD | TBD | TBD | PCC-7 | value/trap | Practical Hell | audit |
+| FM-028 | Collections | `Map<K,V>` | unknown | TBD | TBD | TBD | PCC-7 | value/trap | Practical Hell | audit |
+| FM-029 | Stdlib | `assert` | unknown | TBD | TBD | TBD | PCC-8 | trap | User Pain / Diagnostics Hell | audit |
+| FM-030 | Stdlib | `to_text` | unknown | TBD | TBD | TBD | PCC-8 | value | Practical Hell | audit |
+| FM-031 | Modules | import surface | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
+| FM-032 | Modules | export / re-export surface | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
+| FM-033 | Execution | verifier admission | unknown | TBD | TBD | TBD | PCC-0.5 | verifier | Verifier Hell | audit |
+| FM-034 | Execution | VM execution path | unknown | TBD | TBD | TBD | PCC-0.5 | determinism | VM Hell | audit |
+| FM-035 | Execution | trap taxonomy | unknown | TBD | TBD | TBD | CTF | trap | VM Hell | audit |
+| FM-036 | Execution | determinism matrix | unknown | TBD | TBD | TBD | CTF | determinism | VM Hell | audit |
+| FM-037 | CLI | `smc check` | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
+| FM-038 | CLI | `smc compile` | unknown | TBD | TBD | TBD | PCC-0.5 | none | Lowering Hell | audit |
+| FM-039 | CLI | `smc verify` | unknown | TBD | TBD | TBD | PCC-0.5 | verifier | Verifier Hell | audit |
+| FM-040 | CLI | `smc run-smc` | unknown | TBD | TBD | TBD | PCC-0.5 | determinism | VM Hell | audit |
+| FM-041 | CLI | project model v0 | unknown | TBD | TBD | TBD | PCC-9 | none | Practical Hell | audit |
+| FM-042 | Examples | canonical full-pipeline examples | unknown | TBD | TBD | TBD | PCC-0.5 | determinism | Practical Hell | audit |
+| FM-043 | UI boundary | UI docs phase v0 | confirmed-working | PR-PCC-0A / I67-I69 docs closure | documentation audit | none | none | none | none | keep frozen |
+| FM-044 | UI boundary | Workbench implementation | out-of-scope | PCC-0 truth reset | not applicable | frozen | post-PCC | none | none | exclude |
+| FM-045 | Experimental | sm-quad / packed quad substrate | unknown | TBD | TBD | TBD | post-PCC / experimental | value | none | audit as experimental |
+
+## 10. Audit procedure
+
+For each row:
+
+1. inspect current `main`;
+2. locate code / tests / docs / fixtures;
+3. classify evidence level;
+4. run or cite tested path where available;
+5. resolve status;
+6. write missing edge if partial;
+7. assign owner phase;
+8. mark CTF impact;
+9. mark 7hell stage;
+10. set next action.
+
+Do not mark a row `confirmed-working` because it was discussed, planned,
+merged historically, or assumed from memory.
+
+## 11. Output requirement
+
+PCC-0.5 should leave a filled matrix in one of these forms:
+
+```text
+docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
+```
+
+or, if the matrix becomes too large:
+
+```text
+docs/roadmap/language_maturity/feature_matrix/
+  index.md
+  language_surface.md
+  execution_core.md
+  tooling.md
+  experimental.md
+```
+
+The first pass may remain in this single file. Split only when the file becomes
+hard to review.
+
+## 12. Blocking rule before PCC-1
+
+PCC-1 must not start while any of the following are true:
+
+```text
+[ ] control-flow rows are still unknown
+[ ] verifier / VM rows are still unknown
+[ ] trap / determinism rows are still unknown
+[ ] CLI check/compile/verify/run-smc rows are still unknown
+[ ] canonical example status is unknown
+```
+
+PCC-1 may start with known partials only if each partial has:
+
+- exact missing edge;
+- owner phase;
+- test need;
+- CTF impact;
+- 7hell stage.
+
+## 13. Out of scope
+
+This audit scaffold does not perform implementation.
+
+Out of scope:
+
+- fixing features;
+- adding tests;
+- changing parser / typecheck / IR / VM;
+- changing CLI behavior;
+- implementing 7hell;
+- starting Workbench;
+- starting I70;
+- changing UI runtime docs except reference corrections.
+
+## 14. Acceptance checklist
+
+This PR is complete when:
+
+- PCC-0.5 has a documented purpose;
+- allowed status vocabulary is defined;
+- evidence levels are defined;
+- tested path vocabulary is defined;
+- audit matrix schema is defined;
+- starter rows exist for practical core features;
+- blocking rule before PCC-1 is explicit;
+- UI / Workbench remains frozen;
+- CTF impact field is required;
+- 7hell stage field is required;
+- no code is changed.
+
+## 15. Final state
+
+After this scaffold exists:
+
+```text
+PCC-0 Truth Reset = landed
+PCC-0.5 Live Audit = scaffolded
+PCC-0.6 7hell Seed = next
+PCC-1 Control Flow = still blocked until audit gate is satisfied
+```


### PR DESCRIPTION
## Summary

Adds the PCC-0.5 live feature matrix audit scaffold for Semantic practical core readiness.

This PR does not claim feature readiness. It creates the audit structure required to verify current `main` before PCC-1 begins.

## Scope

Docs-only:

- `docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md`

## Key decisions

- Defines allowed audit statuses:
  - `confirmed-working`
  - `confirmed-partial`
  - `documented-only`
  - `experimental`
  - `out-of-scope`
  - `unknown`
- Defines evidence levels `E0-doc` through `E4-release-gate`.
- Defines tested path vocabulary.
- Adds starter feature matrix rows for practical language core, execution core, CLI, examples, UI boundary, and experimental substrates.
- Keeps rows conservative as `unknown` until audited against current `main`.
- Keeps UI / Workbench frozen.
- Blocks PCC-1 until core rows are resolved.

## Out of scope

- Code changes
- Feature implementation
- Test additions
- Parser/typecheck/IR/VM changes
- 7hell implementation
- Workbench implementation
- I70 or UI runtime widening

## Validation

- docs-only change
- one file added under `docs/roadmap/language_maturity/`
- no code touched

## CTF touched

CTF touched: none
Reason: docs-only audit scaffold; it introduces required CTF impact fields but does not change runtime, verifier, VM, capability, trap, or value behavior.