### PR TITLE
PR-M-HELLO-12A-4 — audit: wire controlled observation audit policy seam

### DIFF
--- a/crates/prom-audit/src/hello_observation_audit.rs
+++ b/crates/prom-audit/src/hello_observation_audit.rs
@@ -3,6 +3,8 @@
 //! This module models future audit records for controlled Hello observation
 //! without wiring into production audit storage or runtime routing.
 
+use crate::{AuditEventId, AuditEventKind, AuditTrail};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HelloObservationAuditEventKind {
     Observation,
@@ -41,6 +43,21 @@ pub struct HelloObservationAuditEvent {
     pub linkage: HelloObservationAuditLinkage,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlledObservationAuditDecision {
+    Record,
+    Redact,
+    NoStore,
+    Deny,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlledObservationAuditResult {
+    Recorded(AuditEventId),
+    NoStore,
+    Denied,
+}
+
 pub fn build_hello_observation_audit_event(
     payload_hash: u64,
     sequence_index: u64,
@@ -55,5 +72,42 @@ pub fn build_hello_observation_audit_event(
         sequence_index: HelloObservationAuditSequenceIndex(sequence_index),
         audit_policy_class,
         linkage,
+    }
+}
+
+pub fn apply_controlled_observation_audit_policy(
+    trail: &mut AuditTrail,
+    text_hash: u64,
+    sequence_index: u64,
+    policy: ControlledObservationAuditDecision,
+    linkage: HelloObservationAuditLinkage,
+) -> ControlledObservationAuditResult {
+    match policy {
+        ControlledObservationAuditDecision::Record => {
+            let event_id = trail.record(AuditEventKind::ControlledObservation {
+                operation_kind: "controlled_observation_text".to_string(),
+                observation_class: "ControlledText".to_string(),
+                payload_hash: Some(text_hash),
+                redacted: false,
+                sequence_index,
+                policy,
+                linkage,
+            });
+            ControlledObservationAuditResult::Recorded(event_id)
+        }
+        ControlledObservationAuditDecision::Redact => {
+            let event_id = trail.record(AuditEventKind::ControlledObservation {
+                operation_kind: "controlled_observation_text".to_string(),
+                observation_class: "ControlledText".to_string(),
+                payload_hash: None,
+                redacted: true,
+                sequence_index,
+                policy,
+                linkage,
+            });
+            ControlledObservationAuditResult::Recorded(event_id)
+        }
+        ControlledObservationAuditDecision::NoStore => ControlledObservationAuditResult::NoStore,
+        ControlledObservationAuditDecision::Deny => ControlledObservationAuditResult::Denied,
     }
 }

--- a/crates/prom-audit/src/lib.rs
+++ b/crates/prom-audit/src/lib.rs
@@ -6,6 +6,7 @@ pub mod hello_observation_audit;
 
 use alloc::string::String;
 use alloc::vec::Vec;
+use hello_observation_audit::ControlledObservationAuditDecision;
 use prom_cap::{CapabilityKind, CapabilityManifestMetadata, CapabilityManifestVersion};
 use sm_runtime_core::ExecutionContext;
 
@@ -40,6 +41,15 @@ pub enum AuditEventKind {
     CapabilityDenied {
         capability: CapabilityKind,
         call: Option<String>,
+    },
+    ControlledObservation {
+        operation_kind: String,
+        observation_class: String,
+        payload_hash: Option<u64>,
+        redacted: bool,
+        sequence_index: u64,
+        policy: ControlledObservationAuditDecision,
+        linkage: crate::hello_observation_audit::HelloObservationAuditLinkage,
     },
     GateRead {
         device_id: u16,
@@ -559,6 +569,46 @@ fn encode_event_kind(out: &mut String, kind: &AuditEventKind) {
                 None => out.push_str("none"),
             }
         }
+        AuditEventKind::ControlledObservation {
+            operation_kind,
+            observation_class,
+            payload_hash,
+            redacted,
+            sequence_index,
+            policy,
+            linkage,
+        } => {
+            out.push_str("\tcontrolled-observation\t");
+            out.push_str(&escape_archive_field(operation_kind));
+            out.push('\t');
+            out.push_str(&escape_archive_field(observation_class));
+            out.push('\t');
+            match payload_hash {
+                Some(hash) => out.push_str(&hash.to_string()),
+                None => out.push_str("none"),
+            }
+            out.push('\t');
+            out.push_str(if *redacted { "true" } else { "false" });
+            out.push('\t');
+            out.push_str(&sequence_index.to_string());
+            out.push('\t');
+            out.push_str(display_controlled_observation_audit_decision(*policy));
+            out.push('\t');
+            match linkage.verifier_admission_ref {
+                Some(value) => out.push_str(&value.to_string()),
+                None => out.push_str("none"),
+            }
+            out.push('\t');
+            match linkage.capability_policy_ref {
+                Some(value) => out.push_str(&value.to_string()),
+                None => out.push_str("none"),
+            }
+            out.push('\t');
+            match linkage.sink_policy_ref {
+                Some(value) => out.push_str(&value.to_string()),
+                None => out.push_str("none"),
+            }
+        }
         AuditEventKind::GateRead { device_id, port } => {
             out.push_str("\tgate-read\t");
             out.push_str(&device_id.to_string());
@@ -639,6 +689,26 @@ fn decode_event_kind(parts: &[&str]) -> Result<AuditEventKind, AuditReplayArchiv
             Ok(AuditEventKind::CapabilityDenied {
                 capability: parse_capability_kind(parts[1])?,
                 call: parse_optional_string(parts[2])?,
+            })
+        }
+        "controlled-observation" => {
+            if parts.len() != 10 {
+                return Err(AuditReplayArchiveFormatError::new(
+                    "invalid controlled-observation payload",
+                ));
+            }
+            Ok(AuditEventKind::ControlledObservation {
+                operation_kind: unescape_archive_field(parts[1])?,
+                observation_class: unescape_archive_field(parts[2])?,
+                payload_hash: parse_optional_u64(parts[3])?,
+                redacted: parse_bool_field(parts[4], "controlled observation redacted flag")?,
+                sequence_index: parse_u64_field(parts[5], "controlled observation sequence index")?,
+                policy: parse_controlled_observation_audit_decision(parts[6])?,
+                linkage: crate::hello_observation_audit::HelloObservationAuditLinkage {
+                    verifier_admission_ref: parse_optional_u64(parts[7])?,
+                    capability_policy_ref: parse_optional_u64(parts[8])?,
+                    sink_policy_ref: parse_optional_u64(parts[9])?,
+                },
             })
         }
         "gate-read" => {
@@ -742,6 +812,17 @@ fn display_capability_kind(kind: CapabilityKind) -> &'static str {
     }
 }
 
+fn display_controlled_observation_audit_decision(
+    decision: ControlledObservationAuditDecision,
+) -> &'static str {
+    match decision {
+        ControlledObservationAuditDecision::Record => "record",
+        ControlledObservationAuditDecision::Redact => "redact",
+        ControlledObservationAuditDecision::NoStore => "no_store",
+        ControlledObservationAuditDecision::Deny => "deny",
+    }
+}
+
 fn parse_capability_kind(
     raw: &str,
 ) -> Result<CapabilityKind, AuditReplayArchiveFormatError> {
@@ -756,6 +837,20 @@ fn parse_capability_kind(
         "ClockRead" => Ok(CapabilityKind::ClockRead),
         _ => Err(AuditReplayArchiveFormatError::new(
             "unknown capability kind in archive",
+        )),
+    }
+}
+
+fn parse_controlled_observation_audit_decision(
+    raw: &str,
+) -> Result<ControlledObservationAuditDecision, AuditReplayArchiveFormatError> {
+    match raw {
+        "record" => Ok(ControlledObservationAuditDecision::Record),
+        "redact" => Ok(ControlledObservationAuditDecision::Redact),
+        "no_store" => Ok(ControlledObservationAuditDecision::NoStore),
+        "deny" => Ok(ControlledObservationAuditDecision::Deny),
+        _ => Err(AuditReplayArchiveFormatError::new(
+            "unknown controlled observation audit decision in archive",
         )),
     }
 }
@@ -820,6 +915,15 @@ fn parse_optional_event_id(
     Ok(Some(AuditEventId(parse_u64_field(raw, "replay last event id")?)))
 }
 
+fn parse_optional_u64(
+    raw: &str,
+) -> Result<Option<u64>, AuditReplayArchiveFormatError> {
+    if raw == "none" {
+        return Ok(None);
+    }
+    Ok(Some(parse_u64_field(raw, "optional u64")?))
+}
+
 fn parse_optional_string(
     raw: &str,
 ) -> Result<Option<String>, AuditReplayArchiveFormatError> {
@@ -880,6 +984,12 @@ fn unescape_archive_field(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hello_observation_audit::{
+        apply_controlled_observation_audit_policy,
+        ControlledObservationAuditDecision,
+        ControlledObservationAuditResult,
+        HelloObservationAuditLinkage,
+    };
 
     fn sample_session() -> AuditSessionMetadata {
         AuditSessionMetadata {
@@ -935,6 +1045,151 @@ mod tests {
             }
             other => panic!("unexpected event {other:?}"),
         }
+    }
+
+    fn controlled_observation_linkage() -> HelloObservationAuditLinkage {
+        HelloObservationAuditLinkage {
+            verifier_admission_ref: Some(17),
+            capability_policy_ref: Some(29),
+            sink_policy_ref: Some(31),
+        }
+    }
+
+    #[test]
+    fn controlled_observation_record_policy_appends_deterministic_event() {
+        let mut trail = AuditTrail::new(sample_session());
+        let result = apply_controlled_observation_audit_policy(
+            &mut trail,
+            0xfeed_beef,
+            7,
+            ControlledObservationAuditDecision::Record,
+            controlled_observation_linkage(),
+        );
+
+        assert_eq!(
+            result,
+            ControlledObservationAuditResult::Recorded(AuditEventId(0))
+        );
+        assert_eq!(trail.events().len(), 1);
+        match &trail.events()[0].kind {
+            AuditEventKind::ControlledObservation {
+                operation_kind,
+                observation_class,
+                payload_hash,
+                redacted,
+                sequence_index,
+                policy,
+                linkage,
+            } => {
+                assert_eq!(operation_kind, "controlled_observation_text");
+                assert_eq!(observation_class, "ControlledText");
+                assert_eq!(*payload_hash, Some(0xfeed_beef));
+                assert!(!redacted);
+                assert_eq!(*sequence_index, 7);
+                assert_eq!(*policy, ControlledObservationAuditDecision::Record);
+                assert_eq!(*linkage, controlled_observation_linkage());
+            }
+            other => panic!("unexpected event {other:?}"),
+        }
+
+        let archive = trail.replay_archive();
+        let text = archive.to_canonical_text();
+        let parsed = AuditReplayArchive::from_canonical_text(&text).expect("parse");
+        assert_eq!(parsed, archive);
+        assert!(text.contains("controlled-observation"));
+        assert!(!text.contains("ControlledObservationSink"));
+    }
+
+    #[test]
+    fn controlled_observation_redact_policy_appends_redacted_event() {
+        let mut trail = AuditTrail::new(sample_session());
+        let result = apply_controlled_observation_audit_policy(
+            &mut trail,
+            0xfeed_beef,
+            9,
+            ControlledObservationAuditDecision::Redact,
+            controlled_observation_linkage(),
+        );
+
+        assert_eq!(
+            result,
+            ControlledObservationAuditResult::Recorded(AuditEventId(0))
+        );
+        assert_eq!(trail.events().len(), 1);
+        match &trail.events()[0].kind {
+            AuditEventKind::ControlledObservation {
+                payload_hash,
+                redacted,
+                policy,
+                sequence_index,
+                ..
+            } => {
+                assert_eq!(*payload_hash, None);
+                assert!(*redacted);
+                assert_eq!(*policy, ControlledObservationAuditDecision::Redact);
+                assert_eq!(*sequence_index, 9);
+            }
+            other => panic!("unexpected event {other:?}"),
+        }
+
+        let archive = trail.replay_archive();
+        let text = archive.to_canonical_text();
+        let parsed = AuditReplayArchive::from_canonical_text(&text).expect("parse");
+        assert_eq!(parsed, archive);
+        assert!(text.contains("controlled-observation"));
+    }
+
+    #[test]
+    fn controlled_observation_no_store_and_deny_are_explicit() {
+        let mut no_store_trail = AuditTrail::new(sample_session());
+        let no_store = apply_controlled_observation_audit_policy(
+            &mut no_store_trail,
+            123,
+            1,
+            ControlledObservationAuditDecision::NoStore,
+            controlled_observation_linkage(),
+        );
+        assert_eq!(no_store, ControlledObservationAuditResult::NoStore);
+        assert!(no_store_trail.events().is_empty());
+
+        let mut deny_trail = AuditTrail::new(sample_session());
+        let denied = apply_controlled_observation_audit_policy(
+            &mut deny_trail,
+            456,
+            2,
+            ControlledObservationAuditDecision::Deny,
+            controlled_observation_linkage(),
+        );
+        assert_eq!(denied, ControlledObservationAuditResult::Denied);
+        assert!(deny_trail.events().is_empty());
+    }
+
+    #[test]
+    fn controlled_observation_archive_representation_is_deterministic() {
+        let linkage = controlled_observation_linkage();
+
+        let mut first = AuditTrail::new(sample_session());
+        apply_controlled_observation_audit_policy(
+            &mut first,
+            0x1234,
+            3,
+            ControlledObservationAuditDecision::Record,
+            linkage,
+        );
+
+        let mut second = AuditTrail::new(sample_session());
+        apply_controlled_observation_audit_policy(
+            &mut second,
+            0x1234,
+            3,
+            ControlledObservationAuditDecision::Record,
+            linkage,
+        );
+
+        assert_eq!(
+            first.replay_archive().to_canonical_text(),
+            second.replay_archive().to_canonical_text()
+        );
     }
 
     #[test]

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -2,11 +2,12 @@
 
 Status: inspection-only readiness audit for `#477`
 
-Implementation note: `M-HELLO-12A-1`, `M-HELLO-12A-2`, and
-`M-HELLO-12A-3` are now implemented as a VM-side non-output controlled
+Implementation note: `M-HELLO-12A-1`, `M-HELLO-12A-2`, `M-HELLO-12A-3`,
+and `M-HELLO-12A-4` are now implemented as a VM-side non-output controlled
 observation event seam, a verifier-side controlled observation admission
-seam, and a production capability gate seam. The broader CLI controlled
-observation path is still not ready.
+seam, a production capability gate seam, and a production audit decision
+/ storage seam. The broader CLI controlled observation path is still not
+ready.
 
 See also:
 
@@ -43,7 +44,7 @@ Inspected owners:
 | verifier admission | admits `ControlledTextObservation` shape | Hello-specific controlled observation admission seam now exists in `sm-verify`, but production `verify_semcode` still maps builtin `print` to `CAP_STDOUT` | partial | wire the verifier seam into the later production admission chain |
 | VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout; the seam is still isolated from verifier / capability / audit / CLI layers | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
 | capability gate | explicit controlled sink allow / deny | `prom-cap` now exposes a `ControlledObservationSink` capability and a production-manifest-aware helper, but the runtime observation route is still not consuming it | partial | wire the production capability gate into the later observation route |
-| audit policy | `record` / `redact` / `no_store` / `deny` decision | isolated `hello_observation_audit` skeleton exists, but production audit storage has no controlled observation policy integration | partial | wire audit decision policy into the observation route |
+| audit policy | `record` / `redact` / `no_store` / `deny` decision | `prom-audit` now can represent controlled observation audit decisions and archive them deterministically, but CLI rendering is still blocked | yes | wire the audit seam into the later observation route / CLI envelope |
 | CLI source-run | `smc run` uses full controlled route | `smc run` compiles source and runs bytes directly; it does not consume a controlled observation result envelope | no | add a source-run route that only renders approved controlled observation results |
 | CLI artifact-run | `run-smc` uses full controlled route | `run-smc` verifies then runs bytes directly; it still does not consume a controlled observation result envelope | no | add a verified-artifact route that only renders approved controlled observation results |
 
@@ -72,7 +73,7 @@ Based on the current code state, the next narrow split should be:
 - `M-HELLO-12A-1` - done: VM-side non-output controlled observation event seam
 - `M-HELLO-12A-2` - done: verifier-side controlled observation admission seam
 - `M-HELLO-12A-3` - done: production capability gate for controlled observation sink
-- `M-HELLO-12A-4` - wire audit decision policy into the observation route
+- `M-HELLO-12A-4` - done: audit decision policy wiring for controlled observation
 - `M-HELLO-12A-5` - add CLI result envelope rendering for source-run and run-smc separately
 
 ## 6. No-Go Decision
@@ -80,8 +81,8 @@ Based on the current code state, the next narrow split should be:
 `M-HELLO-12A-code is not ready.`
 
 Lower-layer production seams are incomplete or still isolated, even though
-`M-HELLO-12A-1`, `M-HELLO-12A-2`, and `M-HELLO-12A-3` are now implemented
-as narrow seams.
+`M-HELLO-12A-1`, `M-HELLO-12A-2`, `M-HELLO-12A-3`, and `M-HELLO-12A-4`
+are now implemented as narrow seams.
 
 The current code has separate `smc run` and `run-smc` commands, but neither
 command is an honest controlled observation CLI implementation yet.


### PR DESCRIPTION
## Summary

Adds a production audit decision / storage policy seam for controlled observation.

This PR does not implement CLI output, VM execution changes, verifier changes, capability model changes, general stdout, or accepted Hello World runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds production audit representation for controlled observation
- adds explicit audit decisions: record / redact / no_store / deny
- keeps audit deterministic and archive-roundtrippable
- bridges Hello observation audit skeleton toward production AuditTrail handling
- adds the minimal prom-audit capability-kind archive exhaustiveness support required by the new capability kind
- keeps VM, verifier, capability, and CLI rendering out of scope

## Result

- `prom-audit` can represent controlled observation audit decisions
- record/redact decisions append deterministic production audit events
- no_store/deny decisions are explicit and do not append persistent events
- audit archive roundtrip covers controlled observation audit records
- #477 remains open

## Out of scope

- CLI output
- `smc run` behavior claim
- `run-smc` behavior claim
- VM execution changes
- verifier changes
- capability model changes
- SemCode format changes
- opcode layout changes
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- README / examples promotion
- closing #477

## Validation

- `git diff --check`
- `cargo test -q -p prom-audit`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test public_api_contracts`