### PR TITLE
PR-M-HELLO-12A-1 — vm: add non-output controlled observation event seam

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -13,6 +13,9 @@ use sm_runtime_core::{
     AccessPath, AdtCarrier, ExecutionConfig, ExecutionContext, QuotaExceeded, QuotaKind,
     RecordCarrier, RuntimeQuotas, RuntimeSymbolTable, RuntimeTrap, SymbolId,
 };
+use sm_runtime_core::hello_observation_sink::{
+    HelloObservationClass, HelloObservationEvent, HelloObservationSequenceIndex,
+};
 use sm_verify::verify_semcode;
 use sm_verify::RejectReport;
 use std::collections::{HashMap, HashSet};
@@ -99,6 +102,8 @@ pub struct VM {
     pub symbols: RuntimeSymbolTable,
     /// PRNG state for random_seed / random_next_i32 (xorshift64; 0 = unseeded).
     pub prng_state: u64,
+    hello_observation_events: Vec<HelloObservationEvent>,
+    hello_observation_sequence_index: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,6 +167,30 @@ impl core::fmt::Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
+impl VM {
+    fn record_controlled_text_observation(&mut self, text: String) -> Result<(), RuntimeError> {
+        if matches!(
+            text.as_str(),
+            "stdout" | "print" | "io.write" | "file" | "network" | "stdin"
+        ) {
+            return Err(RuntimeError::TypeMismatchRuntime(format!(
+                "builtin 'print' does not admit host-output marker '{}'",
+                text
+            )));
+        }
+
+        let event = HelloObservationEvent {
+            operation_kind: "controlled_observation_text",
+            observation_class: HelloObservationClass::ControlledText,
+            text,
+            sequence_index: HelloObservationSequenceIndex(self.hello_observation_sequence_index),
+        };
+        self.hello_observation_sequence_index += 1;
+        self.hello_observation_events.push(event);
+        Ok(())
+    }
+}
+
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     run_semcode_with_config(
         bytes,
@@ -172,6 +201,16 @@ pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     run_verified_semcode_with_config(
         bytes,
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+    )
+}
+
+pub fn run_semcode_collecting_hello_observations(
+    bytes: &[u8],
+) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
+    run_semcode_with_entry_and_config_collecting_hello_observations(
+        bytes,
+        "main",
         ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
     )
 }
@@ -248,6 +287,8 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config<
         effect_calls: 0,
         symbols,
         prng_state: 0,
+        hello_observation_events: Vec::new(),
+        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, entry, Vec::new(), None)?;
     let mut bridge = PrometheusVmHost { host, capabilities };
@@ -279,6 +320,8 @@ pub fn run_verified_semcode_with_ui_capabilities<
         effect_calls: 0,
         symbols,
         prng_state: 0,
+        hello_observation_events: Vec::new(),
+        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, "main", Vec::new(), None)?;
     let mut bridge = PrometheusUiVmHost { host, capabilities, ui_capabilities };
@@ -290,6 +333,15 @@ pub fn run_semcode_with_entry_and_config(
     entry: &str,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
+    run_semcode_with_entry_and_config_collecting_hello_observations(bytes, entry, config)
+        .map(|_| ())
+}
+
+fn run_semcode_with_entry_and_config_collecting_hello_observations(
+    bytes: &[u8],
+    entry: &str,
+    config: ExecutionConfig,
+) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let (_, symbols, functions) = parse_semcode(bytes)?;
     let mut vm = VM {
         functions,
@@ -298,10 +350,13 @@ pub fn run_semcode_with_entry_and_config(
         effect_calls: 0,
         symbols,
         prng_state: 0,
+        hello_observation_events: Vec::new(),
+        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, entry, Vec::new(), None)?;
     let mut host = LegacyVmHost;
-    exec_loop(&mut vm, &mut host)
+    exec_loop(&mut vm, &mut host)?;
+    Ok(vm.hello_observation_events)
 }
 
 pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {
@@ -1813,7 +1868,7 @@ fn exec_loop<H: VmHostBridge>(vm: &mut VM, host: &mut H) -> Result<(), RuntimeEr
                     let r = read_u16_le(&f.code, &mut cur).map_err(map_format_err)?;
                     args.push(get_reg(vm, frame_idx, r)?);
                 }
