### PR TITLE
PR-PCC-2A — tests(numeric): add numeric core gate fixtures

### DIFF
--- a/tests/fixtures/pcc2_numeric/negative_bool_assigned_from_i32.sm
+++ b/tests/fixtures/pcc2_numeric/negative_bool_assigned_from_i32.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let flag: bool = 1 + 2;
+}

--- a/tests/fixtures/pcc2_numeric/negative_i32_assigned_from_bool.sm
+++ b/tests/fixtures/pcc2_numeric/negative_i32_assigned_from_bool.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let value: i32 = true;
+}

--- a/tests/fixtures/pcc2_numeric/negative_i32_comparison_against_bool.sm
+++ b/tests/fixtures/pcc2_numeric/negative_i32_comparison_against_bool.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let cmp: bool = 1 < true;
+}

--- a/tests/fixtures/pcc2_numeric/negative_i32_plus_bool.sm
+++ b/tests/fixtures/pcc2_numeric/negative_i32_plus_bool.sm
@@ -1,0 +1,3 @@
+fn main() {
+    let sum: i32 = 1 + true;
+}

--- a/tests/fixtures/pcc2_numeric/negative_if_numeric_condition.sm
+++ b/tests/fixtures/pcc2_numeric/negative_if_numeric_condition.sm
@@ -1,0 +1,7 @@
+fn main() {
+    if 1 {
+        return;
+    } else {
+        return;
+    }
+}

--- a/tests/fixtures/pcc2_numeric/negative_while_numeric_condition.sm
+++ b/tests/fixtures/pcc2_numeric/negative_while_numeric_condition.sm
@@ -1,0 +1,5 @@
+fn main() {
+    while 1 {
+        return;
+    }
+}

--- a/tests/fixtures/pcc2_numeric/positive_f64_basic.sm
+++ b/tests/fixtures/pcc2_numeric/positive_f64_basic.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: f64 = 1.5 + 2.25 * 2.0;
+    assert(value == 6.0);
+}

--- a/tests/fixtures/pcc2_numeric/positive_fx_basic.sm
+++ b/tests/fixtures/pcc2_numeric/positive_fx_basic.sm
@@ -1,0 +1,7 @@
+fn main() {
+    let a: fx = 2.5;
+    let b: fx = 1.5;
+    let c: fx = a + b;
+    let expected: fx = 4.0;
+    assert(c == expected);
+}

--- a/tests/fixtures/pcc2_numeric/positive_i32_comparisons.sm
+++ b/tests/fixtures/pcc2_numeric/positive_i32_comparisons.sm
@@ -1,0 +1,12 @@
+fn main() {
+    let lt: bool = 2 < 3;
+    let le: bool = 3 <= 3;
+    let gt: bool = 4 > 3;
+    let ge: bool = 4 >= 4;
+    let eq: bool = 3 == 3;
+    assert(lt == true);
+    assert(le == true);
+    assert(gt == true);
+    assert(ge == true);
+    assert(eq == true);
+}

--- a/tests/fixtures/pcc2_numeric/positive_i32_literals_and_arithmetic.sm
+++ b/tests/fixtures/pcc2_numeric/positive_i32_literals_and_arithmetic.sm
@@ -1,0 +1,8 @@
+fn main() {
+    let a: i32 = 1;
+    let b: i32 = 2 + 3;
+    let c: i32 = a + b;
+    let d: i32 = c - 1;
+    let e: i32 = d * 2;
+    assert(e == 10);
+}

--- a/tests/fixtures/pcc2_numeric/positive_numeric_conditions.sm
+++ b/tests/fixtures/pcc2_numeric/positive_numeric_conditions.sm
@@ -1,0 +1,11 @@
+fn main() {
+    let mut i: i32 = 0;
+    while i < 3 {
+        i = i + 1;
+    }
+    if (i + 1) == 4 {
+        return;
+    } else {
+        return;
+    }
+}

--- a/tests/fixtures/pcc2_numeric/positive_u32_basic.sm
+++ b/tests/fixtures/pcc2_numeric/positive_u32_basic.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let count: u32 = 7u32;
+    assert(count == 7u32);
+}

