### PR TITLE
PR-M-HELLO-3B — parser(hello): add isolated Hello grammar parser path

### DIFF
--- a/crates/sm-front/src/hello_parser.rs
+++ b/crates/sm-front/src/hello_parser.rs
@@ -1,0 +1,277 @@
+use crate::lexer::lex_tokens;
+use crate::types::{FrontendError, Token, TokenKind};
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloFile {
+    pub entry: HelloEntry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloEntry {
+    pub name: String,
+    pub body: Vec<HelloStmt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloStmt {
+    State(HelloStateDecl),
+    Require(HelloRequireQuadEq),
+    Observe(HelloObserveText),
+    Complete(HelloCompleteQuad),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloStateType {
+    Quad,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloStateDecl {
+    pub name: String,
+    pub ty: HelloStateType,
+    pub value: HelloQuadLit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloRequireQuadEq {
+    pub state: String,
+    pub value: HelloQuadLit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloObserveText {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloCompleteQuad {
+    pub value: HelloQuadLit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloQuadLit {
+    T,
+    F,
+    N,
+    S,
+}
+
+pub fn parse_hello_file(input: &str) -> Result<HelloFile, FrontendError> {
+    let tokens = lex_tokens(input)?;
+    let mut parser = HelloParser { tokens, idx: 0 };
+    parser.parse_file()
+}
+
+struct HelloParser {
+    tokens: Vec<Token>,
+    idx: usize,
+}
+
+impl HelloParser {
+    fn parse_file(&mut self) -> Result<HelloFile, FrontendError> {
+        self.skip_layout();
+        let entry = self.parse_entry()?;
+        self.skip_layout();
+        if !self.is_eof() {
+            return Err(self.error_here("unexpected trailing tokens after Hello entry"));
+        }
+        Ok(HelloFile { entry })
+    }
+
+    fn parse_entry(&mut self) -> Result<HelloEntry, FrontendError> {
+        if self.peek_kind() == Some(TokenKind::KwFn) {
+            return Err(self.error_here(
+                "legacy Hello syntax is unsupported in isolated parser path; expected `entry`",
+            ));
+        }
+        self.expect_ident_text("entry", "expected `entry` to begin Hello file")?;
+        let name = self.expect_ident("expected Hello entry name after `entry`")?;
+        self.expect_kind(TokenKind::LBrace, "expected `{` after Hello entry name")?;
+
+        let mut body = Vec::new();
+        let mut saw_complete = false;
+        loop {
+            self.skip_layout();
+            if self.eat_kind(TokenKind::RBrace) {
+                break;
+            }
+            if self.is_eof() {
+                return Err(self.error_here("expected `}` to close Hello entry body"));
+            }
+            if saw_complete {
+                return Err(self.error_here("statement after complete is not allowed"));
+            }
+            let stmt = self.parse_stmt()?;
+            if matches!(stmt, HelloStmt::Complete(_)) {
+                saw_complete = true;
+            }
+            body.push(stmt);
+        }
+
+        Ok(HelloEntry { name, body })
+    }
+
+    fn parse_stmt(&mut self) -> Result<HelloStmt, FrontendError> {
+        if self.eat_ident_text("state") {
+            return self.parse_state_decl();
+        }
+        if self.eat_ident_text("require") {
+            return self.parse_require_decl();
+        }
+        if self.eat_ident_text("observe") {
+            return self.parse_observe_stmt();
+        }
+        if self.eat_ident_text("complete") {
+            return self.parse_complete_stmt();
+        }
+        if self.peek_kind() == Some(TokenKind::KwFn) {
+            return Err(self.error_here(
+                "legacy Hello syntax is unsupported in isolated parser path; expected `entry`",
+            ));
+        }
+        Err(self
+            .error_here("expected Hello statement: `state`, `require`, `observe`, or `complete`"))
+    }
+
+    fn parse_state_decl(&mut self) -> Result<HelloStmt, FrontendError> {
+        let name = self.expect_ident("expected state name after `state`")?;
+        self.expect_kind(TokenKind::Colon, "expected `:` after state name")?;
+        self.expect_kind(TokenKind::TyQuad, "expected `quad` in state declaration")?;
+        self.expect_kind(TokenKind::Assign, "expected `=` in state declaration")?;
+        let value = self.parse_quad_lit("expected quad literal in state declaration")?;
+        self.expect_kind(TokenKind::Semi, "expected `;` after state declaration")?;
+        Ok(HelloStmt::State(HelloStateDecl {
+            name,
+            ty: HelloStateType::Quad,
+            value,
+        }))
+    }
+
+    fn parse_require_decl(&mut self) -> Result<HelloStmt, FrontendError> {
+        let state = self.expect_ident("expected state symbol after `require`")?;
+        self.expect_kind(TokenKind::EqEq, "expected `==` after required state symbol")?;
+        let value = self.parse_quad_lit("expected quad literal in requirement")?;
+        self.expect_kind(TokenKind::Semi, "expected `;` after requirement")?;
+        Ok(HelloStmt::Require(HelloRequireQuadEq { state, value }))
+    }
+
+    fn parse_observe_stmt(&mut self) -> Result<HelloStmt, FrontendError> {
+        let text = self.expect_string_literal("expected text literal after `observe`")?;
+        self.expect_kind(TokenKind::Semi, "expected `;` after observation")?;
+        Ok(HelloStmt::Observe(HelloObserveText { text }))
+    }
+
+    fn parse_complete_stmt(&mut self) -> Result<HelloStmt, FrontendError> {
+        let value = self.parse_quad_lit("expected quad literal after `complete`")?;
+        self.expect_kind(TokenKind::Semi, "expected `;` after completion")?;
+        Ok(HelloStmt::Complete(HelloCompleteQuad { value }))
+    }
+
+    fn parse_quad_lit(&mut self, message: &str) -> Result<HelloQuadLit, FrontendError> {
+        let tok = self.next_token().ok_or_else(|| self.error_here(message))?;
+        match tok.kind {
+            TokenKind::QuadT => Ok(HelloQuadLit::T),
+            TokenKind::QuadF => Ok(HelloQuadLit::F),
+            TokenKind::QuadN => Ok(HelloQuadLit::N),
+            TokenKind::QuadS => Ok(HelloQuadLit::S),
+            _ => Err(FrontendError::syntax(tok.pos, message)),
+        }
+    }
+
+    fn expect_ident(&mut self, message: &str) -> Result<String, FrontendError> {
+        let tok = self.next_token().ok_or_else(|| self.error_here(message))?;
+        if tok.kind == TokenKind::Ident {
+            Ok(tok.text)
+        } else {
+            Err(FrontendError::syntax(tok.pos, message))
+        }
+    }
+
+    fn expect_string_literal(&mut self, message: &str) -> Result<String, FrontendError> {
+        let tok = self.next_token().ok_or_else(|| self.error_here(message))?;
+        if tok.kind == TokenKind::String {
+            Ok(tok.text)
+        } else {
+            Err(FrontendError::syntax(tok.pos, message))
+        }
+    }
+
+    fn expect_ident_text(&mut self, expected: &str, message: &str) -> Result<(), FrontendError> {
+        let tok = self.next_token().ok_or_else(|| self.error_here(message))?;
+        if tok.kind == TokenKind::Ident && tok.text == expected {
+            Ok(())
+        } else {
+            Err(FrontendError::syntax(tok.pos, message))
+        }
+    }
+
+    fn expect_kind(&mut self, kind: TokenKind, message: &str) -> Result<(), FrontendError> {
+        let tok = self.next_token().ok_or_else(|| self.error_here(message))?;
+        if tok.kind == kind {
+            Ok(())
+        } else {
+            Err(FrontendError::syntax(tok.pos, message))
+        }
+    }
+
+    fn eat_kind(&mut self, kind: TokenKind) -> bool {
+        if self.peek_kind() == Some(kind) {
+            self.idx += 1;
+            return true;
+        }
+        false
+    }
+
+    fn eat_ident_text(&mut self, expected: &str) -> bool {
+        match self.peek_token() {
+            Some(tok) if tok.kind == TokenKind::Ident && tok.text == expected => {
+                self.idx += 1;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn next_token(&mut self) -> Option<Token> {
+        self.skip_layout();
+        let tok = self.tokens.get(self.idx).cloned();
+        if tok.is_some() {
+            self.idx += 1;
+        }
+        tok
+    }
+
+    fn skip_layout(&mut self) {
+        while matches!(
+            self.tokens.get(self.idx).map(|t| t.kind),
+            Some(TokenKind::Newline | TokenKind::Indent | TokenKind::Dedent)
+        ) {
+            self.idx += 1;
+        }
+    }
+
+    fn peek_token(&mut self) -> Option<Token> {
+        self.skip_layout();
+        self.tokens.get(self.idx).cloned()
+    }
+
+    fn peek_kind(&mut self) -> Option<TokenKind> {
+        self.peek_token().map(|tok| tok.kind)
+    }
+
+    fn is_eof(&mut self) -> bool {
+        self.peek_token().is_none()
+    }
+
+    fn error_here(&mut self, message: impl Into<String>) -> FrontendError {
+        let pos = self.peek_token().map(|tok| tok.pos).unwrap_or_else(|| {
+            self.tokens
+                .last()
+                .map(|tok| tok.pos.saturating_add(tok.text.len()))
+                .unwrap_or(0)
+        });
+        FrontendError::syntax(pos, message)
+    }
+}

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -15,24 +15,83 @@ use alloc::vec::Vec;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use types::{
-    AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg,
-    ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,
-    FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField,
-    LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
-    MatchExpr, MatchExprArm, IterableLoopDesugaring, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
-    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
-    SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
-    SequenceLiteral, SequenceType, MapType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,
-    TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type,
-    UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
-    ValidationVariantPlan,
-    // M9.7
-    PathAvailability, PatternPath,
-};
-#[cfg(any(feature = "alloc", feature = "std"))]
 pub use sm_profile::{CompatibilityMode, ParserProfile};
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub use types::{
+    AdtCtorExpr,
+    AdtDecl,
+    AdtVariant,
+    AstArena,
+    BinaryOp,
+    BlockExpr,
+    CallArg,
+    ClosureCapturePolicy,
+    ClosureLiteral,
+    ClosureType,
+    ClosureValueFamily,
+    Expr,
+    ExprId,
+    FrontendError,
+    FrontendErrorKind,
+    Function,
+    IfExpr,
+    ImplDecl,
+    IterableLoopDesugaring,
+    LogosEntity,
+    LogosEntityField,
+    LogosEntityFieldKind,
+    LogosLaw,
+    LogosProgram,
+    LogosSystem,
+    LogosWhen,
+    LoopExpr,
+    MapType,
+    MatchArm,
+    MatchExpr,
+    MatchExprArm,
+    // M9.7
+    PathAvailability,
+    PatternPath,
+    Program,
+    QuadVal,
+    RecordDecl,
+    RecordField,
+    RecordFieldExpr,
+    RecordInitField,
+    RecordLiteralExpr,
+    RecordUpdateExpr,
+    SchemaDecl,
+    SchemaField,
+    SchemaRole,
+    SchemaShape,
+    SchemaVariant,
+    SchemaVersion,
+    SequenceCollectionFamily,
+    SequenceIndexExpr,
+    SequenceLiteral,
+    SequenceType,
+    Stmt,
+    StmtId,
+    SymbolId,
+    TextLiteral,
+    TextLiteralFamily,
+    Token,
+    TokenKind,
+    TraitBound,
+    TraitDecl,
+    TraitMethodSig,
+    TuplePatternItem,
+    Type,
+    UnaryOp,
+    ValidationCheck,
+    ValidationFieldPlan,
+    ValidationPlan,
+    ValidationShapePlan,
+    ValidationVariantPlan,
+};
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod lexer;
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -166,9 +225,16 @@ impl ScopeEnv {
     }
 
     pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-        self.insert_binding(name, ScopeBinding {
-            ty, is_const: true, is_mutable: false, consumed: false, path_state: Vec::new(),
-        });
+        self.insert_binding(
+            name,
+            ScopeBinding {
+                ty,
+                is_const: true,
+                is_mutable: false,
+                consumed: false,
+                path_state: Vec::new(),
+            },
+        );
     }
 
     /// Mark a variable as consumed (moved out). Subsequent reads will be rejected.
@@ -196,7 +262,9 @@ impl ScopeEnv {
         use crate::types::PatternPath;
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() { return false; }
+            if a.elems.len() > b.elems.len() {
+                return false;
+            }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
 
@@ -207,7 +275,9 @@ impl ScopeEnv {
                 // Rule 1 — new path subsumes longer existing entries of the same state:
                 //   e.g. adding Moved(root) while Moved(root.0) exists → drop root.0.
                 binding.path_state.retain(|(existing, existing_state)| {
-                    if *existing_state != state { return true; }
+                    if *existing_state != state {
+                        return true;
+                    }
                     !path_is_prefix(&path, existing)
                 });
                 // Rule 2 — if an existing entry already covers the new path (same state,
@@ -235,7 +305,9 @@ impl ScopeEnv {
         use crate::types::{PathAvailability, PatternPath};
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() { return false; }
+            if a.elems.len() > b.elems.len() {
+                return false;
+            }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
         fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
@@ -269,7 +341,10 @@ impl ScopeEnv {
                                 stored_path.elems
                             )
                         };
-                        return Err(crate::types::FrontendError { pos: 0, message: msg });
+                        return Err(crate::types::FrontendError {
+                            pos: 0,
+                            message: msg,
+                        });
                     }
                 }
             }
@@ -295,14 +370,18 @@ impl ScopeEnv {
         use crate::types::{CaptureMode, PathAvailability, PatternPath};
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() { return false; }
+            if a.elems.len() > b.elems.len() {
+                return false;
+            }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
         fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
             path_is_prefix(a, b) || path_is_prefix(b, a)
         }
 
-        let Some(binding) = self.binding(name) else { return Ok(()); };
+        let Some(binding) = self.binding(name) else {
+            return Ok(());
+        };
 
         if binding.consumed {
             return Err(crate::types::FrontendError {
@@ -312,18 +391,26 @@ impl ScopeEnv {
         }
 
         for (stored_path, stored_state) in &binding.path_state {
-            if !paths_overlap(stored_path, path) { continue; }
+            if !paths_overlap(stored_path, path) {
+                continue;
+            }
             let msg: Option<&str> = match (stored_state, capture) {
-                (PathAvailability::Borrowed, CaptureMode::Move) =>
-                    Some("cannot move from borrowed path"),
-                (PathAvailability::Moved, CaptureMode::Borrow) =>
-                    Some("cannot borrow from moved path"),
-                (PathAvailability::Moved, CaptureMode::Move) =>
-                    Some("cannot move from already-moved path"),
+                (PathAvailability::Borrowed, CaptureMode::Move) => {
+                    Some("cannot move from borrowed path")
+                }
+                (PathAvailability::Moved, CaptureMode::Borrow) => {
+                    Some("cannot borrow from moved path")
+                }
+                (PathAvailability::Moved, CaptureMode::Move) => {
+                    Some("cannot move from already-moved path")
+                }
                 _ => None,
             };
             if let Some(m) = msg {
-                return Err(crate::types::FrontendError { pos: 0, message: m.to_string() });
+                return Err(crate::types::FrontendError {
+                    pos: 0,
+                    message: m.to_string(),
+                });
             }
         }
         Ok(())
@@ -340,7 +427,9 @@ impl ScopeEnv {
     }
 
     pub fn is_const(&self, name: SymbolId) -> bool {
-        self.binding(name).map(|binding| binding.is_const).unwrap_or(false)
+        self.binding(name)
+            .map(|binding| binding.is_const)
+            .unwrap_or(false)
     }
 
     pub fn is_mutable(&self, name: SymbolId) -> bool {
@@ -389,14 +478,24 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
                 params: f
                     .params
                     .iter()
-                    .map(|(_, t)| canonicalize_declared_type_generic(
-                        t, &record_table, &adt_table, &program.arena, &f.type_params,
-                    ))
+                    .map(|(_, t)| {
+                        canonicalize_declared_type_generic(
+                            t,
+                            &record_table,
+                            &adt_table,
+                            &program.arena,
+                            &f.type_params,
+                        )
+                    })
                     .collect::<Result<Vec<_>, _>>()?,
                 param_names: Some(f.params.iter().map(|(name, _)| *name).collect()),
                 param_defaults: Some(f.param_defaults.clone()),
                 ret: canonicalize_declared_type_generic(
-                    &f.ret, &record_table, &adt_table, &program.arena, &f.type_params,
+                    &f.ret,
+                    &record_table,
+                    &adt_table,
+                    &program.arena,
+                    &f.type_params,
                 )?,
             },
         );
@@ -574,10 +673,7 @@ pub fn canonicalize_declared_type(
             } else {
                 Err(FrontendError {
                     pos: 0,
-                    message: format!(
-                        "unknown enum type '{}'",
-                        resolve_symbol_name(arena, *name)?
-                    ),
+                    message: format!("unknown enum type '{}'", resolve_symbol_name(arena, *name)?),
                 })
             }
         }
@@ -612,25 +708,51 @@ pub fn canonicalize_declared_type_generic(
         Type::Tuple(items) => Ok(Type::Tuple(
             items
                 .iter()
-                .map(|item| canonicalize_declared_type_generic(item, record_table, adt_table, arena, type_params))
+                .map(|item| {
+                    canonicalize_declared_type_generic(
+                        item,
+                        record_table,
+                        adt_table,
+                        arena,
+                        type_params,
+                    )
+                })
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         Type::Sequence(sequence) => Ok(Type::Sequence(SequenceType {
             family: sequence.family,
             item: Box::new(canonicalize_declared_type_generic(
-                sequence.item.as_ref(), record_table, adt_table, arena, type_params,
+                sequence.item.as_ref(),
+                record_table,
+                adt_table,
+                arena,
+                type_params,
             )?),
         })),
         Type::Map(map) => Ok(Type::Map(MapType {
             key: Box::new(canonicalize_declared_type_generic(
-                map.key.as_ref(), record_table, adt_table, arena, type_params,
+                map.key.as_ref(),
+                record_table,
+                adt_table,
+                arena,
+                type_params,
             )?),
             val: Box::new(canonicalize_declared_type_generic(
-                map.val.as_ref(), record_table, adt_table, arena, type_params,
+                map.val.as_ref(),
+                record_table,
+                adt_table,
+                arena,
+                type_params,
             )?),
         })),
         Type::Measured(base, unit) => {
-            let canonical_base = canonicalize_declared_type_generic(base, record_table, adt_table, arena, type_params)?;
+            let canonical_base = canonicalize_declared_type_generic(
+                base,
+                record_table,
+                adt_table,
+                arena,
+                type_params,
+            )?;
             if !canonical_base.is_core_numeric_scalar() {
                 return Err(FrontendError {
                     pos: 0,
@@ -642,21 +764,45 @@ pub fn canonicalize_declared_type_generic(
             }
             Ok(Type::Measured(Box::new(canonical_base), *unit))
         }
-        Type::Option(item) => Ok(Type::Option(Box::new(
-            canonicalize_declared_type_generic(item, record_table, adt_table, arena, type_params)?,
-        ))),
+        Type::Option(item) => Ok(Type::Option(Box::new(canonicalize_declared_type_generic(
+            item,
+            record_table,
+            adt_table,
+            arena,
+            type_params,
+        )?))),
         Type::Result(ok_ty, err_ty) => Ok(Type::Result(
-            Box::new(canonicalize_declared_type_generic(ok_ty, record_table, adt_table, arena, type_params)?),
-            Box::new(canonicalize_declared_type_generic(err_ty, record_table, adt_table, arena, type_params)?),
+            Box::new(canonicalize_declared_type_generic(
+                ok_ty,
+                record_table,
+                adt_table,
+                arena,
+                type_params,
+            )?),
+            Box::new(canonicalize_declared_type_generic(
+                err_ty,
+                record_table,
+                adt_table,
+                arena,
+                type_params,
+            )?),
         )),
         Type::Closure(closure) => Ok(Type::Closure(crate::types::ClosureType {
             family: closure.family,
             capture: closure.capture,
             param: Box::new(canonicalize_declared_type_generic(
-                &closure.param, record_table, adt_table, arena, type_params,
+                &closure.param,
+                record_table,
+                adt_table,
+                arena,
+                type_params,
             )?),
             ret: Box::new(canonicalize_declared_type_generic(
-                &closure.ret, record_table, adt_table, arena, type_params,
+                &closure.ret,
+                record_table,
+                adt_table,
+                arena,
+                type_params,
             )?),
         })),
         Type::Record(name) => {
@@ -687,10 +833,7 @@ pub fn canonicalize_declared_type_generic(
             } else {
                 Err(FrontendError {
                     pos: 0,
-                    message: format!(
-                        "unknown enum type '{}'",
-                        resolve_symbol_name(arena, *name)?
-                    ),
+                    message: format!("unknown enum type '{}'", resolve_symbol_name(arena, *name)?),
                 })
             }
         }
@@ -871,7 +1014,10 @@ fn finalize_ordered_call_args(
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn resolve_symbol_name<'a>(arena: &'a AstArena, id: SymbolId) -> Result<&'a str, FrontendError> {
+pub fn resolve_symbol_name<'a>(
+    arena: &'a AstArena,
+    id: SymbolId,
+) -> Result<&'a str, FrontendError> {
     arena.try_symbol_name(id).ok_or(FrontendError {
         pos: 0,
         message: format!("invalid symbol id {}", id.0),

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -15,83 +15,26 @@ use alloc::vec::Vec;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub use sm_profile::{CompatibilityMode, ParserProfile};
+pub mod hello_parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use types::{
-    AdtCtorExpr,
-    AdtDecl,
-    AdtVariant,
-    AstArena,
-    BinaryOp,
-    BlockExpr,
-    CallArg,
-    ClosureCapturePolicy,
-    ClosureLiteral,
-    ClosureType,
-    ClosureValueFamily,
-    Expr,
-    ExprId,
-    FrontendError,
-    FrontendErrorKind,
-    Function,
-    IfExpr,
-    ImplDecl,
-    IterableLoopDesugaring,
-    LogosEntity,
-    LogosEntityField,
-    LogosEntityFieldKind,
-    LogosLaw,
-    LogosProgram,
-    LogosSystem,
-    LogosWhen,
-    LoopExpr,
-    MapType,
-    MatchArm,
-    MatchExpr,
-    MatchExprArm,
-    // M9.7
-    PathAvailability,
-    PatternPath,
-    Program,
-    QuadVal,
-    RecordDecl,
-    RecordField,
-    RecordFieldExpr,
-    RecordInitField,
-    RecordLiteralExpr,
-    RecordUpdateExpr,
-    SchemaDecl,
-    SchemaField,
-    SchemaRole,
-    SchemaShape,
-    SchemaVariant,
-    SchemaVersion,
-    SequenceCollectionFamily,
-    SequenceIndexExpr,
-    SequenceLiteral,
-    SequenceType,
-    Stmt,
-    StmtId,
-    SymbolId,
-    TextLiteral,
-    TextLiteralFamily,
-    Token,
-    TokenKind,
-    TraitBound,
-    TraitDecl,
-    TraitMethodSig,
-    TuplePatternItem,
-    Type,
-    UnaryOp,
-    ValidationCheck,
-    ValidationFieldPlan,
-    ValidationPlan,
-    ValidationShapePlan,
+    AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg,
+    ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,
+    FrontendError, FrontendErrorKind, Function, IfExpr, ImplDecl, LogosEntity, LogosEntityField,
+    LogosEntityFieldKind, LogosLaw, LogosProgram, LogosSystem, LogosWhen, LoopExpr, MatchArm,
+    MatchExpr, MatchExprArm, IterableLoopDesugaring, Program, QuadVal, RecordDecl, RecordField, RecordFieldExpr,
+    RecordInitField, RecordLiteralExpr, RecordUpdateExpr, SchemaDecl, SchemaField, SchemaRole,
+    SchemaShape, SchemaVariant, SchemaVersion, SequenceCollectionFamily, SequenceIndexExpr,
+    SequenceLiteral, SequenceType, MapType, Stmt, StmtId, SymbolId, TextLiteral, TextLiteralFamily, Token,
+    TokenKind, TraitBound, TraitDecl, TraitMethodSig, TuplePatternItem, Type,
+    UnaryOp, ValidationCheck, ValidationFieldPlan, ValidationPlan, ValidationShapePlan,
     ValidationVariantPlan,
+    // M9.7
+    PathAvailability, PatternPath,
 };
-
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub mod hello_parser;
+pub use sm_profile::{CompatibilityMode, ParserProfile};
+
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod lexer;
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -225,16 +168,9 @@ impl ScopeEnv {
     }
 
     pub fn insert_const(&mut self, name: SymbolId, ty: Type) {
-        self.insert_binding(
-            name,
-            ScopeBinding {
-                ty,
-                is_const: true,
-                is_mutable: false,
-                consumed: false,
-                path_state: Vec::new(),
-            },
-        );
+        self.insert_binding(name, ScopeBinding {
+            ty, is_const: true, is_mutable: false, consumed: false, path_state: Vec::new(),
+        });
     }
 
     /// Mark a variable as consumed (moved out). Subsequent reads will be rejected.
@@ -262,9 +198,7 @@ impl ScopeEnv {
         use crate::types::PatternPath;
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() {
-                return false;
-            }
+            if a.elems.len() > b.elems.len() { return false; }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
 
@@ -275,9 +209,7 @@ impl ScopeEnv {
                 // Rule 1 — new path subsumes longer existing entries of the same state:
                 //   e.g. adding Moved(root) while Moved(root.0) exists → drop root.0.
                 binding.path_state.retain(|(existing, existing_state)| {
-                    if *existing_state != state {
-                        return true;
-                    }
+                    if *existing_state != state { return true; }
                     !path_is_prefix(&path, existing)
                 });
                 // Rule 2 — if an existing entry already covers the new path (same state,
@@ -305,9 +237,7 @@ impl ScopeEnv {
         use crate::types::{PathAvailability, PatternPath};
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() {
-                return false;
-            }
+            if a.elems.len() > b.elems.len() { return false; }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
         fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
@@ -341,10 +271,7 @@ impl ScopeEnv {
                                 stored_path.elems
                             )
                         };
-                        return Err(crate::types::FrontendError {
-                            pos: 0,
-                            message: msg,
-                        });
+                        return Err(crate::types::FrontendError { pos: 0, message: msg });
                     }
                 }
             }
@@ -370,18 +297,14 @@ impl ScopeEnv {
         use crate::types::{CaptureMode, PathAvailability, PatternPath};
 
         fn path_is_prefix(a: &PatternPath, b: &PatternPath) -> bool {
-            if a.elems.len() > b.elems.len() {
-                return false;
-            }
+            if a.elems.len() > b.elems.len() { return false; }
             a.elems.iter().zip(&b.elems).all(|(x, y)| x == y)
         }
         fn paths_overlap(a: &PatternPath, b: &PatternPath) -> bool {
             path_is_prefix(a, b) || path_is_prefix(b, a)
         }
 
-        let Some(binding) = self.binding(name) else {
-            return Ok(());
-        };
+        let Some(binding) = self.binding(name) else { return Ok(()); };
 
         if binding.consumed {
             return Err(crate::types::FrontendError {
@@ -391,26 +314,18 @@ impl ScopeEnv {
         }
 
         for (stored_path, stored_state) in &binding.path_state {
-            if !paths_overlap(stored_path, path) {
-                continue;
-            }
+            if !paths_overlap(stored_path, path) { continue; }
             let msg: Option<&str> = match (stored_state, capture) {
-                (PathAvailability::Borrowed, CaptureMode::Move) => {
-                    Some("cannot move from borrowed path")
-                }
-                (PathAvailability::Moved, CaptureMode::Borrow) => {
-                    Some("cannot borrow from moved path")
-                }
-                (PathAvailability::Moved, CaptureMode::Move) => {
-                    Some("cannot move from already-moved path")
-                }
+                (PathAvailability::Borrowed, CaptureMode::Move) =>
+                    Some("cannot move from borrowed path"),
+                (PathAvailability::Moved, CaptureMode::Borrow) =>
+                    Some("cannot borrow from moved path"),
+                (PathAvailability::Moved, CaptureMode::Move) =>
+                    Some("cannot move from already-moved path"),
                 _ => None,
             };
             if let Some(m) = msg {
-                return Err(crate::types::FrontendError {
-                    pos: 0,
-                    message: m.to_string(),
-                });
+                return Err(crate::types::FrontendError { pos: 0, message: m.to_string() });
             }
         }
         Ok(())
@@ -427,9 +342,7 @@ impl ScopeEnv {
     }
 
     pub fn is_const(&self, name: SymbolId) -> bool {
-        self.binding(name)
-            .map(|binding| binding.is_const)
-            .unwrap_or(false)
+        self.binding(name).map(|binding| binding.is_const).unwrap_or(false)
     }
 
     pub fn is_mutable(&self, name: SymbolId) -> bool {
@@ -478,24 +391,14 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
                 params: f
                     .params
                     .iter()
-                    .map(|(_, t)| {
-                        canonicalize_declared_type_generic(
-                            t,
-                            &record_table,
-                            &adt_table,
-                            &program.arena,
-                            &f.type_params,
-                        )
-                    })
+                    .map(|(_, t)| canonicalize_declared_type_generic(
+                        t, &record_table, &adt_table, &program.arena, &f.type_params,
+                    ))
                     .collect::<Result<Vec<_>, _>>()?,
                 param_names: Some(f.params.iter().map(|(name, _)| *name).collect()),
                 param_defaults: Some(f.param_defaults.clone()),
                 ret: canonicalize_declared_type_generic(
-                    &f.ret,
-                    &record_table,
-                    &adt_table,
-                    &program.arena,
-                    &f.type_params,
+                    &f.ret, &record_table, &adt_table, &program.arena, &f.type_params,
                 )?,
             },
         );
@@ -673,7 +576,10 @@ pub fn canonicalize_declared_type(
             } else {
                 Err(FrontendError {
                     pos: 0,
-                    message: format!("unknown enum type '{}'", resolve_symbol_name(arena, *name)?),
+                    message: format!(
+                        "unknown enum type '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
                 })
             }
         }
@@ -708,51 +614,25 @@ pub fn canonicalize_declared_type_generic(
         Type::Tuple(items) => Ok(Type::Tuple(
             items
                 .iter()
-                .map(|item| {
-                    canonicalize_declared_type_generic(
-                        item,
-                        record_table,
-                        adt_table,
-                        arena,
-                        type_params,
-                    )
-                })
+                .map(|item| canonicalize_declared_type_generic(item, record_table, adt_table, arena, type_params))
                 .collect::<Result<Vec<_>, _>>()?,
         )),
         Type::Sequence(sequence) => Ok(Type::Sequence(SequenceType {
             family: sequence.family,
             item: Box::new(canonicalize_declared_type_generic(
-                sequence.item.as_ref(),
-                record_table,
-                adt_table,
-                arena,
-                type_params,
+                sequence.item.as_ref(), record_table, adt_table, arena, type_params,
             )?),
         })),
         Type::Map(map) => Ok(Type::Map(MapType {
             key: Box::new(canonicalize_declared_type_generic(
-                map.key.as_ref(),
-                record_table,
-                adt_table,
-                arena,
-                type_params,
+                map.key.as_ref(), record_table, adt_table, arena, type_params,
             )?),
             val: Box::new(canonicalize_declared_type_generic(
-                map.val.as_ref(),
-                record_table,
-                adt_table,
-                arena,
-                type_params,
+                map.val.as_ref(), record_table, adt_table, arena, type_params,
             )?),
         })),
         Type::Measured(base, unit) => {
-            let canonical_base = canonicalize_declared_type_generic(
-                base,
-                record_table,
-                adt_table,
-                arena,
-                type_params,
-            )?;
+            let canonical_base = canonicalize_declared_type_generic(base, record_table, adt_table, arena, type_params)?;
             if !canonical_base.is_core_numeric_scalar() {
                 return Err(FrontendError {
                     pos: 0,
@@ -764,45 +644,21 @@ pub fn canonicalize_declared_type_generic(
             }
             Ok(Type::Measured(Box::new(canonical_base), *unit))
         }
-        Type::Option(item) => Ok(Type::Option(Box::new(canonicalize_declared_type_generic(
-            item,
-            record_table,
-            adt_table,
-            arena,
-            type_params,
-        )?))),
+        Type::Option(item) => Ok(Type::Option(Box::new(
+            canonicalize_declared_type_generic(item, record_table, adt_table, arena, type_params)?,
+        ))),
         Type::Result(ok_ty, err_ty) => Ok(Type::Result(
-            Box::new(canonicalize_declared_type_generic(
-                ok_ty,
-                record_table,
-                adt_table,
-                arena,
-                type_params,
-            )?),
-            Box::new(canonicalize_declared_type_generic(
-                err_ty,
-                record_table,
-                adt_table,
-                arena,
-                type_params,
-            )?),
+            Box::new(canonicalize_declared_type_generic(ok_ty, record_table, adt_table, arena, type_params)?),
+            Box::new(canonicalize_declared_type_generic(err_ty, record_table, adt_table, arena, type_params)?),
         )),
         Type::Closure(closure) => Ok(Type::Closure(crate::types::ClosureType {
             family: closure.family,
             capture: closure.capture,
             param: Box::new(canonicalize_declared_type_generic(
-                &closure.param,
-                record_table,
-                adt_table,
-                arena,
-                type_params,
+                &closure.param, record_table, adt_table, arena, type_params,
             )?),
             ret: Box::new(canonicalize_declared_type_generic(
-                &closure.ret,
-                record_table,
-                adt_table,
-                arena,
-                type_params,
+                &closure.ret, record_table, adt_table, arena, type_params,
             )?),
         })),
         Type::Record(name) => {
@@ -833,7 +689,10 @@ pub fn canonicalize_declared_type_generic(
             } else {
                 Err(FrontendError {
                     pos: 0,
-                    message: format!("unknown enum type '{}'", resolve_symbol_name(arena, *name)?),
+                    message: format!(
+                        "unknown enum type '{}'",
+                        resolve_symbol_name(arena, *name)?
+                    ),
                 })
             }
         }
@@ -1014,10 +873,7 @@ fn finalize_ordered_call_args(
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn resolve_symbol_name<'a>(
-    arena: &'a AstArena,
-    id: SymbolId,
-) -> Result<&'a str, FrontendError> {
+pub fn resolve_symbol_name<'a>(arena: &'a AstArena, id: SymbolId) -> Result<&'a str, FrontendError> {
     arena.try_symbol_name(id).ok_or(FrontendError {
         pos: 0,
         message: format!("invalid symbol id {}", id.0),

--- a/docs/language/semantic_hello_parser_sema_plan.md
+++ b/docs/language/semantic_hello_parser_sema_plan.md
@@ -152,3 +152,13 @@ It does not start any of these PRs.
 - no parser / sema implementation
 - no runtime / verifier / capability changes
 - `#477` remains open
+
+## 11. M-HELLO-3B Boundary Note
+
+`M-HELLO-3B` is the parser-only recognition step for the Hello grammar slice.
+
+It may add isolated parser structures and parser-only tests for pending
+fixtures, but it still does not add sema admission, lowering, verifier,
+runtime, or capability behavior.
+
+Pending fixtures remain outside accepted runtime truth until later phases.

--- a/tests/hello_parser_pending.rs
+++ b/tests/hello_parser_pending.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::{
+    parse_hello_file, HelloEntry, HelloObserveText, HelloQuadLit, HelloStmt,
+};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_fixture(rel: &str) -> HelloEntry {
+    let input = fixture_text(rel);
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected {rel}: {err}"));
+    parsed.entry
+}
+
+fn parse_fixture_err(rel: &str) -> String {
+    let input = fixture_text(rel);
+    parse_hello_file(&input)
+        .expect_err(&format!("parser unexpectedly accepted {rel}"))
+        .message
+}
+
+#[test]
+fn hello_parser_pending_positive_verbose_directional_parses() {
+    let entry = parse_fixture("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    assert_eq!(entry.name, "HelloWorld");
+    assert_eq!(entry.body.len(), 4);
+
+    match &entry.body[..] {
+        [HelloStmt::State(state), HelloStmt::Require(require), HelloStmt::Observe(observe), HelloStmt::Complete(complete)] =>
+        {
+            assert_eq!(state.name, "boot");
+            assert_eq!(state.value, HelloQuadLit::T);
+            assert_eq!(require.state, "boot");
+            assert_eq!(require.value, HelloQuadLit::T);
+            assert_eq!(observe.text, "\"Hello, World!\"");
+            assert_eq!(complete.value, HelloQuadLit::T);
+        }
+        other => panic!("unexpected Hello statement shape: {other:?}"),
+    }
+}
+
+#[test]
+fn hello_parser_pending_positive_minimal_observe_parses() {
+    let entry =
+        parse_fixture("tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm");
+    assert_eq!(entry.name, "HelloWorld");
+    assert_eq!(entry.body.len(), 1);
+    match &entry.body[0] {
+        HelloStmt::Observe(HelloObserveText { text }) => {
+            assert_eq!(text, "\"Hello, World!\"");
+        }
+        other => panic!("unexpected Hello statement shape: {other:?}"),
+    }
+}
+
+#[test]
+fn hello_parser_pending_legacy_print_shape_is_unsupported() {
+    let err =
+        parse_fixture_err("tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm");
+    assert!(
+        err.contains("legacy Hello syntax") || err.contains("expected `entry`"),
+        "expected legacy Hello rejection, got: {err}"
+    );
+}
+
+#[test]
+fn hello_parser_pending_general_io_shape_is_unsupported() {
+    let err = parse_fixture_err("tests/fixtures/pending/hello/negative_hello_general_io_shape.sm");
+    assert!(
+        err.contains("expected `entry`")
+            || err.contains("legacy Hello syntax")
+            || err.contains("expected Hello statement"),
+        "expected general I/O rejection to stay parser-level, got: {err}"
+    );
+}
+
+#[test]
+fn hello_parser_pending_non_text_observe_is_parser_rejected() {
+    let err = parse_fixture_err(
+        "tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm",
+    );
+    assert!(
+        err.contains("expected text literal after `observe`"),
+        "expected non-text observe parser rejection, got: {err}"
+    );
+}
+
+#[test]
+fn hello_parser_pending_require_side_effect_shape_is_parser_rejected() {
+    let err = parse_fixture_err(
+        "tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm",
+    );
+    assert!(
+        err.contains("expected `==` after required state symbol"),
+        "expected require-side-effect parser rejection, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds an isolated parser-only path for the pending #477 Hello grammar slice.

This PR parses the narrow `entry/state/require/observe/complete` surface into parser-only structures and adds parser-only tests against pending fixtures. It does not admit the grammar into the normal compile/check/run pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Parser-only plus parser tests/docs:

- isolated Hello parser module/path
- `tests/hello_parser_pending.rs`
- `docs/language/semantic_hello_parser_sema_plan.md`

## Result

- Parses positive pending Hello fixtures through isolated parser path
- Rejects unsupported legacy/general-I/O shapes at parser level
- Documents parser-only status
- Keeps pending fixtures out of accepted runtime truth

## Out of scope

- Semantic analysis admission
- Typechecker behavior
- IR/lowering
- SemCode
- Verifier
- VM/runtime
- Capability/effect admission
- CLI pipeline integration
- `smc check` / `compile` / `verify` / `run` / `run-smc` integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_parser_pending`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated parser-only path; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: parser-only
Reason: adds recognition tests only; no semantic admission, lowering, verifier, or runtime behavior.
