### PR TITLE
PR-M-HELLO-6C — capability: add observation capability model skeleton

### DIFF
--- a/crates/prom-cap/src/hello_observation_capability.rs
+++ b/crates/prom-cap/src/hello_observation_capability.rs
@@ -1,0 +1,66 @@
+//! Isolated Hello observation capability skeleton.
+//!
+//! This module models future capability admission for controlled Hello
+//! observation without wiring into production capability handling.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationCapability {
+    ObservationSink,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HelloObservationCapabilityPolicy;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HelloObservationCapabilityContext {
+    pub observation_sink_present: bool,
+    pub sink_available: bool,
+    pub requested_host_channel: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationCapabilityDecision {
+    Allow,
+    Deny(HelloObservationCapabilityDenial),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationCapabilityDenial {
+    MissingObservationCapability,
+    SinkUnavailable,
+    StdoutNotDefaultSink,
+    GenericIoNotAllowed,
+}
+
+pub fn evaluate_hello_observation_capability(
+    context: &HelloObservationCapabilityContext,
+) -> HelloObservationCapabilityDecision {
+    match context.requested_host_channel {
+        Some("stdout") => {
+            return HelloObservationCapabilityDecision::Deny(
+                HelloObservationCapabilityDenial::StdoutNotDefaultSink,
+            );
+        }
+        Some("print") | Some("io.write") | Some("file") | Some("network") | Some("stdin") => {
+            return HelloObservationCapabilityDecision::Deny(
+                HelloObservationCapabilityDenial::GenericIoNotAllowed,
+            );
+        }
+        _ => {}
+    }
+
+    if !context.observation_sink_present {
+        return HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        );
+    }
+
+    if !context.sink_available {
+        return HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::SinkUnavailable,
+        );
+    }
+
+    HelloObservationCapabilityDecision::Allow
+}
+

--- a/crates/prom-cap/src/lib.rs
+++ b/crates/prom-cap/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+pub mod hello_observation_capability;
+
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use prom_abi::HostCallId;

--- a/docs/language/semantic_hello_policy_fixtures.md
+++ b/docs/language/semantic_hello_policy_fixtures.md
@@ -58,3 +58,15 @@ This document registers pending verifier / capability / runtime / audit policy f
 - no runtime / sink / capability / audit behavior
 - no normal compiler pipeline integration
 - `#477` remains open
+
+## 8. M-HELLO-6C Boundary Note
+
+- isolated observation capability model skeleton exists
+- no production capability admission
+- no verifier integration
+- no runtime routing
+- no host output
+- no stdout default
+- no audit behavior
+- no CLI pipeline integration
+- `#477` remains open

--- a/tests/golden_snapshots/public_api/prom_cap_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_cap_lib.txt
@@ -1,4 +1,5 @@
 source: crates/prom-cap/src/lib.rs
