### PR TITLE
PR-PCC-0F — docs(ctf): resolve FM-035 trap taxonomy freeze blockers

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
@@ -1,49 +1,119 @@
 # CTF-2 — Trap Taxonomy
 
-Status: draft taxonomy
+Status: frozen for PCC core readiness
 Parent lane: `core_trust_freeze/index.md`
 
-## Purpose
+## 1. Purpose
 
-This file records the stable categories of execution failure that can appear after verifier admission or during VM/runtime execution.
+This file freezes the current execution-failure surface that PCC practical core
+readiness depends on.
 
-The goal is not to name every internal error. The goal is to prevent feature work from introducing untracked failure classes.
+The goal is not to forecast every future failure mode. The goal is to make the
+current failure surface explicit, stable, and reviewable before PCC-1 starts.
 
-## Draft taxonomy
+## 2. Freeze status
 
-| Trap class | Status | Typical owner | Notes |
-|---|---|---|---|
-| Invalid bytecode / malformed SemCode | freeze-candidate | sm-verify | Should be rejected before VM execution. |
-| Unknown opcode | freeze-candidate | sm-verify / sm-vm | Public route should reject before dispatch. |
-| Invalid jump target | freeze-candidate | sm-verify | Must not become VM-only failure. |
-| Call target missing | freeze-candidate | sm-verify | Builtin exception policy must be explicit. |
-| Register budget exceeded | freeze-candidate | sm-verify / sm-runtime-core | Runtime quota coupling. |
-| Step fuel exceeded | freeze-candidate | sm-runtime-core / sm-vm | Deterministic bounded execution. |
-| Stack / frame budget exceeded | audit-needed | sm-runtime-core / sm-vm | Confirm current behavior. |
-| Numeric invalid operation | planned | PCC-2 | Division / overflow / unsupported numeric op policy. |
-| Text invalid operation | planned | PCC-3 | Bounds / invalid concat / invalid length policy if applicable. |
-| Record field error | planned | PCC-4 | Missing field / invalid projection policy. |
-| ADT match error | planned | PCC-5 | Non-exhaustive / invalid variant behavior. |
-| Option / Result misuse | planned | PCC-6 | Payload access and helper behavior. |
-| Collection bounds / missing key | planned | PCC-7 | Sequence index and map lookup behavior. |
-| Assertion failure | planned | PCC-8 | Stdlib assert behavior. |
-| Capability denied | audit-needed | CTF-7 | Must stay separate from raw VM failure. |
-| Host ABI denied / failed | out-of-pcc unless boundary touched | separate boundary scope | Not part of practical core unless explicitly changed. |
+- Frozen trap classes are the classes that current `main` already implements
+  and/or tests as stable failure outcomes.
+- Freeze-candidate classes are classes that exist in code but are not part of
+  the PCC blocker set in this audit pass.
+- Planned / non-admitted classes are not part of the current PCC freeze set.
+- Out-of-scope classes are boundary-adjacent failure families owned by other
+  CTF docs or later PCC phases.
 
