### PR TITLE
PR-M-HELLO-4G — semcode(hello): add gated conceptual emitter skeleton

### DIFF
--- a/crates/sm-ir/src/hello_semcode.rs
+++ b/crates/sm-ir/src/hello_semcode.rs
@@ -1,0 +1,65 @@
+use crate::hello_ir::{
+    HelloIrCompleteQuad, HelloIrLocalQuad, HelloIrModule, HelloIrObserveText,
+    HelloIrQuadLit, HelloIrRequireQuadEq, HelloIrStmt,
+};
+use crate::FrontendError;
+use std::string::String;
+use std::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloConceptualSemCode {
+    pub lines: Vec<String>,
+}
+
+pub fn emit_hello_conceptual_semcode(
+    module: &HelloIrModule,
+) -> Result<HelloConceptualSemCode, FrontendError> {
+    let lines = render_hello_conceptual_semcode(module)?;
+    Ok(HelloConceptualSemCode { lines })
+}
+
+pub fn render_hello_conceptual_semcode(
+    module: &HelloIrModule,
+) -> Result<Vec<String>, FrontendError> {
+    let mut lines = Vec::with_capacity(module.entry.body.len());
+
+    for stmt in &module.entry.body {
+        match stmt {
+            HelloIrStmt::LocalQuad(HelloIrLocalQuad { symbol, value }) => {
+                lines.push(format!(
+                    "declare_local_quad {} = {}",
+                    symbol,
+                    render_quad(*value)
+                ));
+            }
+            HelloIrStmt::RequireQuadEq(HelloIrRequireQuadEq { symbol, expected }) => {
+                lines.push(format!(
+                    "require_quad_eq {} {}",
+                    symbol,
+                    render_quad(*expected)
+                ));
+            }
+            HelloIrStmt::ObserveText(HelloIrObserveText { text, .. }) => {
+                lines.push(format!("request_observation_text {text}"));
+            }
+            HelloIrStmt::CompleteQuad(HelloIrCompleteQuad { value }) => {
+                lines.push(format!("complete_quad {}", render_quad(*value)));
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        return Err(FrontendError::syntax(0, "Hello conceptual SemCode requires at least one statement"));
+    }
+
+    Ok(lines)
+}
+
+fn render_quad(value: HelloIrQuadLit) -> &'static str {
+    match value {
+        HelloIrQuadLit::T => "T",
+        HelloIrQuadLit::F => "F",
+        HelloIrQuadLit::N => "N",
+        HelloIrQuadLit::S => "S",
+    }
+}

--- a/crates/sm-ir/src/lib.rs
+++ b/crates/sm-ir/src/lib.rs
@@ -22,6 +22,8 @@ mod local_format;
 
 #[cfg(feature = "std")]
 pub mod hello_ir;
+#[cfg(feature = "std")]
+pub mod hello_semcode;
 
 #[cfg(feature = "std")]
 pub mod semcode_format {

--- a/docs/language/semantic_hello_semcode_representation.md
+++ b/docs/language/semantic_hello_semcode_representation.md
@@ -155,3 +155,13 @@ Recommended next steps:
 - no verifier / runtime / capability changes
 - no accepted runtime behavior
 - `#477` remains open
+
+## 13. M-HELLO-4G Implementation Boundary
+
+- conceptual emitter skeleton exists
+- output is conceptual text only
+- not real SemCode bytes
+- not final opcodes
+- no verifier / runtime / capability behavior
+- no normal compiler pipeline integration
+- pending fixture remains not accepted golden SemCode

--- a/tests/golden_snapshots/public_api/sm_ir_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_ir_lib.txt
@@ -4,6 +4,8 @@ pub use sm_profile::ParserProfile;
 #[cfg(feature = "std")]
 pub mod hello_ir;
 #[cfg(feature = "std")]
+pub mod hello_semcode;
+#[cfg(feature = "std")]
 pub mod semcode_format {
 pub use crate::local_format::{
 #[cfg(feature = "std")]

--- a/tests/hello_semcode_conceptual_emitter_pending.rs
+++ b/tests/hello_semcode_conceptual_emitter_pending.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::lower_hello_checked_file;
+use sm_ir::hello_semcode::{emit_hello_conceptual_semcode, render_hello_conceptual_semcode};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> sm_ir::hello_ir::HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+fn fixture_body_lines() -> String {
+    fixture_text("tests/fixtures/pending/hello_semcode/positive_hello_verbose_conceptual.semcode.txt")
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn hello_semcode_conceptual_emitter_pending_matches_fixture_body() {
+    let module = parse_validate_lower();
+    let conceptual = emit_hello_conceptual_semcode(&module)
+        .expect("conceptual emitter should render planning text");
+    let rendered = conceptual.lines.join("\n");
+    let expected = fixture_body_lines();
+    assert_eq!(rendered.trim_end(), expected.trim_end());
+}
+
+#[test]
+fn hello_semcode_conceptual_emitter_pending_no_print_stdout_or_io() {
+    let module = parse_validate_lower();
+    let conceptual = render_hello_conceptual_semcode(&module)
+        .expect("conceptual emitter should render planning text");
+    let rendered = conceptual.join("\n");
+
+    assert!(rendered.contains("request_observation_text \"Hello, World!\""));
+    assert!(!rendered.contains("print"));
+    assert!(!rendered.contains("stdout"));
+    assert!(!rendered.contains("io.write"));
+    assert!(!rendered.contains("opcode"));
+    assert!(!rendered.contains("bytecode"));
+}


### PR DESCRIPTION
## Summary

Adds a gated conceptual SemCode emitter skeleton for the isolated #477 Hello IR path.

This PR converts `HelloIrModule` into conceptual text lines matching the pending SemCode fixture. It does not emit real SemCode bytes, define final opcodes, touch verifier/runtime/capability behavior, or integrate with the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Conceptual emitter skeleton only:

- `crates/sm-ir/src/hello_semcode.rs`
- `tests/hello_semcode_conceptual_emitter_pending.rs`
- docs boundary note
- public API snapshot update if required

## Result

- Adds conceptual Hello SemCode emitter skeleton
- Emits planning text sequence only
- Matches pending conceptual fixture
- Preserves controlled observation wording
- Keeps runtime/admission behavior out of scope

## Out of scope

- Real SemCode encoder integration
- Final opcode names
- Bytecode format
- Verifier
- VM/runtime
- Capability/effect admission
- Audit implementation
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_semcode_conceptual_fixture_pending`
- `cargo test -q --test hello_semcode_conceptual_emitter_pending`
- `cargo test -q --test hello_ir_shape_pending`
- `cargo test -q --test hello_ir_lowering_pending`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: conceptual emitter skeleton only; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: conceptual SemCode emitter only
Reason: emits planning text sequence only; no real SemCode emission, verifier, runtime, or capability behavior.
