### PR TITLE
PR-M-HELLO-5E — tests(policy): add pending Hello observation policy fixtures

### DIFF
--- a/docs/language/semantic_hello_policy_fixtures.md
+++ b/docs/language/semantic_hello_policy_fixtures.md
@@ -1,0 +1,50 @@
+# Semantic Hello Policy Fixtures
+
+Status: pending policy fixture registry for `#477`
+
+## 1. Purpose
+
+This document registers pending verifier / capability / runtime / audit policy fixtures for Hello controlled observation.
+
+## 2. Status
+
+- pending only
+- declarative planning fixtures
+- not executable
+- not consumed by production verifier / runtime
+- not accepted runtime truth
+- no verifier / capability / runtime / audit implementation exists here
+
+## 3. Fixture Table
+
+| fixture | class | expected future outcome | reason | current status |
+|---|---|---|---|---|
+| `positive_observation_policy_admitted.toml` | positive policy case | admit | all required admission conditions are present | pending |
+| `negative_missing_observation_capability.toml` | capability denial | deny | missing_observation_capability | pending |
+| `negative_stdout_fallback.toml` | runtime shortcut rejection | deny | stdout_not_default_sink | pending |
+| `negative_missing_audit_when_required.toml` | audit denial | deny | audit_required_but_unavailable | pending |
+| `negative_nondeterministic_sink.toml` | determinism denial | deny | nondeterministic_sink_configuration | pending |
+
+## 4. Policy Coverage
+
+- verifier admission: `docs/language/semantic_hello_verifier_admission.md`
+- capability requirement: `docs/language/semantic_hello_observation_policy.md`
+- runtime sink model: `docs/language/semantic_hello_runtime_sink.md`
+- audit requirement: `docs/language/semantic_hello_audit_event.md`
+- deterministic ordering: `docs/language/semantic_hello_runtime_sink.md`
+
+## 5. Boundary
+
+- no verifier implementation
+- no capability implementation
+- no runtime / sink implementation
+- no audit implementation
+- no SemCode / opcode changes
+- no CLI integration
+- no accepted runtime behavior
+
+## 6. Relationship to `#477`
+
+- prepares `#477`
+- does not close `#477`
+- future implementation must decide how these fixture expectations become executable tests

--- a/tests/fixtures/pending/hello_policy/README.md
+++ b/tests/fixtures/pending/hello_policy/README.md
@@ -1,0 +1,12 @@
+# Pending Hello Observation Policy Fixtures
+
+These fixtures are pending policy-planning material for `#477`.
+
+- pending policy fixtures only
+- not executable
+- not production verifier / runtime / capability / audit inputs
+- no implementation exists yet
+- no runtime truth
+- no accepted execution behavior
+
+The fixtures encode future expected policy outcomes only.

--- a/tests/fixtures/pending/hello_policy/negative_missing_audit_when_required.toml
+++ b/tests/fixtures/pending/hello_policy/negative_missing_audit_when_required.toml
@@ -1,0 +1,4 @@
+audit_policy = "required"
+audit_available = false
+expected_policy_result = "deny"
+reason = "audit_required_but_unavailable"

--- a/tests/fixtures/pending/hello_policy/negative_missing_observation_capability.toml
+++ b/tests/fixtures/pending/hello_policy/negative_missing_observation_capability.toml
@@ -1,0 +1,3 @@
+capability_observation_sink = "missing"
+expected_policy_result = "deny"
+reason = "missing_observation_capability"

--- a/tests/fixtures/pending/hello_policy/negative_nondeterministic_sink.toml
+++ b/tests/fixtures/pending/hello_policy/negative_nondeterministic_sink.toml
@@ -1,0 +1,3 @@
+deterministic_order = false
+expected_policy_result = "deny"
+reason = "nondeterministic_sink_configuration"

--- a/tests/fixtures/pending/hello_policy/negative_stdout_fallback.toml
+++ b/tests/fixtures/pending/hello_policy/negative_stdout_fallback.toml
@@ -1,0 +1,3 @@
+requested_host_channel = "stdout"
+expected_policy_result = "deny"
+reason = "stdout_not_default_sink"

--- a/tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml
+++ b/tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml
@@ -1,0 +1,8 @@
+operation_kind = "controlled_observation_text"
+payload_type = "text_literal"
+capability_observation_sink = "present"
+sink_available = true
+audit_policy = "required"
+audit_available = true
+deterministic_order = true
+expected_policy_result = "admit"


### PR DESCRIPTION
## Summary

Adds pending verifier / capability / runtime / audit policy fixtures for future #477 Hello controlled observation.

This PR records expected future policy outcomes for admitted observation, missing capability, stdout fallback, missing audit, and nondeterministic sink configuration without implementing verifier, runtime, capability, audit, SemCode, or CLI behavior.

## Issue

Prepares #477.
Does not close #477.

## Scope

Fixture / docs / planning only:

- `tests/fixtures/pending/hello_policy/README.md`
- `tests/fixtures/pending/hello_policy/*.toml`
- `docs/language/semantic_hello_policy_fixtures.md`

## Result

- Adds pending policy fixture set
- Records future admit / deny expectations
- Covers capability, stdout fallback, audit, and deterministic ordering boundaries
- Keeps implementation blocked

## Out of scope

- Production Rust source changes
- Verifier implementation
- VM/runtime implementation
- Sink implementation
- Capability/effect admission
- Audit implementation
- Audit storage implementation
- SemCode/opcode changes
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: pending policy fixtures only; no execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: policy fixture planning only
Reason: records future policy fixture expectations only; no implementation behavior.
