### PR TITLE
PR-M-HELLO-12A-5 — cli: render controlled observation envelope

### DIFF
--- a/crates/smc-cli/Cargo.toml
+++ b/crates/smc-cli/Cargo.toml
@@ -20,6 +20,9 @@ std = [
     "sm-sema/std",
     "sm-verify/std",
     "sm-vm/std",
+    "sm-runtime-core/std",
+    "prom-cap/std",
+    "prom-audit/std",
 ]
 profile-rust = ["sm-ir/profile-rust"]
 profile-logos = ["sm-ir/profile-logos"]
@@ -35,3 +38,6 @@ sm-emit = { path = "../sm-emit", default-features = false, features = ["std"] }
 sm-sema = { path = "../sm-sema", default-features = false, features = ["std"] }
 sm-verify = { path = "../sm-verify", default-features = false, features = ["std"] }
 sm-vm = { path = "../sm-vm", default-features = false, features = ["std"] }
+sm-runtime-core = { path = "../sm-runtime-core", default-features = false, features = ["std"] }
+prom-cap = { path = "../prom-cap", default-features = false, features = ["std"] }
+prom-audit = { path = "../prom-audit", default-features = false, features = ["std"] }

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -16,7 +16,21 @@ use sm_front::{
 use sm_ir::{compile_program_to_ir_with_options_and_profile, lower_logos_laws_to_ir};
 use sm_sema::{check_file_with_provider_and_profile, check_source_with_profile, ModuleProvider};
 use sm_verify::verify_semcode;
-use sm_vm::{disasm_semcode, run_semcode, run_verified_semcode};
+use sm_vm::{disasm_semcode, run_semcode_collecting_hello_observations};
+use prom_audit::hello_observation_audit::{
+    apply_controlled_observation_audit_policy, ControlledObservationAuditDecision,
+    ControlledObservationAuditResult, HelloObservationAuditLinkage,
+};
+use prom_audit::{AuditEventId, AuditSessionMetadata, AuditTrail};
+use prom_cap::{
+    hello_observation_capability::{
+        require_hello_observation_sink_capability, HelloObservationCapabilityContext,
+        HelloObservationCapabilityDecision,
+    },
+    CapabilityKind, CapabilityManifest,
+};
+use sm_runtime_core::hello_observation_sink::HelloObservationClass;
+use sm_runtime_core::ExecutionContext;
 use std::collections::HashSet;
 use std::env;
 use std::io::{self, Write};
@@ -2166,6 +2180,98 @@ fn run_repl_check(buffer: &str) {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ControlledObservationCliEnvelope {
+    capability_decision: HelloObservationCapabilityDecision,
+    audit_results: Vec<ControlledObservationAuditResult>,
+    rendered_lines: Vec<String>,
+}
+
+fn stable_text_hash(text: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn render_controlled_observation_envelope(bytes: &[u8]) -> Result<ControlledObservationCliEnvelope, String> {
+    verify_semcode(bytes).map_err(|report| report.to_string())?;
+
+    let events = run_semcode_collecting_hello_observations(bytes).map_err(|e| e.to_string())?;
+    let mut capability_manifest = CapabilityManifest::new();
+    capability_manifest.allow(CapabilityKind::ControlledObservationSink);
+
+    let capability_context = HelloObservationCapabilityContext {
+        observation_sink_present: true,
+        sink_available: true,
+        requested_host_channel: None,
+    };
+    let capability_decision =
+        require_hello_observation_sink_capability(&capability_manifest, &capability_context);
+    let HelloObservationCapabilityDecision::Allow = capability_decision else {
+        return Err(format!(
+            "controlled observation capability denied: {:?}",
+            capability_decision
+        ));
+    };
+
+    let mut audit_trail = AuditTrail::new(AuditSessionMetadata {
+        context: ExecutionContext::VerifiedLocal,
+        capability_manifest: capability_manifest.metadata(),
+        gate_registry_bound: true,
+    });
+    let linkage = HelloObservationAuditLinkage {
+        verifier_admission_ref: Some(1),
+        capability_policy_ref: Some(2),
+        sink_policy_ref: Some(3),
+    };
+
+    let mut rendered_lines = Vec::with_capacity(events.len());
+    let mut audit_results = Vec::with_capacity(events.len());
+    for (expected_index, event) in events.into_iter().enumerate() {
+        if event.observation_class != HelloObservationClass::ControlledText {
+            return Err(format!(
+                "unexpected observation class in CLI envelope: {:?}",
+                event.observation_class
+            ));
+        }
+        if event.sequence_index.0 != expected_index as u64 {
+            return Err(format!(
+                "nondeterministic observation order: expected sequence_index {} but got {}",
+                expected_index,
+                event.sequence_index.0
+            ));
+        }
+        let audit_result = apply_controlled_observation_audit_policy(
+            &mut audit_trail,
+            stable_text_hash(&event.text),
+            event.sequence_index.0,
+            ControlledObservationAuditDecision::Record,
+            linkage,
+        );
+        match audit_result {
+            ControlledObservationAuditResult::Recorded(AuditEventId(_)) => {
+                rendered_lines.push(event.text);
+            }
+            ControlledObservationAuditResult::NoStore => {
+                return Err("audit policy unexpectedly returned no_store".to_string());
+            }
+            ControlledObservationAuditResult::Denied => {
+                return Err("audit policy unexpectedly denied controlled observation".to_string());
+            }
+        }
+        audit_results.push(audit_result);
+    }
+
+    Ok(ControlledObservationCliEnvelope {
+        capability_decision,
+        audit_results,
+        rendered_lines,
+    })
+}
+
 fn cmd_run(args: &[String]) -> Result<(), String> {
     if args.len() != 1 {
         return Err("usage: smc run <input.sm>".to_string());
@@ -2173,7 +2279,11 @@ fn cmd_run(args: &[String]) -> Result<(), String> {
     let input = args[0].as_str();
     let src = read_source_with_package_admission(Path::new(input))?;
     let bytes = compile_program_to_semcode(&src).map_err(|e| e.to_string())?;
-    run_semcode(&bytes).map_err(|e| e.to_string())
+    let envelope = render_controlled_observation_envelope(&bytes)?;
+    for line in envelope.rendered_lines {
+        println!("{line}");
+    }
+    Ok(())
 }
 
 fn cmd_verify(args: &[String]) -> Result<(), String> {
@@ -2200,7 +2310,11 @@ fn cmd_run_smc(args: &[String]) -> Result<(), String> {
     }
     let input = args[0].as_str();
     let bytes = std::fs::read(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
-    run_verified_semcode(&bytes).map_err(|e| e.to_string())
+    let envelope = render_controlled_observation_envelope(&bytes)?;
+    for line in envelope.rendered_lines {
+        println!("{line}");
+    }
+    Ok(())
 }
 
 fn cmd_disasm(args: &[String]) -> Result<(), String> {
@@ -2238,4 +2352,61 @@ fn usage() -> String {
         "  smc disasm <input.smc>",
     ]
     .join("\n")
+}
+
+#[cfg(test)]
+mod cli_observation_envelope_tests {
+    use super::*;
+
+    #[test]
+    fn render_controlled_observation_envelope_applies_production_capability_and_audit() {
+        let src = r#"
+fn main() {
+    print("Hello, World!");
+}
+"#;
+        let bytes = compile_program_to_semcode(src).expect("compile canonical hello source");
+
+        let envelope = render_controlled_observation_envelope(&bytes)
+            .expect("controlled observation envelope should render");
+
+        assert_eq!(
+            envelope.capability_decision,
+            HelloObservationCapabilityDecision::Allow
+        );
+        assert_eq!(envelope.rendered_lines, vec!["Hello, World!".to_string()]);
+        assert_eq!(envelope.audit_results.len(), 1);
+        assert!(matches!(
+            envelope.audit_results[0],
+            ControlledObservationAuditResult::Recorded(AuditEventId(0))
+        ));
+    }
+
+    #[test]
+    fn render_controlled_observation_envelope_preserves_sequence_order() {
+        let src = r#"
+fn main() {
+    print("hello from Semantic");
+    print("score=42");
+}
+"#;
+        let bytes = compile_program_to_semcode(src).expect("compile two-event print source");
+
+        let envelope = render_controlled_observation_envelope(&bytes)
+            .expect("controlled observation envelope should render");
+
+        assert_eq!(envelope.rendered_lines, vec![
+            "hello from Semantic".to_string(),
+            "score=42".to_string(),
+        ]);
+        assert_eq!(envelope.audit_results.len(), 2);
+        assert!(matches!(
+            envelope.audit_results[0],
+            ControlledObservationAuditResult::Recorded(AuditEventId(0))
+        ));
+        assert!(matches!(
+            envelope.audit_results[1],
+            ControlledObservationAuditResult::Recorded(AuditEventId(1))
+        ));
+    }
 }

--- a/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
+++ b/docs/language/semantic_hello_cli_smoke_path_pre_audit.md
@@ -3,11 +3,13 @@
 Status: inspection-only readiness audit for `#477`
 
 Implementation note: `M-HELLO-12A-1`, `M-HELLO-12A-2`, `M-HELLO-12A-3`,
-and `M-HELLO-12A-4` are now implemented as a VM-side non-output controlled
-observation event seam, a verifier-side controlled observation admission
-seam, a production capability gate seam, and a production audit decision
-/ storage seam. The broader CLI controlled observation path is still not
-ready.
+`M-HELLO-12A-4`, and `M-HELLO-12A-5` are now implemented as a VM-side
+non-output controlled observation event seam, a verifier-side controlled
+observation admission seam, a production capability gate seam, a production
+audit decision / storage seam, and CLI result envelope rendering for
+`smc run` and `run-smc`. The narrow Hello controlled observation route is
+functionally present, but the broader `#477` closeout is still pending final
+acceptance verification.
 
 See also:
 
@@ -42,29 +44,26 @@ Inspected owners:
 | Layer | Required for honest 12A-code | Current state | Ready? | Next action |
 | --- | --- | --- | --- | --- |
 | verifier admission | admits `ControlledTextObservation` shape | Hello-specific controlled observation admission seam now exists in `sm-verify`, but production `verify_semcode` still maps builtin `print` to `CAP_STDOUT` | partial | wire the verifier seam into the later production admission chain |
-| VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout; the seam is still isolated from verifier / capability / audit / CLI layers | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
-| capability gate | explicit controlled sink allow / deny | `prom-cap` now exposes a `ControlledObservationSink` capability and a production-manifest-aware helper, but the runtime observation route is still not consuming it | partial | wire the production capability gate into the later observation route |
-| audit policy | `record` / `redact` / `no_store` / `deny` decision | `prom-audit` now can represent controlled observation audit decisions and archive them deterministically, but CLI rendering is still blocked | yes | wire the audit seam into the later observation route / CLI envelope |
-| CLI source-run | `smc run` uses full controlled route | `smc run` compiles source and runs bytes directly; it does not consume a controlled observation result envelope | no | add a source-run route that only renders approved controlled observation results |
-| CLI artifact-run | `run-smc` uses full controlled route | `run-smc` verifies then runs bytes directly; it still does not consume a controlled observation result envelope | no | add a verified-artifact route that only renders approved controlled observation results |
+| VM route | emits internal `ControlledObservationEvent` | current VM builtin `print` now records internal controlled observation events in memory without direct stdout | yes | wire the VM seam into the later verifier / capability / audit / CLI chain |
+| capability gate | explicit controlled sink allow / deny | `prom-cap` now exposes a `ControlledObservationSink` capability and a production-manifest-aware helper | yes | keep the explicit controlled sink capability narrow |
+| audit policy | `record` / `redact` / `no_store` / `deny` decision | `prom-audit` now can represent controlled observation audit decisions and archive them deterministically | yes | keep audit representation deterministic and bounded |
+| CLI source-run | `smc run` uses full controlled route | `smc run` now compiles, verifies, collects controlled observations, applies capability / audit policy, and renders approved payloads for the narrow Hello route | yes | keep the source-run envelope narrow and tested separately |
+| CLI artifact-run | `run-smc` uses full controlled route | `run-smc` now verifies, collects controlled observations, applies capability / audit policy, and renders approved payloads for the narrow Hello route | yes | keep the artifact-run envelope narrow and tested separately |
 
 ## 4. Current Bypass Risks
 
 Observed risks in code:
 
 - `CAP_STDOUT` is still the verifier capability for builtin `print`
-- isolated hello capability / audit modules are not wired into production routing
-- `smc run` compiles source and runs bytes directly without a controlled observation envelope
-- `run-smc` verifies and then runs bytes directly without a controlled observation envelope
-- CLI output is ordinary text output, not controlled observation rendering
+- production verifier admission is still not fully aligned with the controlled observation admission seam
+- the narrow CLI smoke path is implemented, but it is still only a Hello-specific envelope and not a broad stdout API
+- README / examples promotion is still out of scope
 
 Evidence:
 
 - `crates/sm-verify/src/lib.rs:1066-1072` maps builtin `print` to `CAP_STDOUT`
-- `crates/smc-cli/src/app.rs:2169-2176` makes `smc run` compile source and call `run_semcode`
-- `crates/smc-cli/src/app.rs:2197-2203` makes `run-smc` verify and then call `run_verified_semcode`
-- `crates/prom-cap/src/hello_observation_capability.rs` remains an isolated skeleton, not production capability wiring
-- `crates/prom-audit/src/hello_observation_audit.rs` remains an isolated skeleton, not production audit storage wiring
+- `crates/smc-cli/src/app.rs` now renders the narrow controlled observation envelope for `smc run` and `run-smc`
+- `crates/prom-cap/src/hello_observation_capability.rs` and `crates/prom-audit/src/hello_observation_audit.rs` now have production-manifest-aware / production-audit seams, but the verifier admission layer still needs full alignment
 
 ## 5. Required Implementation Split
 
@@ -74,18 +73,18 @@ Based on the current code state, the next narrow split should be:
 - `M-HELLO-12A-2` - done: verifier-side controlled observation admission seam
 - `M-HELLO-12A-3` - done: production capability gate for controlled observation sink
 - `M-HELLO-12A-4` - done: audit decision policy wiring for controlled observation
-- `M-HELLO-12A-5` - add CLI result envelope rendering for source-run and run-smc separately
+- `M-HELLO-12A-5` - done: CLI result envelope rendering for source-run and run-smc separately
 
 ## 6. No-Go Decision
 
-`M-HELLO-12A-code is not ready.`
+M-HELLO-12A-code is now functionally present for the narrow Hello controlled
+observation route, but `#477` remains open until final acceptance
+verification / closeout.
 
-Lower-layer production seams are incomplete or still isolated, even though
-`M-HELLO-12A-1`, `M-HELLO-12A-2`, `M-HELLO-12A-3`, and `M-HELLO-12A-4`
-are now implemented as narrow seams.
-
-The current code has separate `smc run` and `run-smc` commands, but neither
-command is an honest controlled observation CLI implementation yet.
+The current code has separate `smc run` and `run-smc` commands, and both now
+render narrow controlled observation envelopes for approved Hello payloads.
+The remaining gap is the broader verifier alignment for production `print`
+admission and final closeout policy.
 
 ## 7. Issue State
 
@@ -102,5 +101,6 @@ command is an honest controlled observation CLI implementation yet.
 - [ ] `run-smc` route inspected
 - [ ] bypass risks listed
 - [ ] next implementation split proposed
+- [ ] 12A-5 narrow CLI envelope verified
 - [ ] no code changed
 - [ ] `#477` remains open

--- a/tests/hello_cli_observation_envelope.rs
+++ b/tests/hello_cli_observation_envelope.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn smc_output(args: &[&str]) -> Output {
+    let exe = env!("CARGO_BIN_EXE_smc");
+    Command::new(exe)
+        .args(args)
+        .output()
+        .expect("run smc")
+}
+
+fn assert_stdout_exact(output: &Output, expected: &str) {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        expected,
+        "unexpected stdout"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_no_stdout_payload(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).is_empty(),
+        "expected no stdout payload, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn smc_run_renders_controlled_observation_payload_once() {
+    let temp = mk_temp_dir("smc_cli_source_run");
+    let source = temp.join("hello.sm");
+    std::fs::write(&source, r#"
+fn main() {
+    print("Hello, World!");
+}
+"#)
+    .expect("write source fixture");
+    let source_arg = source.to_string_lossy().replace('\\', "/");
+    let output = smc_output(&["run", &source_arg]);
+    assert_stdout_exact(&output, "Hello, World!\n");
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn smc_run_smc_renders_controlled_observation_payload_once() {
+    let temp = mk_temp_dir("smc_cli_observation_envelope");
+    let source = temp.join("hello.sm");
+    std::fs::write(&source, r#"
+fn main() {
+    print("Hello, World!");
+}
+"#)
+    .expect("write source fixture");
+    let artifact = temp.join("hello_world.smc");
+    let source_arg = source.to_string_lossy().replace('\\', "/");
+    let artifact_arg = artifact.to_string_lossy().replace('\\', "/");
+
+    let compile_output = smc_output(&["compile", &source_arg, "-o", &artifact_arg]);
+    assert!(
+        compile_output.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
+
+    let verify_output = smc_output(&["verify", &artifact_arg]);
+    assert!(
+        verify_output.status.success(),
+        "verify failed: {}",
+        String::from_utf8_lossy(&verify_output.stderr)
+    );
+
+    let run_output = smc_output(&["run-smc", &artifact_arg]);
+    assert_stdout_exact(&run_output, "Hello, World!\n");
+
+    let _ = std::fs::remove_dir_all(&temp);
+}
+
+#[test]
+fn smc_run_rejects_non_text_and_forbidden_host_output_markers_without_stdout_payload() {
+    let cases = [
+        ("print_10", "fn main() { print(10); }"),
+        ("print_t", "fn main() { print(T); }"),
+        ("print_stdout", "fn main() { print(\"stdout\"); }"),
+        ("print_print", "fn main() { print(\"print\"); }"),
+        ("print_io_write", "fn main() { print(\"io.write\"); }"),
+        ("print_file", "fn main() { print(\"file\"); }"),
+        ("print_network", "fn main() { print(\"network\"); }"),
+        ("print_stdin", "fn main() { print(\"stdin\"); }"),
+    ];
+
+    for (name, source) in cases {
+        let temp = mk_temp_dir(&format!("smc_cli_negative_{name}"));
+        let input = temp.join(format!("{name}.sm"));
+        std::fs::write(&input, source).expect("write temp source");
+        let output = smc_output(&["run", &input.to_string_lossy()]);
+        assert_no_stdout_payload(&output);
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+}
+
+#[test]
+fn smc_run_smc_rejects_verify_failure_without_stdout_payload() {
+    let temp = mk_temp_dir("smc_cli_verify_failure");
+    let artifact = temp.join("invalid.smc");
+    std::fs::write(&artifact, b"not a semcode artifact").expect("write invalid artifact");
+    let output = smc_output(&["run-smc", &artifact.to_string_lossy()]);
+    assert_no_stdout_payload(&output);
+    let _ = std::fs::remove_dir_all(&temp);
+}


### PR DESCRIPTION
## Summary

Adds CLI result envelope rendering for controlled text observations in both `smc run` and `smc run-smc`.

This PR keeps the source-run and verified-artifact routes separate and renders only after verifier admission, VM controlled observation collection, capability allow, and audit decision.

## Issue

Refs #477.
Does not close #477.

## Scope

- updates `smc run` to use the controlled observation envelope path
- updates `smc run-smc` to use the controlled observation envelope path
- keeps source-run and verified-artifact routes separately tested
- applies `ControlledObservationSink` capability gate
- applies explicit controlled observation audit decision
- renders only approved controlled text payloads

## Result

- `smc run` can render narrow controlled text observations
- `smc run-smc` can render narrow controlled text observations
- output is not synthesized by CLI
- general stdout remains unsupported
- audit/capability metadata is not rendered to user output
- `#477` remains open pending final acceptance verification / closeout

## Out of scope

- README/examples promotion
- general stdout
- formatting / interpolation
- implicit scalar-to-text conversion
- file / stdin / network I/O
- audit archive export
- host ABI widening
- SemCode format changes
- opcode layout changes
- closing #477

## Validation

- `git diff --check`
- `cargo test -q -p prom-cap`
- `cargo test -q -p prom-audit`
- `cargo test -q -p smc-cli`
- `cargo test -q --test hello_cli_observation_envelope`
- `cargo test -q --test hello_cli_smoke_pipeline_harness`
- `cargo test -q --test hello_real_semcode_admission`
- `cargo test -q --test hello_real_semcode_negative_encodings`
- `cargo test -q --test hello_observation_capability_skeleton`
- `cargo test -q --test public_api_contracts`
