### PR TITLE
PR-M-HELLO-7C — verify(hello): add verifier admission for controlled observe_text_literal

### DIFF
--- a/crates/sm-verify/src/hello_real_semcode_admission.rs
+++ b/crates/sm-verify/src/hello_real_semcode_admission.rs
@@ -1,0 +1,156 @@
+use std::string::String;
+use std::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloRealSemCodeAdmissionInput {
+    pub ops: Vec<HelloRealSemCodeAdmissionOp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionOp {
+    DeclareLocalQuad { name: String, value: String },
+    RequireQuadEq { name: String, expected: String },
+    ObserveTextLiteral { text: String },
+    CompleteQuad { value: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionDecision {
+    Admit,
+    Reject(HelloRealSemCodeAdmissionError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelloRealSemCodeAdmissionError {
+    InvalidOperationOrder,
+    MissingRequirement,
+    MissingObservation,
+    MissingCompletion,
+    NonTextObservation,
+    StdoutNotAllowed,
+    PrintNotAllowed,
+    GenericIoNotAllowed,
+    OpcodeOrBytecodeNotAllowed,
+    UnsupportedShape,
+}
+
+pub fn admit_hello_real_semcode_skeleton(
+    input: &HelloRealSemCodeAdmissionInput,
+) -> HelloRealSemCodeAdmissionDecision {
+    match input.ops.as_slice() {
+        [] | [HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. }] => {
+            HelloRealSemCodeAdmissionDecision::Reject(
+                HelloRealSemCodeAdmissionError::MissingRequirement,
+            )
+        }
+        [HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. }, HelloRealSemCodeAdmissionOp::ObserveTextLiteral { .. }] => {
+            HelloRealSemCodeAdmissionDecision::Reject(
+                HelloRealSemCodeAdmissionError::MissingRequirement,
+            )
+        }
+        [
+            HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. },
+            HelloRealSemCodeAdmissionOp::RequireQuadEq { .. },
+        ] => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::MissingObservation,
+        ),
+        [
+            HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. },
+            HelloRealSemCodeAdmissionOp::ObserveTextLiteral { .. },
+            HelloRealSemCodeAdmissionOp::CompleteQuad { .. },
+        ] => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::MissingRequirement,
+        ),
+        [
+            HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. },
+            HelloRealSemCodeAdmissionOp::RequireQuadEq { .. },
+            HelloRealSemCodeAdmissionOp::CompleteQuad { .. },
+        ] => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::MissingObservation,
+        ),
+        [
+            HelloRealSemCodeAdmissionOp::DeclareLocalQuad { .. },
+            HelloRealSemCodeAdmissionOp::RequireQuadEq { .. },
+            HelloRealSemCodeAdmissionOp::ObserveTextLiteral { .. },
+        ] => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::MissingCompletion,
+        ),
+        [
+            HelloRealSemCodeAdmissionOp::DeclareLocalQuad { name, value },
+            HelloRealSemCodeAdmissionOp::RequireQuadEq {
+                name: require_name,
+                expected,
+            },
+            HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text },
+            HelloRealSemCodeAdmissionOp::CompleteQuad {
+                value: completion_value,
+            },
+        ] => {
+            if name != "boot" || value != "T" {
+                return HelloRealSemCodeAdmissionDecision::Reject(
+                    HelloRealSemCodeAdmissionError::UnsupportedShape,
+                );
+            }
+            if require_name != "boot" || expected != "T" {
+                return HelloRealSemCodeAdmissionDecision::Reject(
+                    HelloRealSemCodeAdmissionError::MissingRequirement,
+                );
+            }
+            match text.as_str() {
+                "\"Hello, World!\"" => {}
+                "\"stdout\"" => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(
+                        HelloRealSemCodeAdmissionError::StdoutNotAllowed,
+                    );
+                }
+                "\"print\"" => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(
+                        HelloRealSemCodeAdmissionError::PrintNotAllowed,
+                    );
+                }
+                "\"io.write\"" => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(
+                        HelloRealSemCodeAdmissionError::GenericIoNotAllowed,
+                    );
+                }
+                "\"opcode\"" | "\"bytecode\"" => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(
+                        HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed,
+                    );
+                }
+                _ => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(
+                        HelloRealSemCodeAdmissionError::NonTextObservation,
+                    );
+                }
+            }
+
+            if completion_value != "T" {
+                return HelloRealSemCodeAdmissionDecision::Reject(
+                    HelloRealSemCodeAdmissionError::MissingCompletion,
+                );
+            }
+
+            HelloRealSemCodeAdmissionDecision::Admit
+        }
+        [
+            HelloRealSemCodeAdmissionOp::RequireQuadEq { .. },
+            ..
+        ]
+        | [
+            HelloRealSemCodeAdmissionOp::ObserveTextLiteral { .. },
+            ..
+        ]
+        | [HelloRealSemCodeAdmissionOp::CompleteQuad { .. }, ..] => {
+            HelloRealSemCodeAdmissionDecision::Reject(
+                HelloRealSemCodeAdmissionError::InvalidOperationOrder,
+            )
+        }
+        _ if input.ops.len() == 4 => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::InvalidOperationOrder,
+        ),
+        _ => HelloRealSemCodeAdmissionDecision::Reject(
+            HelloRealSemCodeAdmissionError::UnsupportedShape,
+        ),
+    }
+}

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -20,6 +20,8 @@ use std::collections::HashSet;
 
 #[cfg(feature = "std")]
 pub mod hello_pending_admission;
