### PR TITLE
PR-M-HELLO-2 — tests(hello): add pending/admission fixtures for Hello grammar slice

### DIFF
--- a/docs/language/semantic_hello_fixtures.md
+++ b/docs/language/semantic_hello_fixtures.md
@@ -1,0 +1,53 @@
+# Semantic Hello Fixtures
+
+Status: pending fixture registry for `#477`
+
+## 1. Purpose
+
+This document registers pending Hello grammar-slice fixtures.
+
+## 2. Status
+
+- pending only
+- not executable yet
+- not part of accepted test truth
+- not wired into cargo tests as passing behavior
+- implementation later must decide how to admit or reject them
+
+## 3. Fixture Table
+
+| fixture | intended future class | expected future outcome | reason | current status |
+|---|---|---|---|---|
+| `tests/fixtures/pending/hello/positive_hello_verbose_directional.sm` | positive pending Hello grammar slice | accepted once grammar / sema / verifier / runtime support exists | records the recommended canonical direction | pending |
+| `tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm` | possible secondary onboarding shape | possibly accepted later, but not canonical architecture-bearing proof | useful as a lighter shape, but incomplete | pending |
+| `tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm` | rejected legacy Hello sketch | rejected as canonical / bridge-only if ever executable | legacy `fn main` / `print` / `return` shape | pending |
+| `tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm` | negative pending Hello rejection fixture | rejected until first slice only admits text literal observation payload | tests observation payload boundary | pending |
+| `tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm` | negative pending Hello rejection fixture | rejected until requirement is side-effect-free | tests requirement boundary | pending |
+| `tests/fixtures/pending/hello/negative_hello_general_io_shape.sm` | negative pending Hello rejection fixture | rejected until general I/O is explicitly scoped | tests that generic I/O is not canonical Hello observation | pending |
+
+## 4. Admission Boundary
+
+- positive fixtures are not accepted until parser / sema / verifier / runtime
+  support exists
+- negative fixtures define future rejection intent
+- no current compiler behavior is changed
+- no existing test expectation is changed
+
+## 5. Relationship to `#477`
+
+- prepares `#477`
+- does not close `#477`
+- next implementation planning still required
+
+## 6. Acceptance Checklist
+
+- pending fixture directory added
+- positive pending fixtures added
+- negative pending fixtures added
+- docs registry added
+- fixtures not wired into passing cargo tests
+- no parser / typechecker changes
+- no grammar implementation
+- no runtime / verifier / capability changes
+- no Hello World implementation
+- `#477` remains open

--- a/tests/fixtures/pending/hello/README.md
+++ b/tests/fixtures/pending/hello/README.md
@@ -1,0 +1,15 @@
+# Pending Hello Fixtures
+
+These fixtures are pending / admission-only artifacts for the future Hello
+grammar slice.
+
+They are not wired into current passing cargo tests.
+
+Current directory contents:
+
+- `positive_hello_verbose_directional.sm`
+- `positive_hello_minimal_observe_directional.sm`
+- `negative_hello_print_legacy_canonical.sm`
+- `negative_hello_observe_non_text_payload.sm`
+- `negative_hello_require_side_effect_shape.sm`
+- `negative_hello_general_io_shape.sm`

--- a/tests/fixtures/pending/hello/negative_hello_general_io_shape.sm
+++ b/tests/fixtures/pending/hello/negative_hello_general_io_shape.sm
@@ -1,0 +1,6 @@
+// Pending negative fixture.
+// General I/O is not canonical Hello observation.
+entry HelloWorld {
+    io.write("Hello, World!");
+    complete T;
+}

--- a/tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm
+++ b/tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm
@@ -1,0 +1,6 @@
+// Pending negative fixture.
+// First Hello slice should only admit text literal observation payload.
+entry HelloWorld {
+    observe T;
+    complete T;
+}

--- a/tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm
+++ b/tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm
@@ -1,0 +1,7 @@
+// Pending negative fixture.
+// Legacy bridge shape.
+// Rejected as canonical Hello surface.
+fn main() {
+    print("Hello, World!");
+    return;
+}

--- a/tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm
+++ b/tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm
@@ -1,0 +1,6 @@
+// Pending negative fixture.
+// Requirement must not perform observation/effects.
+entry HelloWorld {
+    require observe "Hello, World!";
+    complete T;
+}

--- a/tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm
+++ b/tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm
@@ -1,0 +1,6 @@
+// Pending fixture.
+// Not executable yet.
+// Expected future status: possible secondary onboarding shape, not canonical architecture-bearing proof.
+entry HelloWorld {
+    observe "Hello, World!";
+}

--- a/tests/fixtures/pending/hello/positive_hello_verbose_directional.sm
+++ b/tests/fixtures/pending/hello/positive_hello_verbose_directional.sm
@@ -1,0 +1,9 @@
+// Pending fixture.
+// Not executable yet.
+// Expected future status: positive accepted Hello grammar slice.
+entry HelloWorld {
+    state boot: quad = T;
+    require boot == T;
+    observe "Hello, World!";
+    complete T;
+}


### PR DESCRIPTION
## Summary

Adds pending/admission fixtures for the future #477 Hello grammar slice.

This PR records positive and negative fixture shapes for `entry/state/require/observe/complete` without wiring them into passing cargo tests or implementing parser, typechecker, verifier, runtime, or capability behavior.

## Issue

Prepares #477.
Does not close #477.

## Scope

Fixture/docs-only:

- `docs/language/semantic_hello_fixtures.md`
- `tests/fixtures/pending/hello/README.md`
- `tests/fixtures/pending/hello/*.sm`

## Result

* Adds positive pending Hello grammar fixtures
* Adds negative pending Hello rejection fixtures
* Adds fixture registry
* Marks fixtures as not executable yet
* Keeps current compiler/test behavior unchanged

## Out of scope

* Parser/typechecker changes
* Grammar implementation
* Verifier changes
* VM/runtime changes
* Capability/effect admission changes
* Cargo test wiring that expects new grammar to pass
* Accepted golden SemCode
* README/example rewrites
* Hello World implementation
* `print` / `observe` implementation
* `entry` / `state` / `require` / `complete` implementation
* General I/O
* CTF policy changes
* Linguist readiness
* Workbench / UI / I70

## Validation

* `git diff --check`
* `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: pending fixtures only; no execution trust policy or admitted behavior changes.

## 7hell coverage

7hell coverage: none
Reason: this PR does not change 7hell mapping or implement behavior.