### PR TITLE
PCC-4C — test(records): expand negative diagnostics fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc4_records_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc4_records_live_audit.md
@@ -1,8 +1,8 @@
 # PCC-4 Records Live Audit
 
-Status: PCC-4B in progress
+Status: PCC-4C in progress
 Owner: language maturity stream
-Scope: records readiness and fixture lock
+Scope: records readiness, positive/negative fixture lock
 Non-goal: record architecture redesign
 
 ## 1. Purpose
@@ -11,7 +11,9 @@ This document is a live readiness audit for records before PCC-4 implementation 
 
 PCC-4A was docs-only. It did not change parser, typecheck, lowering, SemCode, verifier, VM, diagnostics, tests, or examples.
 
-PCC-4B adds positive canonical acceptance fixtures only. It does not redesign record architecture or widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
+PCC-4B added positive canonical acceptance fixtures only. It did not redesign record architecture or widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
+
+PCC-4C adds negative diagnostics fixtures only. It continues to avoid record architecture redesign and does not widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
 
 ## 2. Current Known Status
 
@@ -50,7 +52,7 @@ PCC-4 starts with fixture/closeout work rather than new parser/lowering/VM archi
 | verifier | accepts record-related bytecode safely | verifier recognizes record opcodes and validates payload shape | yes | locked through verify path |
 | VM | runtime record value behavior | `Value::Record(RecordCarrier<Value>)` already executes deterministically | yes | locked through run path |
 | diagnostics | clear source errors | record-specific parse/typecheck/runtime diagnostics already exist | yes | expand in PCC-4C negative fixtures |
-| tests | positive/negative coverage | PCC-4B adds dedicated positive acceptance coverage | partial | add PCC-4C negative diagnostics fixtures |
+| tests | positive/negative coverage | Dedicated positive acceptance coverage exists and PCC-4C adds negative diagnostics coverage | yes | closeout evidence sync |
 
 ## 4. PCC-4B Evidence
 
@@ -81,7 +83,28 @@ smc verify out.smc
 
 This makes PCC-4B an end-to-end acceptance lock rather than a parser-only fixture.
 
-## 5. Risk List
+## 5. PCC-4C Evidence
+
+PCC-4C adds `tests/pcc4_records_diagnostics.rs` as the dedicated negative diagnostics fixture suite.
+
+Covered negative cases:
+
+- unknown record type;
+- missing required field;
+- duplicate field in record literal;
+- unknown field access;
+- record field type mismatch.
+
+Each fixture follows the same acceptance contour:
+
+```text
+smc check -> stable rejection diagnostic
+smc compile -> either rejects or emits artifact that does not verify
+```
+
+This makes PCC-4C a diagnostics lock rather than a new record architecture change.
+
+## 6. Risk List
 
 Observed risks:
 
@@ -98,7 +121,7 @@ Not observed:
 - no evidence of missing SemCode opcodes for record construction or access;
 - no evidence that the VM lacks a runtime carrier for records.
 
-## 6. Recommended PCC-4 Split
+## 7. Recommended PCC-4 Split
 
 Because the core seams are already present, the next work is better split as fixture and closeout coverage rather than a new architecture build.
 
@@ -112,7 +135,7 @@ PCC-4D — close PCC-4 with evidence sync and roadmap status update
 
 If a future implementation delta is discovered during PCC-4B or PCC-4C, split it narrowly from the fixture lock before landing.
 
-## 7. Out of Scope
+## 8. Out of Scope
 
 This audit and PCC-4B do not expand into:
 
@@ -130,7 +153,7 @@ This audit and PCC-4B do not expand into:
 - README promotion;
 - host ABI widening.
 
-## 8. Acceptance Checklist
+## 9. Acceptance Checklist
 
 - [x] parser surface inspected
 - [x] typecheck inspected
@@ -146,4 +169,11 @@ This audit and PCC-4B do not expand into:
 - [x] record construction + field read positive fixture added
 - [x] record function-boundary positive fixture added
 - [x] no record architecture redesign
+- [x] PCC-4C negative fixture suite added
+- [x] unknown record type diagnostic locked
+- [x] missing field diagnostic locked
+- [x] duplicate field diagnostic locked
+- [x] unknown field access diagnostic locked
+- [x] field type mismatch diagnostic locked
+- [x] invalid record sources do not verify
 

--- a/tests/fixtures/pcc4_records/negative_duplicate_record_field.sm
+++ b/tests/fixtures/pcc4_records/negative_duplicate_record_field.sm
@@ -1,0 +1,9 @@
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 1, left: 2, right: 3 };
+    return;
+}

--- a/tests/fixtures/pcc4_records/negative_missing_record_field.sm
+++ b/tests/fixtures/pcc4_records/negative_missing_record_field.sm
@@ -1,0 +1,9 @@
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 1 };
+    return;
+}

--- a/tests/fixtures/pcc4_records/negative_record_field_type_mismatch.sm
+++ b/tests/fixtures/pcc4_records/negative_record_field_type_mismatch.sm
@@ -1,0 +1,9 @@
+record Probe {
+    value: i32,
+    active: bool,
+}
+
+fn main() {
+    let probe: Probe = Probe { value: true, active: false };
+    return;
+}

