### PR TITLE
PR-M-HELLO-3C — sema(hello): add isolated Hello semantic admission diagnostics

### DIFF
--- a/crates/sm-front/src/hello_sema.rs
+++ b/crates/sm-front/src/hello_sema.rs
@@ -1,0 +1,87 @@
+use crate::hello_parser::{HelloFile, HelloStmt};
+use crate::types::FrontendError;
+use alloc::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloCheckedFile {
+    pub file: HelloFile,
+    pub report: HelloSemaReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HelloSemaReport {
+    pub canonical_shape: bool,
+    pub architecture_bearing: bool,
+    pub secondary_shape: bool,
+    pub complete_present: bool,
+    pub state_count: usize,
+    pub require_count: usize,
+    pub observe_count: usize,
+}
+
+pub fn validate_hello_file(file: HelloFile) -> Result<HelloCheckedFile, FrontendError> {
+    let entry = &file.entry;
+    if entry.name.trim().is_empty() {
+        return Err(FrontendError::syntax(
+            0,
+            "Hello entry name must not be empty",
+        ));
+    }
+
+    let mut state_names = BTreeSet::new();
+    let mut report = HelloSemaReport::default();
+
+    for stmt in &entry.body {
+        match stmt {
+            HelloStmt::State(state) => {
+                if !state_names.insert(state.name.clone()) {
+                    return Err(FrontendError::syntax(
+                        0,
+                        format!("duplicate Hello state symbol '{}'", state.name),
+                    ));
+                }
+                report.state_count += 1;
+            }
+            HelloStmt::Require(require) => {
+                if !state_names.contains(&require.state) {
+                    return Err(FrontendError::syntax(
+                        0,
+                        format!("unknown Hello state symbol '{}'", require.state),
+                    ));
+                }
+                report.require_count += 1;
+            }
+            HelloStmt::Observe(_) => {
+                report.observe_count += 1;
+            }
+            HelloStmt::Complete(_) => {
+                report.complete_present = true;
+            }
+        }
+    }
+
+    let canonical_shape = report.complete_present
+        && report.state_count == 1
+        && report.require_count == 1
+        && report.observe_count == 1
+        && entry.body.len() == 4;
+    let secondary_shape = !report.complete_present
+        && report.state_count == 0
+        && report.require_count == 0
+        && report.observe_count == 1
+        && entry.body.len() == 1;
+
+    if canonical_shape {
+        report.canonical_shape = true;
+        report.architecture_bearing = true;
+    } else if secondary_shape {
+        report.secondary_shape = true;
+    } else {
+        return Err(FrontendError::syntax(
+            0,
+            "Hello semantic admission requires either the canonical verbose shape or the secondary minimal-observe shape",
+        ));
+    }
+
+    Ok(HelloCheckedFile { file, report })
+}

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -17,6 +17,8 @@ pub mod types;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub mod hello_parser;
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_sema;
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub use types::{
     AdtCtorExpr, AdtDecl, AdtVariant, AstArena, BinaryOp, BlockExpr, CallArg,
     ClosureCapturePolicy, ClosureLiteral, ClosureType, ClosureValueFamily, Expr, ExprId,

--- a/docs/language/semantic_hello_parser_sema_plan.md
+++ b/docs/language/semantic_hello_parser_sema_plan.md
@@ -162,3 +162,13 @@ fixtures, but it still does not add sema admission, lowering, verifier,
 runtime, or capability behavior.
 
 Pending fixtures remain outside accepted runtime truth until later phases.
+
+## 12. M-HELLO-3C Boundary Note
+
+`M-HELLO-3C` is the isolated sema-admission step for the parser-only Hello AST.
+
+It may add semantic validation diagnostics and sema-only tests, but it still
+does not add IR, lowering, SemCode, verifier, runtime, or capability
+behavior.
+
+Pending fixtures remain outside accepted runtime truth until later phases.

--- a/tests/hello_sema_pending.rs
+++ b/tests/hello_sema_pending.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_and_validate(rel: &str) -> sm_front::hello_sema::HelloCheckedFile {
+    let input = fixture_text(rel);
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected {rel}: {err}"));
+    validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected {rel}: {err}"))
+}
+
+fn parse_err(rel: &str) -> String {
+    let input = fixture_text(rel);
+    parse_hello_file(&input)
+        .expect_err(&format!("parser unexpectedly accepted {rel}"))
+        .message
+}
+
+fn validate_src(src: &str) -> Result<sm_front::hello_sema::HelloCheckedFile, String> {
+    let parsed = parse_hello_file(src).map_err(|err| err.message)?;
+    validate_hello_file(parsed).map_err(|err| err.message)
+}
+
+#[test]
+fn hello_sema_pending_positive_verbose_directional_is_architecture_bearing() {
+    let checked =
+        parse_and_validate("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    assert!(checked.report.canonical_shape);
+    assert!(checked.report.architecture_bearing);
+    assert!(!checked.report.secondary_shape);
+    assert!(checked.report.complete_present);
+    assert_eq!(checked.report.state_count, 1);
+    assert_eq!(checked.report.require_count, 1);
+    assert_eq!(checked.report.observe_count, 1);
+}
+
+#[test]
+fn hello_sema_pending_positive_minimal_observe_is_secondary_shape() {
+    let checked = parse_and_validate(
+        "tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm",
+    );
+    assert!(!checked.report.canonical_shape);
+    assert!(!checked.report.architecture_bearing);
+    assert!(checked.report.secondary_shape);
+    assert!(!checked.report.complete_present);
+    assert_eq!(checked.report.observe_count, 1);
+}
+
+#[test]
+fn hello_sema_pending_duplicate_state_rejects() {
+    let src = r#"
+entry HelloWorld {
+    state boot: quad = T;
+    state boot: quad = F;
+    observe "Hello, World!";
+    complete T;
+}
+"#;
+    let err = validate_src(src).expect_err("duplicate state should be rejected");
+    assert!(
+        err.contains("duplicate Hello state symbol"),
+        "expected duplicate state rejection, got: {err}"
+    );
+}
+
+#[test]
+fn hello_sema_pending_unknown_required_state_rejects() {
+    let src = r#"
+entry HelloWorld {
+    state boot: quad = T;
+    require missing == T;
+    observe "Hello, World!";
+    complete T;
+}
+"#;
+    let err = validate_src(src).expect_err("unknown state should be rejected");
+    assert!(
+        err.contains("unknown Hello state symbol"),
+        "expected unknown state rejection, got: {err}"
+    );
+}
+
+#[test]
+fn hello_sema_pending_parser_negative_shapes_stay_parser_rejected() {
+    for rel in [
+        "tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm",
+        "tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm",
+        "tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm",
+        "tests/fixtures/pending/hello/negative_hello_general_io_shape.sm",
+    ] {
+        let err = parse_err(rel);
+        assert!(
+            err.contains("expected") || err.contains("legacy Hello syntax"),
+            "expected parser rejection for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds isolated semantic admission diagnostics for the pending #477 Hello grammar slice.

This PR validates the parser-only Hello AST for local state declarations, requirements, observation classification, and completion shape. It does not lower to IR, emit SemCode, touch verifier/runtime/capability behavior, or integrate with the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Sema-only plus sema tests/docs:

- isolated Hello sema module/path
- `tests/hello_sema_pending.rs`
- `docs/language/semantic_hello_parser_sema_plan.md`

## Result

- Validates positive verbose Hello fixture as architecture-bearing candidate
- Classifies or validates minimal observe fixture according to documented rule
- Rejects duplicate state symbols
- Rejects unknown required state symbols
- Keeps parser-level negatives rejected before sema
- Keeps pending fixtures out of accepted runtime truth

## Out of scope

- IR/lowering
- SemCode
- Verifier
- VM/runtime
- Capability/effect admission
- CLI pipeline integration
- `smc check` / `compile` / `verify` / `run` / `run-smc` integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_parser_pending`
- `cargo test -q --test hello_sema_pending`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated sema-only validation; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: parser/sema-only
Reason: adds semantic admission diagnostics only; no lowering, verifier, runtime, or capability behavior.
