### PR TITLE
PR-M-HELLO-12A-2 — verify: add controlled observation admission seam

### DIFF
--- a/crates/sm-verify/src/hello_real_semcode_admission.rs
+++ b/crates/sm-verify/src/hello_real_semcode_admission.rs
@@ -1,6 +1,11 @@
 use std::string::String;
 use std::vec::Vec;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlledObservationAdmissionKind {
+    ControlledTextLiteral,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HelloRealSemCodeAdmissionInput {
     pub ops: Vec<HelloRealSemCodeAdmissionOp>,
@@ -32,6 +37,32 @@ pub enum HelloRealSemCodeAdmissionError {
     GenericIoNotAllowed,
     OpcodeOrBytecodeNotAllowed,
     UnsupportedShape,
+}
+
+pub fn builtin_call_controlled_observation_admission(
+    name: &str,
+) -> Option<ControlledObservationAdmissionKind> {
+    match name {
+        "print" => Some(ControlledObservationAdmissionKind::ControlledTextLiteral),
+        _ => None,
+    }
+}
+
+pub fn admit_controlled_text_observation_shape(
+    text: &str,
+) -> Result<ControlledObservationAdmissionKind, HelloRealSemCodeAdmissionError> {
+    match text {
+        "\"Hello, World!\"" => Ok(ControlledObservationAdmissionKind::ControlledTextLiteral),
+        "\"stdout\"" => Err(HelloRealSemCodeAdmissionError::StdoutNotAllowed),
+        "\"print\"" => Err(HelloRealSemCodeAdmissionError::PrintNotAllowed),
+        "\"io.write\"" | "\"file\"" | "\"network\"" | "\"stdin\"" => {
+            Err(HelloRealSemCodeAdmissionError::GenericIoNotAllowed)
+        }
+        "\"opcode\"" | "\"bytecode\"" => {
+            Err(HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed)
+        }
+        _ => Err(HelloRealSemCodeAdmissionError::NonTextObservation),
+    }
 }
 
 pub fn admit_hello_real_semcode_skeleton(
@@ -96,32 +127,10 @@ pub fn admit_hello_real_semcode_skeleton(
                     HelloRealSemCodeAdmissionError::MissingRequirement,
                 );
             }
-            match text.as_str() {
-                "\"Hello, World!\"" => {}
-                "\"stdout\"" => {
-                    return HelloRealSemCodeAdmissionDecision::Reject(
-                        HelloRealSemCodeAdmissionError::StdoutNotAllowed,
-                    );
-                }
-                "\"print\"" => {
-                    return HelloRealSemCodeAdmissionDecision::Reject(
-                        HelloRealSemCodeAdmissionError::PrintNotAllowed,
-                    );
-                }
-                "\"io.write\"" | "\"file\"" | "\"network\"" | "\"stdin\"" => {
-                    return HelloRealSemCodeAdmissionDecision::Reject(
-                        HelloRealSemCodeAdmissionError::GenericIoNotAllowed,
-                    );
-                }
-                "\"opcode\"" | "\"bytecode\"" => {
-                    return HelloRealSemCodeAdmissionDecision::Reject(
-                        HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed,
-                    );
-                }
-                _ => {
-                    return HelloRealSemCodeAdmissionDecision::Reject(
-                        HelloRealSemCodeAdmissionError::NonTextObservation,
-                    );
+            match admit_controlled_text_observation_shape(text) {
+                Ok(ControlledObservationAdmissionKind::ControlledTextLiteral) => {}
+                Err(error) => {
+                    return HelloRealSemCodeAdmissionDecision::Reject(error);
                 }
             }
 

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -2,9 +2,10 @@
 
 Status: inspection-only readiness audit for `#477`
 
-Implementation note: `M-HELLO-12A-1` is now implemented as a VM-side
-non-output controlled observation event seam. The broader CLI controlled
-observation path is still not ready.
+Implementation note: `M-HELLO-12A-1` and `M-HELLO-12A-2` are now
+implemented as a VM-side non-output controlled observation event seam and
+a verifier-side controlled observation admission seam. The broader CLI
+controlled observation path is still not ready.
 
 See also:
 
@@ -38,7 +39,7 @@ Inspected owners:
 
 | Layer | Required for honest 12A-code | Current state | Ready? | Next action |
 | --- | --- | --- | --- | --- |
-| verifier admission | admits `ControlledTextObservation` shape | current production verifier still maps builtin `print` to `CAP_STDOUT`; no production `ControlledTextObservation` admission shape is present | no | add a verifier admission seam for controlled observation shape |
+| verifier admission | admits `ControlledTextObservation` shape | Hello-specific controlled observation admission seam now exists in `sm-verify`, but production `verify_semcode` still maps builtin `print` to `CAP_STDOUT` | partial | wire the verifier seam into the later production admission chain |
 | VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout; the seam is still isolated from verifier / capability / audit / CLI layers | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
 | capability gate | explicit controlled sink allow / deny | isolated `hello_observation_capability` skeleton exists, but production capability handling does not expose a controlled observation sink gate | partial | wire a production capability gate for controlled observation sink |
 | audit policy | `record` / `redact` / `no_store` / `deny` decision | isolated `hello_observation_audit` skeleton exists, but production audit storage has no controlled observation policy integration | partial | wire audit decision policy into the observation route |
@@ -68,7 +69,7 @@ Evidence:
 Based on the current code state, the next narrow split should be:
 
 - `M-HELLO-12A-1` - done: VM-side non-output controlled observation event seam
-- `M-HELLO-12A-2` - add verifier admission seam for controlled observation shape
+- `M-HELLO-12A-2` - done: verifier-side controlled observation admission seam
 - `M-HELLO-12A-3` - wire production capability gate for controlled observation sink
 - `M-HELLO-12A-4` - wire audit decision policy into the observation route
 - `M-HELLO-12A-5` - add CLI result envelope rendering for source-run and run-smc separately
@@ -77,7 +78,8 @@ Based on the current code state, the next narrow split should be:
 
 `M-HELLO-12A-code is not ready.`
 
-Lower-layer production seams are incomplete or still isolated.
+Lower-layer production seams are incomplete or still isolated, even though
+`M-HELLO-12A-1` and `M-HELLO-12A-2` are now implemented as narrow seams.
 
 The current code has separate `smc run` and `run-smc` commands, but neither
 command is an honest controlled observation CLI implementation yet.

--- a/tests/hello_real_semcode_admission.rs
+++ b/tests/hello_real_semcode_admission.rs
@@ -7,9 +7,11 @@ use sm_front::hello_parser::parse_hello_file;
 use sm_front::hello_sema::validate_hello_file;
 use sm_ir::hello_ir::lower_hello_checked_file;
 use sm_verify::hello_real_semcode_admission::{
+    admit_controlled_text_observation_shape,
     admit_hello_real_semcode_skeleton, HelloRealSemCodeAdmissionDecision,
     HelloRealSemCodeAdmissionError, HelloRealSemCodeAdmissionInput,
-    HelloRealSemCodeAdmissionOp,
+    HelloRealSemCodeAdmissionOp, builtin_call_controlled_observation_admission,
+    ControlledObservationAdmissionKind,
 };
 use std::vec::Vec;
 
@@ -191,5 +193,22 @@ fn hello_real_semcode_admission_rejects_opcode_and_bytecode_markers() {
     assert_reject(
         bytecode,
         HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed,
+    );
+}
+
+#[test]
+fn hello_real_semcode_controlled_observation_admission_seam_distinguishes_print_from_stdout() {
+    assert_eq!(
+        builtin_call_controlled_observation_admission("print"),
+        Some(ControlledObservationAdmissionKind::ControlledTextLiteral)
+    );
+    assert_eq!(
+        builtin_call_controlled_observation_admission("stdout"),
+        None
+    );
+
+    assert_eq!(
+        admit_controlled_text_observation_shape(&render_text_literal("Hello, World!")),
+        Ok(ControlledObservationAdmissionKind::ControlledTextLiteral)
     );
 }

--- a/tests/hello_real_semcode_negative_encodings.rs
+++ b/tests/hello_real_semcode_negative_encodings.rs
@@ -8,6 +8,7 @@ use sm_front::hello_parser::parse_hello_file;
 use sm_front::hello_sema::validate_hello_file;
 use sm_ir::hello_ir::lower_hello_checked_file;
 use sm_verify::hello_real_semcode_admission::{
+    admit_controlled_text_observation_shape,
     admit_hello_real_semcode_skeleton, HelloRealSemCodeAdmissionDecision,
     HelloRealSemCodeAdmissionError, HelloRealSemCodeAdmissionInput,
     HelloRealSemCodeAdmissionOp,
@@ -170,3 +171,22 @@ fn hello_real_semcode_negative_encodings_reject_order_bypasses_and_missing_ops()
     );
 }
 
+#[test]
+fn hello_real_semcode_controlled_observation_admission_rejects_forbidden_text_markers() {
+    for (replacement, expected) in [
+        ("stdout", HelloRealSemCodeAdmissionError::StdoutNotAllowed),
+        ("print", HelloRealSemCodeAdmissionError::PrintNotAllowed),
+        ("io.write", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("file", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("network", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("stdin", HelloRealSemCodeAdmissionError::GenericIoNotAllowed),
+        ("opcode", HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed),
+        ("bytecode", HelloRealSemCodeAdmissionError::OpcodeOrBytecodeNotAllowed),
+        ("Not Hello", HelloRealSemCodeAdmissionError::NonTextObservation),
+    ] {
+        assert_eq!(
+            admit_controlled_text_observation_shape(&render_text_literal(replacement)),
+            Err(expected)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a verifier-side controlled observation admission seam for the narrow Hello controlled text observation shape.

This PR does not implement CLI output, VM execution changes, capability gate wiring, audit policy wiring, general stdout, or accepted Hello World runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds verifier-side controlled observation admission shape / classification
- preserves canonical Hello skeleton admission
- preserves rejection of stdout / print / io.write / file / network / stdin markers
- distinguishes controlled observation from general stdout
- keeps VM, capability, audit, and CLI rendering out of scope

## Result

- verifier ownership for controlled observation is represented in code
- controlled observation is not treated as broad stdout in the new seam
- existing Hello admission tests remain meaningful
- #477 remains open

## Out of scope

- CLI output
- `smc run` behavior claim
- `run-smc` behavior claim
- VM execution changes
- capability gate wiring
- audit storage / audit policy wiring
- SemCode format changes
- opcode layout changes
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- README / examples promotion
- closing #477

## Validation

- `git diff --check`
- `cargo test -q -p sm-verify`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test public_api_contracts`