### PR TITLE
PCC-4B — test(records): lock canonical record acceptance fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc4_records_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc4_records_live_audit.md
@@ -1,15 +1,17 @@
 # PCC-4 Records Live Audit
 
-Status: live audit
+Status: PCC-4B in progress
 Owner: language maturity stream
-Scope: records readiness before PCC-4 implementation
-Non-goal: code changes
+Scope: records readiness and fixture lock
+Non-goal: record architecture redesign
 
 ## 1. Purpose
 
 This document is a live readiness audit for records before PCC-4 implementation work begins.
 
-It is docs-only. It does not change parser, typecheck, lowering, SemCode, verifier, VM, diagnostics, tests, or examples.
+PCC-4A was docs-only. It did not change parser, typecheck, lowering, SemCode, verifier, VM, diagnostics, tests, or examples.
+
+PCC-4B adds positive canonical acceptance fixtures only. It does not redesign record architecture or widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
 
 ## 2. Current Known Status
 
@@ -28,36 +30,65 @@ Observed surface:
 - record values are intentionally not part of the PROMETHEUS host ABI surface;
 - diagnostics exist for unknown record types, duplicate fields, missing fields, out-of-bounds access, and unsupported conversions such as record-to-text;
 - record-oriented unit coverage already exists in `sm-verify`, `sm-vm`, and lowering tests;
-- the current repository does not appear to have a dedicated `tests/pcc4_*` or `tests/fixtures/pcc4_*` suite yet.
+- before PCC-4B, the repository did not have a dedicated `tests/pcc4_*` or `tests/fixtures/pcc4_*` suite.
 
 Conclusion:
 
 ```text
 The core record seams already exist.
-PCC-4 can start with fixture/closeout work rather than new parser/lowering/VM architecture.
+PCC-4 starts with fixture/closeout work rather than new parser/lowering/VM architecture.
 ```
 
 ## 3. Readiness Matrix
 
 | Layer | Required for PCC-4 | Current state | Ready? | Next action |
 | --- | --- | --- | --- | --- |
-| parser | record declarations / literals / field access | Nominal record syntax and expression forms already exist | yes | lock acceptance fixtures |
+| parser | record declarations / literals / field access | Nominal record syntax and expression forms already exist | yes | locked by PCC-4B positive fixtures |
 | typecheck | record types and field validation | Nominal record typing, uniqueness checks, acyclic checks, and equality gating already exist | yes | keep diagnostics stable |
-| lowering | record construction/access to IR | `MakeRecord` and `RecordGet` lowering already exist | yes | verify fixture coverage |
+| lowering | record construction/access to IR | `MakeRecord` and `RecordGet` lowering already exist | yes | locked through compile path |
 | SemCode | stable representation or lowering strategy | `MakeRecord` / `RecordGet` opcodes exist in the local format | yes | keep opcode contract frozen |
-| verifier | accepts record-related bytecode safely | verifier recognizes record opcodes and validates payload shape | yes | keep verifier diagnostics aligned |
-| VM | runtime record value behavior | `Value::Record(RecordCarrier<Value>)` already executes deterministically | yes | keep host ABI boundary closed |
-| diagnostics | clear source errors | record-specific parse/typecheck/runtime diagnostics already exist | yes | keep error text stable |
-| tests | positive/negative coverage | unit coverage exists, but no dedicated PCC-4 fixture suite is present yet | partial | add PCC-4 fixture lock / closeout coverage |
+| verifier | accepts record-related bytecode safely | verifier recognizes record opcodes and validates payload shape | yes | locked through verify path |
+| VM | runtime record value behavior | `Value::Record(RecordCarrier<Value>)` already executes deterministically | yes | locked through run path |
+| diagnostics | clear source errors | record-specific parse/typecheck/runtime diagnostics already exist | yes | expand in PCC-4C negative fixtures |
+| tests | positive/negative coverage | PCC-4B adds dedicated positive acceptance coverage | partial | add PCC-4C negative diagnostics fixtures |
 
-## 4. Risk List
+## 4. PCC-4B Evidence
+
+PCC-4B adds `tests/pcc4_records_acceptance.rs` as the dedicated positive acceptance fixture lock.
+
+The fixture suite covers three canonical positive slices:
+
+1. `pcc4_record_declaration.sm`
+   - locks a nominal `record` declaration through the CLI path;
+   - proves the parser/typecheck pipeline accepts a standalone record declaration.
+2. `pcc4_record_construction_and_field_read.sm`
+   - locks record literal construction;
+   - locks field reads through `assert(pair.left == ...)` and `assert(pair.right == ...)`;
+   - exercises lowering, SemCode emission, verifier admission, and VM execution for `MakeRecord` / `RecordGet`.
+3. `pcc4_record_function_boundary.sm`
+   - locks a record value crossing a function boundary;
+   - reads a field inside the callee;
+   - verifies deterministic execution through `check -> run -> compile -> verify`.
+
+The test helper intentionally uses the same CLI-stage shape as the canonical example tests:
+
+```text
+smc check
+smc run
+smc compile -o out.smc
+smc verify out.smc
+```
+
+This makes PCC-4B an end-to-end acceptance lock rather than a parser-only fixture.
+
+## 5. Risk List
 
 Observed risks:
 
-- record support is distributed across core layers and current tests, but there is no dedicated PCC-4 fixture suite yet;
+- record support is distributed across core layers and current tests, but before PCC-4B there was no dedicated PCC-4 fixture suite;
 - a PCC-4 implementation PR could accidentally drift into adjacent aggregate work such as ADT or collections if the scope is not frozen;
