### PR TITLE
PCC-4D — docs(records): close PCC-4 with evidence sync and roadmap status update

### DIFF
--- a/docs/roadmap/language_maturity/pcc4_records_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc4_records_live_audit.md
@@ -1,8 +1,8 @@
 # PCC-4 Records Live Audit
 
-Status: PCC-4C in progress
+Status: PCC-4 closed / evidence synced
 Owner: language maturity stream
-Scope: records readiness, positive/negative fixture lock
+Scope: records readiness, positive/negative fixture lock, closeout
 Non-goal: record architecture redesign
 
 ## 1. Purpose
@@ -14,6 +14,8 @@ PCC-4A was docs-only. It did not change parser, typecheck, lowering, SemCode, ve
 PCC-4B added positive canonical acceptance fixtures only. It did not redesign record architecture or widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
 
 PCC-4C adds negative diagnostics fixtures only. It continues to avoid record architecture redesign and does not widen ADT, schema, PROMETHEUS host ABI, UI, Workbench, or runtime ownership scope.
+
+PCC-4D closes the records track for the current Practical Core scope and synchronizes the evidence into roadmap status.
 
 ## 2. Current Known Status
 
@@ -104,7 +106,40 @@ smc compile -> either rejects or emits artifact that does not verify
 
 This makes PCC-4C a diagnostics lock rather than a new record architecture change.
 
-## 6. Risk List
+## 6. PCC-4D Closeout
+
+PCC-4A established that the core record seams already exist.
+
+PCC-4B added positive canonical acceptance fixtures:
+
+- `pcc4_record_declaration.sm`
+- `pcc4_record_construction_and_field_read.sm`
+- `pcc4_record_function_boundary.sm`
+
+PCC-4C added negative diagnostics fixtures:
+
+- unknown record type;
+- missing required field;
+- duplicate field in record literal;
+- unknown field access;
+- record field type mismatch.
+
+Final verdict:
+
+```text
+PCC-4 records end-to-end is closed for the current Practical Core Completion scope.
+```
+
+Future expansions remain out of scope for PCC-4:
+
+- ADT;
+- schema;
+- collections;
+- general object model;
+- host ABI widening;
+- runtime ownership widening.
+
+## 7. Risk List
 
 Observed risks:
 
@@ -121,7 +156,7 @@ Not observed:
 - no evidence of missing SemCode opcodes for record construction or access;
 - no evidence that the VM lacks a runtime carrier for records.
 
-## 7. Recommended PCC-4 Split
+## 8. Recommended PCC-4 Split
 
 Because the core seams are already present, the next work is better split as fixture and closeout coverage rather than a new architecture build.
 
@@ -135,7 +170,7 @@ PCC-4D — close PCC-4 with evidence sync and roadmap status update
 
 If a future implementation delta is discovered during PCC-4B or PCC-4C, split it narrowly from the fixture lock before landing.
 
-## 8. Out of Scope
+## 9. Out of Scope
 
 This audit and PCC-4B do not expand into:
 
@@ -153,7 +188,7 @@ This audit and PCC-4B do not expand into:
 - README promotion;
 - host ABI widening.
 
-## 9. Acceptance Checklist
+## 10. Acceptance Checklist
 
 - [x] parser surface inspected
 - [x] typecheck inspected
@@ -176,4 +211,8 @@ This audit and PCC-4B do not expand into:
 - [x] unknown field access diagnostic locked
 - [x] field type mismatch diagnostic locked
 - [x] invalid record sources do not verify
+- [x] PCC-4D closeout evidence synced
+- [x] PCC-4 roadmap status updated
+- [x] feature matrix records rows updated
+- [x] PCC-4 closed without record architecture redesign
 

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -383,6 +383,15 @@ Live audit:
 
 - `docs/roadmap/language_maturity/pcc4_records_live_audit.md`
 
