### PR TITLE
PR-M-HELLO-10B — semcode: emit gated Hello observation bytes

### DIFF
--- a/crates/sm-emit/src/hello_observation_bytes.rs
+++ b/crates/sm-emit/src/hello_observation_bytes.rs
@@ -1,0 +1,119 @@
+use crate::hello_real_semcode::{HelloRealSemCodeModule, HelloRealSemCodeOp};
+use std::string::String;
+use std::vec::Vec;
+
+const FORMAT_STATUS: &str = "gated_provisional_not_production";
+const CONTROLLED_OBSERVATION_SYMBOL: &str = "OBSERVE_TEXT_LITERAL";
+const CONTROLLED_OBSERVATION_CLASS: &str = "ControlledText";
+const CANONICAL_HELLO_TEXT: &str = "Hello, World!";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelloObservationByteModule {
+    pub records: Vec<HelloObservationByteRecord>,
+    pub format_status: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloObservationByteRecord {
+    DeclareLocalQuad { symbol: String, value: String },
+    RequireQuadEq { symbol: String, expected: String },
+    ObserveTextLiteral {
+        symbolic_op: &'static str,
+        text_const_index: u32,
+        observation_class: &'static str,
+        sequence_index: u32,
+        policy_ref: u32,
+    },
+    CompleteQuad { value: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloObservationByteEmissionError {
+    UnsupportedShape,
+    MissingControlledObservation,
+    ForbiddenHostOutput,
+}
+
+pub fn emit_hello_observation_bytes_gated(
+    module: &HelloRealSemCodeModule,
+) -> Result<HelloObservationByteModule, HelloObservationByteEmissionError> {
+    let _ = validate_and_extract_controlled_text(module)?;
+    Ok(HelloObservationByteModule {
+        records: vec![
+            HelloObservationByteRecord::DeclareLocalQuad {
+                symbol: "boot".to_string(),
+                value: "T".to_string(),
+            },
+            HelloObservationByteRecord::RequireQuadEq {
+                symbol: "boot".to_string(),
+                expected: "T".to_string(),
+            },
+            HelloObservationByteRecord::ObserveTextLiteral {
+                symbolic_op: CONTROLLED_OBSERVATION_SYMBOL,
+                text_const_index: 0,
+                observation_class: CONTROLLED_OBSERVATION_CLASS,
+                sequence_index: 0,
+                policy_ref: 0,
+            },
+            HelloObservationByteRecord::CompleteQuad {
+                value: "T".to_string(),
+            },
+        ],
+        format_status: FORMAT_STATUS,
+    })
+}
+
+pub fn render_hello_observation_bytes_gated(
+    module: &HelloRealSemCodeModule,
+) -> Result<Vec<u8>, HelloObservationByteEmissionError> {
+    let text = validate_and_extract_controlled_text(module)?;
+    let rendered = format!(
+        "FORMAT_STATUS {FORMAT_STATUS}\nDECLARE_LOCAL_QUAD boot T\nREQUIRE_QUAD_EQ boot T\nOBSERVE_TEXT_LITERAL const#0 ControlledText seq#0 policy#0\nCOMPLETE_QUAD T\nCONST_TEXT #0 {text:?}",
+    );
+    Ok(rendered.into_bytes())
+}
+
+fn validate_and_extract_controlled_text(
+    module: &HelloRealSemCodeModule,
+) -> Result<&str, HelloObservationByteEmissionError> {
+    if !module
+        .ops
+        .iter()
+        .any(|stmt| matches!(stmt, HelloRealSemCodeOp::ObserveTextLiteral { .. }))
+    {
+        return Err(HelloObservationByteEmissionError::MissingControlledObservation);
+    }
+
+    match module.ops.as_slice() {
+        [
+            HelloRealSemCodeOp::DeclareLocalQuad { name, value },
+            HelloRealSemCodeOp::RequireQuadEq {
+                name: require_symbol,
+                expected,
+            },
+            HelloRealSemCodeOp::ObserveTextLiteral { text },
+            HelloRealSemCodeOp::CompleteQuad { value: complete_value },
+        ] if name == "boot" && value == "T" && require_symbol == "boot" && expected == "T" && complete_value == "T" =>
+        {
+            let text = strip_rendered_text(text);
+            if is_forbidden_host_output(text) {
+                return Err(HelloObservationByteEmissionError::ForbiddenHostOutput);
+            }
+            if text != CANONICAL_HELLO_TEXT {
+                return Err(HelloObservationByteEmissionError::UnsupportedShape);
+            }
+            Ok(text)
+        }
+        _ => Err(HelloObservationByteEmissionError::UnsupportedShape),
+    }
+}
+
+fn strip_rendered_text(text: &str) -> &str {
+    text.strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(text)
+}
+
+fn is_forbidden_host_output(text: &str) -> bool {
+    matches!(text, "stdout" | "print" | "io.write" | "file" | "network" | "stdin")
+}

--- a/crates/sm-emit/src/lib.rs
+++ b/crates/sm-emit/src/lib.rs
@@ -27,6 +27,9 @@ pub use sm_ir::{
 #[cfg(feature = "std")]
 pub mod hello_real_semcode;
 
+#[cfg(feature = "std")]
+pub mod hello_observation_bytes;
+
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;

--- a/docs/language/semantic_hello_controlled_observation_encoding.md
+++ b/docs/language/semantic_hello_controlled_observation_encoding.md
@@ -171,13 +171,24 @@ Clarifications:
 - update examples/README only after real behavior exists
 - keep `#477` open
 
-## 11. Issue State
+## 11. M-HELLO-10B Boundary Note
+
+- gated provisional byte-emission skeleton exists
+- representation is deterministic but not production SemCode
+- `OBSERVE_TEXT_LITERAL` remains symbolic / not a numeric opcode ID
+- no stable bytecode format is claimed
+- no production encoder integration
+- no verifier / VM / runtime / capability / audit / CLI behavior
+- no accepted golden SemCode
+- `#477` remains open
+
+## 12. Issue State
 
 - this PR does not close `#477`
 - this PR does not satisfy `#477` acceptance criteria
 - this PR only removes the design fork between dedicated encoding and host-call fallback
 
-## 12. Acceptance Checklist
+## 13. Acceptance Checklist
 
 - [ ] dedicated encoding decision recorded
 - [ ] typed host-call fallback documented but not selected
@@ -192,4 +203,3 @@ Clarifications:
 - [ ] no bytecode format changes
 - [ ] no accepted runtime behavior
 - [ ] `#477` remains open
-

--- a/tests/hello_observation_byte_emission.rs
+++ b/tests/hello_observation_byte_emission.rs
@@ -1,0 +1,157 @@
+use std::path::PathBuf;
+
+use sm_emit::hello_observation_bytes::{
+    emit_hello_observation_bytes_gated, render_hello_observation_bytes_gated,
+    HelloObservationByteEmissionError, HelloObservationByteRecord,
+};
+use sm_emit::hello_real_semcode::{
+    emit_hello_real_semcode_skeleton, HelloRealSemCodeModule, HelloRealSemCodeOp,
+};
+use sm_front::hello_parser::parse_hello_file;
+use sm_front::hello_sema::validate_hello_file;
+use sm_ir::hello_ir::lower_hello_checked_file;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_text(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("failed to read fixture {rel}: {err}"))
+}
+
+fn parse_validate_lower() -> sm_ir::hello_ir::HelloIrModule {
+    let input = fixture_text("tests/fixtures/pending/hello/positive_hello_verbose_directional.sm");
+    let parsed = parse_hello_file(&input)
+        .unwrap_or_else(|err| panic!("parser unexpectedly rejected canonical hello fixture: {err}"));
+    let checked = validate_hello_file(parsed)
+        .unwrap_or_else(|err| panic!("sema unexpectedly rejected canonical hello fixture: {err}"));
+    lower_hello_checked_file(&checked)
+        .unwrap_or_else(|err| panic!("lowering unexpectedly rejected canonical hello fixture: {err}"))
+}
+
+fn canonical_real_semcode() -> HelloRealSemCodeModule {
+    let module = parse_validate_lower();
+    emit_hello_real_semcode_skeleton(&module)
+        .expect("canonical verbose Hello should lower to real SemCode skeleton")
+}
+
+fn render_text_literal(text: &str) -> String {
+    format!("{text:?}")
+}
+
+fn assert_reject(
+    module: &HelloRealSemCodeModule,
+    expected: HelloObservationByteEmissionError,
+) {
+    assert_eq!(
+        emit_hello_observation_bytes_gated(module),
+        Err(expected.clone())
+    );
+    assert_eq!(render_hello_observation_bytes_gated(module), Err(expected));
+}
+
+#[test]
+fn hello_observation_byte_emission_emits_gated_provisional_representation() {
+    let module = canonical_real_semcode();
+    let emitted = emit_hello_observation_bytes_gated(&module)
+        .expect("canonical hello should emit gated observation bytes");
+    let rendered = render_hello_observation_bytes_gated(&module)
+        .expect("canonical hello should render gated observation bytes");
+    let rendered_text = String::from_utf8(rendered).expect("utf8 rendered bytes");
+
+    assert_eq!(emitted.format_status, "gated_provisional_not_production");
+    assert_eq!(emitted.records.len(), 4);
+    match &emitted.records[..] {
+        [
+            HelloObservationByteRecord::DeclareLocalQuad { symbol, value },
+            HelloObservationByteRecord::RequireQuadEq {
+                symbol: req_symbol,
+                expected,
+            },
+            HelloObservationByteRecord::ObserveTextLiteral {
+                symbolic_op,
+                text_const_index,
+                observation_class,
+                sequence_index,
+                policy_ref,
+            },
+            HelloObservationByteRecord::CompleteQuad { value: complete_value },
+        ] => {
+            assert_eq!(symbol, "boot");
+            assert_eq!(value, "T");
+            assert_eq!(req_symbol, "boot");
+            assert_eq!(expected, "T");
+            assert_eq!(*symbolic_op, "OBSERVE_TEXT_LITERAL");
+            assert_eq!(*text_const_index, 0);
+            assert_eq!(*observation_class, "ControlledText");
+            assert_eq!(*sequence_index, 0);
+            assert_eq!(*policy_ref, 0);
+            assert_eq!(complete_value, "T");
+        }
+        other => panic!("unexpected gated observation byte record order: {other:?}"),
+    }
+
+    let expected = "\
+FORMAT_STATUS gated_provisional_not_production
+DECLARE_LOCAL_QUAD boot T
+REQUIRE_QUAD_EQ boot T
+OBSERVE_TEXT_LITERAL const#0 ControlledText seq#0 policy#0
+COMPLETE_QUAD T
+CONST_TEXT #0 \"Hello, World!\"
+";
+    assert_eq!(rendered_text, expected.trim_end());
+}
+
+#[test]
+fn hello_observation_byte_emission_rejects_host_output_markers() {
+    let module = canonical_real_semcode();
+
+    for marker in ["stdout", "print", "io.write", "file", "network", "stdin"] {
+        let mut mutated = module.clone();
+        if let HelloRealSemCodeOp::ObserveTextLiteral { text } = &mut mutated.ops[2] {
+            *text = render_text_literal(marker);
+        }
+        assert_reject(
+            &mutated,
+            HelloObservationByteEmissionError::ForbiddenHostOutput,
+        );
+    }
+}
+
+#[test]
+fn hello_observation_byte_emission_rejects_missing_observation_and_wrong_order() {
+    let module = canonical_real_semcode();
+
+    let mut missing_observation = module.clone();
+    missing_observation.ops.remove(2);
+    assert_reject(
+        &missing_observation,
+        HelloObservationByteEmissionError::MissingControlledObservation,
+    );
+
+    let mut wrong_order = module.clone();
+    wrong_order.ops.swap(1, 2);
+    assert_reject(
+        &wrong_order,
+        HelloObservationByteEmissionError::UnsupportedShape,
+    );
+}
+
+#[test]
+fn hello_observation_byte_emission_rejects_non_hello_text() {
+    let module = canonical_real_semcode();
+
+    let mut mutated = module.clone();
+    if let HelloRealSemCodeOp::ObserveTextLiteral { text } = &mut mutated.ops[2] {
+        *text = render_text_literal("Not Hello");
+    }
+
+    assert_reject(
+        &mutated,
+        HelloObservationByteEmissionError::UnsupportedShape,
+    );
+}


### PR DESCRIPTION
## Summary

Adds a gated provisional byte-emission skeleton for future #477 Hello controlled observation.

This PR converts the canonical Hello real SemCode-level skeleton into a deterministic gated representation using the symbolic `OBSERVE_TEXT_LITERAL` operation selected in M-HELLO-10A. The output is explicitly marked `gated_provisional_not_production`.

It does not integrate with the production SemCode encoder, assign final numeric opcode IDs, change bytecode format, wire verifier/VM/runtime/capability/audit/CLI behavior, or create accepted golden SemCode.

## Issue

Prepares #477.
Does not close #477.

## Scope

Isolated SemCode byte-emission skeleton only:

- `crates/sm-emit/src/hello_observation_bytes.rs`
- focused gated emission tests
- docs boundary note
- public API export from `sm-emit`

## Result

- Emits deterministic gated provisional representation for canonical Hello
- Uses symbolic `OBSERVE_TEXT_LITERAL`
- Rejects stdout / print / generic I/O substitutions
- Rejects missing observation and wrong order
- Keeps production bytecode and runtime behavior out of scope

## Out of scope

- Production SemCode encoder integration
- Final numeric opcode IDs
- Stable bytecode format
- SemCode spec binary layout update
- Production verifier integration
- VM/runtime execution
- Production capability admission
- AuditTrail / audit storage
- Host ABI / prom-abi / HostCallId changes
- CLI / smc integration
- Accepted golden SemCode
- Runtime output
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70
- Closing #477

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_byte_emission`
- `cargo test -q --test hello_real_semcode_skeleton`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated gated emission skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: gated SemCode emission skeleton only
Reason: emits provisional controlled observation representation only; no production bytecode, verifier, VM/runtime, capability, audit, or CLI behavior.
