### PR TITLE
PR-M-HELLO-6B — runtime: add observation sink interface skeleton, no host output

### DIFF
--- a/crates/sm-runtime-core/src/hello_observation_sink.rs
+++ b/crates/sm-runtime-core/src/hello_observation_sink.rs
@@ -1,0 +1,36 @@
+use alloc::string::String;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloObservationEvent {
+    pub operation_kind: &'static str,
+    pub observation_class: HelloObservationClass,
+    pub text: String,
+    pub sequence_index: HelloObservationSequenceIndex,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationClass {
+    ControlledText,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HelloObservationSequenceIndex(pub u64);
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationSinkError {
+    Unavailable,
+    Denied,
+    NondeterministicOrder,
+}
+
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub trait HelloObservationSink {
+    fn observe(
+        &mut self,
+        event: HelloObservationEvent,
+    ) -> Result<(), HelloObservationSinkError>;
+}

--- a/crates/sm-runtime-core/src/lib.rs
+++ b/crates/sm-runtime-core/src/lib.rs
@@ -11,6 +11,9 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_observation_sink;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordCarrier<T> {
     pub type_name: String,

--- a/docs/language/semantic_hello_runtime_sink.md
+++ b/docs/language/semantic_hello_runtime_sink.md
@@ -168,3 +168,14 @@ Recommended next steps:
 - no SemCode / opcode changes
 - no accepted runtime behavior
 - `#477` remains open
+
+## 13. M-HELLO-6B Implementation Boundary
+
+- isolated runtime observation sink interface skeleton exists
+- no host output
+- no stdout default
+- no print
+- no VM / runtime route integration
+- no capability / audit behavior
+- no CLI pipeline integration
+- `#477` remains open

--- a/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_runtime_core_lib.txt
@@ -1,5 +1,7 @@
 source: crates/sm-runtime-core/src/lib.rs
 #[cfg(any(feature = "alloc", feature = "std"))]
+pub mod hello_observation_sink;
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordCarrier<T> {
 pub type_name: String,

--- a/tests/hello_observation_sink_skeleton.rs
+++ b/tests/hello_observation_sink_skeleton.rs
@@ -1,0 +1,63 @@
+use std::vec::Vec;
+
+use sm_runtime_core::hello_observation_sink::{
+    HelloObservationClass, HelloObservationEvent, HelloObservationSequenceIndex,
+    HelloObservationSink, HelloObservationSinkError,
+};
+
+#[derive(Default)]
+struct InMemoryHelloObservationSink {
+    events: Vec<HelloObservationEvent>,
+}
+
+impl HelloObservationSink for InMemoryHelloObservationSink {
+    fn observe(
+        &mut self,
+        event: HelloObservationEvent,
+    ) -> Result<(), HelloObservationSinkError> {
+        self.events.push(event);
+        Ok(())
+    }
+}
+
+fn controlled_event(sequence_index: u64, text: &str) -> HelloObservationEvent {
+    HelloObservationEvent {
+        operation_kind: "controlled_observation_text",
+        observation_class: HelloObservationClass::ControlledText,
+        text: text.to_string(),
+        sequence_index: HelloObservationSequenceIndex(sequence_index),
+    }
+}
+
+#[test]
+fn hello_observation_sink_skeleton_preserves_deterministic_order() {
+    let mut sink = InMemoryHelloObservationSink::default();
+    sink.observe(controlled_event(0, "Hello, World!"))
+        .expect("first observation should store locally");
+    sink.observe(controlled_event(1, "Hello, World!"))
+        .expect("second observation should store locally");
+
+    assert_eq!(sink.events.len(), 2);
+    assert_eq!(sink.events[0].sequence_index, HelloObservationSequenceIndex(0));
+    assert_eq!(sink.events[1].sequence_index, HelloObservationSequenceIndex(1));
+    assert_eq!(sink.events[0].observation_class, HelloObservationClass::ControlledText);
+    assert_eq!(sink.events[0].operation_kind, "controlled_observation_text");
+    assert_ne!(sink.events[0].operation_kind, "print");
+    assert_ne!(sink.events[0].operation_kind, "stdout");
+    assert_ne!(sink.events[0].operation_kind, "io.write");
+}
+
+#[test]
+fn hello_observation_sink_skeleton_stores_controlled_text_only_locally() {
+    let mut sink = InMemoryHelloObservationSink::default();
+    let event = controlled_event(9, "Hello, World!");
+
+    sink.observe(event.clone())
+        .expect("controlled observation should stay local to the test sink");
+
+    assert_eq!(sink.events, vec![event]);
+    assert!(sink.events.iter().all(|evt| matches!(
+        evt.observation_class,
+        HelloObservationClass::ControlledText
+    )));
+}


### PR DESCRIPTION
## Summary

Adds an isolated runtime observation sink interface skeleton for future #477 Hello controlled observation.

This PR introduces minimal event/sink types for controlled text observation and a test-only in-memory sink path. It does not print to stdout, route VM output, implement observe effects, touch verifier/capability/audit behavior, or integrate with the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Runtime-core skeleton only:

- isolated observation event/sink types
- local skeleton tests
- docs boundary note
- public API snapshot update if required

## Result

- Adds controlled observation sink interface skeleton
- Preserves deterministic sequence index
- Preserves not-stdout / not-print / not-general-I/O boundary
- Keeps VM/runtime routing, capability, audit, SemCode, and CLI behavior out of scope

## Out of scope

- VM integration
- Real runtime routing
- Host output
- stdout default
- `print` implementation
- `observe` effect implementation
- General I/O
- SemCode/opcode changes
- Verifier integration
- Capability/effect admission
- Audit implementation
- Audit storage implementation
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_sink_skeleton`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated runtime sink interface skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: runtime sink skeleton only
Reason: defines future observation sink interface only; no VM routing, capability, audit, or CLI behavior.