+pub mod hello_observation_capability;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CapabilityKind {
 pub const fn required_capability_for_call(call: HostCallId) -> CapabilityKind {

--- a/tests/hello_observation_capability_skeleton.rs
+++ b/tests/hello_observation_capability_skeleton.rs
@@ -1,0 +1,104 @@
+use prom_abi::HostCallId;
+use prom_cap::hello_observation_capability::{
+    evaluate_hello_observation_capability, HelloObservationCapability,
+    HelloObservationCapabilityContext, HelloObservationCapabilityDecision,
+    HelloObservationCapabilityDenial, HelloObservationCapabilityPolicy,
+};
+use prom_cap::{CapabilityKind, required_capability_for_call};
+
+fn allow_context() -> HelloObservationCapabilityContext {
+    HelloObservationCapabilityContext {
+        observation_sink_present: true,
+        sink_available: true,
+        requested_host_channel: None,
+    }
+}
+
+fn missing_capability_context() -> HelloObservationCapabilityContext {
+    HelloObservationCapabilityContext {
+        observation_sink_present: false,
+        sink_available: true,
+        requested_host_channel: None,
+    }
+}
+
+fn sink_unavailable_context() -> HelloObservationCapabilityContext {
+    HelloObservationCapabilityContext {
+        observation_sink_present: true,
+        sink_available: false,
+        requested_host_channel: None,
+    }
+}
+
+fn requested_channel_context(channel: &'static str) -> HelloObservationCapabilityContext {
+    HelloObservationCapabilityContext {
+        observation_sink_present: true,
+        sink_available: true,
+        requested_host_channel: Some(channel),
+    }
+}
+
+#[test]
+fn hello_observation_capability_skeleton_allows_explicit_sink_access() {
+    let _policy = HelloObservationCapabilityPolicy;
+    let capability = HelloObservationCapability::ObservationSink;
+    assert_eq!(capability, HelloObservationCapability::ObservationSink);
+    assert_eq!(
+        evaluate_hello_observation_capability(&allow_context()),
+        HelloObservationCapabilityDecision::Allow
+    );
+}
+
+#[test]
+fn hello_observation_capability_skeleton_denies_missing_capability() {
+    assert_eq!(
+        evaluate_hello_observation_capability(&missing_capability_context()),
+        HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        )
+    );
+}
+
+#[test]
+fn hello_observation_capability_skeleton_denies_unavailable_sink() {
+    assert_eq!(
+        evaluate_hello_observation_capability(&sink_unavailable_context()),
+        HelloObservationCapabilityDecision::Deny(HelloObservationCapabilityDenial::SinkUnavailable)
+    );
+}
+
+#[test]
+fn hello_observation_capability_skeleton_denies_stdout_fallback() {
+    assert_eq!(
+        evaluate_hello_observation_capability(&requested_channel_context("stdout")),
+        HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::StdoutNotDefaultSink,
+        )
+    );
+}
+
+#[test]
+fn hello_observation_capability_skeleton_denies_generic_io_fallbacks() {
+    for channel in ["print", "io.write", "file", "network", "stdin"] {
+        assert_eq!(
+            evaluate_hello_observation_capability(&requested_channel_context(channel)),
+            HelloObservationCapabilityDecision::Deny(
+                HelloObservationCapabilityDenial::GenericIoNotAllowed,
+            ),
+            "channel {channel} must not be admitted"
+        );
+    }
+}
+
+#[test]
+fn hello_observation_capability_skeleton_keeps_existing_host_call_mapping_unchanged() {
+    assert_eq!(
+        required_capability_for_call(HostCallId::GateRead),
+        CapabilityKind::GateRead
+    );
+    assert_eq!(
+        required_capability_for_call(HostCallId::PulseEmit),
+        CapabilityKind::PulseEmit
+    );
+}
+


### PR DESCRIPTION
## Summary

Adds an isolated observation capability model skeleton for future #477 Hello controlled observation.

This PR introduces minimal capability/policy decision types for controlled observation sink permission. It does not wire the model into production capability admission, verifier, VM/runtime routing, audit, SemCode, host ABI, or the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Capability skeleton only:

- isolated observation capability model
- local skeleton tests
- docs boundary note
- public API snapshot update if required

## Result

- Adds controlled observation capability skeleton
- Supports allow/deny decisions for observation sink presence
- Rejects stdout fallback and generic I/O fallback
- Keeps production capability admission, verifier, runtime, audit, SemCode, and CLI behavior out of scope

## Out of scope

- Production capability admission
- prom-abi / HostCallId changes
- VM integration
- Real runtime routing
- Host output
- stdout default
- `print` implementation
- `observe` effect implementation
- General I/O
- SemCode/opcode changes
- Verifier integration
- Audit implementation
- Audit storage implementation
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_capability_skeleton`
- `cargo test -q --test hello_observation_sink_skeleton`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated capability skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: capability skeleton only
Reason: defines future observation capability model only; no production verifier, runtime, audit, SemCode, or CLI behavior.
