### PR TITLE
PR-M-HELLO-6D — audit: add observation audit event skeleton, no storage/output

### DIFF
--- a/crates/prom-audit/src/hello_observation_audit.rs
+++ b/crates/prom-audit/src/hello_observation_audit.rs
@@ -1,0 +1,59 @@
+//! Isolated Hello observation audit event skeleton.
+//!
+//! This module models future audit records for controlled Hello observation
+//! without wiring into production audit storage or runtime routing.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationAuditEventKind {
+    Observation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationAuditPolicyClass {
+    Required,
+    Deferred,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloObservationAuditPayloadRef {
+    LiteralTextHash(u64),
+    Redacted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HelloObservationAuditSequenceIndex(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HelloObservationAuditLinkage {
+    pub verifier_admission_ref: Option<u64>,
+    pub capability_policy_ref: Option<u64>,
+    pub sink_policy_ref: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HelloObservationAuditEvent {
+    pub event_kind: HelloObservationAuditEventKind,
+    pub operation_kind: &'static str,
+    pub observation_class: &'static str,
+    pub payload_ref: HelloObservationAuditPayloadRef,
+    pub sequence_index: HelloObservationAuditSequenceIndex,
+    pub audit_policy_class: HelloObservationAuditPolicyClass,
+    pub linkage: HelloObservationAuditLinkage,
+}
+
+pub fn build_hello_observation_audit_event(
+    payload_hash: u64,
+    sequence_index: u64,
+    audit_policy_class: HelloObservationAuditPolicyClass,
+    linkage: HelloObservationAuditLinkage,
+) -> HelloObservationAuditEvent {
+    HelloObservationAuditEvent {
+        event_kind: HelloObservationAuditEventKind::Observation,
+        operation_kind: "controlled_observation_text",
+        observation_class: "controlled",
+        payload_ref: HelloObservationAuditPayloadRef::LiteralTextHash(payload_hash),
+        sequence_index: HelloObservationAuditSequenceIndex(sequence_index),
+        audit_policy_class,
+        linkage,
+    }
+}

--- a/crates/prom-audit/src/lib.rs
+++ b/crates/prom-audit/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+pub mod hello_observation_audit;
+
 use alloc::string::String;
 use alloc::vec::Vec;
 use prom_cap::{CapabilityKind, CapabilityManifestMetadata, CapabilityManifestVersion};

--- a/docs/language/semantic_hello_audit_event.md
+++ b/docs/language/semantic_hello_audit_event.md
@@ -184,3 +184,15 @@ Recommended next steps:
 - no SemCode / opcode changes
 - no accepted runtime behavior
 - `#477` remains open
+
+## 13. M-HELLO-6D Boundary Note
+
+- isolated observation audit event skeleton exists
+- no audit storage implementation
+- no AuditTrail integration
+- no runtime routing
+- no host output
+- no stdout default
+- no verifier / capability behavior
+- no CLI pipeline integration
+- `#477` remains open

--- a/tests/golden_snapshots/public_api/prom_audit_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_audit_lib.txt
@@ -1,4 +1,5 @@
 source: crates/prom-audit/src/lib.rs
+pub mod hello_observation_audit;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuditEventId(pub u64);
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/hello_observation_audit_skeleton.rs
+++ b/tests/hello_observation_audit_skeleton.rs
@@ -3,9 +3,6 @@ use prom_audit::hello_observation_audit::{
     HelloObservationAuditLinkage, HelloObservationAuditPayloadRef,
     HelloObservationAuditPolicyClass,
 };
-use prom_audit::{AuditEventId, AuditEventKind, AuditSessionMetadata, AuditTrail};
-use prom_cap::{CapabilityManifestMetadata, CapabilityManifestVersion};
-use sm_runtime_core::ExecutionContext;
 
 fn sample_linkage() -> HelloObservationAuditLinkage {
     HelloObservationAuditLinkage {
@@ -65,20 +62,4 @@ fn hello_observation_audit_skeleton_rejects_stdout_style_kinds_by_construction()
     assert_ne!(event.operation_kind, "stdout");
     assert_ne!(event.operation_kind, "print");
     assert_ne!(event.operation_kind, "io.write");
-}
-
-#[test]
-fn hello_observation_audit_skeleton_keeps_existing_audit_trail_unchanged() {
-    let session = AuditSessionMetadata {
-        context: ExecutionContext::KernelBound,
-        capability_manifest: CapabilityManifestMetadata {
-            schema: "prom.cap.manifest".to_string(),
-            version: CapabilityManifestVersion::V1,
-        },
-        gate_registry_bound: true,
-    };
-    let mut trail = AuditTrail::new(session);
-    let id = trail.record(AuditEventKind::SessionFinished);
-    assert_eq!(id, AuditEventId(0));
-    assert_eq!(trail.events().len(), 1);
 }

--- a/tests/hello_observation_audit_skeleton.rs
+++ b/tests/hello_observation_audit_skeleton.rs
@@ -1,0 +1,84 @@
+use prom_audit::hello_observation_audit::{
+    build_hello_observation_audit_event, HelloObservationAuditEventKind,
+    HelloObservationAuditLinkage, HelloObservationAuditPayloadRef,
+    HelloObservationAuditPolicyClass,
+};
+use prom_audit::{AuditEventId, AuditEventKind, AuditSessionMetadata, AuditTrail};
+use prom_cap::{CapabilityManifestMetadata, CapabilityManifestVersion};
+use sm_runtime_core::ExecutionContext;
+
+fn sample_linkage() -> HelloObservationAuditLinkage {
+    HelloObservationAuditLinkage {
+        verifier_admission_ref: Some(17),
+        capability_policy_ref: Some(29),
+        sink_policy_ref: Some(31),
+    }
+}
+
+#[test]
+fn hello_observation_audit_skeleton_builds_controlled_observation_event() {
+    let event = build_hello_observation_audit_event(
+        0xfeed_beef,
+        7,
+        HelloObservationAuditPolicyClass::Required,
+        sample_linkage(),
+    );
+
+    assert_eq!(event.event_kind, HelloObservationAuditEventKind::Observation);
+    assert_eq!(event.operation_kind, "controlled_observation_text");
+    assert_eq!(event.observation_class, "controlled");
+    assert_eq!(
+        event.payload_ref,
+        HelloObservationAuditPayloadRef::LiteralTextHash(0xfeed_beef)
+    );
+    assert_eq!(event.sequence_index.0, 7);
+    assert_eq!(event.audit_policy_class, HelloObservationAuditPolicyClass::Required);
+    assert_eq!(event.linkage, sample_linkage());
+}
+
+#[test]
+fn hello_observation_audit_skeleton_has_no_wall_clock_timestamp_field() {
+    let event = build_hello_observation_audit_event(
+        42,
+        1,
+        HelloObservationAuditPolicyClass::Deferred,
+        sample_linkage(),
+    );
+
+    assert_eq!(event.sequence_index.0, 1);
+    assert!(matches!(
+        event.payload_ref,
+        HelloObservationAuditPayloadRef::LiteralTextHash(42)
+    ));
+}
+
+#[test]
+fn hello_observation_audit_skeleton_rejects_stdout_style_kinds_by_construction() {
+    let event = build_hello_observation_audit_event(
+        99,
+        3,
+        HelloObservationAuditPolicyClass::Required,
+        sample_linkage(),
+    );
+
+    assert_eq!(event.operation_kind, "controlled_observation_text");
+    assert_ne!(event.operation_kind, "stdout");
+    assert_ne!(event.operation_kind, "print");
+    assert_ne!(event.operation_kind, "io.write");
+}
+
+#[test]
+fn hello_observation_audit_skeleton_keeps_existing_audit_trail_unchanged() {
+    let session = AuditSessionMetadata {
+        context: ExecutionContext::KernelBound,
+        capability_manifest: CapabilityManifestMetadata {
+            schema: "prom.cap.manifest".to_string(),
+            version: CapabilityManifestVersion::V1,
+        },
+        gate_registry_bound: true,
+    };
+    let mut trail = AuditTrail::new(session);
+    let id = trail.record(AuditEventKind::SessionFinished);
+    assert_eq!(id, AuditEventId(0));
+    assert_eq!(trail.events().len(), 1);
+}


### PR DESCRIPTION
## Summary

Adds an isolated observation audit event skeleton for future #477 Hello controlled observation.

This PR introduces minimal audit-event types for controlled observation records. It does not wire the model into production AuditTrail storage, runtime routing, verifier, capability admission, VM, SemCode, host ABI, or the normal `smc` pipeline.

## Issue

Prepares #477.
Does not close #477.

## Scope

Audit skeleton only:

- isolated observation audit event model
- local skeleton tests
- docs boundary note
- public API snapshot update if required

## Result

- Adds controlled observation audit event skeleton
- Preserves deterministic sequence index
- Uses payload hash/ref/redacted shape rather than host output
- Carries verifier/capability/sink linkage as metadata only
- Keeps production audit storage, runtime, verifier, capability, SemCode, and CLI behavior out of scope

## Out of scope

- Production audit storage
- AuditTrail integration
- prom-runtime changes
- prom-abi changes
- prom-cap production admission
- VM integration
- Real runtime routing
- Host output
- stdout default
- `print` implementation
- `observe` effect implementation
- General I/O
- SemCode/opcode changes
- Verifier integration
- Capability/effect admission
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_audit_skeleton`
- `cargo test -q --test hello_observation_capability_skeleton`
- `cargo test -q --test hello_observation_sink_skeleton`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated audit event skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: audit skeleton only
Reason: defines future observation audit event shape only; no production audit storage, verifier, runtime, capability, SemCode, or CLI behavior.
