### PR TITLE
PR-M-HELLO-8B — capability: gate observation sink route

### DIFF
--- a/docs/language/semantic_hello_runtime_sink.md
+++ b/docs/language/semantic_hello_runtime_sink.md
@@ -189,6 +189,16 @@ Recommended next steps:
 - no stdout default
 - no print / general I/O
 - no capability admission
+
+## 15. M-HELLO-8B Implementation Boundary
+
+- isolated capability-gated observation route test harness exists
+- capability allow is required before route skeleton is called
+- denied capability does not route
+- route remains explicit sink only
+- no production capability admission
+- no VM / runtime production routing
+- no host output
 - no audit storage
 - no CLI / smc integration
 - `#477` remains open

--- a/tests/hello_capability_gated_observation_route.rs
+++ b/tests/hello_capability_gated_observation_route.rs
@@ -1,0 +1,273 @@
+use std::vec::Vec;
+
+use prom_cap::hello_observation_capability::{
+    evaluate_hello_observation_capability, HelloObservationCapabilityContext,
+    HelloObservationCapabilityDecision, HelloObservationCapabilityDenial,
+};
+use sm_runtime_core::hello_observation_sink::{
+    HelloObservationClass, HelloObservationEvent, HelloObservationSequenceIndex,
+    HelloObservationSink, HelloObservationSinkError,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HelloObservationRouteError {
+    NotAdmitted,
+    NonControlledText,
+    ForbiddenHostOutput,
+    SinkRejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HelloObservationRouteResult {
+    Routed,
+    NotRouted(HelloObservationRouteError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HelloObservationRouteInput {
+    admitted: bool,
+    text: String,
+    sequence_index: HelloObservationSequenceIndex,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CapabilityGatedRouteResult {
+    Routed,
+    CapabilityDenied(HelloObservationCapabilityDenial),
+    RouteDenied(HelloObservationRouteError),
+}
+
+#[derive(Default)]
+struct InMemorySink {
+    events: Vec<HelloObservationEvent>,
+    reject: bool,
+}
+
+impl HelloObservationSink for InMemorySink {
+    fn observe(
+        &mut self,
+        event: HelloObservationEvent,
+    ) -> Result<(), HelloObservationSinkError> {
+        if self.reject {
+            return Err(HelloObservationSinkError::Denied);
+        }
+        self.events.push(event);
+        Ok(())
+    }
+}
+
+fn route_hello_observation_to_sink<S: HelloObservationSink>(
+    input: HelloObservationRouteInput,
+    sink: &mut S,
+) -> HelloObservationRouteResult {
+    if !input.admitted {
+        return HelloObservationRouteResult::NotRouted(HelloObservationRouteError::NotAdmitted);
+    }
+
+    match input.text.as_str() {
+        "Hello, World!" => {
+            let event = HelloObservationEvent {
+                operation_kind: "controlled_observation_text",
+                observation_class: HelloObservationClass::ControlledText,
+                text: input.text,
+                sequence_index: input.sequence_index,
+            };
+
+            match sink.observe(event) {
+                Ok(()) => HelloObservationRouteResult::Routed,
+                Err(_) => HelloObservationRouteResult::NotRouted(
+                    HelloObservationRouteError::SinkRejected,
+                ),
+            }
+        }
+        "stdout" | "print" | "io.write" | "file" | "network" | "stdin" => {
+            HelloObservationRouteResult::NotRouted(
+                HelloObservationRouteError::ForbiddenHostOutput,
+            )
+        }
+        _ => HelloObservationRouteResult::NotRouted(
+            HelloObservationRouteError::NonControlledText,
+        ),
+    }
+}
+
+fn capability_gate_then_route<S: HelloObservationSink>(
+    capability_context: HelloObservationCapabilityContext,
+    route_input: HelloObservationRouteInput,
+    sink: &mut S,
+) -> CapabilityGatedRouteResult {
+    match evaluate_hello_observation_capability(&capability_context) {
+        HelloObservationCapabilityDecision::Allow => {
+            match route_hello_observation_to_sink(route_input, sink) {
+                HelloObservationRouteResult::Routed => CapabilityGatedRouteResult::Routed,
+                HelloObservationRouteResult::NotRouted(err) => {
+                    CapabilityGatedRouteResult::RouteDenied(err)
+                }
+            }
+        }
+        HelloObservationCapabilityDecision::Deny(reason) => {
+            CapabilityGatedRouteResult::CapabilityDenied(reason)
+        }
+    }
+}
+
+fn allowed_capability_context() -> HelloObservationCapabilityContext {
+    HelloObservationCapabilityContext {
+        observation_sink_present: true,
+        sink_available: true,
+        requested_host_channel: None,
+    }
+}
+
+fn admitted_route_input() -> HelloObservationRouteInput {
+    HelloObservationRouteInput {
+        admitted: true,
+        text: "Hello, World!".to_string(),
+        sequence_index: HelloObservationSequenceIndex(0),
+    }
+}
+
+#[test]
+fn hello_capability_gated_route_routes_admitted_hello_only_after_allow() {
+    let mut sink = InMemorySink::default();
+    let result = capability_gate_then_route(
+        allowed_capability_context(),
+        admitted_route_input(),
+        &mut sink,
+    );
+
+    assert!(matches!(result, CapabilityGatedRouteResult::Routed));
+    assert_eq!(sink.events.len(), 1);
+    let event = &sink.events[0];
+    assert_eq!(event.operation_kind, "controlled_observation_text");
+    assert_eq!(event.observation_class, HelloObservationClass::ControlledText);
+    assert_eq!(event.text, "Hello, World!");
+    assert_eq!(event.sequence_index, HelloObservationSequenceIndex(0));
+}
+
+#[test]
+fn hello_capability_gated_route_denies_before_route_when_capability_denied() {
+    for (context, expected_reason) in [
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: false,
+            sink_available: true,
+            requested_host_channel: None,
+        },
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: false,
+            requested_host_channel: None,
+        },
+            HelloObservationCapabilityDenial::SinkUnavailable,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("stdout"),
+        },
+            HelloObservationCapabilityDenial::StdoutNotDefaultSink,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("print"),
+        },
+            HelloObservationCapabilityDenial::GenericIoNotAllowed,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("io.write"),
+        },
+            HelloObservationCapabilityDenial::GenericIoNotAllowed,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("file"),
+        },
+            HelloObservationCapabilityDenial::GenericIoNotAllowed,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("network"),
+        },
+            HelloObservationCapabilityDenial::GenericIoNotAllowed,
+        ),
+        (
+            HelloObservationCapabilityContext {
+            observation_sink_present: true,
+            sink_available: true,
+            requested_host_channel: Some("stdin"),
+        },
+            HelloObservationCapabilityDenial::GenericIoNotAllowed,
+        ),
+    ] {
+        let mut sink = InMemorySink::default();
+        let result = capability_gate_then_route(context, admitted_route_input(), &mut sink);
+        assert_eq!(
+            result,
+            CapabilityGatedRouteResult::CapabilityDenied(expected_reason)
+        );
+        assert!(sink.events.is_empty());
+    }
+}
+
+#[test]
+fn hello_capability_gated_route_respects_route_rejection_and_non_admitted_inputs() {
+    let mut sink = InMemorySink::default();
+
+    let not_admitted = HelloObservationRouteInput {
+        admitted: false,
+        text: "Hello, World!".to_string(),
+        sequence_index: HelloObservationSequenceIndex(1),
+    };
+    let result = capability_gate_then_route(allowed_capability_context(), not_admitted, &mut sink);
+    assert!(matches!(
+        result,
+        CapabilityGatedRouteResult::RouteDenied(HelloObservationRouteError::NotAdmitted)
+    ));
+    assert!(sink.events.is_empty());
+
+    for forbidden in ["stdout", "print", "io.write", "file", "network", "stdin"] {
+        let result = capability_gate_then_route(
+            allowed_capability_context(),
+            HelloObservationRouteInput {
+                admitted: true,
+                text: forbidden.to_string(),
+                sequence_index: HelloObservationSequenceIndex(2),
+            },
+            &mut sink,
+        );
+        assert!(matches!(
+            result,
+            CapabilityGatedRouteResult::RouteDenied(
+                HelloObservationRouteError::ForbiddenHostOutput
+            )
+        ));
+    }
+
+    let non_controlled = capability_gate_then_route(
+        allowed_capability_context(),
+        HelloObservationRouteInput {
+            admitted: true,
+            text: "Not Hello".to_string(),
+            sequence_index: HelloObservationSequenceIndex(3),
+        },
+        &mut sink,
+    );
+    assert!(matches!(
+        non_controlled,
+        CapabilityGatedRouteResult::RouteDenied(HelloObservationRouteError::NonControlledText)
+    ));
+}