+#[cfg(feature = "std")]
+pub mod hello_real_semcode_admission;
 
 #[cfg(feature = "std")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/language/semantic_hello_real_semcode_encoding.md
+++ b/docs/language/semantic_hello_real_semcode_encoding.md
@@ -198,3 +198,30 @@ Recommended next steps:
 - no capability / audit behavior
 - no CLI pipeline integration
 - `#477` remains open
+
+## 15. M-HELLO-7C Implementation Boundary
+
+- isolated verifier admission for Hello real SemCode-level skeleton exists
+- admits controlled `observe_text_literal` only
+- no real SemCode byte verification
+- no numeric opcode IDs
+- no bytecode format changes
+- no production verifier pipeline integration
+- no VM/runtime routing
+- no capability / audit behavior
+- no CLI / smc integration
+- `#477` remains open
+
+
+## 14. M-HELLO-7B Implementation Boundary
+
+- isolated real SemCode-level emission skeleton exists
+- emits typed / planning SemCode-level operations only
+- no real SemCode bytes
+- no opcode IDs
+- no bytecode format changes
+- no verifier admission
+- no VM/runtime routing
+- no capability / audit behavior
+- no CLI pipeline integration
+- `#477` remains open

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -2,6 +2,8 @@ source: crates/sm-verify/src/lib.rs
 #[cfg(feature = "std")]
 pub mod hello_pending_admission;
 #[cfg(feature = "std")]
+pub mod hello_real_semcode_admission;
+#[cfg(feature = "std")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VerificationCode {
 #[cfg(feature = "std")]

