### PR TITLE
PR-M-HELLO-3D — tests(hello): add pending fixture harness without runtime admission

### DIFF
--- a/docs/language/semantic_hello_fixtures.md
+++ b/docs/language/semantic_hello_fixtures.md
@@ -51,3 +51,12 @@ This document registers pending Hello grammar-slice fixtures.
 - no runtime / verifier / capability changes
 - no Hello World implementation
 - `#477` remains open
+
+## 7. M-HELLO-3D Harness
+
+- pending fixtures are now covered by an isolated parser / sema harness
+- this is still not accepted runtime truth
+- no normal compiler pipeline admission
+- no SemCode / golden output
+- no verifier / runtime / capability behavior
+- pending fixture classification remains an admission-prep layer only

--- a/tests/hello_pending_fixture_harness.rs
+++ b/tests/hello_pending_fixture_harness.rs
@@ -1,0 +1,98 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingHelloFixtureClass {
+    ParseAndSemaCanonical,
+    ParseAndSemaSecondary,
+    ParserReject,
+    ParserRejectOrSemaReject,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingHelloFixtureCase {
+    rel: &'static str,
+    expected: PendingHelloFixtureClass,
+}
+
+const CASES: &[PendingHelloFixtureCase] = &[
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/positive_hello_verbose_directional.sm",
+        expected: PendingHelloFixtureClass::ParseAndSemaCanonical,
+    },
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm",
+        expected: PendingHelloFixtureClass::ParseAndSemaSecondary,
+    },
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/negative_hello_print_legacy_canonical.sm",
+        expected: PendingHelloFixtureClass::ParserReject,
+    },
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/negative_hello_observe_non_text_payload.sm",
+        expected: PendingHelloFixtureClass::ParserReject,
+    },
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/negative_hello_require_side_effect_shape.sm",
+        expected: PendingHelloFixtureClass::ParserReject,
+    },
+    PendingHelloFixtureCase {
+        rel: "tests/fixtures/pending/hello/negative_hello_general_io_shape.sm",
+        expected: PendingHelloFixtureClass::ParserReject,
+    },
+];
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn registry_text() -> String {
+    fixture_text("docs/language/semantic_hello_fixtures.md")
+}
+
+fn classify_fixture(rel: &str) -> PendingHelloFixtureClass {
+    let input = fixture_text(rel);
+    match parse_hello_file(&input) {
+        Err(_) => PendingHelloFixtureClass::ParserReject,
+        Ok(parsed) => match validate_hello_file(parsed) {
+            Ok(checked) if checked.report.canonical_shape => {
+                PendingHelloFixtureClass::ParseAndSemaCanonical
+            }
+            Ok(checked) if checked.report.secondary_shape => {
+                PendingHelloFixtureClass::ParseAndSemaSecondary
+            }
+            Ok(_) => panic!("unexpected Hello sema classification for {rel}"),
+            Err(_) => PendingHelloFixtureClass::ParserRejectOrSemaReject,
+        },
+    }
+}
+
+#[test]
+fn hello_pending_fixture_harness_reads_registry_and_classifies_all_fixtures() {
+    let registry = registry_text();
+
+    for case in CASES {
+        assert!(
+            registry.contains(case.rel),
+            "fixture registry should mention {}",
+            case.rel
+        );
+
+        let actual = classify_fixture(case.rel);
+        assert_eq!(
+            actual, case.expected,
+            "unexpected pending Hello classification for {}",
+            case.rel
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated pending fixture harness for the isolated #477 Hello parser/sema path.

This PR verifies the six pending Hello fixtures against parser/sema-only classifications without integrating them into the normal `smc` pipeline or accepting runtime behavior.

## Issue

Prepares #477.
Does not close #477.

## Scope

Test/docs only:

- `tests/hello_pending_fixture_harness.rs`
- `docs/language/semantic_hello_fixtures.md`

## Result

- Enumerates all pending Hello fixtures
- Classifies canonical verbose fixture through parser+sema as architecture-bearing
- Classifies minimal observe fixture as secondary
- Confirms legacy print/general I/O/non-text/effect-in-requirement fixtures reject before admission
- Keeps pending fixtures outside accepted runtime truth

## Out of scope

- Parser/sema behavior changes
- IR/lowering
- SemCode
- Verifier
- VM/runtime
- Capability/effect admission
- CLI pipeline integration
- `smc check` / `compile` / `verify` / `run` / `run-smc` integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_parser_pending`
- `cargo test -q --test hello_sema_pending`
- `cargo test -q --test hello_pending_fixture_harness`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated parser/sema fixture harness only; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: parser/sema harness only
Reason: validates pending fixture classification only; no lowering, verifier, runtime, or capability behavior.
