### PR TITLE
PR-M-HELLO-4F — tests/fixtures(semcode): add conceptual Hello SemCode shape fixture

### DIFF
--- a/docs/language/semantic_hello_semcode_fixtures.md
+++ b/docs/language/semantic_hello_semcode_fixtures.md
@@ -1,0 +1,48 @@
+# Semantic Hello SemCode Fixtures
+
+Status: pending conceptual fixture registry for `#477`
+
+## 1. Purpose
+
+This document registers conceptual SemCode planning fixtures for Hello.
+
+## 2. Status
+
+- pending only
+- conceptual only
+- not executable
+- not final opcode names
+- not bytecode format
+- not accepted golden SemCode
+- not runtime truth
+- no emitter exists yet
+
+## 3. Fixture Table
+
+| fixture | source shape | intended future class | current status | reason |
+|---|---|---|---|---|
+| `tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt` | canonical verbose Hello IR shape | conceptual SemCode planning fixture | pending | records the intended future conceptual sequence without committing to opcodes or bytecode |
+
+## 4. Conceptual Sequence
+
+- `declare_local_quad boot = T`
+- `require_quad_eq boot T`
+- `request_observation_text "Hello, World!"`
+- `complete_quad T`
+
+## 5. Boundary
+
+- no SemCode emission
+- no opcode implementation
+- no verifier admission
+- no VM/runtime behavior
+- no capability/effect admission
+- no audit implementation
+- no CLI pipeline integration
+- no accepted golden SemCode
+
+## 6. Relationship to `#477`
+
+- prepares `#477`
+- does not close `#477`
+- future emitter skeleton must treat this as conceptual planning guidance only

--- a/tests/fixtures/pending/hello_semcode/README.md
+++ b/tests/fixtures/pending/hello_semcode/README.md
@@ -1,0 +1,9 @@
+# Pending Hello SemCode Fixture
+
+- pending conceptual fixture
+- no SemCode emission exists yet
+- no final opcode names
+- no bytecode format
+- no verifier / runtime / capability behavior
+- not accepted golden SemCode
+- not runtime truth

--- a/tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt
+++ b/tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt
@@ -1,0 +1,10 @@
+# Pending conceptual SemCode fixture for Hello verbose shape.
+# Not executable.
+# Not final opcode names.
+# Not bytecode format.
+# Not accepted golden SemCode.
+
+declare_local_quad boot = T
+require_quad_eq boot T
+request_observation_text "Hello, World!"
+complete_quad T

--- a/tests/hello_semcode_conceptual_fixture_pending.rs
+++ b/tests/hello_semcode_conceptual_fixture_pending.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::{
+    lower_hello_checked_file, HelloIrModule, HelloIrObservationClass, HelloIrQuadLit, HelloIrStmt,
+};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+fn render_conceptual_semcode(module: &HelloIrModule) -> String {
+    let mut out = String::new();
+    for stmt in &module.entry.body {
+        match stmt {
+            HelloIrStmt::LocalQuad(local) => {
+                out.push_str(&format!(
+                    "declare_local_quad {} = {}\n",
+                    local.symbol,
+                    render_quad(local.value)
+                ));
+            }
+            HelloIrStmt::RequireQuadEq(require) => {
+                out.push_str(&format!(
+                    "require_quad_eq {} {}\n",
+                    require.symbol,
+                    render_quad(require.expected)
+                ));
+            }
+            HelloIrStmt::ObserveText(observe) => {
+                out.push_str(&format!(
+                    "request_observation_text {}\n",
+                    observe.text
+                ));
+                assert_eq!(observe.observation_class, HelloIrObservationClass::Controlled);
+            }
+            HelloIrStmt::CompleteQuad(complete) => {
+                out.push_str(&format!("complete_quad {}\n", render_quad(complete.value)));
+            }
+        }
+    }
+    out
+}
+
+fn render_quad(value: HelloIrQuadLit) -> &'static str {
+    match value {
+        HelloIrQuadLit::T => "T",
+        HelloIrQuadLit::F => "F",
+        HelloIrQuadLit::N => "N",
+        HelloIrQuadLit::S => "S",
+    }
+}
+
+fn fixture_body_lines() -> String {
+    fixture_text("tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt")
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn hello_semcode_conceptual_fixture_matches_conceptual_shape() {
+    let module = parse_validate_lower();
+    let rendered = render_conceptual_semcode(&module);
+    let expected = fixture_body_lines();
+    assert_eq!(rendered.trim_end(), expected.trim_end());
+}
+
+#[test]
+fn hello_semcode_conceptual_fixture_stays_out_of_emitter_scope() {
+    let module = parse_validate_lower();
+    let rendered = render_conceptual_semcode(&module);
+
+    // No SemCode emission exists yet; this test only checks the planning shape.
+    assert!(rendered.contains("declare_local_quad boot = T"));
+    assert!(rendered.contains("request_observation_text \"Hello, World!\""));
+    assert!(!rendered.contains("opcode"));
+    assert!(!rendered.contains("bytecode"));
+}


### PR DESCRIPTION
## Summary

Adds a pending conceptual SemCode fixture for the future #477 Hello path.

This PR records the intended conceptual sequence for the canonical verbose Hello shape without implementing SemCode emission, final opcodes, bytecode format, verifier/runtime/capability behavior, or CLI integration.

## Issue

Prepares #477.
Does not close #477.

## Scope

Fixture/docs planning only:

- `tests/fixtures/pending/hello_semcode/README.md`
- `tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt`
- `docs/language/semantic_hello_semcode_fixtures.md`

Optional if added:

- `tests/hello_semcode_conceptual_fixture_pending.rs`

## Result

- Adds conceptual SemCode planning fixture
- Records conceptual sequence for canonical verbose Hello
- Marks fixture as non-executable and non-final
- Keeps SemCode emission and runtime behavior out of scope

## Out of scope

- SemCode emitter
- Final opcode names
- Bytecode format
- Verifier
- VM/runtime
- Capability/effect admission
- Audit implementation
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_semcode_conceptual_fixture_pending`
- `cargo test -q --test hello_ir_shape_pending`
- `cargo test -q --test hello_ir_lowering_pending`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: conceptual fixture only; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: conceptual SemCode fixture only
Reason: records future conceptual sequence only; no emission, verifier, runtime, or capability behavior.
