### PR TITLE
PR-M-HELLO-6A — verify: add pending verifier admission model behind isolated path

### DIFF
--- a/crates/sm-verify/src/hello_pending_admission.rs
+++ b/crates/sm-verify/src/hello_pending_admission.rs
@@ -1,0 +1,62 @@
+#[cfg(feature = "std")]
+use std::string::String;
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloPendingPolicyInput {
+    pub operation_kind: String,
+    pub payload_type: String,
+    pub capability_observation_sink: String,
+    pub sink_available: bool,
+    pub audit_policy: String,
+    pub audit_available: bool,
+    pub deterministic_order: bool,
+    pub requested_host_channel: Option<String>,
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloPendingPolicyReason {
+    MissingObservationCapability,
+    StdoutNotDefaultSink,
+    AuditRequiredButUnavailable,
+    NondeterministicSinkConfiguration,
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloPendingPolicyResult {
+    Admit,
+    Deny { reason: HelloPendingPolicyReason },
+}
+
+#[cfg(feature = "std")]
+pub fn evaluate_hello_pending_policy(
+    input: &HelloPendingPolicyInput,
+) -> HelloPendingPolicyResult {
+    if input.capability_observation_sink != "present" || !input.sink_available {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::MissingObservationCapability,
+        };
+    }
+
+    if matches!(input.requested_host_channel.as_deref(), Some("stdout")) {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::StdoutNotDefaultSink,
+        };
+    }
+
+    if input.audit_policy == "required" && !input.audit_available {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::AuditRequiredButUnavailable,
+        };
+    }
+
+    if !input.deterministic_order {
+        return HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::NondeterministicSinkConfiguration,
+        };
+    }
+
+    HelloPendingPolicyResult::Admit
+}

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -19,6 +19,9 @@ use sm_runtime_core::RuntimeQuotas;
 use std::collections::HashSet;
 
 #[cfg(feature = "std")]
+pub mod hello_pending_admission;
+
+#[cfg(feature = "std")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerificationCode {
     BadHeader,

--- a/docs/language/semantic_hello_policy_fixtures.md
+++ b/docs/language/semantic_hello_policy_fixtures.md
@@ -48,3 +48,13 @@ This document registers pending verifier / capability / runtime / audit policy f
 - prepares `#477`
 - does not close `#477`
 - future implementation must decide how these fixture expectations become executable tests
+
+## 7. M-HELLO-6A Boundary Note
+
+- isolated pending verifier-admission model exists
+- evaluates planning fixtures only
+- not production verifier admission
+- not real SemCode verification
+- no runtime / sink / capability / audit behavior
+- no normal compiler pipeline integration
+- `#477` remains open

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -1,5 +1,7 @@
 source: crates/sm-verify/src/lib.rs
 #[cfg(feature = "std")]
+pub mod hello_pending_admission;
+#[cfg(feature = "std")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerificationCode {
 #[cfg(feature = "std")]