--- a/tests/fixtures/pcc4_records/negative_unknown_record_field_access.sm
+++ b/tests/fixtures/pcc4_records/negative_unknown_record_field_access.sm
@@ -1,0 +1,10 @@
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 1, right: 2 };
+    let bad: i32 = pair.middle;
+    return;
+}

--- a/tests/fixtures/pcc4_records/negative_unknown_record_type.sm
+++ b/tests/fixtures/pcc4_records/negative_unknown_record_type.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let probe: MissingRecord = MissingRecord { value: 1 };
+    return;
+}

--- a/tests/pcc4_records_diagnostics.rs
+++ b/tests/pcc4_records_diagnostics.rs
@@ -1,0 +1,135 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_path(rel: &str) -> String {
+    repo_path(&format!("tests/fixtures/pcc4_records/{rel}"))
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn assert_record_check_error(rel: &str, code: &str, needle: &str) {
+    let input = fixture_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains(&format!("Error [{code}]")),
+        "expected diagnostic code {code} for {rel}, got: {err}"
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+    );
+}
+
+fn assert_invalid_record_source_does_not_verify(rel: &str, code: &str, needle: &str) {
+    assert_record_check_error(rel, code, needle);
+
+    let input = fixture_path(rel);
+    let dir = mk_temp_dir("pcc4_records_diagnostics_invalid");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let compile_res = smc_cli::run(vec![
+        "compile".to_string(),
+        input.clone(),
+        "-o".to_string(),
+        out_arg.clone(),
+    ]);
+
+    match compile_res {
+        Ok(()) => {
+            let bytes = std::fs::read(&out).unwrap_or_else(|err| {
+                panic!("compile succeeded but emitted artifact for {input} was not readable: {err}")
+            });
+            assert!(
+                !bytes.is_empty(),
+                "compile succeeded but emitted artifact for {input} was empty"
+            );
+            let verify_err = cli_err(
+                vec!["verify".to_string(), out_arg.clone()],
+                &format!("smc verify for {out_arg}"),
+            );
+            assert!(
+                verify_err.contains("Error ["),
+                "expected verify to reject invalid record artifact for {rel}, got: {verify_err}"
+            );
+        }
+        Err(err) => {
+            assert!(
+                err.contains(&format!("Error [{code}]")) || err.contains(needle),
+                "expected compile failure to mention {code} or '{needle}' for {rel}, got: {err}"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc4_records_unknown_type_rejects_and_does_not_verify() {
+    assert_invalid_record_source_does_not_verify(
+        "negative_unknown_record_type.sm",
+        "E0201",
+        "unknown record type 'MissingRecord'",
+    );
+}
+
+#[test]
+fn pcc4_records_missing_required_field_rejects_and_does_not_verify() {
+    assert_invalid_record_source_does_not_verify(
+        "negative_missing_record_field.sm",
+        "E0201",
+        "record literal 'Pair' is missing field 'right'",
+    );
+}
+
+#[test]
+fn pcc4_records_duplicate_field_rejects_and_does_not_verify() {
+    assert_invalid_record_source_does_not_verify(
+        "negative_duplicate_record_field.sm",
+        "E0201",
+        "record literal 'Pair' cannot repeat field 'left'",
+    );
+}
+
+#[test]
+fn pcc4_records_unknown_field_access_rejects_and_does_not_verify() {
+    assert_invalid_record_source_does_not_verify(
+        "negative_unknown_record_field_access.sm",
+        "E0201",
+        "record type 'Pair' has no field named 'middle'",
+    );
+}
+
+#[test]
+fn pcc4_records_field_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_record_source_does_not_verify(
+        "negative_record_field_type_mismatch.sm",
+        "E0201",
+        "type mismatch in record field 'Probe.value'",
+    );
+}


### PR DESCRIPTION
## Summary

Expands PCC-4 with a dedicated negative diagnostics suite for records.

This PR is test/evidence focused and does not redesign record architecture.

## Scope

- adds `tests/pcc4_records_diagnostics.rs`
- adds negative record fixtures under `tests/fixtures/pcc4_records/`
- locks stable diagnostics for:
  - unknown record type
  - missing required field
  - duplicate field in record literal
  - unknown field access
  - record field type mismatch
- updates `docs/roadmap/language_maturity/pcc4_records_live_audit.md` with PCC-4C evidence

## Result

- invalid record programs are rejected with stable diagnostics
- invalid record sources do not reach a verified execution path
- PCC-4B positive acceptance coverage remains green
- PCC-4 remains evidence-based rather than architecture-driven

## Out of scope

- record architecture redesign
- new record semantics
- ADT
- schema
- collections
- runtime ownership widening
- PROMETHEUS host ABI widening
- UI / Workbench / Studio
- README promotion

## Validation

- `cargo test --test pcc4_records_diagnostics`
- `cargo test --test pcc4_records_acceptance`
- `git diff --check`
- `git status`
