### PR TITLE
PR-M-HELLO-12A-3 — cap: wire controlled observation sink capability

### DIFF
--- a/crates/prom-audit/src/lib.rs
+++ b/crates/prom-audit/src/lib.rs
@@ -734,6 +734,7 @@ fn display_capability_kind(kind: CapabilityKind) -> &'static str {
         CapabilityKind::GateRead => "GateRead",
         CapabilityKind::GateWrite => "GateWrite",
         CapabilityKind::PulseEmit => "PulseEmit",
+        CapabilityKind::ControlledObservationSink => "ControlledObservationSink",
         CapabilityKind::StateQuery => "StateQuery",
         CapabilityKind::StateUpdate => "StateUpdate",
         CapabilityKind::EventPost => "EventPost",
@@ -748,6 +749,7 @@ fn parse_capability_kind(
         "GateRead" => Ok(CapabilityKind::GateRead),
         "GateWrite" => Ok(CapabilityKind::GateWrite),
         "PulseEmit" => Ok(CapabilityKind::PulseEmit),
+        "ControlledObservationSink" => Ok(CapabilityKind::ControlledObservationSink),
         "StateQuery" => Ok(CapabilityKind::StateQuery),
         "StateUpdate" => Ok(CapabilityKind::StateUpdate),
         "EventPost" => Ok(CapabilityKind::EventPost),
@@ -933,6 +935,22 @@ mod tests {
             }
             other => panic!("unexpected event {other:?}"),
         }
+    }
+
+    #[test]
+    fn replay_archive_roundtrips_controlled_observation_sink_capability_kind() {
+        let mut trail = AuditTrail::new(sample_session());
+        trail.record(AuditEventKind::CapabilityDenied {
+            capability: CapabilityKind::ControlledObservationSink,
+            call: Some("ControlledObservationSink".to_string()),
+        });
+
+        let archive = trail.replay_archive();
+        let text = archive.to_canonical_text();
+        let parsed = AuditReplayArchive::from_canonical_text(&text).expect("parse");
+
+        assert_eq!(parsed, archive);
+        assert!(text.contains("ControlledObservationSink"));
     }
 
     #[test]

--- a/crates/prom-cap/src/hello_observation_capability.rs
+++ b/crates/prom-cap/src/hello_observation_capability.rs
@@ -3,6 +3,8 @@
 //! This module models future capability admission for controlled Hello
 //! observation without wiring into production capability handling.
 
+use super::{CapabilityChecker, CapabilityKind};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HelloObservationCapability {
     ObservationSink,
@@ -62,5 +64,43 @@ pub fn evaluate_hello_observation_capability(
     }
 
     HelloObservationCapabilityDecision::Allow
+}
+
+pub fn require_hello_observation_sink_capability<C: CapabilityChecker>(
+    checker: &C,
+    context: &HelloObservationCapabilityContext,
+) -> HelloObservationCapabilityDecision {
+    match context.requested_host_channel {
+        Some("stdout") => {
+            return HelloObservationCapabilityDecision::Deny(
+                HelloObservationCapabilityDenial::StdoutNotDefaultSink,
+            );
+        }
+        Some("print") | Some("io.write") | Some("file") | Some("network") | Some("stdin") => {
+            return HelloObservationCapabilityDecision::Deny(
+                HelloObservationCapabilityDenial::GenericIoNotAllowed,
+            );
+        }
+        _ => {}
+    }
+
+    if !context.observation_sink_present {
+        return HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        );
+    }
+
+    if !context.sink_available {
+        return HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::SinkUnavailable,
+        );
+    }
+
+    match checker.require(CapabilityKind::ControlledObservationSink) {
+        Ok(()) => HelloObservationCapabilityDecision::Allow,
+        Err(_) => HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        ),
+    }
 }
 

