### PR TITLE
PR-PCC-2G — docs(ui): record PCC-2 UI freeze guard result

### DIFF
--- a/docs/roadmap/language_maturity/pcc2_numeric_ui_freeze_guard.md
+++ b/docs/roadmap/language_maturity/pcc2_numeric_ui_freeze_guard.md
@@ -1,0 +1,80 @@
+# PCC-2 Numeric UI Freeze Guard Result
+
+Status: draft guard note
+Track: PCC-2G record PCC-2 UI freeze guard result
+Layer: language maturity / UI freeze guard
+Scope: documentation only
+Implementation: out of scope
+Owner: language maturity stream
+
+Related:
+
+- `pcc2_numeric_closeout.md`
+- `practical_core_completion_v0_3.md`
+
+## 1. Purpose
+
+This document records the UI freeze guard result for PCC-2 Numeric Core.
+
+It states that PCC-2 was closed without introducing UI, Workbench, I70, or
+Tauri/runtime UI implementation work.
+
+## 2. Guard result
+
+```text
+PCC-2 UI freeze guard result: passed
+```
+
+Meaning:
+
+- no UI implementation entered PCC-2;
+- no Workbench implementation entered PCC-2;
+- no I70 work entered PCC-2;
+- no Tauri/runtime UI code entered PCC-2;
+- no package builder work entered PCC-2;
+- PCC-2 stayed limited to numeric tests, fixtures, docs, CTF impact record,
+  7hell mapping, and closeout.
+
+## 3. Evidence
+
+Merged PCC-2 PRs and their UI / Workbench / I70 impact:
+
+| PR | Result | UI / Workbench / I70 impact |
+|---|---|---|---|
+| `#588` PCC-2A | merged | Workbench/UI/I70 untouched |
+| `#589` PCC-2B | merged | Workbench/UI/I70 untouched |
+| `#590` PCC-2C | merged | Workbench/UI/I70 untouched |
+| `#591` PCC-2D | merged | Workbench/UI/I70 untouched |
+| `#592` PCC-2E | merged | Workbench/UI/I70 untouched |
+| `#593` PCC-2F | merged | Workbench/UI/I70 untouched |
+
+## 4. Freeze boundary
+
+UI / Workbench / I70 remained frozen for PCC-2.
+
+The UI boundary may only be reopened by a separate explicit post-PCC or
+dedicated UI-track scope decision.
+
+Do not interpret this as cancellation of UI work.
+
+Do not interpret this as abandonment of Workbench work.
+
+Do not interpret this as I70 starting now.
+
+Do not interpret this as package builder work starting now.
+
+## 5. PCC-3 impact
+
+PCC-3 may become eligible after maintainer acceptance with UI / Workbench /
+I70 still frozen unless explicitly reopened by a separate scope decision.
+
+PCC-3 is not started by this PR.
+
+## 6. Acceptance checklist
+
+- PCC-2 UI freeze guard result recorded
+- no UI / Workbench / I70 implementation entered PCC-2
+- no code, test, or fixture changes
+- no CTF classification changes
+- PCC-3 not started
+- package builder not started

--- a/docs/roadmap/language_maturity/pcc2_numeric_ui_freeze_guard.md
+++ b/docs/roadmap/language_maturity/pcc2_numeric_ui_freeze_guard.md
@@ -40,7 +40,7 @@ Meaning:
 Merged PCC-2 PRs and their UI / Workbench / I70 impact:
 
 | PR | Result | UI / Workbench / I70 impact |
-|---|---|---|---|
+|---|---|---|
 | `#588` PCC-2A | merged | Workbench/UI/I70 untouched |
 | `#589` PCC-2B | merged | Workbench/UI/I70 untouched |
 | `#590` PCC-2C | merged | Workbench/UI/I70 untouched |


### PR DESCRIPTION
## Summary

Records the UI freeze guard result for PCC-2 Numeric Core.

This PR confirms that PCC-2 did not include UI, Workbench, I70, Tauri/runtime UI, or package-builder implementation work.

## Issue

Closes #587.

## Scope

Docs-only:

- `docs/roadmap/language_maturity/pcc2_numeric_ui_freeze_guard.md`

## Guard result

PCC-2 UI freeze guard result: `passed`

Reason:
PCC-2 remained limited to numeric tests, fixtures, docs, CTF impact record, 7hell mapping, and closeout. UI / Workbench / I70 remained frozen.

## Out of scope

- Rust code changes
- Test changes
- Fixture changes
- CLI changes
- 7hell implementation
- VM / verifier / runtime changes
- UI implementation
- Workbench implementation
- I70 work
- Tauri/runtime UI code
- Package builder
- CTF policy changes
- PCC-3 implementation

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: docs-only UI freeze guard record; no CTF policy or trust classification changes.

## 7hell coverage

7hell coverage: none
Reason: this PR does not change 7hell mapping or implement any 7hell behavior.