--- a/tests/hello_pending_verifier_admission.rs
+++ b/tests/hello_pending_verifier_admission.rs
@@ -1,0 +1,145 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use sm_verify::hello_pending_admission::{
+    evaluate_hello_pending_policy, HelloPendingPolicyInput, HelloPendingPolicyReason,
+    HelloPendingPolicyResult,
+};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_fixture(rel: &str) -> BTreeMap<String, String> {
+    let input = fixture_text(rel);
+    let mut map = BTreeMap::new();
+
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let (key, value) = trimmed
+            .split_once('=')
+            .unwrap_or_else(|| panic!("invalid fixture line in {rel}: {trimmed}"));
+        let key = key.trim().to_string();
+        let value = value.trim();
+        let parsed = if value.starts_with('"') && value.ends_with('"') && value.len() >= 2 {
+            value[1..value.len() - 1].to_string()
+        } else {
+            value.to_string()
+        };
+        map.insert(key, parsed);
+    }
+
+    map
+}
+
+fn parse_bool(value: &str, rel: &str, key: &str) -> bool {
+    match value {
+        "true" => true,
+        "false" => false,
+        other => panic!("expected boolean for {key} in {rel}, got {other}"),
+    }
+}
+
+fn fixture_input(rel: &str) -> HelloPendingPolicyInput {
+    let fields = parse_fixture(rel);
+    let requested_host_channel = fields.get("requested_host_channel").cloned();
+
+    HelloPendingPolicyInput {
+        operation_kind: fields
+            .get("operation_kind")
+            .cloned()
+            .unwrap_or_else(|| "controlled_observation_text".to_string()),
+        payload_type: fields
+            .get("payload_type")
+            .cloned()
+            .unwrap_or_else(|| "text_literal".to_string()),
+        capability_observation_sink: fields
+            .get("capability_observation_sink")
+            .cloned()
+            .unwrap_or_else(|| "present".to_string()),
+        sink_available: fields
+            .get("sink_available")
+            .map(|value| parse_bool(value, rel, "sink_available"))
+            .unwrap_or(true),
+        audit_policy: fields
+            .get("audit_policy")
+            .cloned()
+            .unwrap_or_else(|| "required".to_string()),
+        audit_available: fields
+            .get("audit_available")
+            .map(|value| parse_bool(value, rel, "audit_available"))
+            .unwrap_or(true),
+        deterministic_order: fields
+            .get("deterministic_order")
+            .map(|value| parse_bool(value, rel, "deterministic_order"))
+            .unwrap_or(true),
+        requested_host_channel,
+    }
+}
+
+fn assert_admission(rel: &str, expected: HelloPendingPolicyResult) -> HelloPendingPolicyInput {
+    let input = fixture_input(rel);
+    let actual = evaluate_hello_pending_policy(&input);
+    assert_eq!(actual, expected, "fixture {rel} evaluated unexpectedly");
+    input
+}
+
+#[test]
+fn hello_pending_verifier_admission_evaluates_all_policy_fixtures() {
+    let positive = assert_admission(
+        "tests/fixtures/pending/hello_policy/positive_observation_policy_admitted.toml",
+        HelloPendingPolicyResult::Admit,
+    );
+    assert_eq!(positive.operation_kind, "controlled_observation_text");
+    assert_eq!(positive.payload_type, "text_literal");
+
+    assert_admission(
+        "tests/fixtures/pending/hello_policy/negative_missing_observation_capability.toml",
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::MissingObservationCapability,
+        },
+    );
+    assert_admission(
+        "tests/fixtures/pending/hello_policy/negative_stdout_fallback.toml",
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::StdoutNotDefaultSink,
+        },
+    );
+    assert_admission(
+        "tests/fixtures/pending/hello_policy/negative_missing_audit_when_required.toml",
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::AuditRequiredButUnavailable,
+        },
+    );
+    assert_admission(
+        "tests/fixtures/pending/hello_policy/negative_nondeterministic_sink.toml",
+        HelloPendingPolicyResult::Deny {
+            reason: HelloPendingPolicyReason::NondeterministicSinkConfiguration,
+        },
+    );
+}
+
+#[test]
+fn hello_pending_verifier_admission_policy_registry_stays_pending_only() {
+    let registry = fixture_text("docs/language/semantic_hello_policy_fixtures.md");
+    let readme = fixture_text("tests/fixtures/pending/hello_policy/README.md");
+
+    for needle in ["pending", "not executable", "not production verifier"] {
+        assert!(
+            registry.contains(needle) || readme.contains(needle),
+            "policy registry/readme should mention {needle}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds an isolated pending verifier-admission model for future #477 Hello controlled observation policy fixtures.

This PR evaluates the pending Hello policy fixtures and returns admit/deny according to the documented policy model. It does not integrate with the production verifier, verify real SemCode bytes, touch runtime/sink/capability/audit behavior, or integrate with the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Pending verifier model only:

- isolated pending admission model
- `tests/hello_pending_verifier_admission.rs`
- docs boundary note
- public API snapshot update if required

## Result

- Adds pending Hello policy evaluator
- Positive fixture evaluates to admit
- Missing capability / stdout fallback / missing audit / nondeterministic sink fixtures evaluate to deny with expected reasons
- Keeps production verifier/runtime/capability/audit behavior out of scope

## Out of scope

- Production verifier integration
- Real SemCode verification
- Opcode admission
- Bytecode format changes
- VM/runtime
- Sink implementation
- Capability/effect admission
- Audit implementation
- Audit storage implementation
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- `observe` effect implementation
- `print` implementation
- General I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated pending verifier model only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: pending verifier model only
Reason: evaluates pending policy fixtures only; no production verifier, runtime, capability, or audit behavior.