--- a/tests/pcc2_numeric_core_gate.rs
+++ b/tests/pcc2_numeric_core_gate.rs
@@ -1,0 +1,304 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_path(rel: &str) -> String {
+    repo_path(&format!("tests/fixtures/pcc2_numeric/{rel}"))
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn run_public_numeric_pipeline(rel: &str) {
+    let input = fixture_path(rel);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let dir = mk_temp_dir("pcc2_numeric_core_gate");
+    let out = dir.join(format!("{rel}.smc"));
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+
+    let bytes = std::fs::read(&out)
+        .unwrap_or_else(|err| panic!("compiled numeric artifact for {input} was not readable: {err}"));
+    assert!(
+        !bytes.is_empty(),
+        "expected emitted numeric artifact for {input} to be non-empty"
+    );
+
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+fn compile_numeric_fixture_to_bytes(rel: &str, out_tag: &str) -> Vec<u8> {
+    let input = fixture_path(rel);
+    let dir = mk_temp_dir("pcc2_numeric_core_gate_bytes");
+    let out = dir.join(format!("{rel}_{out_tag}.smc"));
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    let bytes = std::fs::read(&out)
+        .unwrap_or_else(|err| panic!("compiled numeric artifact for {input} was not readable: {err}"));
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+    bytes
+}
+
+fn assert_stable_numeric_diagnostic(rel: &str, code: &str, needle: &str) {
+    let input = fixture_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains(&format!("Error [{code}]")),
+        "expected diagnostic code {code} for {rel}, got: {err}"
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+    );
+}
+
+fn assert_invalid_numeric_compile_path_does_not_verify(rel: &str, code: &str, needle: &str) {
+    let input = fixture_path(rel);
+    let dir = mk_temp_dir("pcc2_numeric_core_gate_invalid");
+    let out = dir.join(format!("{rel}.smc"));
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let compile_res = smc_cli::run(vec![
+        "compile".to_string(),
+        input.clone(),
+        "-o".to_string(),
+        out_arg.clone(),
+    ]);
+    match compile_res {
+        Ok(()) => {
+            let bytes = std::fs::read(&out).unwrap_or_else(|err| {
+                panic!("compile succeeded but emitted artifact for {input} was not readable: {err}")
+            });
+            assert!(
+                !bytes.is_empty(),
+                "compile succeeded but emitted artifact for {input} was empty"
+            );
+            let verify_err = cli_err(
+                vec!["verify".to_string(), out_arg.clone()],
+                &format!("smc verify for {out_arg}"),
+            );
+            assert!(
+                verify_err.contains("Error ["),
+                "expected verify to reject invalid numeric artifact for {rel}, got: {verify_err}"
+            );
+        }
+        Err(err) => {
+            assert!(
+                err.contains(&format!("Error [{code}]")) || err.contains(needle),
+                "expected compile failure to mention {code} or '{needle}' for {rel}, got: {err}"
+            );
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// PCC-2 numeric gate maps later to:
+// - Type Hell
+// - Lowering Hell
+// - Verifier Hell
+// - VM Hell
+// - Practical Hell
+// - User Pain / Diagnostics Hell
+
+#[test]
+fn pcc2_i32_literals_and_arithmetic_positive_pipeline() {
+    run_public_numeric_pipeline("positive_i32_literals_and_arithmetic.sm");
+}
+
+#[test]
+fn pcc2_i32_comparisons_positive_pipeline() {
+    run_public_numeric_pipeline("positive_i32_comparisons.sm");
+}
+
+#[test]
+fn pcc2_numeric_conditions_positive_pipeline() {
+    run_public_numeric_pipeline("positive_numeric_conditions.sm");
+}
+
+#[test]
+fn pcc2_optional_numeric_paths_reflect_current_support() {
+    for rel in [
+        "positive_u32_basic.sm",
+        "positive_f64_basic.sm",
+        "positive_fx_basic.sm",
+    ] {
+        run_public_numeric_pipeline(rel);
+    }
+}
+
+#[test]
+fn pcc2_invalid_numeric_cases_have_stable_diagnostics() {
+    let cases = [
+        (
+            "negative_bool_assigned_from_i32.sm",
+            "E0201",
+            "type mismatch in let",
+        ),
+        (
+            "negative_i32_assigned_from_bool.sm",
+            "E0201",
+            "type mismatch in let",
+        ),
+        (
+            "negative_i32_plus_bool.sm",
+            "E0201",
+            "I32",
+        ),
+        (
+            "negative_i32_comparison_against_bool.sm",
+            "E0201",
+            "cannot compare I32 and Bool",
+        ),
+        (
+            "negative_while_numeric_condition.sm",
+            "E0201",
+            "while condition must be bool",
+        ),
+        (
+            "negative_if_numeric_condition.sm",
+            "E0201",
+            "if condition must be bool",
+        ),
+    ];
+
+    for (rel, code, needle) in cases {
+        assert_stable_numeric_diagnostic(rel, code, needle);
+    }
+}
+
+#[test]
+fn pcc2_invalid_numeric_compile_path_does_not_verify() {
+    let cases = [
+        (
+            "negative_bool_assigned_from_i32.sm",
+            "E0201",
+            "type mismatch in let",
+        ),
+        (
+            "negative_i32_assigned_from_bool.sm",
+            "E0201",
+            "type mismatch in let",
+        ),
+        (
+            "negative_i32_plus_bool.sm",
+            "E0201",
+            "I32",
+        ),
+        (
+            "negative_i32_comparison_against_bool.sm",
+            "E0201",
+            "cannot compare I32 and Bool",
+        ),
+        (
+            "negative_while_numeric_condition.sm",
+            "E0201",
+            "while condition must be bool",
+        ),
+        (
+            "negative_if_numeric_condition.sm",
+            "E0201",
+            "if condition must be bool",
+        ),
+    ];
+
+    for (rel, code, needle) in cases {
+        assert_invalid_numeric_compile_path_does_not_verify(rel, code, needle);
+    }
+}
+
+#[test]
+fn pcc2_numeric_repeated_pipeline_is_byte_stable() {
+    let first = compile_numeric_fixture_to_bytes("positive_i32_literals_and_arithmetic.sm", "a");
+    let second = compile_numeric_fixture_to_bytes("positive_i32_literals_and_arithmetic.sm", "b");
+    assert_eq!(
+        first, second,
+        "expected repeated compiles of the same numeric source to emit identical .smc bytes"
+    );
+
+    let dir = mk_temp_dir("pcc2_numeric_core_gate_repeat_run");
+    let out = dir.join("stable.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let input = fixture_path("positive_i32_literals_and_arithmetic.sm");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary\n\nStarts PCC-2 Numeric Core by adding dedicated numeric public pipeline gate coverage.\n\nThis PR adds focused tests for currently supported numeric behavior through the public CLI path, including i32 arithmetic, i32 comparisons, invalid numeric cases, compile/verify/run-smc coverage, and repeated SemCode byte stability.\n\n## Issue\n\nCloses #581.\n\n## Scope\n\n- Adds PCC-2 numeric core gate tests\n- Adds fixtures where useful\n- Uses public smc_cli::run route\n- Records current numeric truth without overclaiming unsupported numeric surfaces\n\n## Current numeric truth\n\nConfirmed by this PR:\n\n- i32: supported for literals, arithmetic, comparisons, and numeric control-flow conditions\n- u32: basic equality path confirmed; arithmetic remains outside this gate\n- f64: supported for the current basic arithmetic/public pipeline path\n- fx: supported for the current basic literal/arithmetic/public pipeline path\n\n## Out of scope\n\n- Broad parser/typechecker rewrite\n- Lowering rewrite\n- IR/emitter refactor\n- VM/verifier changes\n- CLI expansion\n- 7hell implementation\n- Workbench / UI / I70\n- Package builder\n- PCC-3 text work\n- CTF changes\n\n## Validation\n\n- git diff --check\n- cargo test -q --test pcc2_numeric_core_gate\n- cargo test -q --test pcc1_control_flow_gate\n- cargo test -q --test pcc1_control_flow_lowering_stability\n- cargo test -q --test pcc1_control_flow_diagnostics\n- git diff --name-only origin/main...HEAD\n\n## CTF touched\n\nCTF touched: none\nReason: numeric gate coverage only; CTF impact is tracked separately in #584.\n\n## 7hell coverage\n\n7hell coverage: fixture pressure only\nReason: this PR adds PCC-2 numeric gate pressure that can later be mapped to 7hell, but does not implement the 7hell command.