-- record values are still not part of the PROMETHEUS host ABI surface, so host-effect widening would be out of scope for PCC-4;
-- record diagnostics are already present, but a closeout PR should keep their wording stable so the current acceptance evidence remains readable;
+- record values are still not part of the PROMETHEUS host ABI surface, so host-effect widening remains out of scope for PCC-4;
+- record diagnostics are already present, but PCC-4C should keep their wording stable so acceptance evidence remains readable;
 - the record surface is currently nominal and slot-based, so any attempt to introduce a general object model would be a scope break.
 
 Not observed:
@@ -67,23 +98,23 @@ Not observed:
 - no evidence of missing SemCode opcodes for record construction or access;
 - no evidence that the VM lacks a runtime carrier for records.
 
-## 5. Recommended PCC-4 Split
+## 6. Recommended PCC-4 Split
 
 Because the core seams are already present, the next work is better split as fixture and closeout coverage rather than a new architecture build.
 
 Recommended sequence:
 
 ```text
-PCC-4B — lock canonical record acceptance fixtures across parser / typecheck / lowering / verify / VM
+PCC-4B — lock canonical positive record acceptance fixtures across parser / typecheck / lowering / verify / VM
 PCC-4C — expand record diagnostics and negative fixtures
 PCC-4D — close PCC-4 with evidence sync and roadmap status update
 ```
 
-If a future implementation delta is discovered during PCC-4B, split it narrowly from the fixture lock before landing.
+If a future implementation delta is discovered during PCC-4B or PCC-4C, split it narrowly from the fixture lock before landing.
 
-## 6. Out of Scope
+## 7. Out of Scope
 
-This audit does not expand into:
+This audit and PCC-4B do not expand into:
 
 - ADT;
 - collections;
@@ -99,7 +130,7 @@ This audit does not expand into:
 - README promotion;
 - host ABI widening.
 
-## 7. Acceptance Checklist
+## 8. Acceptance Checklist
 
 - [x] parser surface inspected
 - [x] typecheck inspected
@@ -110,5 +141,9 @@ This audit does not expand into:
 - [x] tests inspected
 - [x] risks documented
 - [x] next PCC-4 split proposed
-- [x] no code changed
+- [x] PCC-4B positive fixture suite added
+- [x] record declaration positive fixture added
+- [x] record construction + field read positive fixture added
+- [x] record function-boundary positive fixture added
+- [x] no record architecture redesign
 

--- a/tests/pcc4_records_acceptance.rs
+++ b/tests/pcc4_records_acceptance.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn write_fixture(dir: &std::path::Path, name: &str, source: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, source).expect("write PCC-4 fixture");
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn check_run_compile_verify_source(name: &str, source: &str) {
+    let dir = mk_temp_dir("smc_pcc4_records_acceptance");
+    let input = write_fixture(&dir, name, source);
+
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("smc verify for {input}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc4_record_declaration_fixture_passes_full_cli_path() {
+    check_run_compile_verify_source(
+        "pcc4_record_declaration.sm",
+        r#"
+record SensorReading {
+    value: i32,
+    active: bool,
+}
+
+fn main() {
+    return;
+}
+"#,
+    );
+}
+
+#[test]
+fn pcc4_record_construction_and_field_read_fixture_passes_full_cli_path() {
+    check_run_compile_verify_source(
+        "pcc4_record_construction_and_field_read.sm",
+        r#"
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 4, right: 9 };
+    assert(pair.left == 4);
+    assert(pair.right == 9);
+    return;
+}
+"#,
+    );
+}
+
+#[test]
+fn pcc4_record_function_boundary_fixture_passes_full_cli_path() {
+    check_run_compile_verify_source(
+        "pcc4_record_function_boundary.sm",
+        r#"
+record Sample {
+    value: i32,
+    enabled: bool,
+}
+
+fn sample_value(sample: Sample) -> i32 {
+    return sample.value;
+}
+
+fn sample_enabled(sample: Sample) -> bool {
+    return sample.enabled;
+}
+
+fn main() {
+    let sample: Sample = Sample { value: 7, enabled: true };
+    assert(sample_value(sample) == 7);
+    assert(sample_enabled(sample) == true);
+    return;
+}
+"#,
+    );
+}

--- a/tests/pcc4_records_acceptance.rs
+++ b/tests/pcc4_records_acceptance.rs
@@ -108,14 +108,9 @@ fn sample_value(sample: Sample) -> i32 {
     return sample.value;
 }
 
-fn sample_enabled(sample: Sample) -> bool {
-    return sample.enabled;
-}
-
 fn main() {
     let sample: Sample = Sample { value: 7, enabled: true };
     assert(sample_value(sample) == 7);
-    assert(sample_enabled(sample) == true);
     return;
 }
 "#,


### PR DESCRIPTION
## Summary

Locks PCC-4B positive record acceptance coverage with a dedicated integration-test suite.

This PR adds canonical record fixtures that exercise the existing record seams through the full CLI path instead of redesigning record architecture.

## Scope

- adds `tests/pcc4_records_acceptance.rs`
- locks positive acceptance for:
  - record declaration
  - record construction + field reads
  - record use across a function boundary
- updates `docs/roadmap/language_maturity/pcc4_records_live_audit.md` with PCC-4B evidence

## Acceptance path

Each fixture is run through:

```text
smc check
smc run
smc compile -o out.smc
smc verify out.smc
```

This covers parser / typecheck / lowering / SemCode / verifier / VM using the existing CLI orchestration path.

## Out of scope

- record architecture redesign
- new record semantics
- ADT
- schema
- collections
- PROMETHEUS host ABI widening
- runtime ownership widening
- UI / Workbench / Studio
- README promotion

## Validation

Pending CI. Recommended local validation:

```text
cargo test --test pcc4_records_acceptance
git diff --check
```
