### PR TITLE
PR-M-HELLO-4A — docs(ir): plan Hello IR/SemCode lowering boundary

### DIFF
--- a/docs/language/semantic_hello_lowering_boundary.md
+++ b/docs/language/semantic_hello_lowering_boundary.md
@@ -1,0 +1,128 @@
+# Semantic Hello Lowering Boundary
+
+Status: planning document for `#477`
+
+## 1. Purpose
+
+This document plans the future lowering boundary for Hello.
+
+- docs-only
+- no IR changes
+- no lowering implementation
+- no SemCode changes
+- no verifier/runtime/capability behavior
+- no accepted runtime behavior
+
+## 2. Non-goals
+
+- no Rust code
+- no IR implementation
+- no lowering implementation
+- no SemCode emission
+- no verifier admission
+- no VM/runtime execution
+- no capability/effect admission
+- no CLI pipeline integration
+- no accepted golden SemCode
+- no runtime output
+- no observe effect
+- no print implementation
+- no README/examples rewrite
+- no Linguist readiness
+- no UI / Workbench / I70
+
+## 3. Input Boundary
+
+Future lowering input is the isolated Hello checked AST:
+
+- `HelloCheckedFile`
+- `HelloSemaReport`
+
+For the first architecture-bearing lowering candidate, the input is the canonical verbose shape only.
+
+The minimal observe secondary shape remains non-canonical and deferred unless explicitly scoped later.
+
+## 4. Lowering Candidates
+
+| Hello source element | Future IR/lowering role | First-slice plan | Deferred |
+|---|---|---|---|
+| `entry HelloWorld` | isolated entry function / module boundary candidate | canonical verbose lowering target | broader entry syntax, multi-entry, modules |
+| `state boot: quad = T` | local quad binding candidate | lowered as a bounded local state declaration | mutable state, heap state, richer types |
+| `require boot == T` | precondition / admission check candidate | lowered as a structural precondition gate | arbitrary expressions, side effects |
+| `observe "Hello, World!"` | controlled observation request candidate | lowered as controlled observation request, not general I/O | generic stdout, file/stdin/network I/O |
+| `complete T` | explicit completion result candidate | lowered as explicit completion marker | arbitrary return values, implicit completion semantics |
+
+## 5. SemCode Planning Boundary
+
+| concern | allowed in first planning slice | explicitly not allowed |
+|---|---|---|
+| quad literal | yes | final opcode commitment |
+| text literal | yes | general I/O payload semantics |
+| local state | yes | broad state-memory model |
+| requirement | yes | final verifier semantics |
+| observation | yes | generic stdout emission |
+| completion | yes | implicit control-flow return rules |
+| capability | no | capability policy commitment |
+| audit | no | final audit protocol |
+| runtime output | no | accepted runtime behavior |
+| golden SemCode | no | executable truth claim |
+
+## 6. Placeholder Opcode Warning
+
+This PR must not define final opcodes.
+
+If placeholder names are mentioned, they are planning placeholders only, not SemCode commitments:
+
+- `HELLO_STATE_QUAD`
+- `HELLO_REQUIRE_QUAD_EQ`
+- `HELLO_OBSERVE_TEXT`
+- `HELLO_COMPLETE_QUAD`
+
+## 7. Effect / Capability Boundary
+
+- `observe` must not lower as generic stdout.
+- observation lowering must later pass through verifier / runtime / capability design.
+- no capability policy is changed here.
+- no effect admission is changed here.
+- output ordering / audit policy remains future work.
+
+## 8. Failure Boundary
+
+Future failure classes to plan for:
+
+- sema accepted but lowering unsupported
+- observation lowering blocked by capability policy
+- invalid checked shape
+- unsupported secondary shape
+- missing completion for architecture-bearing shape
+- text literal encoding decision pending
+- audit sink unavailable
+
+No failure behavior is implemented here.
+
+## 9. Future Implementation Sequence
+
+Recommended next steps:
+
+- `M-HELLO-4B` - docs(ir): decide exact Hello IR representation
+- `M-HELLO-4C` - ir/lowering: add isolated Hello lowering skeleton, no SemCode emission
+- `M-HELLO-4D` - semcode: plan Hello SemCode representation
+- `M-HELLO-5A` - verifier/runtime/capability observation policy plan
+- `M-HELLO-5B+` - implementation only after policy acceptance
+
+## 10. Acceptance Checklist
+
+- lowering boundary documented
+- input boundary documented
+- canonical verbose shape selected as first lowering candidate
+- minimal observe shape deferred / classified
+- source element to lowering role table added
+- SemCode planning boundary table added
+- placeholder opcode warning added
+- effect / capability boundary preserved
+- failure boundary listed
+- no code changes
+- no IR / lowering / SemCode implementation
+- no verifier / runtime / capability changes
+- no accepted runtime behavior
+- `#477` remains open


### PR DESCRIPTION
## Summary

Adds a docs-only lowering boundary plan for the future #477 Hello grammar slice.

This PR defines the input boundary from isolated Hello sema, the future source-to-lowering roles, SemCode planning constraints, effect/capability boundary, and failure boundary without implementing IR, lowering, SemCode, verifier, runtime, or capability behavior.

## Issue

Prepares #477.
Does not close #477.

## Scope

Docs-only:

- `docs/language/semantic_hello_lowering_boundary.md`

Optional if changed:

- `docs/language/semantic_hello_parser_sema_plan.md`
- `docs/language/semantic_hello_fixtures.md`

## Result

- Documents Hello lowering boundary
- Documents input boundary from `HelloCheckedFile`
- Chooses canonical verbose shape as first lowering candidate
- Defers minimal observe shape unless explicitly scoped later
- Adds source-to-lowering planning table
- Adds SemCode planning boundary
- Preserves effect/capability boundary
- Lists future failure classes
- Keeps implementation blocked

## Out of scope

- Rust code changes
- Parser/sema changes
- IR/lowering implementation
- SemCode emission
- Verifier changes
- VM/runtime changes
- Capability/effect admission changes
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: docs-only lowering boundary plan; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: lowering planning only
Reason: documents future lowering boundary only; no lowering, verifier, runtime, or capability behavior.