-                if let Some(result) = try_eval_builtin_call(&callee, &args)? {
+                if let Some(result) = try_eval_builtin_call(vm, &callee, &args)? {
                     if has_dst {
                         set_reg(vm, frame_idx, dst, result)?;
                     }
@@ -2330,7 +2385,11 @@ fn value_eq(a: &Value, b: &Value) -> Result<bool, RuntimeError> {
     }
 }
 
-fn try_eval_builtin_call(name: &str, args: &[Value]) -> Result<Option<Value>, RuntimeError> {
+fn try_eval_builtin_call(
+    vm: &mut VM,
+    name: &str,
+    args: &[Value],
+) -> Result<Option<Value>, RuntimeError> {
     let value = match name {
         "sin" => Value::F64(expect_builtin_unary_f64(name, args)?.sin()),
         "cos" => Value::F64(expect_builtin_unary_f64(name, args)?.cos()),
@@ -2358,7 +2417,7 @@ fn try_eval_builtin_call(name: &str, args: &[Value]) -> Result<Option<Value>, Ru
                     )));
                 }
             };
-            println!("{}", text);
+            vm.record_controlled_text_observation(text)?;
             Value::Unit
         }
         _ => return Ok(None),
@@ -3257,6 +3316,8 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
+            hello_observation_events: Vec::new(),
+            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push frame");
@@ -3282,6 +3343,8 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
+            hello_observation_events: Vec::new(),
+            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push main");
@@ -3313,6 +3376,8 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
+            hello_observation_events: Vec::new(),
+            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push frame");
@@ -3337,6 +3402,8 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
+            hello_observation_events: Vec::new(),
+            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push main");
@@ -4001,6 +4068,85 @@ mod tests {
         bytes[opcode_pos] = 0xff;
         let err = run_verified_semcode(&bytes).expect_err("must fail");
         assert!(matches!(err, RuntimeError::VerifierRejected(_)));
+    }
+
+    #[test]
+    fn vm_builtin_print_collects_controlled_text_observation_in_memory() {
+        let src = r#"
+            fn main() {
+                print("Hello, World!");
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let events = run_semcode_collecting_hello_observations(&bytes).expect("run");
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event.operation_kind, "controlled_observation_text");
+        assert_eq!(event.observation_class, HelloObservationClass::ControlledText);
+        assert_eq!(event.text, "Hello, World!");
+        assert_eq!(event.sequence_index, HelloObservationSequenceIndex(0));
+    }
+
+    #[test]
+    fn vm_builtin_print_assigns_deterministic_sequence_indexes() {
+        let src = r#"
+            fn main() {
+                print("Hello, World!");
+                print("Hello, World!");
+                return;
+            }
+        "#;
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let events = run_semcode_collecting_hello_observations(&bytes).expect("run");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].sequence_index, HelloObservationSequenceIndex(0));
+        assert_eq!(events[1].sequence_index, HelloObservationSequenceIndex(1));
+    }
+
+    #[test]
+    fn vm_builtin_print_rejects_non_text_values_without_implicit_conversion() {
+        let mut vm = VM {
+            functions: HashMap::new(),
+            callstack: Vec::new(),
+            config: ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+            effect_calls: 0,
+            symbols: RuntimeSymbolTable::new(),
+            prng_state: 0,
+            hello_observation_events: Vec::new(),
+            hello_observation_sequence_index: 0,
+        };
+
+        let err = try_eval_builtin_call(&mut vm, "print", &[Value::I32(10)])
+            .expect_err("i32 must fail");
+        assert!(matches!(err, RuntimeError::TypeMismatchRuntime(_)));
+
+        let err = try_eval_builtin_call(&mut vm, "print", &[Value::Quad(QuadVal::T)])
+            .expect_err("quad must fail");
+        assert!(matches!(err, RuntimeError::TypeMismatchRuntime(_)));
+    }
+
+    #[test]
+    fn vm_builtin_print_rejects_host_output_markers_without_observation_leakage() {
+        for forbidden in ["stdout", "print", "io.write", "file", "network", "stdin"] {
+            let src = format!(
+                r#"
+                    fn main() {{
+                        print("{forbidden}");
+                        return;
+                    }}
+                "#
+            );
+            let bytes = compile_program_to_semcode(&src).expect("compile");
+            let err = run_semcode_collecting_hello_observations(&bytes)
+                .expect_err("host-output marker must fail");
+            assert!(
+                matches!(err, RuntimeError::TypeMismatchRuntime(_)),
+                "unexpected error for {forbidden}: {err}"
+            );
+        }
     }
 
     fn ownership_tracking_bytes() -> Vec<u8> {

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -102,8 +102,59 @@ pub struct VM {
     pub symbols: RuntimeSymbolTable,
     /// PRNG state for random_seed / random_next_i32 (xorshift64; 0 = unseeded).
     pub prng_state: u64,
-    hello_observation_events: Vec<HelloObservationEvent>,
-    hello_observation_sequence_index: u64,
+}
+
+enum HelloObservationMode<'a> {
+    Discard,
+    Collect(&'a mut Vec<HelloObservationEvent>),
+}
+
+struct HelloObservationRuntime<'a> {
+    mode: HelloObservationMode<'a>,
+    sequence_index: u64,
+}
+
+impl<'a> HelloObservationRuntime<'a> {
+    fn discard() -> Self {
+        Self {
+            mode: HelloObservationMode::Discard,
+            sequence_index: 0,
+        }
+    }
+
+    fn collect(events: &'a mut Vec<HelloObservationEvent>) -> Self {
+        Self {
+            mode: HelloObservationMode::Collect(events),
+            sequence_index: 0,
+        }
+    }
+
+    fn record_controlled_text_observation(
+        &mut self,
+        text: String,
+    ) -> Result<(), RuntimeError> {
+        if matches!(
+            text.as_str(),
+            "stdout" | "print" | "io.write" | "file" | "network" | "stdin"
+        ) {
+            return Err(RuntimeError::TypeMismatchRuntime(format!(
+                "builtin 'print' does not admit host-output marker '{}'",
+                text
+            )));
+        }
+
+        let event = HelloObservationEvent {
+            operation_kind: "controlled_observation_text",
+            observation_class: HelloObservationClass::ControlledText,
+            text,
+            sequence_index: HelloObservationSequenceIndex(self.sequence_index),
+        };
+        self.sequence_index += 1;
+        if let HelloObservationMode::Collect(events) = &mut self.mode {
+            events.push(event);
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,30 +218,6 @@ impl core::fmt::Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
-impl VM {
-    fn record_controlled_text_observation(&mut self, text: String) -> Result<(), RuntimeError> {
-        if matches!(
-            text.as_str(),
-            "stdout" | "print" | "io.write" | "file" | "network" | "stdin"
-        ) {
-            return Err(RuntimeError::TypeMismatchRuntime(format!(
-                "builtin 'print' does not admit host-output marker '{}'",
-                text
-            )));
-        }
-
-        let event = HelloObservationEvent {
-            operation_kind: "controlled_observation_text",
-            observation_class: HelloObservationClass::ControlledText,
-            text,
-            sequence_index: HelloObservationSequenceIndex(self.hello_observation_sequence_index),
-        };
-        self.hello_observation_sequence_index += 1;
-        self.hello_observation_events.push(event);
-        Ok(())
-    }
-}
-
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     run_semcode_with_config(
         bytes,
@@ -208,11 +235,15 @@ pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_semcode_collecting_hello_observations(
     bytes: &[u8],
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
-    run_semcode_with_entry_and_config_collecting_hello_observations(
+    let mut events = Vec::new();
+    let collected = run_semcode_with_entry_and_config_with_observation_runtime(
         bytes,
         "main",
         ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
-    )
+        HelloObservationRuntime::collect(&mut events),
+    )?;
+    debug_assert!(events.is_empty());
+    Ok(collected)
 }
 
 pub fn run_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeError> {
@@ -287,12 +318,11 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config<
         effect_calls: 0,
         symbols,
         prng_state: 0,
-        hello_observation_events: Vec::new(),
-        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, entry, Vec::new(), None)?;
     let mut bridge = PrometheusVmHost { host, capabilities };
-    exec_loop(&mut vm, &mut bridge)
+    let mut observation = HelloObservationRuntime::discard();
+    exec_loop(&mut vm, &mut bridge, &mut observation)
 }
 
 /// Run verified SemCode with both a standard capability checker and a UI
@@ -320,12 +350,11 @@ pub fn run_verified_semcode_with_ui_capabilities<
         effect_calls: 0,
         symbols,
         prng_state: 0,
-        hello_observation_events: Vec::new(),
-        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, "main", Vec::new(), None)?;
     let mut bridge = PrometheusUiVmHost { host, capabilities, ui_capabilities };
-    exec_loop(&mut vm, &mut bridge)
+    let mut observation = HelloObservationRuntime::discard();
+    exec_loop(&mut vm, &mut bridge, &mut observation)
 }
 
 pub fn run_semcode_with_entry_and_config(
@@ -333,14 +362,20 @@ pub fn run_semcode_with_entry_and_config(
     entry: &str,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    run_semcode_with_entry_and_config_collecting_hello_observations(bytes, entry, config)
-        .map(|_| ())
+    run_semcode_with_entry_and_config_with_observation_runtime(
+        bytes,
+        entry,
+        config,
+        HelloObservationRuntime::discard(),
+    )
+    .map(|_| ())
 }
 
-fn run_semcode_with_entry_and_config_collecting_hello_observations(
+fn run_semcode_with_entry_and_config_with_observation_runtime<'a>(
     bytes: &[u8],
     entry: &str,
     config: ExecutionConfig,
+    mut observation: HelloObservationRuntime<'a>,
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let (_, symbols, functions) = parse_semcode(bytes)?;
     let mut vm = VM {
@@ -350,13 +385,14 @@ fn run_semcode_with_entry_and_config_collecting_hello_observations(
         effect_calls: 0,
         symbols,
         prng_state: 0,
-        hello_observation_events: Vec::new(),
-        hello_observation_sequence_index: 0,
     };
     push_frame(&mut vm, entry, Vec::new(), None)?;
     let mut host = LegacyVmHost;
-    exec_loop(&mut vm, &mut host)?;
-    Ok(vm.hello_observation_events)
+    exec_loop(&mut vm, &mut host, &mut observation)?;
+    match observation.mode {
+        HelloObservationMode::Discard => Ok(Vec::new()),
+        HelloObservationMode::Collect(events) => Ok(std::mem::take(events)),
+    }
 }
 
 pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {
@@ -1162,7 +1198,11 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker, U: UiCapabilityChecker> VmH
     }
 }
 
-fn exec_loop<H: VmHostBridge>(vm: &mut VM, host: &mut H) -> Result<(), RuntimeError> {
+fn exec_loop<'a, H: VmHostBridge>(
+    vm: &mut VM,
+    host: &mut H,
+    observation: &mut HelloObservationRuntime<'a>,
+) -> Result<(), RuntimeError> {
     loop {
         let Some(frame_idx) = vm.callstack.len().checked_sub(1) else {
             return Ok(());
@@ -1868,7 +1908,7 @@ fn exec_loop<H: VmHostBridge>(vm: &mut VM, host: &mut H) -> Result<(), RuntimeEr
                     let r = read_u16_le(&f.code, &mut cur).map_err(map_format_err)?;
                     args.push(get_reg(vm, frame_idx, r)?);
                 }
-                if let Some(result) = try_eval_builtin_call(vm, &callee, &args)? {
+                if let Some(result) = try_eval_builtin_call(observation, &callee, &args)? {
                     if has_dst {
                         set_reg(vm, frame_idx, dst, result)?;
                     }
@@ -2385,8 +2425,8 @@ fn value_eq(a: &Value, b: &Value) -> Result<bool, RuntimeError> {
     }
 }
 
-fn try_eval_builtin_call(
-    vm: &mut VM,
+fn try_eval_builtin_call<'a>(
+    observation: &mut HelloObservationRuntime<'a>,
     name: &str,
     args: &[Value],
 ) -> Result<Option<Value>, RuntimeError> {
@@ -2417,7 +2457,7 @@ fn try_eval_builtin_call(
                     )));
                 }
             };
-            vm.record_controlled_text_observation(text)?;
+            observation.record_controlled_text_observation(text)?;
             Value::Unit
         }
         _ => return Ok(None),
@@ -3316,8 +3356,6 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
-            hello_observation_events: Vec::new(),
-            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push frame");
@@ -3343,8 +3381,6 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
-            hello_observation_events: Vec::new(),
-            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push main");
@@ -3376,8 +3412,6 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
-            hello_observation_events: Vec::new(),
-            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push frame");
@@ -3402,8 +3436,6 @@ mod tests {
             effect_calls: 0,
             symbols,
             prng_state: 0,
-            hello_observation_events: Vec::new(),
-            hello_observation_sequence_index: 0,
         };
 
         push_frame(&mut vm, "main", Vec::new(), None).expect("push main");
@@ -4108,22 +4140,13 @@ mod tests {
 
     #[test]
     fn vm_builtin_print_rejects_non_text_values_without_implicit_conversion() {
-        let mut vm = VM {
-            functions: HashMap::new(),
-            callstack: Vec::new(),
-            config: ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
-            effect_calls: 0,
-            symbols: RuntimeSymbolTable::new(),
-            prng_state: 0,
-            hello_observation_events: Vec::new(),
-            hello_observation_sequence_index: 0,
-        };
+        let mut observation = HelloObservationRuntime::discard();
 
-        let err = try_eval_builtin_call(&mut vm, "print", &[Value::I32(10)])
+        let err = try_eval_builtin_call(&mut observation, "print", &[Value::I32(10)])
             .expect_err("i32 must fail");
         assert!(matches!(err, RuntimeError::TypeMismatchRuntime(_)));
 
-        let err = try_eval_builtin_call(&mut vm, "print", &[Value::Quad(QuadVal::T)])
+        let err = try_eval_builtin_call(&mut observation, "print", &[Value::Quad(QuadVal::T)])
             .expect_err("quad must fail");
         assert!(matches!(err, RuntimeError::TypeMismatchRuntime(_)));
     }

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -2,6 +2,10 @@
 
 Status: inspection-only readiness audit for `#477`
 
+Implementation note: `M-HELLO-12A-1` is now implemented as a VM-side
+non-output controlled observation event seam. The broader CLI controlled
+observation path is still not ready.
+
 See also:
 
 - [`semantic_hello_cli_smoke_path.md`](semantic_hello_cli_smoke_path.md)
@@ -35,7 +39,7 @@ Inspected owners:
 | Layer | Required for honest 12A-code | Current state | Ready? | Next action |
 | --- | --- | --- | --- | --- |
 | verifier admission | admits `ControlledTextObservation` shape | current production verifier still maps builtin `print` to `CAP_STDOUT`; no production `ControlledTextObservation` admission shape is present | no | add a verifier admission seam for controlled observation shape |
-| VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` calls `println!` directly; no internal controlled observation event route exists | no | replace direct stdout print with a non-output controlled observation event seam |
+| VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout; the seam is still isolated from verifier / capability / audit / CLI layers | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
 | capability gate | explicit controlled sink allow / deny | isolated `hello_observation_capability` skeleton exists, but production capability handling does not expose a controlled observation sink gate | partial | wire a production capability gate for controlled observation sink |
 | audit policy | `record` / `redact` / `no_store` / `deny` decision | isolated `hello_observation_audit` skeleton exists, but production audit storage has no controlled observation policy integration | partial | wire audit decision policy into the observation route |
 | CLI source-run | `smc run` uses full controlled route | `smc run` compiles source and runs bytes directly; it does not consume a controlled observation result envelope | no | add a source-run route that only renders approved controlled observation results |
@@ -45,7 +49,6 @@ Inspected owners:
 
 Observed risks in code:
 
-- direct `println!` in VM builtin `print`
 - `CAP_STDOUT` is still the verifier capability for builtin `print`
 - isolated hello capability / audit modules are not wired into production routing
 - `smc run` compiles source and runs bytes directly without a controlled observation envelope
@@ -55,7 +58,6 @@ Observed risks in code:
 Evidence:
 
 - `crates/sm-verify/src/lib.rs:1066-1072` maps builtin `print` to `CAP_STDOUT`
-- `crates/sm-vm/src/semcode_vm.rs:2345-2361` routes builtin `print` to direct `println!`
 - `crates/smc-cli/src/app.rs:2169-2176` makes `smc run` compile source and call `run_semcode`
 - `crates/smc-cli/src/app.rs:2197-2203` makes `run-smc` verify and then call `run_verified_semcode`
 - `crates/prom-cap/src/hello_observation_capability.rs` remains an isolated skeleton, not production capability wiring
@@ -65,7 +67,7 @@ Evidence:
 
 Based on the current code state, the next narrow split should be:
 
-- `M-HELLO-12A-1` - replace direct builtin print output with a non-output controlled observation event seam
+- `M-HELLO-12A-1` - done: VM-side non-output controlled observation event seam
 - `M-HELLO-12A-2` - add verifier admission seam for controlled observation shape
 - `M-HELLO-12A-3` - wire production capability gate for controlled observation sink
 - `M-HELLO-12A-4` - wire audit decision policy into the observation route

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -41,6 +41,7 @@ pub prng_state: u64,
 pub enum RuntimeError {
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
 pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
+pub fn run_semcode_collecting_hello_observations( bytes: &[u8], ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
 pub fn run_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeError> {
 pub fn run_semcode_with_config(bytes: &[u8], config: ExecutionConfig) -> Result<(), RuntimeError> {
 pub fn run_verified_semcode_with_config( bytes: &[u8], config: ExecutionConfig, ) -> Result<(), RuntimeError> {


### PR DESCRIPTION
## Summary

Replaces the VM builtin `print` direct stdout behavior with a non-output controlled observation event seam.

This PR does not implement CLI output, capability gate wiring, audit policy wiring, general stdout, or accepted Hello World runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- removes direct VM stdout behavior from builtin `print`
- adds a VM-side controlled observation event seam
- preserves text-only builtin `print` type restriction
- preserves deterministic event order
- uses discard mode for non-collecting execution so VM runs do not buffer observation history
- keeps capability, audit, and CLI rendering out of scope

## Result

- VM can model controlled text observation without writing to stdout
- direct `println!` is no longer the builtin `print` route
- controlled observation events can be collected in memory only when explicitly requested
- public `VM` struct literal compatibility is preserved
- #477 remains open

## Out of scope

- CLI output
- `smc run` behavior claim
- `run-smc` behavior claim
- capability gate wiring
- audit storage / audit policy wiring
- SemCode format changes
- opcode layout changes
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- README / examples promotion
- closing #477

## Validation

- `git diff --check`
- `cargo test -q -p sm-vm`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test public_api_contracts`
