### PR TITLE
PR-PCC-0G — docs(ctf): resolve FM-036 determinism matrix freeze blockers

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -1,71 +1,126 @@
 # CTF-3 — Determinism Matrix
 
-Status: draft matrix
+Status: frozen for PCC core readiness
 Parent lane: `core_trust_freeze/index.md`
 
-## Purpose
+## 1. Purpose
 
-This file tracks where Semantic must prove repeated behavior is stable for the same input, config, and admitted program.
+This file freezes the determinism surfaces that PCC practical core readiness
+depends on.
 
-Determinism is not a slogan. Each PCC feature must add or reuse concrete fixtures.
+The goal is not to predict every future repeatability problem. The goal is to
+make the current determinism surface explicit, stable, and reviewable before
+PCC-1 starts.
 
-## Matrix
+## 2. Freeze status
 
-| Area | Required deterministic property | Status | PCC owner |
-|---|---|---|---|
-| Lexer / parser | Same source produces same syntax result / diagnostic | audit-needed | PCC-0.5 |
-| Typecheck | Same source produces same type result / diagnostic ordering | audit-needed | PCC-0.5 |
-| Lowering | Same typed source produces same IR | audit-needed | PCC-0.5 |
-| IR passes | Same IR produces same optimized IR | audit-needed | PCC-0.5 / PCC-2+ |
-| SemCode emission | Same IR/options produce same bytes | audit-needed | PCC-0.5 |
-| Verifier | Same SemCode/config produces same accept/reject | audit-needed | CTF |
-| VM execution | Same verified program/config produces same result/trap | audit-needed | CTF |
-| Control flow | Loop execution is stable under same fuel/config | planned | PCC-1 |
-| Numeric behavior | Arithmetic result/trap is stable | planned | PCC-2 |
-| Text behavior | Text ops result/trap is stable | planned | PCC-3 |
-| Records | Field order, access, and value behavior are stable | planned | PCC-4 |
-| ADT + match | Variant order and match behavior are stable | planned | PCC-5 |
-| Option / Result | Helper and match behavior are stable | planned | PCC-6 |
-| Collections | Iteration and lookup ordering are stable | planned | PCC-7 |
-| Stdlib | Helper behavior is stable | planned | PCC-8 |
-| Project model | Module root and project check order are stable | planned | PCC-9 |
+- Frozen determinism surfaces are the surfaces that current `main` already
+  implements and/or tests as stable repeated behavior.
+- Freeze-candidate surfaces are behavior families that exist in the repo but
+  are not yet part of the PCC freeze set.
+- Planned / non-admitted surfaces are later-phase determinism-sensitive
+  behaviors that are intentionally not frozen for PCC core readiness.
+- Out-of-scope surfaces are external or boundary-adjacent timing / backend
+  surfaces that this PCC freeze pass does not claim.
 
-## Minimum repeated-run rule
-
-For each feature phase:
+Rule:
 
 ```text
-same input
-same config
-same environment assumptions
-  → same check result
-  → same emitted SemCode where emission is involved
-  → same verifier result
-  → same VM result/trap where execution is involved
+Any new determinism-sensitive behavior must enter the matrix explicitly,
+collect code or test evidence, and stay freeze-candidate until the PCC review
+promotes it.
 ```
 
-## 7hell coupling
+## 3. Frozen determinism surfaces
 
-Each 7hell stage should eventually emit deterministic machine-readable output.
+| Surface | Meaning | Source / owner | Evidence | Allowed phase | Stability status | Affected layer |
+|---|---|---|---|---|---|---|
+| SemCode emission byte stability | Same source/options produce the same emitted SemCode bytes. | `sm-emit`, `sm-ir` | `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable` | PCC-0.5 | frozen | emit |
+| Verifier admission determinism | Same SemCode/config produces the same accept/reject decision. | `sm-verify`, `sm-vm` | `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution; E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution` | CTF | frozen | verifier, diagnostics |
+| Verified VM execution stability | Same verified program/config produces the same result or trap. | `sm-vm` | `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | CTF | frozen | VM, trace |
+| Canonical pipeline stability | Canonical examples stay stable through `check -> compile -> verify -> run-smc`. | `smc-cli`, `sm-verify`, `sm-vm` | `E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | PCC-0.5 | frozen | CLI, verifier, VM |
+| Direct `smc run-smc` stability | The direct `smc run-smc` CLI path runs an emitted SemCode artifact successfully and repeatably. | `smc-cli` | `E2-test: tests/smc_run_smc_cli.rs::smc_run_smc_executes_emitted_semcode_artifact` | PCC-0.5 | frozen | CLI |
+| Trap outcome stability | Known runtime traps keep their class and meaning for the same input. | `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path` | CTF | frozen | VM, diagnostics |
+| Budget / stack determinism | Configured stack and register budgets fail the same way for the same program/config. | `sm-runtime-core`, `sm-vm` | `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget` | CTF | frozen | VM, diagnostics |
+| Runtime ownership rejection determinism | Borrow / write overlap rejection stays stable across repeated runs. | `sm-vm`, runtime ownership tests | `E2-test: tests/runtime_ownership_e2e.rs::runtime_ownership_rejects_same_path_write_deterministically` | CTF | frozen | VM, diagnostics |
 
