### PR TITLE
PR-M-HELLO-12A — docs: define CLI controlled observation smoke path

### DIFF
--- a/docs/language/semantic_hello_cli_smoke_path.md
+++ b/docs/language/semantic_hello_cli_smoke_path.md
@@ -1,72 +1,152 @@
 # Semantic Hello CLI Smoke Path
 
-Status: planning document for `#477`
+Status: CLI smoke-path contract note for `#477`
 
 ## 1. Purpose
 
-This document records the future CLI smoke path boundary for `#477`.
+This document defines the CLI smoke path for controlled text observation after
+verifier / VM route / capability / audit are accepted.
 
-- docs-only
-- test/docs-only bridge harness description
-- no production CLI implementation
-- no `smc` integration
-- no runtime output
-- no accepted runtime behavior
-- no verifier / capability / audit / SemCode implementation
+It does not define general stdout, formatting, file I/O, stdin, network, debug
+output, or README / user-facing promotion.
 
-## 2. Current Status
-
-- isolated CLI smoke harness exists
-- no production CLI / `smc` integration
-- no runtime output
-- no user-visible Hello World claim
-
-## 3. Pipeline Modeled
+## 2. CLI Smoke Model
 
 ```text
-fixture source
-→ parser
-→ sema
-→ lowering
-→ real SemCode-level skeleton
-→ isolated verifier admission
-→ isolated capability gate
-→ isolated runtime route
-→ isolated audit decision
+source file
+  -> smc check
+  -> smc compile
+  -> smc verify
+  -> smc run / run-smc
+  -> verified VM execution
+  -> controlled observation event
+  -> capability allow
+  -> audit decision
+  -> CLI observation sink
 ```
 
-## 4. Not Implemented
+The CLI must only render the observation after the full controlled route
+succeeds.
+The CLI must not synthesize the output independently.
 
-- no `smc check`
-- no `smc compile`
-- no `smc verify`
-- no `smc run`
-- no `smc run-smc`
-- no VM execution
-- no bytecode
-- no opcode IDs
-- no production runtime route
-- no production capability admission
-- no AuditTrail storage
-- no host output
-- no README / examples alignment
+## 3. CLI Output Contract
 
-## 5. Acceptance Gate For Later Real CLI PR
+```text
+input observation class: ControlledText
+allowed output: exact controlled text payload
+ordering: deterministic sequence order
+sink: CLI observation sink only
+non-goals: general stdout, formatting, interpolation, file, stdin, network
+```
 
-Later real CLI integration may start only after:
+For the current Hello smoke scope:
 
-- the skeleton chain stays green
-- verifier, runtime, capability, and audit boundaries are stable
-- observation routing remains explicit sink only
-- negative fixtures stay rejected
-- `#477` remains open until real CLI behavior is accepted
+```text
+Expected payload: Hello, World!
+Expected behavior: one controlled text observation rendered once
+```
 
-## 6. Boundary Note
+This is not a stable public stdout API claim.
 
