### PR TITLE
PR-PCC-3-0 — docs(readiness): reset text surface boundary before PCC-3

### DIFF
--- a/docs/roadmap/language_maturity/pcc3_text_surface_boundary_reset.md
+++ b/docs/roadmap/language_maturity/pcc3_text_surface_boundary_reset.md
@@ -1,0 +1,145 @@
+# PCC-3 Text Surface Boundary Reset
+
+Status: pre-entry guard
+Track: PCC-3-0
+Layer: language maturity / readiness
+Scope: documentation only
+Implementation: out of scope
+Owner: language maturity stream
+
+Related:
+
+- `docs/roadmap/language_maturity/practical_core_completion_v0_3.md`
+- `#477`
+- `#478`
+- `#479`
+- `#356`
+
+## 1. Purpose
+
+This document resets the text/string surface boundary before PCC-3.
+
+PCC-3 may work on text/string mechanics, but it must not canonize legacy surface vocabulary while doing so. The purpose of this reset is to keep Semantic from drifting into a C/Rust-like source surface with strings by accident.
+
+Hello World remains required as proof of life. It is not a general stdout story; it is controlled observation, bounded by the current surface and the language maturity boundary.
+
+## 2. Current phase state
+
+| Phase | State |
+|---|---|
+| PCC-1 Control Flow Core | closed |
+| PCC-2 Numeric Core | closed |
+| PCC-3 Text/String Core | not started |
+| PCC-3-0 Text Surface Boundary Reset | active / pre-entry guard |
+
+## 3. Boundary rules
+
+- Text/string mechanics may be stabilized in PCC-3.
+- Public surface vocabulary is not frozen by PCC-3A tests.
+- `fn main`, `print`, `return`, `assert` must not be treated as canonical Semantic vocabulary.
+- Legacy forms may remain bridge-only if currently needed by the existing frontend.
+- Canonical direction must be decided through `#478` and `#479`.
+- Hello World / observation boundary remains blocked until the text surface boundary is clear.
+- Linguist recognition remains deferred.
+
+## 4. Hello World decision
+
+Hello World is required.
+It is not optional.
+It is the proof-of-life path for mature engineers and external readers.
+
+But the canonical Hello World must not be:
+
+```text
+fn main() {
+    print("Hello, World!");
+    return;
+}
+```
+
+That form is explicitly not canonical Semantic surface.
+
+Instead, the direction is:
+
+```text
+entry HelloWorld {
+    state boot: quad = T;
+    require boot == T;
+    observe "Hello, World!";
+    complete T;
+}
+```
+
+This is semantic-native direction / future canonical direction unless and until the grammar and implementation already support it. This document does not claim that syntax is executable.
+
+## 5. Vocabulary boundary table
+
+| Legacy / bridge term | Semantic-native direction | Status before audit |
+|---|---|---|
+| `fn main` | `entry` | bridge / not canonical |
+| `print` | `observe` | bridge / not canonical |
+| `return` | `complete` | bridge / not canonical |
+| `assert` | `require` | bridge / not canonical |
+| `stdout` | observation sink | not general I/O |
+| `I/O` | controlled observation/effect | capability-bound |
+| `run` | execute / transition / evaluate | layer-dependent |
+
+## 6. Relationship to future issues
+
+- `#478` should audit legacy surface vocabulary.
+- `#479` should define command lexicon and density/style rules.
+- `#477` should be revisited only after this boundary is accepted.
+- `#356` / Linguist readiness remains deferred until public surface identity stabilizes.
+
+## 7. PCC-3 entry rule
+
+PCC-3A may start only after this PR lands.
+
+PCC-3A may add text/string core gate fixtures, but it must not:
+
+- implement Hello World;
+- add general observation;
+- canonize `print`, `main`, `return`, or `assert`;
+- start Linguist readiness;
+- touch UI / Workbench / I70.
+
+## 8. Explicit non-goals
+
+This PR does not:
+
+- implement text/string features;
+- implement `observe` / `print`;
+- implement Hello World;
+- implement new grammar;
+- rename current syntax globally;
+- modify examples;
+- modify tests;
+- modify frontend/parser/typechecker;
+- start `#477`;
+- close `#478` or `#479`;
+- start Linguist recognition;
+- start UI / Workbench / I70;
+- start package builder.
+
+## 9. Acceptance checklist
+
+- PCC-3 pre-entry boundary recorded
+- Hello World requirement acknowledged
+- legacy Hello World form rejected as canonical
+- semantic-native observation direction recorded
+- `#477` remains blocked / dependent
+- `#478` / `#479` remain future surface decision issues
+- Linguist readiness remains deferred
+- no code / test / fixture changes
+- no grammar changes
+- no UI / Workbench / I70
+- PCC-3A not started
+
+## 10. Boundary summary
+
+```text
+Hello World is required.
+Legacy Hello World is not canonical.
+Text mechanics may proceed.
+Observation vocabulary must remain guarded.
+```

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -303,6 +303,9 @@ Trust DoD:
 
 ## 10. PCC-3 — Text Core
 
+Pre-entry surface boundary reset:
+`docs/roadmap/language_maturity/pcc3_text_surface_boundary_reset.md`
+
 Scope:
 
 - text literal;


### PR DESCRIPTION
## Summary

Adds a pre-entry boundary reset before PCC-3 Text/String Core.

This PR records that PCC-3 may work on text/string mechanics, but must not canonize legacy `fn main` / `print` / `return` / `assert` vocabulary or start Hello World / observation implementation prematurely.

## Scope

Docs-only:

- `docs/roadmap/language_maturity/pcc3_text_surface_boundary_reset.md`
- `docs/roadmap/language_maturity/practical_core_completion_v0_3.md`

## Related issues

Related:
- #477
- #478
- #479
- #356

This PR does not close those issues.

## Boundary result

PCC-3 Text/String Core: `not started`

PCC-3-0 Text Surface Boundary Reset: `recorded`

Hello World: required as proof of life, but not through canonical `fn main` / `print` / `return`.

Canonical direction:
`entry` / `state` / `require` / `observe` / `complete`

## Out of scope

- Rust code changes
- Test changes
- Fixture changes
- Parser/typechecker changes
- Grammar implementation
- Hello World implementation
- `print` / `observe` implementation
- VM / verifier / runtime changes
- CTF policy changes
- 7hell implementation
- Workbench / UI / I70
- Package builder
- Linguist readiness implementation

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: docs-only surface boundary reset; no execution trust policy changes.

## 7hell coverage

7hell coverage: none
Reason: this PR does not change 7hell mapping or implement any 7hell behavior.