### PR TITLE
PR-PCC-1B — tests(control-flow): add edge-case diagnostics for nested loop control

### DIFF
--- a/tests/fixtures/pcc1_control_flow/negative_break_after_nested_loop_outside_loop.sm
+++ b/tests/fixtures/pcc1_control_flow/negative_break_after_nested_loop_outside_loop.sm
@@ -1,0 +1,10 @@
+fn main() {
+    let mut outer: i32 = 0;
+    while outer < 1 {
+        outer = outer + 1;
+        loop {
+            break;
+        }
+    }
+    break;
+}

--- a/tests/fixtures/pcc1_control_flow/negative_continue_after_nested_loop_outside_loop.sm
+++ b/tests/fixtures/pcc1_control_flow/negative_continue_after_nested_loop_outside_loop.sm
@@ -1,0 +1,10 @@
+fn main() {
+    let mut outer: i32 = 0;
+    while outer < 1 {
+        outer = outer + 1;
+        loop {
+            break;
+        }
+    }
+    continue;
+}

--- a/tests/fixtures/pcc1_control_flow/positive_nested_loop_break_then_outer_continue.sm
+++ b/tests/fixtures/pcc1_control_flow/positive_nested_loop_break_then_outer_continue.sm
@@ -1,0 +1,20 @@
+fn main() {
+    let mut outer: i32 = 0;
+    let mut inner_breaks: i32 = 0;
+    let mut tail: i32 = 0;
+    while outer < 3 {
+        outer = outer + 1;
+        loop {
+            inner_breaks = inner_breaks + 1;
+            break;
+        }
+        if outer < 3 {
+            continue;
+        }
+        tail = tail + 1;
+    }
+    assert(outer == 3);
+    assert(inner_breaks == 3);
+    assert(tail == 1);
+    return;
+}

--- a/tests/fixtures/pcc1_control_flow/positive_nested_loop_continue.sm
+++ b/tests/fixtures/pcc1_control_flow/positive_nested_loop_continue.sm
@@ -1,0 +1,19 @@
+fn main() {
+    let mut outer: i32 = 0;
+    let mut inner_steps: i32 = 0;
+    while outer < 2 {
+        outer = outer + 1;
+        let mut inner: i32 = 0;
+        loop {
+            inner = inner + 1;
+            inner_steps = inner_steps + 1;
+            if inner < 2 {
+                continue;
+            }
+            break;
+        }
+    }
+    assert(outer == 2);
+    assert(inner_steps == 4);
+    return;
+}

--- a/tests/fixtures/pcc1_control_flow/positive_nested_while_break.sm
+++ b/tests/fixtures/pcc1_control_flow/positive_nested_while_break.sm
@@ -1,0 +1,16 @@
+fn main() {
+    let mut outer: i32 = 0;
+    let mut inner_breaks: i32 = 0;
+    while outer < 3 {
+        outer = outer + 1;
+        let mut inner: i32 = 0;
+        while inner < 4 {
+            inner = inner + 1;
+            inner_breaks = inner_breaks + 1;
+            break;
+        }
+    }
+    assert(outer == 3);
+    assert(inner_breaks == 3);
+    return;
+}

--- a/tests/pcc1_control_flow_gate.rs
+++ b/tests/pcc1_control_flow_gate.rs
@@ -159,3 +159,73 @@ fn pcc1_control_flow_repeated_pipeline_is_stable() {
     let second = compile_verify_run_smc(input, "repeated_second.smc");
     assert_eq!(first, second, "emitted SemCode drifted across repeated PCC-1 gate runs");
 }
+
+#[test]
+fn pcc1_nested_while_break_positive_pipeline() {
+    compile_verify_run_smc(
+        "tests/fixtures/pcc1_control_flow/positive_nested_while_break.sm",
+        "nested_while_break_positive.smc",
+    );
+}
+
+#[test]
+fn pcc1_nested_loop_continue_positive_pipeline() {
+    compile_verify_run_smc(
+        "tests/fixtures/pcc1_control_flow/positive_nested_loop_continue.sm",
+        "nested_loop_continue_positive.smc",
+    );
+}
+
+#[test]
+fn pcc1_nested_loop_break_then_outer_continue_positive_pipeline() {
+    compile_verify_run_smc(
+        "tests/fixtures/pcc1_control_flow/positive_nested_loop_break_then_outer_continue.sm",
+        "nested_loop_break_then_outer_continue_positive.smc",
+    );
+}
+
+#[test]
+fn pcc1_break_after_nested_loop_outside_loop_rejects() {
+    let input = repo_path(
+        "tests/fixtures/pcc1_control_flow/negative_break_after_nested_loop_outside_loop.sm",
+    );
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains("Error [E0201]"),
+        "expected stable control-flow diagnostic code for break-after-nested-loop rejection, got: {err}"
+    );
+    assert!(
+        err.contains("bare break is allowed only inside while or statement loop"),
+        "expected break-after-nested-loop diagnostic, got: {err}"
+    );
+}
+
+#[test]
+fn pcc1_continue_after_nested_loop_outside_loop_rejects() {
+    let input = repo_path(
+        "tests/fixtures/pcc1_control_flow/negative_continue_after_nested_loop_outside_loop.sm",
+    );
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains("Error [E0201]"),
+        "expected stable control-flow diagnostic code for continue-after-nested-loop rejection, got: {err}"
+    );
+    assert!(
+        err.contains("continue is allowed only inside while or statement loop"),
+        "expected continue-after-nested-loop diagnostic, got: {err}"
+    );
+}
+
+#[test]
+fn pcc1_nested_control_flow_repeated_pipeline_is_stable() {
+    let input = "tests/fixtures/pcc1_control_flow/positive_nested_loop_break_then_outer_continue.sm";
+    let first = compile_verify_run_smc(input, "nested_repeated_first.smc");
+    let second = compile_verify_run_smc(input, "nested_repeated_second.smc");
+    assert_eq!(first, second, "nested control-flow emitted SemCode drifted across repeated PCC-1 gate runs");
+}


### PR DESCRIPTION
## Summary

Extends PCC-1 control-flow gate coverage with nested loop-control edge cases.

This PR adds focused tests and fixtures for nested `while` / `loop`, inner `break`, inner `continue`, outer-loop continuation behavior, and invalid loop-control diagnostics after nested loop scope exits.

## Scope

- Updates `tests/pcc1_control_flow_gate.rs`
- Adds nested control-flow fixtures under `tests/fixtures/pcc1_control_flow/`

## Out of scope

- Parser rewrite
- Typechecker rewrite
- Lowering rewrite
- VM refactor
- Verifier refactor
- CLI expansion
- 7hell implementation
- Workbench / UI / I70
- Package builder
- CTF changes
- PCC-0 gate changes

## Validation

- `git diff --check`
- `cargo test -q --test pcc1_control_flow_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: nested control-flow gate coverage only; no runtime, verifier, VM, trap, determinism, capability, or trace policy changes.

## 7hell coverage

7hell coverage: fixture pressure only
Reason: this PR adds nested PCC-1 control-flow cases that can later be wired into 7hell, but does not implement the 7hell command.
