### PR TITLE
PR-M-HELLO-4C — ir/lowering: add isolated Hello IR structs and lowering skeleton

### DIFF
--- a/crates/sm-ir/src/hello_ir.rs
+++ b/crates/sm-ir/src/hello_ir.rs
@@ -1,0 +1,134 @@
+use sm_front::hello_parser::{
+    HelloCompleteQuad, HelloEntry, HelloObserveText, HelloQuadLit, HelloRequireQuadEq, HelloStateDecl,
+    HelloStmt,
+};
+use sm_front::hello_sema::HelloCheckedFile;
+use sm_front::FrontendError;
+use std::string::String;
+use std::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrModule {
+    pub entry: HelloIrEntry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrEntry {
+    pub name: String,
+    pub body: Vec<HelloIrStmt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloIrStmt {
+    LocalQuad(HelloIrLocalQuad),
+    RequireQuadEq(HelloIrRequireQuadEq),
+    ObserveText(HelloIrObserveText),
+    CompleteQuad(HelloIrCompleteQuad),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrLocalQuad {
+    pub symbol: String,
+    pub value: HelloIrQuadLit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrRequireQuadEq {
+    pub symbol: String,
+    pub expected: HelloIrQuadLit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrObserveText {
+    pub text: String,
+    pub observation_class: HelloIrObservationClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloIrCompleteQuad {
+    pub value: HelloIrQuadLit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloIrObservationClass {
+    Controlled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloIrQuadLit {
+    T,
+    F,
+    N,
+    S,
+}
+
+pub fn lower_hello_checked_file(
+    checked: &HelloCheckedFile,
+) -> Result<HelloIrModule, FrontendError> {
+    if checked.report.secondary_shape {
+        return Err(FrontendError::syntax(
+            0,
+            "secondary Hello shape is not admitted for IR lowering",
+        ));
+    }
+    if !checked.report.canonical_shape || !checked.report.architecture_bearing {
+        return Err(FrontendError::syntax(
+            0,
+            "only the canonical verbose Hello shape is admitted for IR lowering",
+        ));
+    }
+
+    let entry = lower_entry(&checked.file.entry)?;
+    Ok(HelloIrModule { entry })
+}
+
+fn lower_entry(entry: &HelloEntry) -> Result<HelloIrEntry, FrontendError> {
+    let body = entry
+        .body
+        .iter()
+        .map(lower_stmt)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(HelloIrEntry {
+        name: entry.name.clone(),
+        body,
+    })
+}
+
+fn lower_stmt(stmt: &HelloStmt) -> Result<HelloIrStmt, FrontendError> {
+    match stmt {
+        HelloStmt::State(HelloStateDecl { name, value, .. }) => Ok(HelloIrStmt::LocalQuad(
+            HelloIrLocalQuad {
+                symbol: name.clone(),
+                value: (*value).into(),
+            },
+        )),
+        HelloStmt::Require(HelloRequireQuadEq { state, value }) => {
+            Ok(HelloIrStmt::RequireQuadEq(HelloIrRequireQuadEq {
+                symbol: state.clone(),
+                expected: (*value).into(),
+            }))
+        }
+        HelloStmt::Observe(HelloObserveText { text }) => Ok(HelloIrStmt::ObserveText(
+            HelloIrObserveText {
+                text: text.clone(),
+                observation_class: HelloIrObservationClass::Controlled,
+            },
+        )),
+        HelloStmt::Complete(HelloCompleteQuad { value }) => Ok(HelloIrStmt::CompleteQuad(
+            HelloIrCompleteQuad {
+                value: (*value).into(),
+            },
+        )),
+    }
+}
+
+impl From<HelloQuadLit> for HelloIrQuadLit {
+    fn from(value: HelloQuadLit) -> Self {
+        match value {
+            HelloQuadLit::T => HelloIrQuadLit::T,
+            HelloQuadLit::F => HelloIrQuadLit::F,
+            HelloQuadLit::N => HelloIrQuadLit::N,
+            HelloQuadLit::S => HelloIrQuadLit::S,
+        }
+    }
+}

--- a/crates/sm-ir/src/lib.rs
+++ b/crates/sm-ir/src/lib.rs
@@ -21,6 +21,9 @@ mod frontend {
 mod local_format;
 
 #[cfg(feature = "std")]
+pub mod hello_ir;
+
+#[cfg(feature = "std")]
 pub mod semcode_format {
     pub use crate::local_format::{
         header_spec_from_magic, read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8,

--- a/docs/language/semantic_hello_ir_representation.md
+++ b/docs/language/semantic_hello_ir_representation.md
@@ -161,3 +161,11 @@ Recommended next steps:
 - no verifier / runtime / capability changes
 - no accepted runtime behavior
 - `#477` remains open
+
+## 14. M-HELLO-4C Implementation Boundary
+
+- isolated Hello IR structs and lowering skeleton exist
+- no SemCode emission
+- no verifier / runtime / capability behavior
+- no normal compiler pipeline integration
+- pending fixtures remain outside accepted runtime truth

--- a/tests/golden_snapshots/public_api/sm_ir_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_ir_lib.txt
@@ -2,6 +2,8 @@ source: crates/sm-ir/src/lib.rs
 pub use sm_front::{
 pub use sm_profile::ParserProfile;
 #[cfg(feature = "std")]
+pub mod hello_ir;
+#[cfg(feature = "std")]
 pub mod semcode_format {
 pub use crate::local_format::{
 #[cfg(feature = "std")]

--- a/tests/hello_ir_lowering_pending.rs
+++ b/tests/hello_ir_lowering_pending.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::{
+    lower_hello_checked_file, HelloIrObservationClass, HelloIrQuadLit, HelloIrStmt,
+};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate(rel: &str) -> sm_front::hello_sema::HelloCheckedFile {
+    let input = fixture_text(rel);
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected {rel}: {err}"));
+    validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected {rel}: {err}"))
+}
+
+#[test]
+fn hello_ir_lowering_pending_verbose_fixture_lowers_in_order() {
+    let checked =
+        parse_validate("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let module =
+        lower_hello_checked_file(&checked).expect("canonical verbose Hello should lower to IR");
+
+    assert_eq!(module.entry.name, "HelloWorld");
+    assert_eq!(module.entry.body.len(), 4);
+
+    match &module.entry.body[..] {
+        [
+            HelloIrStmt::LocalQuad(state),
+            HelloIrStmt::RequireQuadEq(require),
+            HelloIrStmt::ObserveText(observe),
+            HelloIrStmt::CompleteQuad(complete),
+        ] => {
+            assert_eq!(state.symbol, "boot");
+            assert_eq!(state.value, HelloIrQuadLit::T);
+            assert_eq!(require.symbol, "boot");
+            assert_eq!(require.expected, HelloIrQuadLit::T);
+            assert_eq!(observe.text, "\"Hello, World!\"");
+            assert_eq!(observe.observation_class, HelloIrObservationClass::Controlled);
+            assert_eq!(complete.value, HelloIrQuadLit::T);
+        }
+        other => panic!("unexpected Hello IR shape: {other:?}"),
+    }
+}
+
+#[test]
+fn hello_ir_lowering_pending_minimal_observe_shape_is_rejected() {
+    let checked = parse_validate("tests/fixtures/pending/hello/positive_hello_minimal_observe_directional.sm");
+    let err = lower_hello_checked_file(&checked)
+        .expect_err("secondary Hello shape should not lower yet");
+    assert!(
+        err.message.contains("secondary Hello shape is not admitted for IR lowering"),
+        "expected secondary-shape IR rejection, got: {}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Summary

Adds isolated Hello IR structures and a lowering skeleton from the isolated #477 Hello sema output.

This PR lowers only the canonical verbose Hello shape into an isolated Hello IR representation and adds IR-shape tests. It does not emit SemCode, touch verifier/runtime/capability behavior, or integrate with the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

IR/lowering skeleton only:

- isolated Hello IR structs
- isolated lowering function or adapter
- `tests/hello_ir_lowering_pending.rs`
- `docs/language/semantic_hello_ir_representation.md`

## Result

- Adds isolated Hello IR representation
- Lowers canonical verbose Hello fixture to IR
- Preserves source order and structural fields
- Rejects secondary minimal observe shape from lowering
- Keeps pending fixtures outside accepted runtime truth

## Out of scope

- SemCode emission
- Verifier
- VM/runtime
- Capability/effect admission
- CLI pipeline integration
- `smc check` / `compile` / `verify` / `run` / `run-smc` integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_parser_pending`
- `cargo test -q --test hello_sema_pending`
- `cargo test -q --test hello_pending_fixture_harness`
- `cargo test -q --test hello_ir_lowering_pending`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated IR/lowering skeleton only; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: parser/sema/lowering skeleton only
Reason: adds isolated IR shape lowering only; no SemCode, verifier, runtime, or capability behavior.