+Closeout note:
+
+```text
+PCC-4A/B/C/D evidence is complete for the current Practical Core scope.
+Positive and negative fixture coverage exists.
+PCC-4 is closed for current scope.
+Further aggregate work moves to PCC-5 ADT + Basic Match, then PCC-6 Option / Result, PCC-7 Collections v0, and PCC-8 Stdlib v0.
+```
+
 DoD:
 
 ```text

--- a/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
+++ b/docs/roadmap/language_maturity/practical_core_feature_matrix_live_audit.md
@@ -211,9 +211,9 @@ be audited against current `main` before it can support planning claims.
 | FM-016 | Text core | text literal | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
 | FM-017 | Text core | text equality | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
 | FM-018 | Text core | text concat | unknown | TBD | TBD | TBD | PCC-3 | value | Practical Hell | audit |
-| FM-019 | Records | record declaration | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
-| FM-020 | Records | record construction | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
-| FM-021 | Records | field access | unknown | TBD | TBD | TBD | PCC-4 | value | Practical Hell | audit |
+| FM-019 | Records | record declaration | confirmed-working | `E3-pipeline: tests/pcc4_records_acceptance.rs::pcc4_record_declaration_fixture_passes_full_cli_path; E2-test: tests/pcc4_records_diagnostics.rs::pcc4_records_unknown_type_rejects_and_does_not_verify` | check -> run -> compile -> verify | none | PCC-4 | value | Practical Hell | closed for PCC-4 current scope |
+| FM-020 | Records | record construction | confirmed-working | `E3-pipeline: tests/pcc4_records_acceptance.rs::pcc4_record_construction_and_field_read_fixture_passes_full_cli_path; E2-test: tests/pcc4_records_diagnostics.rs::pcc4_records_missing_required_field_rejects_and_does_not_verify; E2-test: tests/pcc4_records_diagnostics.rs::pcc4_records_duplicate_field_rejects_and_does_not_verify` | check -> run -> compile -> verify | none | PCC-4 | value | Practical Hell | closed for PCC-4 current scope |
+| FM-021 | Records | field access | confirmed-working | `E3-pipeline: tests/pcc4_records_acceptance.rs::pcc4_record_construction_and_field_read_fixture_passes_full_cli_path; E3-pipeline: tests/pcc4_records_acceptance.rs::pcc4_record_function_boundary_fixture_passes_full_cli_path; E2-test: tests/pcc4_records_diagnostics.rs::pcc4_records_unknown_field_access_rejects_and_does_not_verify` | check -> run -> compile -> verify | none | PCC-4 | value | Practical Hell | closed for PCC-4 current scope |
 | FM-022 | ADT / match | enum declaration | unknown | TBD | TBD | TBD | PCC-5 | value | Practical Hell | audit |
 | FM-023 | ADT / match | constructor expression | unknown | TBD | TBD | TBD | PCC-5 | value | Practical Hell | audit |
 | FM-024 | ADT / match | basic ADT match | unknown | TBD | TBD | TBD | PCC-5 | determinism | Practical Hell | audit |


### PR DESCRIPTION
## Summary

Closes PCC-4 for the current Practical Core scope and synchronizes the evidence trail.

This PR is docs-only and does not change parser, typecheck, lowering, SemCode, verifier, VM, tests, fixtures, examples, or README behavior.

## Scope

- updates PCC-4 live audit status to closed / evidence synced
- records the PCC-4A / PCC-4B / PCC-4C / PCC-4D evidence chain
- updates the practical core feature matrix record rows to confirmed-working
- adds a PCC-4 closeout note to the Practical Core roadmap

## Result

- PCC-4 is closed for the current Practical Core Completion scope
- record declaration, construction, and field access are evidence-backed in the matrix
- the roadmap no longer leaves Records in an in-progress state
- further aggregate work remains assigned to later PCC phases

## Out of scope

- code changes
- tests
- fixtures
- record architecture redesign
- ADT
- schema
- collections
- runtime ownership widening
- PROMETHEUS host ABI widening
- UI / Workbench / Studio
- README promotion

## Validation

- `git diff --check`
- `git diff --name-only origin/main...HEAD`
- `git status`
