### PR TITLE
PR-M-HELLO-7D — tests(verify): reject stdout print generic I/O encodings

### DIFF
--- a/crates/sm-verify/src/hello_real_semcode_admission.rs
+++ b/crates/sm-verify/src/hello_real_semcode_admission.rs
@@ -108,7 +108,7 @@ pub fn admit_hello_real_semcode_skeleton(
                         HelloRealSemCodeAdmissionError::PrintNotAllowed,
                     );
                 }
-                "\"io.write\"" => {
+                "\"io.write\"" | "\"file\"" | "\"network\"" | "\"stdin\"" => {
                     return HelloRealSemCodeAdmissionDecision::Reject(
                         HelloRealSemCodeAdmissionError::GenericIoNotAllowed,
                     );

--- a/docs/language/semantic_hello_real_semcode_encoding.md
+++ b/docs/language/semantic_hello_real_semcode_encoding.md
@@ -212,16 +212,14 @@ Recommended next steps:
 - no CLI / smc integration
 - `#477` remains open
 
+## 16. M-HELLO-7D Implementation Boundary
 
-## 14. M-HELLO-7B Implementation Boundary
-
-- isolated real SemCode-level emission skeleton exists
-- emits typed / planning SemCode-level operations only
-- no real SemCode bytes
-- no opcode IDs
-- no bytecode format changes
-- no verifier admission
-- no VM/runtime routing
-- no capability / audit behavior
-- no CLI pipeline integration
+- negative verifier tests exist for forbidden observation encodings
+- stdout / print / io.write / file / network / stdin are rejected
+- opcode / bytecode markers are rejected
+- tests target isolated verifier-admission skeleton only
+- no production verifier pipeline integration
+- no real SemCode byte verification
+- no VM/runtime/capability/audit behavior
+- no CLI / smc integration
 - `#477` remains open

--- a/tests/hello_real_semcode_negative_encodings.rs
+++ b/tests/hello_real_semcode_negative_encodings.rs
@@ -1,0 +1,172 @@
+use std::path::PathBuf;
+use std::vec::Vec;
+
+use sm_emit::hello_real_semcode::{
+    emit_hello_real_semcode_skeleton, HelloRealSemCodeOp,
+};
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::lower_hello_checked_file;
+use sm_verify::hello_real_semcode_admission::{
+    admit_hello_real_semcode_skeleton, HelloRealSemCodeAdmissionDecision,
+    HelloRealSemCodeAdmissionError, HelloRealSemCodeAdmissionInput,
+    HelloRealSemCodeAdmissionOp,
+};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> sm_ir::hello_ir::HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+fn render_text_literal(text: &str) -> String {
+    format!("{text:?}")
+}
+
+fn skeleton_to_admission_input(ops: &[HelloRealSemCodeOp]) -> HelloRealSemCodeAdmissionInput {
+    let mut admission_ops = Vec::with_capacity(ops.len());
+    for op in ops {
+        admission_ops.push(match op {
+            HelloRealSemCodeOp::DeclareLocalQuad { name, value } => {
+                HelloRealSemCodeAdmissionOp::DeclareLocalQuad {
+                    name: name.clone(),
+                    value: value.clone(),
+                }
+            }
+            HelloRealSemCodeOp::RequireQuadEq { name, expected } => {
+                HelloRealSemCodeAdmissionOp::RequireQuadEq {
+                    name: name.clone(),
+                    expected: expected.clone(),
+                }
+            }
+            HelloRealSemCodeOp::ObserveTextLiteral { text } => {
+                HelloRealSemCodeAdmissionOp::ObserveTextLiteral {
+                    text: text.clone(),
+                }
+            }
+            HelloRealSemCodeOp::CompleteQuad { value } => {
+                HelloRealSemCodeAdmissionOp::CompleteQuad {
+                    value: value.clone(),
+                }
+            }
+        });
+    }
+
+    HelloRealSemCodeAdmissionInput { ops: admission_ops }
+}
+
+fn canonical_admission_input() -> HelloRealSemCodeAdmissionInput {
+    let module = parse_validate_lower();
+    let semcode = emit_hello_real_semcode_skeleton(&module)
+        .expect("canonical verbose Hello should lower to real SemCode skeleton");
+    skeleton_to_admission_input(&semcode.ops)
+}
+
+fn assert_admit(input: &HelloRealSemCodeAdmissionInput) {
+    assert_eq!(
+        admit_hello_real_semcode_skeleton(input),
+        HelloRealSemCodeAdmissionDecision::Admit
+    );
+}
+
+fn assert_reject(input: HelloRealSemCodeAdmissionInput, expected: HelloRealSemCodeAdmissionError) {
+    match admit_hello_real_semcode_skeleton(&input) {
+        HelloRealSemCodeAdmissionDecision::Admit => panic!("expected rejection, got admit"),
+        HelloRealSemCodeAdmissionDecision::Reject(reason) => assert_eq!(reason, expected),
+    }
+}
+
+#[test]
+fn hello_real_semcode_negative_encodings_accept_canonical_and_reject_forbidden_variants() {
+    let canonical = canonical_admission_input();
+    assert_admit(&canonical);
+
+    for (replacement, expected) in [
+        ("stdout", HelloRealSemCodeAdmissionError::StdoutNotAllowed),
+        ("print", HelloRealSemCodeAdmissionError::PrintNotAllowed),
+        ("io.write", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("file", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("network", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("stdin", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("opcode", HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed),
+        ("bytecode", HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed),
+        ("Not Hello", HelloRealSemCodeAdmissionError::NonTextObservation),
+    ] {
+        let mut input = canonical.clone();
+        if let HelloRealSemCodeAdmissionOp::ObserveTextLiteral { text } = &mut input.ops[2] {
+            *text = render_text_literal(replacement);
+        } else {
+            panic!("canonical observation slot changed");
+        }
+        assert_reject(input, expected);
+    }
+}
+
+#[test]
+fn hello_real_semcode_negative_encodings_reject_order_bypasses_and_missing_ops() {
+    let canonical = canonical_admission_input();
+
+    let mut observation_before_requirement = canonical.clone();
+    observation_before_requirement.ops.swap(1, 2);
+    assert_reject(
+        observation_before_requirement,
+        HelloRealSemCodeAdmissionError::InvalidOperationOrder,
+    );
+
+    let mut completion_before_observation = canonical.clone();
+    completion_before_observation.ops.swap(2, 3);
+    assert_reject(
+        completion_before_observation,
+        HelloRealSemCodeAdmissionError::InvalidOperationOrder,
+    );
+
+    let mut extra_observation = canonical.clone();
+    extra_observation.ops.insert(
+        3,
+        HelloRealSemCodeAdmissionOp::ObserveTextLiteral {
+            text: render_text_literal("extra observation"),
+        },
+    );
+    assert_reject(
+        extra_observation,
+        HelloRealSemCodeAdmissionError::UnsupportedShape,
+    );
+
+    let mut missing_requirement = canonical.clone();
+    missing_requirement.ops.remove(1);
+    assert_reject(
+        missing_requirement,
+        HelloRealSemCodeAdmissionError::MissingRequirement,
+    );
+
+    let mut missing_observation = canonical.clone();
+    missing_observation.ops.remove(2);
+    assert_reject(
+        missing_observation,
+        HelloRealSemCodeAdmissionError::MissingObservation,
+    );
+
+    let mut missing_completion = canonical.clone();
+    missing_completion.ops.remove(3);
+    assert_reject(
+        missing_completion,
+        HelloRealSemCodeAdmissionError::MissingCompletion,
+    );
+}
+


### PR DESCRIPTION
## Summary

Adds focused negative tests for the isolated Hello real SemCode verifier-admission skeleton.

This PR proves that forbidden observation encodings such as stdout, print, io.write, generic I/O aliases, opcode markers, and bytecode markers are rejected. It keeps the canonical controlled `observe_text_literal "Hello, World!"` path admitted.

## Issue

Prepares #477.
Does not close #477.

## Scope

Verifier negative tests only:

- `tests/hello_real_semcode_negative_encodings.rs`

Optional if needed:

- isolated admission skeleton refinement
- docs boundary note
- public API snapshot only if public API changes

## Result

- Canonical controlled observation still admits
- stdout / print / io.write substitutions reject
- generic I/O aliases reject
- opcode / bytecode markers reject
- invalid operation-order bypasses reject
- production verifier/runtime/capability/audit/CLI behavior remains untouched

## Out of scope

- Production verifier integration
- Real SemCode byte verification
- Numeric opcode IDs
- Opcode implementation
- Bytecode format changes
- Production SemCode encoder integration
- VM/runtime routing
- Capability/effect admission
- Audit implementation/storage
- CLI pipeline integration
- Accepted golden SemCode
- Runtime output
- stdout / print / general I/O implementation
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_skeleton`
- `cargo test -q --test hello_isolated_policy_harness`
- `cargo test -q --test hello_pending_verifier_admission`
- `cargo test -q --test public_api_contracts`
- `cargo test -q --test pcc3_text_core_gate`
- `cargo test -q --test pcc2_numeric_core_gate`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated negative verifier tests only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: verifier negative coverage only
Reason: tests forbidden observation encodings against isolated skeleton only; no real bytecode, VM/runtime, capability, audit, or CLI behavior.