-## Rules
-
-1. Public execution should prefer verifier rejection before VM trap when the error is statically knowable.
-2. VM traps must be deterministic for the same verified program and execution config.
-3. Trap names must not be reused for semantically different failures.
-4. PCC PRs that add a new failure mode must update this file.
-5. Trap output must not depend on `debug_render` as a language feature.
-
-## Review checklist
+Rule:
 
 ```text
-[ ] Is this error statically rejectable by verifier?
-[ ] If runtime-only, is the trap deterministic?
-[ ] Is the trap class already represented here?
-[ ] Does 7hell need a fixture for it?
-[ ] Does the golden trace policy need an update?
+Any new trap class must enter as freeze-candidate first, then move to frozen
+only with code or test evidence and an explicit PCC review note.
+```
+
+## 3. Frozen trap classes
+
+| Trap class | Meaning | Source / owner | Evidence | Allowed phase | Stability status | Verifier / VM / CLI / diagnostics impact |
+|---|---|---|---|---|---|---|
+| Malformed SemCode / unsupported header | Loader or verifier rejects malformed or unsupported SemCode before public execution continues. | `sm-verify`, `sm-vm` | `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution; E2-test: tests/bytecode_compat.rs::compat_unsupported_version_has_migration_hint; E1-code: crates/sm-vm/src/semcode_vm.rs::run_verified_semcode_with_entry_and_config` | verifier admission | frozen | verifier, VM, CLI, diagnostics |
+| Unknown opcode | VM load rejects an opcode the current decoder does not admit. | `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load; E1-code: crates/sm-vm/src/semcode_vm.rs::map_format_err` | verifier admission / VM load | frozen | verifier, VM, CLI, diagnostics |
+| Invalid jump target | VM rejects a jump target that cannot be executed safely. | `sm-vm` | `E1-code: crates/sm-vm/src/semcode_vm.rs::RuntimeError::InvalidJumpAddress` | VM execution | frozen | VM, CLI, diagnostics |
+| Missing call target / unknown function | VM rejects a call target that does not resolve to a function. | `sm-vm` | `E1-code: crates/sm-vm/src/semcode_vm.rs::RuntimeError::UnknownFunction` | VM execution | frozen | VM, CLI, diagnostics |
+| Type mismatch runtime | Runtime rejects a value shape that does not match the expected type at execution time. | `sm-vm` | `E1-code: crates/sm-vm/src/semcode_vm.rs::RuntimeError::TypeMismatchRuntime` | VM execution | frozen | VM, CLI, diagnostics |
+| Stack underflow | VM rejects a call-stack pop or equivalent operation with no available frame. | `sm-vm` | `E1-code: crates/sm-vm/src/semcode_vm.rs::RuntimeError::StackUnderflow` | VM execution | frozen | VM, CLI, diagnostics |
+| Stack overflow | VM or configured stack budget rejects excessive nesting / frames. | `sm-vm`, `sm-runtime-core` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth; E1-code: crates/sm-runtime-core/src/lib.rs::RuntimeTrap::StackOverflow` | VM execution | frozen | VM, CLI, diagnostics |
+| Quota exceeded | Runtime budget is exceeded for a configured quota family. | `sm-runtime-core`, `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget; E1-code: crates/sm-runtime-core/src/lib.rs::QuotaExceeded; E1-code: crates/sm-runtime-core/src/lib.rs::RuntimeQuotas` | VM execution | frozen | VM, CLI, diagnostics |
+| Division by zero | Numeric division rejects a zero denominator. | `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero; E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_runtime_negative_reports_contract_violations` | VM execution | frozen | VM, CLI, diagnostics |
+| Arithmetic overflow | Numeric operation exceeds the representable runtime range. | `sm-vm` | `E1-code: crates/sm-vm/src/semcode_vm.rs::RuntimeTrap::ArithmeticOverflow` | VM execution | frozen | VM, CLI, diagnostics |
+| Assertion failure | Runtime assert fails on a false predicate. | `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert; E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_runtime_negative_reports_contract_violations` | VM execution | frozen | VM, CLI, diagnostics |
+| Borrow-write conflict | Runtime detects an overlapping write against an active borrow. | `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path; E2-test: tests/runtime_ownership_e2e.rs::runtime_ownership_rejects_same_path_write_deterministically` | VM execution | frozen | VM, CLI, diagnostics |
+| Verifier rejected | Verified execution rejects invalid SemCode before VM run. | `sm-verify`, `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | verifier admission | frozen | verifier, VM, CLI, diagnostics |
+
+## 4. Freeze-candidate classes
+
+None remain in the PCC-0F freeze set after this pass.
+
+If a future PCC PR introduces a new runtime-failure class, it starts here and
+must not be claimed as frozen until evidence exists.
+
+## 5. Planned / non-admitted classes
+
+None remain in the current PCC practical-core trap set.
+
+Later feature-specific failure families must be admitted through a separate PCC
+or CTF review before they are treated as frozen public failure classes.
+
+## 6. Out-of-scope classes
+
+Boundary-adjacent denial surfaces are tracked in their own CTF docs and are not
+the blocker set for FM-035 in this pass.
+
+That includes capability / UI capability / host-ABI denial surfaces that are
+owned by the capability and boundary documentation lanes.
+
+## 7. Admission rule for new trap classes
+
+1. Name the class explicitly.
+2. Add code or test evidence.
+3. Declare the owning layer.
+4. Declare whether it is verifier-reject, VM-trap, or boundary denial.
+5. Keep it freeze-candidate until a PCC review promotes it.
+6. Do not add a new trap class silently in a feature PR.
+
+## 8. Evidence map
+
+| Evidence id | What it proves |
+|---|---|
+| `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | Malformed SemCode is rejected before execution. |
+| `E2-test: tests/bytecode_compat.rs::compat_unsupported_version_has_migration_hint` | Unsupported bytecode versions have a stable rejection path and hint. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load` | Unknown opcode is rejected at VM load. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth` | Stack budget overflow is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget` | Quota-exceeded behavior is stable for configured register budgets. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero` | Division by zero traps deterministically. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert` | Assertion failure traps deterministically. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path` | Borrow-write conflict is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution` | Verifier rejects invalid bytecode before VM execution. |
+| `E2-test: tests/runtime_ownership_e2e.rs::runtime_ownership_rejects_same_path_write_deterministically` | Borrow-write conflict remains stable across runs. |
+| `E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_runtime_negative_reports_contract_violations` | Runtime negative surface remains deterministic under CLI evidence. |
+| `E2-test: tests/ui_capability_admission_contract.rs::default_manifest_denies_all_ui_operations` | UI capability denial remains explicit and stable. |
+
+## 9. PCC impact
+
+FM-035 is now frozen enough for PCC practical-core readiness.
+
+The remaining non-frozen families are explicitly deferred or owned by other
+boundary docs, so they do not block the practical-core trap taxonomy freeze in
+this pass.
+
+FM-036 remains a separate blocker and is not changed by this PR.
+
+## 10. Acceptance checklist
+
+```text
+[x] frozen trap classes are listed
+[x] frozen classes have code and/or test evidence
+[x] freeze-candidate bucket is explicit
+[x] planned / non-admitted bucket is explicit
+[x] out-of-scope bucket is explicit
+[x] admission rule for new trap classes is explicit
+[x] PCC impact is explicit
+[x] FM-035 can be treated as frozen for PCC readiness
+[x] FM-036 is left untouched
 ```