-- `M-HELLO-9A` is not user-visible Hello World
-- it is not accepted runtime behavior
-- it is a controlled smoke-path harness only
-- production CLI remains blocked
+## 4. Required Lower-Layer Prerequisites
+
+| Prerequisite | Owner | Required before CLI output |
+| --- | --- | --- |
+| source check | frontend / checker path | source must pass check |
+| compile | emit / SemCode path | source must compile |
+| verify | `sm-verify` | SemCode must be admitted |
+| VM route | `sm-vm` | controlled observation event produced |
+| capability gate | `prom-cap` | explicit controlled sink allow |
+| audit policy | `prom-audit` | record / redact / no_store / deny decision |
+| CLI sink | `smc-cli` | render only approved observation envelope |
+
+## 5. CLI Denial Matrix
+
+| Case | Expected CLI result |
+| --- | --- |
+| check fails | no output |
+| compile fails | no output |
+| verify fails | no output |
+| VM route missing | no output |
+| capability denied | no output |
+| audit denied | no output |
+| audit policy missing | no output |
+| observation class not ControlledText | no output |
+| file / stdin / network target appears | reject / no output |
+| formatting / interpolation requested | reject / no output |
+| valid controlled text observation approved | render exact payload once |
+
+## 6. Smoke Commands
+
+Target commands:
+
+```bash
+cargo run --bin smc -- check examples/hello_world.sm
+cargo run --bin smc -- compile examples/hello_world.sm -o hello_world.smc
+cargo run --bin smc -- verify hello_world.smc
+cargo run --bin smc -- run examples/hello_world.sm
+cargo run --bin smc -- run-smc hello_world.smc
+```
+
+If this PR is docs-only, these are target commands, not implemented behavior.
+
+## 7. Code Implementation Gate
+
+Code implementation may start only when the lower-layer route is already
+implemented and testable.
+Until then, this document is the CLI contract for the later implementation PR.
+
+## 8. Owner Boundary
+
+| Concern | Owner | M-HELLO-12A action |
+| --- | --- | --- |
+| verifier admission | `sm-verify` | prerequisite only |
+| VM event route | `sm-vm` | prerequisite only |
+| capability gate | `prom-cap` | prerequisite only |
+| audit decision / storage policy | `prom-audit` | prerequisite only |
+| CLI smoke path | `smc-cli` | define or wire narrow smoke path |
+| README / user examples | README / examples | out of scope until 12B |
+
+## 9. Not Implemented
+
+```text
+no CLI output implemented
+no smc run output claim
+no run-smc output claim
+no example promotion
+no README promotion
+no general stdout
+no formatting / interpolation
+no implicit scalar-to-text conversion
+no file / stdin / network
+no closure of #477
+```
+
+## 10. Next PR Split
+
+```text
+12A-code - implement CLI smoke path once lower layers are real
+12B - user-facing examples / README promotion only after CLI smoke path passes
+```
+
+## 11. Issue State
+
+```text
+This document does not close #477.
+This document does not satisfy #477 acceptance criteria.
+```
+
+## 12. Acceptance Checklist
+
+```text
+[ ] CLI smoke-path contract documented
+[ ] lower-layer prerequisites explicit
+[ ] CLI denial matrix documented
+[ ] target smoke commands documented without claiming they pass
+[ ] owner boundary correct
+[ ] no fake output path exists
+[ ] #477 remains open
+```
 
 See also: [`semantic_hello_implementation_closeout.md`](semantic_hello_implementation_closeout.md)
 

--- a/docs/language/semantic_hello_cli_smoke_path.md
+++ b/docs/language/semantic_hello_cli_smoke_path.md
@@ -12,12 +12,12 @@ output, or README / user-facing promotion.
 
 ## 2. CLI Smoke Model
 
+### Route A - source run path
+
 ```text
 source file
-  -> smc check
-  -> smc compile
-  -> smc verify
-  -> smc run / run-smc
+  -> smc run
+  -> internal check/compile/verify path
   -> verified VM execution
   -> controlled observation event
   -> capability allow
@@ -25,6 +25,25 @@ source file
   -> CLI observation sink
 ```
 
+### Route B - verified artifact path
+
+```text
+source file
+  -> smc check
+  -> smc compile
+  -> .smc artifact
+  -> smc verify
+  -> smc run-smc
+  -> verified VM execution
+  -> controlled observation event
+  -> capability allow
+  -> audit decision
+  -> CLI observation sink
+```
+
+`smc run` owns the source execution workflow.
+`smc run-smc` owns the verified artifact execution workflow.
+They must be tested separately.
 The CLI must only render the observation after the full controlled route
 succeeds.
 The CLI must not synthesize the output independently.
@@ -64,17 +83,17 @@ This is not a stable public stdout API claim.
 
 | Case | Expected CLI result |
 | --- | --- |
-| check fails | no output |
-| compile fails | no output |
-| verify fails | no output |
-| VM route missing | no output |
-| capability denied | no output |
-| audit denied | no output |
-| audit policy missing | no output |
-| observation class not ControlledText | no output |
-| file / stdin / network target appears | reject / no output |
-| formatting / interpolation requested | reject / no output |
-| valid controlled text observation approved | render exact payload once |
+| check fails | non-zero exit + diagnostic; no observation payload |
+| compile fails | non-zero exit + diagnostic; no observation payload |
+| verify fails | non-zero exit + diagnostic; no observation payload |
+| VM route missing | non-zero exit + diagnostic; no observation payload |
+| capability denied | non-zero exit + diagnostic; no observation payload |
+| audit denied | non-zero exit + diagnostic; no observation payload |
+| audit policy missing | non-zero exit + diagnostic; no observation payload |
+| observation class not ControlledText | non-zero exit + diagnostic; no observation payload |
+| file / stdin / network target appears | reject with non-zero exit + diagnostic; no observation payload |
+| formatting / interpolation requested | reject with non-zero exit + diagnostic; no observation payload |
+| valid controlled text observation approved | zero exit + render exact payload once |
 
 ## 6. Smoke Commands
 
@@ -119,6 +138,7 @@ no general stdout
 no formatting / interpolation
 no implicit scalar-to-text conversion
 no file / stdin / network
