### PR TITLE
PR-M-HELLO-7B — semcode(hello): add gated real Hello SemCode emission skeleton

### DIFF
--- a/crates/sm-emit/src/hello_real_semcode.rs
+++ b/crates/sm-emit/src/hello_real_semcode.rs
@@ -1,0 +1,111 @@
+use sm_ir::hello_ir::{
+    HelloIrCompleteQuad, HelloIrLocalQuad, HelloIrModule, HelloIrObserveText,
+    HelloIrObservationClass, HelloIrQuadLit, HelloIrRequireQuadEq, HelloIrStmt,
+};
+use std::string::String;
+use std::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloRealSemCodeModule {
+    pub ops: Vec<HelloRealSemCodeOp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeOp {
+    DeclareLocalQuad { name: String, value: String },
+    RequireQuadEq { name: String, expected: String },
+    ObserveTextLiteral { text: String },
+    CompleteQuad { value: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeError {
+    UnsupportedShape,
+}
+
+pub fn emit_hello_real_semcode_skeleton(
+    module: &HelloIrModule,
+) -> Result<HelloRealSemCodeModule, HelloRealSemCodeError> {
+    let ops = render_hello_real_semcode_skeleton(module)?;
+    Ok(HelloRealSemCodeModule { ops })
+}
+
+pub fn render_hello_real_semcode_skeleton(
+    module: &HelloIrModule,
+) -> Result<Vec<HelloRealSemCodeOp>, HelloRealSemCodeError> {
+    if module.entry.name != "HelloWorld" {
+        return Err(HelloRealSemCodeError::UnsupportedShape);
+    }
+
+    let ops = match module.entry.body.as_slice() {
+        [
+            HelloIrStmt::LocalQuad(HelloIrLocalQuad {
+                symbol,
+                value: HelloIrQuadLit::T,
+            }),
+            HelloIrStmt::RequireQuadEq(HelloIrRequireQuadEq {
+                symbol: require_symbol,
+                expected: HelloIrQuadLit::T,
+            }),
+            HelloIrStmt::ObserveText(HelloIrObserveText {
+                text,
+                observation_class: HelloIrObservationClass::Controlled,
+            }),
+            HelloIrStmt::CompleteQuad(HelloIrCompleteQuad {
+                value: HelloIrQuadLit::T,
+            }),
+        ] => vec![
+            HelloRealSemCodeOp::DeclareLocalQuad {
+                name: symbol.clone(),
+                value: render_quad(HelloIrQuadLit::T).to_string(),
+            },
+            HelloRealSemCodeOp::RequireQuadEq {
+                name: require_symbol.clone(),
+                expected: render_quad(HelloIrQuadLit::T).to_string(),
+            },
+            HelloRealSemCodeOp::ObserveTextLiteral {
+                text: text.clone(),
+            },
+            HelloRealSemCodeOp::CompleteQuad {
+                value: render_quad(HelloIrQuadLit::T).to_string(),
+            },
+        ],
+        _ => return Err(HelloRealSemCodeError::UnsupportedShape),
+    };
+
+    if ops.len() != 4 {
+        return Err(HelloRealSemCodeError::UnsupportedShape);
+    }
+
+    Ok(ops)
+}
+
+pub fn render_hello_real_semcode_skeleton_text(
+    module: &HelloIrModule,
+) -> Result<Vec<String>, HelloRealSemCodeError> {
+    let ops = render_hello_real_semcode_skeleton(module)?;
+    Ok(ops
+        .into_iter()
+        .map(|op| match op {
+            HelloRealSemCodeOp::DeclareLocalQuad { name, value } => {
+                format!("declare_local_quad {name} = {value}")
+            }
+            HelloRealSemCodeOp::RequireQuadEq { name, expected } => {
+                format!("require_quad_eq {name} {expected}")
+            }
+            HelloRealSemCodeOp::ObserveTextLiteral { text } => {
+                format!("observe_text_literal {text}")
+            }
+            HelloRealSemCodeOp::CompleteQuad { value } => format!("complete_quad {value}"),
+        })
+        .collect())
+}
+
+fn render_quad(value: HelloIrQuadLit) -> &'static str {
+    match value {
+        HelloIrQuadLit::T => "T",
+        HelloIrQuadLit::F => "F",
+        HelloIrQuadLit::N => "N",
+        HelloIrQuadLit::S => "S",
+    }
+}

--- a/crates/sm-emit/src/lib.rs
+++ b/crates/sm-emit/src/lib.rs
@@ -24,6 +24,9 @@ pub use sm_ir::{
     compile_program_to_semcode_with_options_debug, emit_ir_to_semcode, CompileProfile, OptLevel,
 };
 
+#[cfg(feature = "std")]
+pub mod hello_real_semcode;
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;

--- a/docs/language/semantic_hello_real_semcode_encoding.md
+++ b/docs/language/semantic_hello_real_semcode_encoding.md
@@ -186,3 +186,15 @@ Recommended next steps:
 - no accepted runtime behavior
 - `#477` remains open
 
+## 14. M-HELLO-7B Implementation Boundary
+
+- isolated real SemCode-level emission skeleton exists
+- emits typed / planning SemCode-level operations only
+- no real SemCode bytes
+- no opcode IDs
+- no bytecode format changes
+- no verifier admission
+- no VM/runtime routing
+- no capability / audit behavior
+- no CLI pipeline integration
+- `#477` remains open

--- a/tests/hello_real_semcode_skeleton.rs
+++ b/tests/hello_real_semcode_skeleton.rs
@@ -1,0 +1,87 @@
+use std::path::PathBuf;
+
+use sm_emit::hello_real_semcode::{
+    emit_hello_real_semcode_skeleton, render_hello_real_semcode_skeleton_text,
+    HelloRealSemCodeOp,
+};
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::lower_hello_checked_file;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> sm_ir::hello_ir::HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+#[test]
+fn hello_real_semcode_skeleton_emits_decided_operation_order() {
+    let module = parse_validate_lower();
+    let semcode = emit_hello_real_semcode_skeleton(&module)
+        .expect("canonical verbose Hello should lower to real SemCode skeleton");
+
+    assert_eq!(semcode.ops.len(), 4);
+    match &semcode.ops[..] {
+        [
+            HelloRealSemCodeOp::DeclareLocalQuad { name, value },
+            HelloRealSemCodeOp::RequireQuadEq { name: req_name, expected },
+            HelloRealSemCodeOp::ObserveTextLiteral { text },
+            HelloRealSemCodeOp::CompleteQuad { value: complete_value },
+        ] => {
+            assert_eq!(name, "boot");
+            assert_eq!(value, "T");
+            assert_eq!(req_name, "boot");
+            assert_eq!(expected, "T");
+            assert_eq!(text, "\"Hello, World!\"");
+            assert_eq!(complete_value, "T");
+        }
+        other => panic!("unexpected Hello real SemCode skeleton order: {other:?}"),
+    }
+}
+
+#[test]
+fn hello_real_semcode_skeleton_renders_expected_text() {
+    let module = parse_validate_lower();
+    let rendered = render_hello_real_semcode_skeleton_text(&module)
+        .expect("canonical verbose Hello should render real SemCode skeleton");
+    let expected = "\
+declare_local_quad boot = T
+require_quad_eq boot T
+observe_text_literal \"Hello, World!\"
+complete_quad T
+";
+
+    assert_eq!(rendered.join("\n"), expected.trim_end());
+}
+
+#[test]
+fn hello_real_semcode_skeleton_no_stdout_print_or_opcode_words() {
+    let module = parse_validate_lower();
+    let rendered = render_hello_real_semcode_skeleton_text(&module)
+        .expect("canonical verbose Hello should render real SemCode skeleton");
+    let joined = rendered.join("\n");
+
+    assert!(joined.contains("observe_text_literal \"Hello, World!\""));
+    assert!(!joined.contains("request_observation_text"));
+    assert!(!joined.contains("print"));
+    assert!(!joined.contains("stdout"));
+    assert!(!joined.contains("io.write"));
+    assert!(!joined.contains("opcode"));
+    assert!(!joined.contains("bytecode"));
+}


### PR DESCRIPTION
## Summary

Adds an isolated real SemCode-level emission skeleton for future #477 Hello controlled observation.

This PR converts the canonical Hello IR shape into a typed SemCode-level skeleton using the M-HELLO-7A operation sequence. It does not emit real SemCode bytes, assign opcode IDs, modify bytecode format, integrate with the production encoder, verifier, VM/runtime, capability admission, audit storage, host ABI, or `smc`.

## Issue

Prepares #477.
Does not close #477.

## Scope

Isolated SemCode-level skeleton only:

- `crates/sm-emit/src/hello_real_semcode.rs`
- skeleton render/test
- docs boundary note
- public API snapshot update if required

## Result

- Adds typed Hello real SemCode-level skeleton
- Emits the decided operation sequence:

  - `declare_local_quad`
  - `require_quad_eq`
  - `observe_text_literal`
  - `complete_quad`

- Preserves controlled observation wording
- Keeps real bytecode/opcodes/admission/runtime out of scope

## Out of scope

- Production SemCode encoder integration
- Real SemCode byte emission
- Numeric opcode IDs
- Opcode implementation
- Bytecode format changes
- Verifier implementation
- VM/runtime routing
- Capability/effect admission
- Audit implementation/storage
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- stdout / print / general I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_real_semcode_skeleton`
- `cargo test -q --test hello_ir_lowering_pending`
- `cargo test -q --test hello_ir_shape_pending`
- `cargo test -q --test hello_semcode_conceptual_emitter_pending`
- `cargo test -q --test hello_isolated_policy_harness`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated SemCode-level skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: SemCode skeleton only
Reason: defines future SemCode-level operation skeleton only; no real bytecode, verifier, runtime, capability, audit, or CLI behavior.