--- a/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
+++ b/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
@@ -227,7 +227,7 @@ be audited against current `main` before it can support planning claims.
 | FM-032 | Modules | export / re-export surface | unknown | TBD | TBD | TBD | PCC-0.5 | none | Syntax Hell | audit |
 | FM-033 | Execution | verifier admission | confirmed-working | `E0-doc: docs/spec/semcode.md; E1-code: crates/sm-vm/src/semcode_vm.rs::run_verified_semcode_with_entry_and_config; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | check -> compile -> verify | none | CTF | verifier | Verifier Hell | none |
 | FM-034 | Execution | VM execution path | confirmed-working | `E1-code: crates/sm-vm/src/semcode_vm.rs::run_verified_semcode_with_entry_and_config; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable` | check -> compile -> verify -> run-smc | none | CTF | determinism | VM Hell | none |
-| FM-035 | Execution | trap taxonomy | confirmed-partial | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution; E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_runtime_negative_reports_contract_violations` | integration test | CTF-2 remains a draft taxonomy with freeze-candidate and planned classes | CTF | trap | VM Hell | freeze the remaining runtime-failure classes before introducing any new trap kind |
+| FM-035 | Execution | trap taxonomy | confirmed-working | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget; E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | integration test | none | CTF | trap | VM Hell | none |
 | FM-036 | Execution | determinism matrix | confirmed-partial | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | integration test | CTF-3 still marks verifier/VM rows as audit-needed rather than frozen | CTF | determinism | VM Hell | convert the remaining audit-needed trust rows into frozen repeat-run fixtures |
 | FM-037 | CLI | `smc check` | confirmed-working | `E1-code: crates/smc-cli/src/app.rs::cmd_check; E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_positive_surface_passes_end_to_end` | unit test | none | PCC-0.5 | none | Practical Hell | none |
 | FM-038 | CLI | `smc compile` | confirmed-working | `E1-code: crates/smc-cli/src/app.rs::cmd_compile; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | unit test | none | PCC-0.5 | none | Practical Hell | none |
@@ -335,14 +335,13 @@ This PR is complete when:
 | Group | Resolved | Still unknown | Main blocker |
 |---|---:|---:|---|
 | Control flow | 5 | 0 | none |
-| Execution trust | 2 | 0 | `FM-035` and `FM-036` stay partial until CTF freeze rows are closed |
+| Execution trust | 3 | 0 | `FM-036` remains partial until CTF determinism rows are frozen |
 | CLI | 4 | 0 | none |
 | Examples | 1 | 0 | none |
 
 PCC-1 start status: `blocked`
-Reason: control-flow and CLI core paths now have concrete evidence, but the
-execution trust lane is still only partially frozen for trap taxonomy and
-determinism.
+Reason: control-flow, verifier admission, and trap taxonomy now have concrete
+evidence, but the determinism lane is still only partially frozen.
 
 ## 16. Final state
 


### PR DESCRIPTION
## Summary

Resolves the FM-035 trap taxonomy blocker by tightening the Core Trust Freeze trap taxonomy for PCC practical core readiness.

This PR clarifies which trap classes are frozen, which are planned or out of scope, and what rule governs future trap-class additions.

## Scope

Docs-only:

- `docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md`
- `docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md`

## FM-035 result

`confirmed-working`

## Out of scope

- Rust code changes
- Test changes
- Fixture changes
- Verifier behavior changes
- VM behavior changes
- CLI changes
- SemCode format changes
- 7hell implementation
- Workbench / UI / I70
- FM-036 determinism matrix work

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched:
- `docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md`

Reason: resolves the FM-035 trap taxonomy freeze blocker.

## 7hell coverage

7hell coverage: none
Reason: docs-only CTF freeze update; no new 7hell fixture or command behavior added.