+no fake success on failure cases
 no closure of #477
 ```
 
@@ -140,9 +160,13 @@ This document does not satisfy #477 acceptance criteria.
 
 ```text
 [ ] CLI smoke-path contract documented
+[ ] source-run route documented separately
+[ ] verified-artifact route documented separately
 [ ] lower-layer prerequisites explicit
 [ ] CLI denial matrix documented
 [ ] target smoke commands documented without claiming they pass
+[ ] denied / error cases require non-zero exit + diagnostic
+[ ] observation payload is suppressed on failure
 [ ] owner boundary correct
 [ ] no fake output path exists
 [ ] #477 remains open

--- a/docs/language/semantic_hello_controlled_observation_encoding.md
+++ b/docs/language/semantic_hello_controlled_observation_encoding.md
@@ -11,6 +11,7 @@ See also:
 - [`semantic_hello_vm_observation_execution_route.md`](semantic_hello_vm_observation_execution_route.md)
 - [`semantic_hello_observation_capability_gate.md`](semantic_hello_observation_capability_gate.md)
 - [`semantic_hello_observation_audit_policy.md`](semantic_hello_observation_audit_policy.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 

--- a/docs/language/semantic_hello_observation_admission_runtime_path.md
+++ b/docs/language/semantic_hello_observation_admission_runtime_path.md
@@ -10,6 +10,7 @@ See also:
 - [`semantic_hello_observation_capability_gate.md`](semantic_hello_observation_capability_gate.md)
 - [`semantic_hello_observation_audit_policy.md`](semantic_hello_observation_audit_policy.md)
 - [`semantic_hello_implementation_closeout.md`](semantic_hello_implementation_closeout.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 

--- a/docs/language/semantic_hello_observation_admission_shape.md
+++ b/docs/language/semantic_hello_observation_admission_shape.md
@@ -9,6 +9,7 @@ See also:
 - [`semantic_hello_observation_capability_gate.md`](semantic_hello_observation_capability_gate.md)
 - [`semantic_hello_observation_audit_policy.md`](semantic_hello_observation_audit_policy.md)
 - [`semantic_hello_controlled_observation_encoding.md`](semantic_hello_controlled_observation_encoding.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 

--- a/docs/language/semantic_hello_observation_audit_policy.md
+++ b/docs/language/semantic_hello_observation_audit_policy.md
@@ -9,6 +9,7 @@ See also:
 - [`semantic_hello_observation_admission_runtime_path.md`](semantic_hello_observation_admission_runtime_path.md)
 - [`semantic_hello_observation_admission_shape.md`](semantic_hello_observation_admission_shape.md)
 - [`semantic_hello_controlled_observation_encoding.md`](semantic_hello_controlled_observation_encoding.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 

--- a/docs/language/semantic_hello_observation_capability_gate.md
+++ b/docs/language/semantic_hello_observation_capability_gate.md
@@ -9,6 +9,7 @@ See also:
 - [`semantic_hello_observation_admission_shape.md`](semantic_hello_observation_admission_shape.md)
 - [`semantic_hello_observation_audit_policy.md`](semantic_hello_observation_audit_policy.md)
 - [`semantic_hello_controlled_observation_encoding.md`](semantic_hello_controlled_observation_encoding.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 

--- a/docs/language/semantic_hello_vm_observation_execution_route.md
+++ b/docs/language/semantic_hello_vm_observation_execution_route.md
@@ -9,6 +9,7 @@ See also:
 - [`semantic_hello_observation_capability_gate.md`](semantic_hello_observation_capability_gate.md)
 - [`semantic_hello_observation_audit_policy.md`](semantic_hello_observation_audit_policy.md)
 - [`semantic_hello_controlled_observation_encoding.md`](semantic_hello_controlled_observation_encoding.md)
+- [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
 
 ## 1. Purpose
 


### PR DESCRIPTION
## Summary

Defines the CLI smoke-path contract for controlled text observation after verifier admission, VM route, capability gate, and audit policy.

This PR is docs-only. It does not implement `smc run`, `run-smc`, CLI output, general stdout, or accepted Hello World runtime behavior.

This revision splits source-run and verified-artifact smoke routes and makes failure signaling explicit.

## Issue

Refs #477.
Does not close #477.

## Scope

- defines the CLI controlled observation smoke-path model
- records lower-layer prerequisites
- records CLI denial matrix
- records target smoke commands
- keeps implementation and README promotion out of scope

## Result

- CLI smoke path contract is documented
- `smc-cli` ownership is clarified
- verifier / VM / capability / audit remain required prerequisites
- #477 remains open

## Out of scope

- CLI output implementation
- `smc run` behavior claim
- `run-smc` behavior claim
- README / examples promotion
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- closing #477

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`