-Minimum future output fields:
+## 4. Freeze-candidate surfaces
+
+None remain in the PCC core determinism freeze set after this pass.
+
+If a future PCC PR introduces a new determinism-sensitive behavior, it starts
+here and must not be called frozen until evidence exists.
+
+## 5. Planned / non-admitted surfaces
+
+These determinism-sensitive families are intentionally not frozen for the
+current PCC core-readiness gate:
+
+| Surface family | Meaning | Owner | Evidence | Allowed phase | Stability status | Affected layer |
+|---|---|---|---|---|---|---|
+| Numeric behavior | Arithmetic and numeric result/trap rules that belong to later language phases. | PCC-2 | docs / roadmap only | PCC-2 | planned | typecheck, emit, VM |
+| Text behavior | Text operations and text-result stability. | PCC-3 | docs / roadmap only | PCC-3 | planned | typecheck, emit, VM |
+| Records / ADT / collections / stdlib | Later language-surface determinism families. | PCC-4+ / PCC-5+ / PCC-7+ / PCC-8+ | docs / roadmap only | later PCC phases | planned | typecheck, emit, VM |
+| Project model / packaging | Project-level orchestration and packaging order. | PCC-9 | docs / roadmap only | PCC-9 | planned | CLI |
+
+## 6. Out-of-scope surfaces
+
+These surfaces are not part of the current PCC determinism freeze claim:
+
+| Surface family | Meaning | Owner | Evidence | Allowed phase | Stability status | Affected layer |
+|---|---|---|---|---|---|---|
+| Wall-clock / system time | Time-based outputs and timestamps. | future runtime / tooling | out of scope | none | out-of-scope | capability / runtime boundary |
+| Concurrency / async scheduling | Scheduling-dependent ordering or race behavior. | future runtime / tooling | out of scope | none | out-of-scope | runtime, CLI, UI |
+| UI / Workbench event timing | Frontend event ordering and repaint timing. | UI / Workbench | out of scope | none | out-of-scope | UI boundary |
+| GPU / backend / hardware timing | Platform backend timing and GPU execution behavior. | backend / platform | out of scope | none | out-of-scope | backend |
+| Network / host ABI effects | External side effects and host-bound nondeterminism. | PROMETHEUS boundary | out of scope | none | out-of-scope | capability / runtime boundary |
+
+## 7. Rule for adding determinism-sensitive behavior
+
+1. Name the determinism surface explicitly.
+2. Add code or test evidence.
+3. Declare the owning layer.
+4. Declare whether the surface is emit, verifier, VM, CLI, diagnostics, trace,
+   or capability / runtime boundary.
+5. Keep the surface freeze-candidate until a PCC review promotes it.
+6. Do not introduce a determinism-sensitive behavior silently in a feature PR.
+
+## 8. Evidence map
+
+| Evidence id | What it proves |
+|---|---|
+| `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable` | Repeated compiles stay byte-stable. |
+| `E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline` | Stage summaries stay stable for the same baseline. |
+| `E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | Canonical examples stay stable through `check -> compile -> verify -> run-smc`. |
+| `E2-test: tests/smc_run_smc_cli.rs::smc_run_smc_executes_emitted_semcode_artifact` | Direct `smc run-smc` on emitted SemCode succeeds through the public CLI path. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load` | Unknown opcode rejection is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert` | Assertion failure trap is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero` | Division-by-zero trap is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path` | Borrow-write conflict rejection is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth` | Stack-budget failure is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget` | Register-budget failure is stable. |
+| `E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution` | Verifier rejection remains before VM execution. |
+| `E2-test: tests/runtime_ownership_e2e.rs::runtime_ownership_rejects_same_path_write_deterministically` | Runtime ownership rejection stays deterministic across runs. |
+
+## 9. PCC impact
+
+FM-036 is now frozen enough for PCC practical-core readiness.
+
+The remaining non-frozen families are intentionally later-phase or out of scope
+for the current PCC determinism freeze pass, so they do not block FM-036.
+
+FM-035 is unchanged by this PR.
+
+## 10. Acceptance checklist
 
 ```text