--- a/tests/hello_capability_gated_observation_route.rs
+++ b/tests/hello_capability_gated_observation_route.rs
@@ -4,31 +4,14 @@ use prom_cap::hello_observation_capability::{
     evaluate_hello_observation_capability, HelloObservationCapabilityContext,
     HelloObservationCapabilityDecision, HelloObservationCapabilityDenial,
 };
+use sm_runtime_core::hello_observation_route::{
+    route_hello_observation_to_sink, HelloObservationRouteError,
+    HelloObservationRouteInput, HelloObservationRouteResult,
+};
 use sm_runtime_core::hello_observation_sink::{
     HelloObservationClass, HelloObservationEvent, HelloObservationSequenceIndex,
     HelloObservationSink, HelloObservationSinkError,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HelloObservationRouteError {
-    NotAdmitted,
-    NonControlledText,
-    ForbiddenHostOutput,
-    SinkRejected,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HelloObservationRouteResult {
-    Routed,
-    NotRouted(HelloObservationRouteError),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct HelloObservationRouteInput {
-    admitted: bool,
-    text: String,
-    sequence_index: HelloObservationSequenceIndex,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CapabilityGatedRouteResult {
@@ -53,41 +36,6 @@ impl HelloObservationSink for InMemorySink {
         }
         self.events.push(event);
         Ok(())
-    }
-}
-
-fn route_hello_observation_to_sink<S: HelloObservationSink>(
-    input: HelloObservationRouteInput,
-    sink: &mut S,
-) -> HelloObservationRouteResult {
-    if !input.admitted {
-        return HelloObservationRouteResult::NotRouted(HelloObservationRouteError::NotAdmitted);
-    }
-
-    match input.text.as_str() {
-        "Hello, World!" => {
-            let event = HelloObservationEvent {
-                operation_kind: "controlled_observation_text",
-                observation_class: HelloObservationClass::ControlledText,
-                text: input.text,
-                sequence_index: input.sequence_index,
-            };
-
-            match sink.observe(event) {
-                Ok(()) => HelloObservationRouteResult::Routed,
-                Err(_) => HelloObservationRouteResult::NotRouted(
-                    HelloObservationRouteError::SinkRejected,
-                ),
-            }
-        }
-        "stdout" | "print" | "io.write" | "file" | "network" | "stdin" => {
-            HelloObservationRouteResult::NotRouted(
-                HelloObservationRouteError::ForbiddenHostOutput,
-            )
-        }
-        _ => HelloObservationRouteResult::NotRouted(
-            HelloObservationRouteError::NonControlledText,
-        ),
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an isolated capability-gated observation route harness for future #477 Hello controlled observation.

This PR composes the isolated observation capability model with a test-local runtime observation route helper and the existing observation sink skeleton. It proves that the route is called only after capability allow, and that denied capability cases do not route or create sink events.

## Issue

Prepares #477.
Does not close #477.

## Scope

Test/docs only:

- `tests/hello_capability_gated_observation_route.rs`
- docs boundary note

## Result

- Capability allow gates admitted `Hello, World!` route to explicit sink
- Missing capability / unavailable sink / stdout / print / generic I/O requests deny before route
- Non-admitted route input remains not routed
- Forbidden route text remains not routed
- Production runtime/capability behavior remains untouched

## Out of scope

- Production capability admission
- `required_capability_for_call` changes
- prom-abi / HostCallId changes
- VM integration
- Production runtime routing
- Host output
- stdout default
- `print` implementation
- `observe` effect implementation
- General I/O implementation
- Real SemCode byte execution
- Numeric opcode IDs
- Verifier integration
- AuditTrail integration
- Audit storage
- CLI pipeline integration
- Accepted runtime behavior
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_capability_gated_observation_route`
- `cargo test -q --test hello_observation_sink_skeleton`
- `cargo test -q --test hello_observation_capability_skeleton`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated test harness only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: capability-gated route harness only
Reason: composes isolated capability and route logic locally with the sink skeleton only; no VM/runtime production route, audit, SemCode byte execution, or CLI behavior.
