### PR TITLE
PR-M-HELLO-9B — docs(hello): close skeleton phase before real CLI

### DIFF
--- a/docs/language/semantic_hello_cli_smoke_path.md
+++ b/docs/language/semantic_hello_cli_smoke_path.md
@@ -68,3 +68,5 @@ Later real CLI integration may start only after:
 - it is a controlled smoke-path harness only
 - production CLI remains blocked
 
+See also: [`semantic_hello_implementation_closeout.md`](semantic_hello_implementation_closeout.md)
+

--- a/docs/language/semantic_hello_implementation_closeout.md
+++ b/docs/language/semantic_hello_implementation_closeout.md
@@ -1,0 +1,145 @@
+# Semantic Hello Implementation Closeout
+
+Status: closeout draft for `#477`
+
+See also:
+
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
+- [`semantic_hello_real_semcode_encoding.md`](semantic_hello_real_semcode_encoding.md)
+- [`semantic_hello_runtime_sink.md`](semantic_hello_runtime_sink.md)
+- [`semantic_hello_audit_event.md`](semantic_hello_audit_event.md)
+- [`semantic_hello_policy_fixtures.md`](semantic_hello_policy_fixtures.md)
+- [`semantic_hello_verifier_admission.md`](semantic_hello_verifier_admission.md)
+
+## 1. Purpose
+
+This document closes the skeleton / planning implementation phase for `#477`
+and records the remaining blockers before any real production CLI work may
+begin.
+
+- docs-only
+- no code changes
+- no tests
+- no fixtures
+- no CLI integration
+- no runtime output
+- no accepted Hello World behavior
+- `#477` remains open
+
+## 2. What Is Now Covered
+
+| Area | Status | Evidence |
+|---|---|---|
+| parser path | covered | `#628` |
+| sema path | covered | `#629` |
+| IR lowering | covered | `#633` |
+| real SemCode-level skeleton | covered | `#649` |
+| verifier admission skeleton | covered | `#650` |
+| negative verifier coverage | covered | `#651` |
+| runtime explicit sink skeleton | covered | `#652` |
+| capability-gated route harness | covered | `#653` |
+| audit decision harness | covered | `#654` |
+| isolated CLI smoke harness | covered | `#655` |
+
+## 3. Current Accepted Boundary
+
+Accepted:
+
+```text
+source fixture
+→ isolated parser
+→ isolated sema
+→ isolated lowering
+→ typed SemCode-level skeleton
+→ isolated verifier admission
+→ isolated capability gate
+→ isolated explicit sink route
+→ isolated audit decision
+```
+
+Not accepted:
+
+```text
+source
+→ smc check
+→ smc compile
+→ smc verify
+→ smc run
+→ VM execution
+→ user-visible output
+```
+
+## 4. Remaining Blockers Before Real CLI
+
+- [ ] Decide real SemCode byte encoding / opcode allocation or admitted typed host-call form
+- [ ] Implement real SemCode byte emission for Hello operation sequence
+- [ ] Add production verifier admission for real encoded observation operation
+- [ ] Connect VM/runtime execution path to explicit observation sink
+- [ ] Gate route through production capability/effect policy
+- [ ] Decide and implement production audit behavior or explicit audit-deferred policy
+- [ ] Add CLI / smc smoke path only after verifier/runtime/capability/audit are accepted
+- [ ] Add accepted golden SemCode fixture
+- [ ] Add examples/hello_world.sm only when it actually passes check → compile → verify → run
+- [ ] Update README only after real behavior exists
+- [ ] Ensure negative fixtures reject through production path
+- [ ] Keep observation as controlled sink, not stdout/print/general I/O
+
+## 5. Explicitly Blocked Actions
+
+- no README claim
+- no example claim
+- no `smc run` claim
+- no "Hello World works" claim
+- no stdout claim
+- no print support claim
+- no accepted golden SemCode claim
+- no closure of `#477`
+
+## 6. Real CLI Readiness Gate
+
+Real CLI PR may start only when:
+
+- real SemCode representation is implemented or explicitly admitted
+- production verifier can admit/reject it
+- runtime route is explicit sink only
+- capability gate is production-wired
+- audit policy is production-decided
+- negative cases remain rejected
+- user-visible output is produced only through the controlled observation sink
+
+## 7. Issue State
+
+- `#477` must remain open after this closeout
+- this closeout does not satisfy the acceptance criteria of `#477`
+- the closeout only prepares the transition from skeleton harnesses to real implementation PRs
+
+## 8. Suggested Next PR Sequence
+
+```text
+M-HELLO-10A — semcode: assign controlled observation opcode/encoding decision or typed host-call decision
+M-HELLO-10B — semcode: emit real Hello SemCode bytes behind gated path
+M-HELLO-10C — verify: admit real controlled observation encoding
+M-HELLO-10D — tests: reject real stdout/print/general I/O encodings
+M-HELLO-11A — runtime/vm: execute admitted controlled observation to explicit sink
+M-HELLO-11B — capability: wire production observation route gate
+M-HELLO-11C — audit: wire production observation audit/deferred policy
+M-HELLO-12A — cli: add smc check/compile/verify/run smoke path
+M-HELLO-12B — examples/docs: add real hello example after behavior is accepted
+M-HELLO-12C — close #477 only after acceptance criteria pass
+```
+
+## 9. Acceptance Checklist
+
+- [ ] skeleton phase coverage table added
+- [ ] accepted vs not accepted boundary documented
+- [ ] real CLI blockers listed
+- [ ] blocked claims listed
+- [ ] readiness gate documented
+- [ ] next implementation sequence proposed
+- [ ] docs-only
+- [ ] no code/test/fixture changes
+- [ ] no CLI/smc integration
+- [ ] no runtime output
+- [ ] no accepted Hello World behavior
+- [ ] `#477` remains open
+


### PR DESCRIPTION
## Summary

Adds a docs-only closeout for the M-HELLO skeleton implementation phase.

This PR records what is now covered by isolated parser/sema/lowering/SemCode/verifier/runtime/capability/audit/CLI-smoke harnesses, and lists the remaining blockers before real production CLI / `smc` Hello World integration may begin.

It does not add code, tests, fixtures, CLI behavior, VM execution, real SemCode bytes, opcode IDs, runtime output, README/examples, or accepted Hello World behavior.

## Issue

Prepares #477.
Does not close #477.

## Scope

Docs-only:

- `docs/language/semantic_hello_implementation_closeout.md`

Optional:

- small cross-reference from `docs/language/semantic_hello_cli_smoke_path.md`

## Result

- Records skeleton phase coverage
- Documents accepted isolated boundary
- Documents not-yet-accepted production boundary
- Lists real CLI blockers
- Lists blocked claims
- Defines readiness gate for later real CLI PRs
- Proposes next implementation sequence

## Out of scope

- Rust code
- Tests / fixtures
- SemCode encoder implementation
- Opcode allocation
- Bytecode format changes
- Production verifier integration
- VM/runtime execution
- Production capability admission
- AuditTrail / audit storage
- CLI / smc integration
- Runtime output
- Accepted golden SemCode
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70
- Closing #477

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: docs-only closeout; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: skeleton closeout only
Reason: documents completed skeleton coverage and blockers before real CLI; no production behavior.