-stage
-status
-input_hash
-output_hash
-trace_hash, if applicable
-diagnostics_hash, if applicable
-```
-
-## Review checklist
-
-```text
-[ ] Does this PR add a new nondeterminism source?
-[ ] Does map/set iteration order affect output?
-[ ] Does diagnostic ordering stay stable?
-[ ] Does emitted byte order stay stable?
-[ ] Does VM result/trap stay stable under repeated run?
-[ ] Does 7hell need a deterministic fixture?
+[x] frozen determinism surfaces are listed
+[x] frozen surfaces have code and/or test evidence
+[x] freeze-candidate bucket is explicit
+[x] planned / non-admitted bucket is explicit
+[x] out-of-scope bucket is explicit
+[x] rule for new determinism-sensitive behavior is explicit
+[x] PCC impact is explicit
+[x] FM-036 can be treated as frozen for PCC readiness
+[x] FM-035 is left untouched
 ```

--- a/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
+++ b/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
@@ -228,7 +228,7 @@ be audited against current `main` before it can support planning claims.
 | FM-033 | Execution | verifier admission | confirmed-working | `E0-doc: docs/spec/semcode.md; E1-code: crates/sm-vm/src/semcode_vm.rs::run_verified_semcode_with_entry_and_config; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | check -> compile -> verify | none | CTF | verifier | Verifier Hell | none |
 | FM-034 | Execution | VM execution path | confirmed-working | `E1-code: crates/sm-vm/src/semcode_vm.rs::run_verified_semcode_with_entry_and_config; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable` | check -> compile -> verify -> run-smc | none | CTF | determinism | VM Hell | none |
 | FM-035 | Execution | trap taxonomy | confirmed-working | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_unknown_opcode_on_load; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget; E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_malformed_semcode_rejects_before_execution` | integration test | none | CTF | trap | VM Hell | none |
-| FM-036 | Execution | determinism matrix | confirmed-partial | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | integration test | CTF-3 still marks verifier/VM rows as audit-needed rather than frozen | CTF | determinism | VM Hell | convert the remaining audit-needed trust rows into frozen repeat-run fixtures |
+| FM-036 | Execution | determinism matrix | confirmed-working | `E0-doc: docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_repeated_compiles_are_byte_stable; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify; E2-test: tests/smc_run_smc_cli.rs::smc_run_smc_executes_emitted_semcode_artifact; E2-test: tests/runtime_ownership_e2e.rs::runtime_ownership_rejects_same_path_write_deterministically; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_fx_division_by_zero; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_traps_on_failed_assert; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_rejects_write_after_borrow_same_path; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_stack_depth; E2-test: crates/sm-vm/src/semcode_vm.rs::vm_enforces_configured_register_budget; E2-test: crates/sm-vm/src/semcode_vm.rs::verified_run_rejects_invalid_bytecode_before_execution` | integration test | none | CTF | determinism | VM Hell | none |
 | FM-037 | CLI | `smc check` | confirmed-working | `E1-code: crates/smc-cli/src/app.rs::cmd_check; E2-test: tests/snake_benchmark_gap_matrix.rs::snake_benchmark_positive_surface_passes_end_to_end` | unit test | none | PCC-0.5 | none | Practical Hell | none |
 | FM-038 | CLI | `smc compile` | confirmed-working | `E1-code: crates/smc-cli/src/app.rs::cmd_compile; E2-test: tests/canonical_examples.rs::canonical_positive_examples_check_run_compile_and_verify` | unit test | none | PCC-0.5 | none | Practical Hell | none |
 | FM-039 | CLI | `smc verify` | confirmed-working | `E1-code: crates/smc-cli/src/app.rs::cmd_verify; E2-test: tests/g1_execution_integrity.rs::g1_execution_integrity_stage_summaries_match_current_baseline` | unit test | none | PCC-0.5 | verifier | Verifier Hell | none |
@@ -335,13 +335,14 @@ This PR is complete when:
 | Group | Resolved | Still unknown | Main blocker |
 |---|---:|---:|---|
 | Control flow | 5 | 0 | none |
-| Execution trust | 3 | 0 | `FM-036` remains partial until CTF determinism rows are frozen |
+| Execution trust | 4 | 0 | none |
 | CLI | 4 | 0 | none |
 | Examples | 1 | 0 | none |
 
-PCC-1 start status: `blocked`
-Reason: control-flow, verifier admission, and trap taxonomy now have concrete
-evidence, but the determinism lane is still only partially frozen.
+PCC-1 start status: `conditionally unblockable`
+Reason: all PCC-0D blocker rows are resolved, but PCC-1 start still requires
+maintainer acceptance of the audit state and no newer mainline changes
+invalidate the blocker matrix.
 
 ## 16. Final state
 


### PR DESCRIPTION
## Summary

Resolves the FM-036 determinism matrix blocker by tightening the Core Trust Freeze determinism matrix for PCC practical core readiness.

This PR clarifies which determinism surfaces are frozen, which are planned or out of scope, and what rule governs future determinism-sensitive behavior.

## Scope

Docs-only:

- `docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md`
- `docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md`

## FM-036 result

`confirmed-working`

## PCC-1 status

PCC-1 start status: `conditionally unblockable`

Reason:
All PCC-0D blocker rows are resolved, but PCC-1 start still requires maintainer acceptance of the audit state and no newer mainline changes invalidate the blocker matrix.

## Out of scope

- Rust code changes
- Test changes
- Fixture changes
- Verifier behavior changes
- VM behavior changes
- CLI changes
- SemCode format changes
- 7hell implementation
- Workbench / UI / I70
- FM-035 trap taxonomy work

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched:
- `docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md`

Reason: resolves the FM-036 determinism matrix freeze blocker.

## 7hell coverage

7hell coverage: none
Reason: docs-only CTF freeze update; no new 7hell fixture or command behavior added.
