### PR TITLE
docs(roadmap): add private custody mode

### DIFF
--- a/docs/roadmap/private_custody_mode.md
+++ b/docs/roadmap/private_custody_mode.md
@@ -1,0 +1,107 @@
+# Private Custody Mode
+
+Status: repository custody and access discipline note.
+
+This document records the operational posture used when the Semantic repository
+is private. It does not change the language, SemCode, verifier, VM, runtime,
+capability, audit, or UI contracts.
+
+## Purpose
+
+Private custody mode exists to protect active R&D while preserving the same
+engineering discipline used for public-facing work.
+
+The privacy boundary is an access-control boundary, not a shortcut around the
+project's normal evidence rules.
+
+## Invariants
+
+- `main` remains protected by pull-request flow.
+- Squash merge remains the preferred merge path for a clean `main` history.
+- Code, spec, and docs changes still move through reviewable branches.
+- Claims about implemented behavior still require matching tests or explicit
+  inspection evidence.
+- Private visibility must not be used to hide unstable or contradictory public
+  contract language.
+- External publication remains a separate release decision, not an automatic
+  consequence of landing changes on `main`.
+
+## Access Discipline
+
+Private repository access should be treated as capability-bearing access.
+
+Minimum rules:
+
+- grant access only to accounts that need the repository;
+- avoid using alternate accounts for real project operations unless there is a
+  clear ownership or recovery reason;
+- keep branch and PR history reviewable even for private-only work;
+- prefer issues, PR bodies, and docs over private memory for architectural
+  decisions;
+- record sensitive exclusions as scope boundaries without exposing unnecessary
+  implementation detail.
+
+## PR Discipline While Private
+
+Docs-only, code, and mixed PRs should keep their intent explicit.
+
+| PR class | Expected evidence |
+|---|---|
+| Docs-only | changed document list, scope boundary, no contract widening unless stated |
+| Spec | affected contract surface, precedence note, downstream implementation impact |
+| Code | tests, negative cases where relevant, verifier/runtime boundary statement |
+| Release-facing | checklist alignment, asset or CI evidence, known limits preserved |
+
+A private PR may be smaller and more iterative, but it should not become
+untraceable. The repository being private reduces outside exposure; it does not
+reduce the need for internal auditability.
+
+## Relationship to Public Documents
+
+Existing documents that use public-facing language still matter. They define
+what can safely be said if a release, snapshot, README, paper, or external
+package is later published.
+
+Private custody mode therefore separates two questions:
+
+```text
+What is safe to work on privately?
+What is safe to claim publicly?
+```
+
+The first question is governed by access control and project custody. The
+second is governed by specs, tests, release notes, and explicit non-claims.
+
+## Non-Goals
+
+Private custody mode does not imply:
+
+- weakening branch protection;
+- bypassing CI when CI is relevant;
+- hiding known limitations;
+- treating planned architecture as implemented behavior;
+- publishing private details by accident;
+- converting Semantic into an undocumented private prototype.
+
+## Operational Checklist
+
+After changing repository visibility or access policy, verify:
+
+- repository visibility matches the intended custody state;
+- `main` is still the default branch;
+- pull request protection remains active for `main`;
+- merge commits and rebase merges remain disabled if squash-only history is the
+  intended policy;
+- CI still runs on pull requests;
+- external-facing documents still distinguish implemented, stable, and planned
+  behavior;
+- release-facing documents do not claim broader behavior than the current tests
+  and specs support.
+
+## Blocking Rule
+
+Do not use private visibility as a substitute for architectural clarity.
+
+If a change would be misleading in public language, either keep it private and
+clearly marked as experimental, or update the relevant status, roadmap, and
+non-claim documents in the same change series.

--- a/docs/roadmap/public_maturity_snapshot.md
+++ b/docs/roadmap/public_maturity_snapshot.md
@@ -69,6 +69,14 @@ Current public documentation does not claim:
 | Controlled observation | Finish M-Hello as a narrow verified observation path with capability and audit boundaries. | Controlled observation does not become general stdout by accident. |
 | Production hardening | Harden specs, tests, diagnostics, release artifacts, runtime contracts, and public status labels. | No public claim widens without spec + tests + verifier/VM/CLI coverage. |
 