--- a/tests/hello_real_semcode_admission.rs
+++ b/tests/hello_real_semcode_admission.rs
@@ -1,0 +1,195 @@
+use std::path::PathBuf;
+
+use sm_emit::hello_real_semcode::{
+    emit_hello_real_semcode_skeleton, HelloRealSemCodeOp,
+};
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::lower_hello_checked_file;
+use sm_verify::hello_real_semcode_admission::{
+    admit_hello_real_semcode_skeleton, HelloRealSemCodeAdmissionDecision,
+    HelloRealSemCodeAdmissionError, HelloRealSemCodeAdmissionInput,
+    HelloRealSemCodeAdmissionOp,
+};
+use std::vec::Vec;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> sm_ir::hello_ir::HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+fn render_text_literal(text: &str) -> String {
+    format!("{text:?}")
+}
+
+fn skeleton_to_admission_input(ops: &[HelloRealSemCodeOp]) -> HelloRealSemCodeAdmissionInput {
+    let mut admission_ops = Vec::new();
+    for op in ops {
+        let admission_op = match op {
+            HelloRealSemCodeOp::DeclareLocalQuad { name, value } => {
+                HelloRealSemCodeAdmissionOp::DeclareLocalQuad {
+                    name: name.clone(),
+                    value: value.clone(),
+                }
+            }
+            HelloRealSemCodeOp::RequireQuadEq { name, expected } => {
+                HelloRealSemCodeAdmissionOp::RequireQuadEq {
+                    name: name.clone(),
+                    expected: expected.clone(),
+                }
+            }
+            HelloRealSemCodeOp::ObserveTextLiteral { text } => {
+                HelloRealSemCodeAdmissionOp::ObserveTextLiteral {
+                    text: text.clone(),
+                }
+            }
+            HelloRealSemCodeOp::CompleteQuad { value } => {
+                HelloRealSemCodeAdmissionOp::CompleteQuad {
+                    value: value.clone(),
+                }
+            }
+        };
+        admission_ops.push(admission_op);
+    }
+
+    HelloRealSemCodeAdmissionInput { ops: admission_ops }
+}
+
+fn canonical_admission_input() -> HelloRealSemCodeAdmissionInput {
+    let module = parse_validate_lower();
+    let semcode = emit_hello_real_semcode_skeleton(&module)
+        .expect("canonical verbose Hello should lower to real SemCode skeleton");
+    skeleton_to_admission_input(&semcode.ops)
+}
+
+fn assert_reject(input: HelloRealSemCodeAdmissionInput, expected: HelloRealSemCodeAdmissionError) {
+    match admit_hello_real_semcode_skeleton(&input) {
+        HelloRealSemCodeAdmissionDecision::Admit => {
+            panic!("expected rejection, got admit")
+        }
+        HelloRealSemCodeAdmissionDecision::Reject(reason) => assert_eq!(reason, expected),
+    }
+}
+
+#[test]
+fn hello_real_semcode_admission_accepts_canonical_skeleton() {
+    let input = canonical_admission_input();
+    assert_eq!(
+        admit_hello_real_semcode_skeleton(&input),
+        HelloRealSemCodeAdmissionDecision::Admit
+    );
+}
+
+#[test]
+fn hello_real_semcode_admission_rejects_order_and_shape_mutations() {
+    let canonical = canonical_admission_input();
+
+    let mut swapped = canonical.clone();
+    swapped.ops.swap(1, 2);
+    assert_reject(
+        swapped,
+        HelloRealSemCodeAdmissionError::InvalidOperationOrder,
+    );
+
+    let mut missing_requirement = canonical.clone();
+    missing_requirement.ops.remove(1);
+    assert_reject(
+        missing_requirement,
+        HelloRealSemCodeAdmissionError::MissingRequirement,
+    );
+
+    let mut missing_observation = canonical.clone();
+    missing_observation.ops.remove(2);
+    assert_reject(
+        missing_observation,
+        HelloRealSemCodeAdmissionError::MissingObservation,
+    );
+
+    let mut missing_completion = canonical.clone();
+    missing_completion.ops.remove(3);
+    assert_reject(
+        missing_completion,
+        HelloRealSemCodeAdmissionError::MissingCompletion,
+    );
+
+    let mut wrong_name = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::DeclareLocalQuad { name, .. } = &mut wrong_name.ops[0] {
+        *name = "not_boot".to_string();
+    }
+    assert_reject(wrong_name, HelloRealSemCodeAdmissionError::UnsupportedShape);
+
+    let mut wrong_value = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::DeclareLocalQuad { value, .. } = &mut wrong_value.ops[0] {
+        *value = "F".to_string();
+    }
+    assert_reject(wrong_value, HelloRealSemCodeAdmissionError::UnsupportedShape);
+
+    let mut wrong_completion = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::CompleteQuad { value } = &mut wrong_completion.ops[3] {
+        *value = "F".to_string();
+    }
+    assert_reject(
+        wrong_completion,
+        HelloRealSemCodeAdmissionError::MissingCompletion,
+    );
+}
+
+#[test]
+fn hello_real_semcode_admission_rejects_stdout_print_and_generic_io_text() {
+    let canonical = canonical_admission_input();
+
+    let mut stdout = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut stdout.ops[2] {
+        *text = render_text_literal("stdout");
+    }
+    assert_reject(stdout, HelloRealSemCodeAdmissionError::StdoutNotAllowed);
+
+    let mut print = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut print.ops[2] {
+        *text = render_text_literal("print");
+    }
+    assert_reject(print, HelloRealSemCodeAdmissionError::PrintNotAllowed);
+
+    let mut io_write = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut io_write.ops[2] {
+        *text = render_text_literal("io.write");
+    }
+    assert_reject(io_write, HelloRealSemCodeAdmissionError::GenericIoNotAllowed);
+}
+
+#[test]
+fn hello_real_semcode_admission_rejects_opcode_and_bytecode_markers() {
+    let canonical = canonical_admission_input();
+
+    let mut opcode = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut opcode.ops[2] {
+        *text = render_text_literal("opcode");
+    }
+    assert_reject(opcode, HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed);
+
+    let mut bytecode = canonical.clone();
+    if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut bytecode.ops[2] {
+        *text = render_text_literal("bytecode");
+    }
+    assert_reject(
+        bytecode,
+        HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed,
+    );
+}


### PR DESCRIPTION
## Summary

Adds an isolated verifier-admission model for future #477 Hello controlled observation.

This PR admits only the typed Hello real SemCode-level skeleton sequence containing controlled `observe_text_literal`. It rejects ordering violations, missing required operations, stdout / print / generic I/O substitutions, and wrong local / completion shapes.

It does not verify real SemCode bytes, assign opcode IDs, change bytecode format, integrate with the production verifier, VM/runtime, capability admission, audit storage, host ABI, or `smc`.

## Issue

Prepares #477.
Does not close #477.

## Scope

Isolated verifier-admission skeleton only:

- `crates/sm-verify/src/hello_real_semcode_admission.rs`
- admission tests
- docs boundary note
- public API snapshot update if required

## Result

- Adds isolated admission for the Hello real SemCode-level skeleton
- Admits only:

  - `declare_local_quad boot = T`
  - `require_quad_eq boot T`
  - `observe_text_literal "Hello, World!"`
  - `complete_quad T`

- Rejects stdout / print / generic I/O substitutions
- Keeps real bytecode, production verifier, VM/runtime, capability, audit, and CLI behavior out of scope

## Out of Scope

- Production verifier integration
- Real SemCode byte verification
- Numeric opcode IDs
- Opcode implementation
- Bytecode format changes
- Production SemCode encoder integration
- VM/runtime routing
- Capability/effect admission
- Audit implementation/storage
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- stdout / print / general I/O
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_skeleton`
- `cargo test -q --test hello_isolated_policy_harness`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated verifier admission skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: verifier skeleton only
Reason: admits future Hello SemCode-level skeleton only; no real bytecode, VM/runtime, capability, audit, or CLI behavior.