--- a/crates/prom-cap/src/lib.rs
+++ b/crates/prom-cap/src/lib.rs
@@ -14,6 +14,7 @@ pub enum CapabilityKind {
     GateRead,
     GateWrite,
     PulseEmit,
+    ControlledObservationSink,
     StateQuery,
     StateUpdate,
     EventPost,
@@ -43,6 +44,7 @@ pub const fn capability_surface_class(kind: CapabilityKind) -> CapabilitySurface
         CapabilityKind::GateRead => CapabilitySurfaceClass::StableV1,
         CapabilityKind::GateWrite => CapabilitySurfaceClass::StableV1,
         CapabilityKind::PulseEmit => CapabilitySurfaceClass::StableV1,
+        CapabilityKind::ControlledObservationSink => CapabilitySurfaceClass::PlannedPostStable,
         CapabilityKind::StateQuery => CapabilitySurfaceClass::PlannedPostStable,
         CapabilityKind::StateUpdate => CapabilitySurfaceClass::PlannedPostStable,
         CapabilityKind::EventPost => CapabilitySurfaceClass::PlannedPostStable,
@@ -406,6 +408,10 @@ mod tests {
             CapabilitySurfaceClass::StableV1
         );
         assert_eq!(
+            capability_surface_class(CapabilityKind::ControlledObservationSink),
+            CapabilitySurfaceClass::PlannedPostStable
+        );
+        assert_eq!(
             capability_surface_class(CapabilityKind::ClockRead),
             CapabilitySurfaceClass::PlannedPostStable
         );
@@ -416,7 +422,19 @@ mod tests {
         let manifest = CapabilityManifest::gate_surface();
         assert!(manifest.allows(CapabilityKind::GateRead));
         assert!(!manifest.allows(CapabilityKind::StateQuery));
+        assert!(!manifest.allows(CapabilityKind::ControlledObservationSink));
         assert!(!manifest.allows(CapabilityKind::ClockRead));
+    }
+
+    #[test]
+    fn manifest_can_allow_controlled_observation_sink_only_when_explicitly_granted() {
+        let mut manifest = CapabilityManifest::new();
+        assert!(!manifest.allows(CapabilityKind::ControlledObservationSink));
+        manifest.allow(CapabilityKind::ControlledObservationSink);
+        assert!(manifest.allows(CapabilityKind::ControlledObservationSink));
+        manifest
+            .require(CapabilityKind::ControlledObservationSink)
+            .expect("explicitly granted capability must admit");
     }
 
     #[test]

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -2,10 +2,11 @@
 
 Status: inspection-only readiness audit for `#477`
 
-Implementation note: `M-HELLO-12A-1` and `M-HELLO-12A-2` are now
-implemented as a VM-side non-output controlled observation event seam and
-a verifier-side controlled observation admission seam. The broader CLI
-controlled observation path is still not ready.
+Implementation note: `M-HELLO-12A-1`, `M-HELLO-12A-2`, and
+`M-HELLO-12A-3` are now implemented as a VM-side non-output controlled
+observation event seam, a verifier-side controlled observation admission
+seam, and a production capability gate seam. The broader CLI controlled
+observation path is still not ready.
 
 See also:
 
@@ -41,7 +42,7 @@ Inspected owners:
 | --- | --- | --- | --- | --- |
 | verifier admission | admits `ControlledTextObservation` shape | Hello-specific controlled observation admission seam now exists in `sm-verify`, but production `verify_semcode` still maps builtin `print` to `CAP_STDOUT` | partial | wire the verifier seam into the later production admission chain |
 | VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout; the seam is still isolated from verifier / capability / audit / CLI layers | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
-| capability gate | explicit controlled sink allow / deny | isolated `hello_observation_capability` skeleton exists, but production capability handling does not expose a controlled observation sink gate | partial | wire a production capability gate for controlled observation sink |
+| capability gate | explicit controlled sink allow / deny | `prom-cap` now exposes a `ControlledObservationSink` capability and a production-manifest-aware helper, but the runtime observation route is still not consuming it | partial | wire the production capability gate into the later observation route |
 | audit policy | `record` / `redact` / `no_store` / `deny` decision | isolated `hello_observation_audit` skeleton exists, but production audit storage has no controlled observation policy integration | partial | wire audit decision policy into the observation route |
 | CLI source-run | `smc run` uses full controlled route | `smc run` compiles source and runs bytes directly; it does not consume a controlled observation result envelope | no | add a source-run route that only renders approved controlled observation results |
 | CLI artifact-run | `run-smc` uses full controlled route | `run-smc` verifies then runs bytes directly; it still does not consume a controlled observation result envelope | no | add a verified-artifact route that only renders approved controlled observation results |
@@ -70,7 +71,7 @@ Based on the current code state, the next narrow split should be:
 
 - `M-HELLO-12A-1` - done: VM-side non-output controlled observation event seam
 - `M-HELLO-12A-2` - done: verifier-side controlled observation admission seam
-- `M-HELLO-12A-3` - wire production capability gate for controlled observation sink
+ - `M-HELLO-12A-3` - done: production capability gate for controlled observation sink
 - `M-HELLO-12A-4` - wire audit decision policy into the observation route
 - `M-HELLO-12A-5` - add CLI result envelope rendering for source-run and run-smc separately
 
@@ -79,7 +80,8 @@ Based on the current code state, the next narrow split should be:
 `M-HELLO-12A-code is not ready.`
 
 Lower-layer production seams are incomplete or still isolated, even though
-`M-HELLO-12A-1` and `M-HELLO-12A-2` are now implemented as narrow seams.
+`M-HELLO-12A-1`, `M-HELLO-12A-2`, and `M-HELLO-12A-3` are now implemented
+as narrow seams.
 
 The current code has separate `smc run` and `run-smc` commands, but neither
 command is an honest controlled observation CLI implementation yet.

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -71,7 +71,7 @@ Based on the current code state, the next narrow split should be:
 
 - `M-HELLO-12A-1` - done: VM-side non-output controlled observation event seam
 - `M-HELLO-12A-2` - done: verifier-side controlled observation admission seam
- - `M-HELLO-12A-3` - done: production capability gate for controlled observation sink
+- `M-HELLO-12A-3` - done: production capability gate for controlled observation sink
 - `M-HELLO-12A-4` - wire audit decision policy into the observation route
 - `M-HELLO-12A-5` - add CLI result envelope rendering for source-run and run-smc separately
 

--- a/tests/hello_observation_capability_skeleton.rs
+++ b/tests/hello_observation_capability_skeleton.rs
@@ -1,10 +1,11 @@
 use prom_abi::HostCallId;
 use prom_cap::hello_observation_capability::{
-    evaluate_hello_observation_capability, HelloObservationCapability,
-    HelloObservationCapabilityContext, HelloObservationCapabilityDecision,
-    HelloObservationCapabilityDenial, HelloObservationCapabilityPolicy,
+    evaluate_hello_observation_capability, require_hello_observation_sink_capability,
+    HelloObservationCapability, HelloObservationCapabilityContext,
+    HelloObservationCapabilityDecision, HelloObservationCapabilityDenial,
+    HelloObservationCapabilityPolicy,
 };
-use prom_cap::{CapabilityKind, required_capability_for_call};
+use prom_cap::{CapabilityKind, CapabilityManifest, CapabilitySurfaceClass, required_capability_for_call, capability_surface_class};
 
 fn allow_context() -> HelloObservationCapabilityContext {
     HelloObservationCapabilityContext {
@@ -86,6 +87,55 @@ fn hello_observation_capability_skeleton_denies_generic_io_fallbacks() {
                 HelloObservationCapabilityDenial::GenericIoNotAllowed,
             ),
             "channel {channel} must not be admitted"
+        );
+    }
+}
+
+#[test]
+fn hello_observation_capability_skeleton_requires_explicit_controlled_observation_sink_capability() {
+    let mut manifest = CapabilityManifest::new();
+    let context = allow_context();
+
+    assert_eq!(
+        require_hello_observation_sink_capability(&manifest, &context),
+        HelloObservationCapabilityDecision::Deny(
+            HelloObservationCapabilityDenial::MissingObservationCapability,
+        )
+    );
+
+    manifest.allow(CapabilityKind::ControlledObservationSink);
+    assert_eq!(
+        require_hello_observation_sink_capability(&manifest, &context),
+        HelloObservationCapabilityDecision::Allow
+    );
+
+    let gate_surface = CapabilityManifest::gate_surface();
+    assert!(!gate_surface.allows(CapabilityKind::ControlledObservationSink));
+    assert_eq!(
+        capability_surface_class(CapabilityKind::ControlledObservationSink),
+        CapabilitySurfaceClass::PlannedPostStable
+    );
+}
+
+#[test]
+fn hello_observation_capability_skeleton_keeps_controlled_observation_separate_from_stdout() {
+    let mut manifest = CapabilityManifest::new();
+    manifest.allow(CapabilityKind::ControlledObservationSink);
+
+    for channel in ["stdout", "print", "io.write", "file", "network", "stdin"] {
+        let context = requested_channel_context(channel);
+        assert_eq!(
+            require_hello_observation_sink_capability(&manifest, &context),
+            if channel == "stdout" {
+                HelloObservationCapabilityDecision::Deny(
+                    HelloObservationCapabilityDenial::StdoutNotDefaultSink,
+                )
+            } else {
+                HelloObservationCapabilityDecision::Deny(
+                    HelloObservationCapabilityDenial::GenericIoNotAllowed,
+                )
+            },
+            "channel {channel} must be denied"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds a production capability gate seam for the controlled observation sink.

This PR does not implement CLI output, VM execution changes, verifier changes, audit policy wiring, general stdout, or accepted Hello World runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds production `ControlledObservationSink` capability
- keeps the capability explicit opt-in
- keeps controlled observation separate from stdout/general I/O
- bridges Hello observation capability checking toward production manifest handling
- adds the minimal prom-audit display/parse exhaustiveness support required by the new capability kind
- keeps VM, verifier, audit policy, and CLI rendering out of scope

## Result

- `prom-cap` can represent controlled observation sink permission
- default manifests do not grant controlled observation sink permission
- gate surface does not grant controlled observation sink permission
- Hello observation capability can be allowed only by explicit controlled sink capability
- prom-audit archive encoding remains exhaustive for the production `CapabilityKind`
- #477 remains open

## Out of scope

- CLI output
- `smc run` behavior claim
- `run-smc` behavior claim
- VM execution changes
- verifier changes
- audit storage / audit policy wiring
- SemCode format changes
- opcode layout changes
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- README / examples promotion
- closing #477

## Validation

- `git diff --check`
- `cargo test -q -p prom-cap`
- `cargo test -q -p prom-audit`
- `cargo test -q --test hello_observation_capability_skeleton`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test public_api_contracts`