### PR TITLE
PR-M-HELLO-10C — semcode: bridge Hello skeleton to gated observation bytes

### DIFF
--- a/crates/sm-emit/src/hello_observation_bytes.rs
+++ b/crates/sm-emit/src/hello_observation_bytes.rs
@@ -34,6 +34,12 @@ pub enum HelloObservationByteEmissionError {
     ForbiddenHostOutput,
 }
 
+pub fn emit_hello_observation_bytes_from_real_semcode_skeleton(
+    module: &HelloRealSemCodeModule,
+) -> Result<HelloObservationByteModule, HelloObservationByteEmissionError> {
+    emit_hello_observation_bytes_gated(module)
+}
+
 pub fn emit_hello_observation_bytes_gated(
     module: &HelloRealSemCodeModule,
 ) -> Result<HelloObservationByteModule, HelloObservationByteEmissionError> {

--- a/docs/language/semantic_hello_controlled_observation_encoding.md
+++ b/docs/language/semantic_hello_controlled_observation_encoding.md
@@ -182,13 +182,25 @@ Clarifications:
 - no accepted golden SemCode
 - `#477` remains open
 
-## 12. Issue State
+## 12. M-HELLO-10C Bridge Note
+
+- bridge API now makes the handoff from the Hello real SemCode skeleton to the gated provisional observation bytes explicit
+- the bridge remains provisional and non-production
+- the bridge preserves the same canonical validation rules as M-HELLO-10B
+- no final numeric opcode ID is assigned
+- no stable bytecode format is claimed
+- no production encoder integration
+- no verifier / VM / runtime / capability / audit / CLI behavior
+- no accepted golden SemCode
+- `#477` remains open
+
+## 13. Issue State
 
 - this PR does not close `#477`
 - this PR does not satisfy `#477` acceptance criteria
 - this PR only removes the design fork between dedicated encoding and host-call fallback
 
-## 13. Acceptance Checklist
+## 14. Acceptance Checklist
 
 - [ ] dedicated encoding decision recorded
 - [ ] typed host-call fallback documented but not selected

--- a/tests/hello_observation_byte_emission.rs
+++ b/tests/hello_observation_byte_emission.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use sm_emit::hello_observation_bytes::{
+    emit_hello_observation_bytes_from_real_semcode_skeleton,
     emit_hello_observation_bytes_gated, render_hello_observation_bytes_gated,
     HelloObservationByteEmissionError, HelloObservationByteRecord,
 };
@@ -55,15 +56,18 @@ fn assert_reject(
 }
 
 #[test]
-fn hello_observation_byte_emission_emits_gated_provisional_representation() {
+fn hello_observation_byte_bridge_emits_gated_provisional_representation() {
     let module = canonical_real_semcode();
-    let emitted = emit_hello_observation_bytes_gated(&module)
+    let emitted = emit_hello_observation_bytes_from_real_semcode_skeleton(&module)
+        .expect("canonical hello should emit gated observation bytes");
+    let gated_emitted = emit_hello_observation_bytes_gated(&module)
         .expect("canonical hello should emit gated observation bytes");
     let rendered = render_hello_observation_bytes_gated(&module)
         .expect("canonical hello should render gated observation bytes");
     let rendered_text = String::from_utf8(rendered).expect("utf8 rendered bytes");
 
     assert_eq!(emitted.format_status, "gated_provisional_not_production");
+    assert_eq!(gated_emitted, emitted);
     assert_eq!(emitted.records.len(), 4);
     match &emitted.records[..] {
         [


### PR DESCRIPTION
## Summary

Adds a narrow bridge from the existing Hello real SemCode skeleton to the gated provisional observation byte representation introduced in M-HELLO-10B.

This PR keeps the handoff explicit and provisional. It does not integrate with the production SemCode encoder, assign final numeric opcode IDs, change bytecode format, wire verifier/VM/runtime/capability/audit/CLI behavior, or create accepted golden SemCode.

## Issue

Refs #477.
Does not close #477.

## Scope

Allowed changes only:

- `crates/sm-emit/src/hello_observation_bytes.rs`
- `tests/hello_observation_byte_emission.rs`
- `docs/language/semantic_hello_controlled_observation_encoding.md`

## Result

- Adds an explicit bridge API from the Hello real SemCode skeleton to gated provisional observation bytes
- Preserves the canonical Hello validation rules from M-HELLO-10B
- Keeps stdout / print / generic I/O substitutions rejected
- Keeps missing observation, wrong order, and non-Hello text rejected
- Remains provisional and non-production

## Out of scope

- Production SemCode encoder integration
- Final numeric opcode IDs
- Stable bytecode format
- SemCode spec binary layout update
- Production verifier integration
- VM/runtime execution
- Production capability admission
- AuditTrail / audit storage
- Host ABI / prom-abi / HostCallId changes
- CLI / smc integration
- Accepted golden SemCode
- Runtime output
- README/example rewrites
- Linguist readiness
- Workbench / UI / I70
- Closing #477

## Validation

- `git diff --check`
- `cargo test -q --test hello_observation_byte_emission`
- `cargo test -q --test hello_real_semcode_skeleton`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test public_api_contracts`
- `git diff --name-only origin/main...HEAD`

## CTF touched

CTF touched: none
Reason: isolated bridge skeleton only; no production execution trust policy or admitted runtime behavior changes.

## 7hell coverage

7hell coverage: gated observation byte bridge only
Reason: bridges the real SemCode skeleton to provisional observation bytes; no production bytecode, verifier, VM/runtime, capability, audit, or CLI behavior.
