### PR TITLE
PR-PCC-1G — docs(ctf): record PCC-1 control-flow CTF guard result

### DIFF
--- a/docs/roadmap/language_maturity/pcc1_control_flow_ctf_guard.md
+++ b/docs/roadmap/language_maturity/pcc1_control_flow_ctf_guard.md
@@ -1,0 +1,97 @@
+# PCC-1 Control Flow CTF Guard Result
+
+Status: draft guard note
+Track: PCC-1G record PCC-1 control-flow CTF guard result
+Layer: language maturity / trust guard
+Scope: documentation only
+Implementation: out of scope
+Owner: language maturity stream
+
+Related:
+
+- `pcc1_control_flow_closeout.md`
+- `core_trust_freeze/trap_taxonomy.md`
+- `core_trust_freeze/determinism_matrix.md`
+- `practical_core_completion_v0_3.md`
+
+## 1. Purpose
+
+This document records the CTF guard result for PCC-1 Control Flow Core.
+
+It states that the PCC-1 control-flow work was checked against the Core Trust
+Freeze lane and did not alter any CTF trust classifications.
+
+## 2. Guard result
+
+```text
+PCC-1 CTF guard result: passed
+```
+
+Meaning:
+
+- PCC-1 did not change CTF trap taxonomy classifications.
+- PCC-1 did not change CTF determinism matrix classifications.
+- PCC-1 did not change verifier-first, VM, or runtime trust policy.
+- PCC-1 added tests, fixtures, and closeout documentation only for
+  control-flow qualification and closeout.
+
+## 3. Evidence
+
+Merged PCC-1 PRs and their CTF impact statements:
+
+| PR | Result | CTF impact statement |
+|---|---|---|
+| `#566` PCC-1A | merged | `CTF touched: none` |
+| `#567` PCC-1B | merged | `CTF touched: none` |
+| `#575` PCC-1C | merged | `CTF touched: none` |
+| `#576` PCC-1D | merged | `CTF touched: none` |
+| `#577` PCC-1E | merged | `CTF touched: none` |
+| `#578` PCC-1F | merged | `CTF touched: none` |
+
+## 4. Trust-lane boundary
+
+CTF remains a separate trust lane.
+
+CTF remains authoritative for:
+
+- trap taxonomy;
+- determinism matrix;
+- verifier-first policy;
+- golden trace policy;
+- capability / effect denial policy.
+
+PCC-1 does not own these classifications.
+
+## 5. No classification changes
+
+This PR does not modify:
+
+- trap taxonomy;
+- determinism matrix;
+- runtime value registry;
+- verifier-first policy;
+- golden trace policy;
+- capability / effect denial matrix.
+
+## 6. PCC-2 impact
+
+PCC-2 Numeric Core may begin after maintainer acceptance with the
+understanding that CTF guardrails remain active and any numeric work that
+affects runtime values, traps, determinism, verifier behavior, or SemCode must
+be checked against the CTF lane.
+
+This does not mean CTF is closed forever.
+
+This does not mean PCC-2 is automatically started.
+
+This does not exempt numeric work from CTF.
+
+## 7. Acceptance checklist
+
+- PCC-1 CTF guard result recorded
+- no CTF classification changed
+- no code, test, or fixture changes
+- CTF remains separate trust lane
+- PCC-2 not started
+- Workbench / UI / I70 untouched
+


### PR DESCRIPTION
## Summary\n\nRecords the CTF guard result for PCC-1 Control Flow Core.\n\nThis PR confirms that PCC-1 did not change CTF trap taxonomy, determinism matrix, verifier-first policy, runtime trust policy, or CTF classifications.\n\n## Issue\n\nCloses #572.\n\n## Scope\n\nDocs-only:\n\n- docs/roadmap/language_maturity/pcc1_control_flow_ctf_guard.md\n\n## Guard result\n\nPCC-1 CTF guard result: passed\n\nReason:\nPCC-1 control-flow PRs added tests/docs and closeout records only. They did not alter CTF trust classifications or execution trust policies.\n\n## Out of scope\n\n- Rust code changes\n- Test changes\n- Fixture changes\n- CLI changes\n- 7hell implementation\n- VM / verifier / runtime changes\n- Trap taxonomy changes\n- Determinism matrix changes\n- CTF policy changes\n- Workbench / UI / I70\n- PCC-2 implementation\n\n## Validation\n\n- git diff --check\n- git diff --name-only origin/main...HEAD\n\n## CTF touched\n\nCTF touched: guard record only\nReason: documents PCC-1 CTF impact without changing any CTF trust classification.\n\n## 7hell coverage\n\n7hell coverage: none\nReason: this PR does not change 7hell mapping or implement any 7hell behavior.