+## Custody and visibility note
+
+Repository visibility is an access-control posture, not a change to the technical maturity model.
+
+When the repository is private, `docs/roadmap/private_custody_mode.md` defines the custody discipline used to keep branch protection, PR traceability, release-facing non-claims, and public communication boundaries intact.
+
+Private work can be broader than public claims, but public-facing language still remains constrained by specs, tests, status documents, and explicit non-claims.
+
 ## How to read this repository
 
 A first-time reader should not treat the repository as a finished general-purpose language product. It is better read as a serious R&D / platform project with a real staged architecture and active contract-hardening work.
@@ -83,6 +91,7 @@ The practical reading order is:
 6. `docs/spec/vm.md`
 7. `docs/spec/runtime_ownership.md`
 8. `docs/language/semantic_hello_*`
+9. `docs/roadmap/private_custody_mode.md`, when repository custody / visibility policy is relevant
 
 ## Public communication rule
 

--- a/docs/roadmap/release_bundle_checklist.md
+++ b/docs/roadmap/release_bundle_checklist.md
@@ -17,6 +17,7 @@ Verify the bundle includes:
 - `docs/roadmap/compatibility_statement.md`
 - `docs/roadmap/release_asset_smoke_matrix.md`
 - `docs/roadmap/stable_release_policy.md`
+- `docs/roadmap/private_custody_mode.md`, if the repository is private or if release preparation follows a private custody period
 - published asset notes for `smc.exe`, `svm.exe`, and the Windows zip when a GitHub release is cut
 
 Reproducible check command:
@@ -57,6 +58,7 @@ Verify the release notes include:
 - explicit snapshot regeneration rule
 - compatibility-sensitive contract families
 - which packaged assets were published for the current tag
+- whether the release was prepared from a private custody period, without exposing private-only implementation details
 
 ## Required Asset Smoke
 
@@ -70,6 +72,16 @@ Reproducible command:
 
 - `pwsh -File scripts/verify_release_assets.ps1 -Tag <tag> -AssetsDirectory <downloaded-assets-dir>`
 
+## Custody Transition Check
+
+Before publishing anything derived from a private repository state, verify:
+
+- public-facing documents still distinguish implemented, stable, planned, and experimental behavior;
+- private-only architecture notes are not accidentally promoted into public claims;
+- known limits remain visible in release-facing notes;
+- repository visibility and access-control changes are treated as operational facts, not technical maturity evidence;
+- the final release branch or tag points only to content intended for that release surface.
+
 ## Blocking Rule
 
 Do not mark the bundle release-ready if:
@@ -79,3 +91,4 @@ Do not mark the bundle release-ready if:
 - compatibility-sensitive tests were not run
 - runtime snapshots were regenerated without review
 - readiness and compatibility documents disagree with actual repository behavior
+- private custody mode is used to bypass PR, CI, or release evidence discipline


### PR DESCRIPTION
## Summary

Adds a docs-only private custody mode note for the repository after moving Semantic to private visibility.

This PR keeps the change operational/documentation-only. It does not alter source code, SemCode, verifier, VM, runtime, capability, audit, UI, or release artifact behavior.

## Scope

- adds `docs/roadmap/private_custody_mode.md`
- links custody mode from `docs/roadmap/public_maturity_snapshot.md`
- adds private-custody transition checks to `docs/roadmap/release_bundle_checklist.md`

## Intent

The goal is to make the new private repository posture explicit without weakening the existing discipline:

- `main` remains PR-protected
- squash-only flow remains the intended history model
- private visibility is treated as an access-control boundary, not maturity evidence
- public-facing claims remain governed by specs, tests, release notes, and explicit non-claims

## Validation

Docs-only inspection:

- `docs/roadmap/private_custody_mode.md` is a new custody/access discipline note
- no code files changed
- no contract surface widened
- no CI/runtime behavior expected to change

## Out of scope

- changing repository visibility settings
- changing rulesets / branch protection
- changing CI
- changing release artifacts
- changing language/runtime behavior
