### PR TITLE
PR-M-HELLO-8C — audit: record observation audit event or audit-deferred decision

### DIFF
--- a/docs/language/semantic_hello_audit_event.md
+++ b/docs/language/semantic_hello_audit_event.md
@@ -196,3 +196,17 @@ Recommended next steps:
 - no verifier / capability behavior
 - no CLI pipeline integration
 - `#477` remains open
+
+## 14. M-HELLO-8C Boundary Note
+
+- isolated observation audit decision test harness exists
+- required audit policy records local audit event skeleton only
+- deferred audit policy produces local Deferred decision
+- denied route produces local NotRecorded decision
+- no production AuditTrail integration
+- no audit storage
+- no VM / runtime production routing
+- no host output
+- no capability / verifier behavior
+- no CLI / smc integration
+- `#477` remains open

--- a/tests/hello_observation_audit_decision.rs
+++ b/tests/hello_observation_audit_decision.rs
@@ -1,0 +1,262 @@
+use std::vec::Vec;
+
+use prom_audit::hello_observation_audit::{
+    build_hello_observation_audit_event, HelloObservationAuditEvent,
+    HelloObservationAuditLinkage, HelloObservationAuditPayloadRef,
+    HelloObservationAuditPolicyClass, HelloObservationAuditEventKind,
+};
+use sm_runtime_core::hello_observation_route::{
+    route_hello_observation_to_sink, HelloObservationRouteError,
+    HelloObservationRouteInput, HelloObservationRouteResult,
+};
+use sm_runtime_core::hello_observation_sink::{
+    HelloObservationClass, HelloObservationEvent, HelloObservationSequenceIndex,
+    HelloObservationSink, HelloObservationSinkError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HelloObservationAuditDecision {
+    Recorded(HelloObservationAuditEvent),
+    Deferred,
+    NotRecorded(&'static str),
+}
+
+#[derive(Default)]
+struct InMemorySink {
+    events: Vec<HelloObservationEvent>,
+    reject: bool,
+}
+
+impl HelloObservationSink for InMemorySink {
+    fn observe(
+        &mut self,
+        event: HelloObservationEvent,
+    ) -> Result<(), HelloObservationSinkError> {
+        if self.reject {
+            return Err(HelloObservationSinkError::Denied);
+        }
+        self.events.push(event);
+        Ok(())
+    }
+}
+
+fn deterministic_text_hash(text: &str, sequence_index: u64) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64 ^ sequence_index;
+    for byte in text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn route_with_sink(
+    admitted: bool,
+    text: &str,
+    sequence_index: u64,
+    sink: &mut InMemorySink,
+) -> HelloObservationRouteResult {
+    route_hello_observation_to_sink(
+        HelloObservationRouteInput {
+            admitted,
+            text: text.to_string(),
+            sequence_index: HelloObservationSequenceIndex(sequence_index),
+        },
+        sink,
+    )
+}
+
+fn audit_after_route(
+    route_result: HelloObservationRouteResult,
+    text: &str,
+    sequence_index: u64,
+    audit_policy_class: HelloObservationAuditPolicyClass,
+    linkage: HelloObservationAuditLinkage,
+) -> HelloObservationAuditDecision {
+    match route_result {
+        HelloObservationRouteResult::Routed => match audit_policy_class {
+            HelloObservationAuditPolicyClass::Deferred => HelloObservationAuditDecision::Deferred,
+            HelloObservationAuditPolicyClass::Required => {
+                HelloObservationAuditDecision::Recorded(build_hello_observation_audit_event(
+                    deterministic_text_hash(text, sequence_index),
+                    sequence_index,
+                    HelloObservationAuditPolicyClass::Required,
+                    linkage,
+                ))
+            }
+        },
+        HelloObservationRouteResult::NotRouted(_) => {
+            HelloObservationAuditDecision::NotRecorded("route_not_routed")
+        }
+    }
+}
+
+#[test]
+fn hello_observation_audit_decision_records_required_routed_observation() {
+    let mut sink = InMemorySink::default();
+    let route_result = route_with_sink(true, "Hello, World!", 0, &mut sink);
+    assert_eq!(route_result, HelloObservationRouteResult::Routed);
+    assert_eq!(sink.events.len(), 1);
+    let event = &sink.events[0];
+    assert_eq!(event.operation_kind, "controlled_observation_text");
+    assert_eq!(event.observation_class, HelloObservationClass::ControlledText);
+    assert_eq!(event.text, "Hello, World!");
+    assert_eq!(event.sequence_index, HelloObservationSequenceIndex(0));
+
+    let decision = audit_after_route(
+        route_result,
+        "Hello, World!",
+        0,
+        HelloObservationAuditPolicyClass::Required,
+        HelloObservationAuditLinkage {
+            verifier_admission_ref: Some(17),
+            capability_policy_ref: Some(23),
+            sink_policy_ref: Some(31),
+        },
+    );
+
+    match decision {
+        HelloObservationAuditDecision::Recorded(recorded) => {
+            assert_eq!(recorded.event_kind, HelloObservationAuditEventKind::Observation);
+            assert_eq!(recorded.operation_kind, "controlled_observation_text");
+            assert_eq!(recorded.observation_class, "controlled");
+            assert_eq!(
+                recorded.payload_ref,
+                HelloObservationAuditPayloadRef::LiteralTextHash(deterministic_text_hash(
+                    "Hello, World!",
+                    0,
+                ))
+            );
+            assert_eq!(
+                recorded.sequence_index,
+                prom_audit::hello_observation_audit::HelloObservationAuditSequenceIndex(0)
+            );
+            assert_eq!(
+                recorded.audit_policy_class,
+                HelloObservationAuditPolicyClass::Required
+            );
+            assert_eq!(
+                recorded.linkage,
+                HelloObservationAuditLinkage {
+                    verifier_admission_ref: Some(17),
+                    capability_policy_ref: Some(23),
+                    sink_policy_ref: Some(31),
+                }
+            );
+        }
+        other => panic!("expected recorded audit event, got {other:?}"),
+    }
+}
+
+#[test]
+fn hello_observation_audit_decision_deferred_stays_local() {
+    let mut sink = InMemorySink::default();
+    let route_result = route_with_sink(true, "Hello, World!", 0, &mut sink);
+    assert_eq!(route_result, HelloObservationRouteResult::Routed);
+
+    let decision = audit_after_route(
+        route_result,
+        "Hello, World!",
+        0,
+        HelloObservationAuditPolicyClass::Deferred,
+        HelloObservationAuditLinkage {
+            verifier_admission_ref: Some(2),
+            capability_policy_ref: Some(3),
+            sink_policy_ref: Some(5),
+        },
+    );
+
+    assert_eq!(decision, HelloObservationAuditDecision::Deferred);
+    assert_eq!(sink.events.len(), 1);
+}
+
+#[test]
+fn hello_observation_audit_decision_does_not_record_for_not_routed_variants() {
+    let mut sink = InMemorySink::default();
+
+    let not_admitted = route_with_sink(false, "Hello, World!", 0, &mut sink);
+    assert_eq!(
+        not_admitted,
+        HelloObservationRouteResult::NotRouted(HelloObservationRouteError::NotAdmitted)
+    );
+    assert_eq!(
+        audit_after_route(
+            not_admitted,
+            "Hello, World!",
+            0,
+            HelloObservationAuditPolicyClass::Required,
+            HelloObservationAuditLinkage {
+                verifier_admission_ref: None,
+                capability_policy_ref: None,
+                sink_policy_ref: None,
+            },
+        ),
+        HelloObservationAuditDecision::NotRecorded("route_not_routed")
+    );
+
+    for forbidden in ["stdout", "print", "io.write", "file", "network", "stdin"] {
+        let route_result = route_with_sink(true, forbidden, 1, &mut sink);
+        assert_eq!(
+            route_result,
+            HelloObservationRouteResult::NotRouted(
+                HelloObservationRouteError::ForbiddenHostOutput
+            )
+        );
+        assert_eq!(
+            audit_after_route(
+                route_result,
+                forbidden,
+                1,
+                HelloObservationAuditPolicyClass::Required,
+                HelloObservationAuditLinkage {
+                    verifier_admission_ref: None,
+                    capability_policy_ref: None,
+                    sink_policy_ref: None,
+                },
+            ),
+            HelloObservationAuditDecision::NotRecorded("route_not_routed")
+        );
+    }
+
+    let sink_rejected = route_with_sink(true, "Hello, World!", 2, &mut InMemorySink {
+        events: Vec::new(),
+        reject: true,
+    });
+    assert_eq!(
+        sink_rejected,
+        HelloObservationRouteResult::NotRouted(HelloObservationRouteError::SinkRejected)
+    );
+    assert_eq!(
+        audit_after_route(
+            sink_rejected,
+            "Hello, World!",
+            2,
+            HelloObservationAuditPolicyClass::Required,
+            HelloObservationAuditLinkage {
+                verifier_admission_ref: None,
+                capability_policy_ref: None,
+                sink_policy_ref: None,
+            },
+        ),
+        HelloObservationAuditDecision::NotRecorded("route_not_routed")
+    );
+
+    let non_controlled = route_with_sink(true, "Not Hello", 3, &mut sink);
+    assert_eq!(
+        non_controlled,
+        HelloObservationRouteResult::NotRouted(HelloObservationRouteError::NonControlledText)
+    );
+    assert_eq!(
+        audit_after_route(
+            non_controlled,
+            "Not Hello",
+            3,
+            HelloObservationAuditPolicyClass::Required,
+            HelloObservationAuditLinkage {
+                verifier_admission_ref: None,
+                capability_policy_ref: None,
+                sink_policy_ref: None,
+            },
+        ),
+        HelloObservationAuditDecision::NotRecorded("route_not_routed")
+    );
+}


### PR DESCRIPTION
## Summary

Adds an isolated audit decision harness for future #477 Hello controlled observation.

This PR composes the isolated runtime observation route skeleton with the isolated observation audit event skeleton. It proves that a routed controlled observation can create a local audit event skeleton under Required policy, that Deferred policy stays local and non-recording, and that denied route results do not create audit events.

## Issue

Prepares #477.
Does not close #477.

## Scope

Test/docs only:

- `tests/hello_observation_audit_decision.rs`
- docs boundary note

## Result

- Required + Routed creates local `HelloObservationAuditEvent`
- Deferred + Routed returns local Deferred decision
- NotRouted results return local NotRecorded decision
- Payload uses deterministic hash/ref shape
- Linkage metadata is preserved
- Production audit storage remains untouched

## Out of scope

- Production AuditTrail integration
- `AuditTrail::record`
- Audit storage
- prom-runtime changes
- VM integration
- Production runtime routing
- Production verifier integration
- Production capability admission
- SemCode byte execution
- Numeric opcode IDs
- Host output
- stdout default
- `print` implementation
- `observe` effect implementation
- CLI pipeline integration
- Accepted runtime behavior
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_audit_decision`
- `cargo test -q --test hello_observation_audit_skeleton`
- `cargo test -q --test hello_observation_route_skeleton`
- `cargo test -q --test hello_capability_gated_observation_route`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated audit decision harness only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: audit decision harness only
Reason: composes isolated route and audit event skeletons only; no production audit storage, VM/runtime production route, capability, verifier, SemCode byte execution, or CLI behavior.
