### PR TITLE
PR-PCC-5B — test(adt): lock canonical ADT declaration / constructor fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
@@ -23,6 +23,7 @@ Current `main` already contains the ADT and basic match seam across the full pra
 - The VM already carries ADT runtime values and executes ADT constructor/tag/access instructions.
 - Diagnostics for invalid ADT and match shapes already exist.
 - Existing tests already exercise the surface end-to-end through the snake benchmark path.
+- PCC-5B adds a dedicated positive ADT acceptance fixture suite for declaration and constructor use.
 
 Audit verdict:
 
@@ -51,7 +52,7 @@ Reason: docs-only audit; no runtime value, trap, determinism, verifier, SymbolId
 | verifier | validates ADT/match bytecode | confirmed-working | yes | keep bytecode checks stable |
 | VM | executes ADT/match runtime values | confirmed-working | yes | keep runtime carrier behavior stable |
 | diagnostics | clear ADT/match errors | confirmed-working | yes | keep diagnostic needles stable |
-| tests | positive/negative coverage | confirmed-partial | partial | add PCC-5-named fixture suite if desired |
+| tests | positive/negative coverage | confirmed-partial | partial | PCC-5B positive fixtures exist; PCC-5C/PCC-5D still needed for full lock |
 
 ## 4. Risk List
 
@@ -78,6 +79,27 @@ PCC-5E — docs(adt): close PCC-5 with evidence sync and roadmap status update
 ```
 
 If a dedicated fixture suite becomes necessary for roadmap hygiene, add it as evidence work, not as a new language design PR.
+
+## PCC-5B Evidence
+
+PCC-5B adds dedicated positive ADT declaration / constructor acceptance fixtures.
+
+Covered positive cases:
+
+- enum / ADT declaration;
+- unit-like constructor expression;
+- constructor value across a function boundary;
+- optional minimal constructor observation is deferred because stable equality is not admitted for the nominal enum shape in this slice.
+
+Validation:
+
+- `cargo test --test pcc5_adt_acceptance`
+- `cargo test --test snake_benchmark_gap_matrix snake_benchmark_positive_surface_passes_end_to_end`
+- `git diff --check`
+
+PCC-5B does not close match coverage.
+Basic match fixture lock remains PCC-5C.
+Negative diagnostics remain PCC-5D.
 
 ## 6. Out of Scope
 

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -416,6 +416,15 @@ Live audit:
 
 - `docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md`
 
+PCC-5 boundary note:
+
+```text
+records are closed as nominal value aggregates;
+ADT is a separate aggregate family;
+collections are not records;
+host ABI stays closed to record values.
+```
+
 DoD:
 
 ```text

--- a/tests/fixtures/pcc5_adt/positive_adt_constructor_function_boundary.sm
+++ b/tests/fixtures/pcc5_adt/positive_adt_constructor_function_boundary.sm
@@ -1,0 +1,19 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn choose_right() -> Direction {
+    return Direction::Right;
+}
+
+fn accept_direction(dir: Direction) -> Direction {
+    return dir;
+}
+
+fn main() {
+    let dir: Direction = accept_direction(choose_right());
+    return;
+}

--- a/tests/fixtures/pcc5_adt/positive_adt_declaration_only.sm
+++ b/tests/fixtures/pcc5_adt/positive_adt_declaration_only.sm
@@ -1,0 +1,9 @@
+enum Signal {
+    Red,
+    Green,
+    Blue,
+}
+
+fn main() {
+    return;
+}

--- a/tests/fixtures/pcc5_adt/positive_adt_unit_constructor.sm
+++ b/tests/fixtures/pcc5_adt/positive_adt_unit_constructor.sm
@@ -1,0 +1,11 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn main() {
+    let dir: Direction = Direction::Right;
+    return;
+}

--- a/tests/pcc5_adt_acceptance.rs
+++ b/tests/pcc5_adt_acceptance.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn check_run_compile_verify(rel: &str) {
+    let input = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    cli_ok(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for {input}"),
+    );
+
+    let dir = mk_temp_dir("smc_pcc5_adt_acceptance");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {input}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("smc verify for {input}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc5_adt_declaration_only_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_adt/positive_adt_declaration_only.sm");
+}
+
+#[test]
+fn pcc5_adt_unit_constructor_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_adt/positive_adt_unit_constructor.sm");
+}
+
+#[test]
+fn pcc5_adt_constructor_function_boundary_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_adt/positive_adt_constructor_function_boundary.sm");
+}


### PR DESCRIPTION
## Summary

Locks canonical ADT declaration / constructor acceptance fixtures for PCC-5.

This PR is test + docs only. It does not change parser, typecheck, lowering, SemCode, verifier, VM, CLI, or runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds dedicated PCC-5 ADT acceptance fixtures
- validates enum / ADT declaration through the full CLI path
- validates unit-like constructor expressions through the full CLI path
- validates constructor use across a function boundary through the full CLI path
- updates the PCC-5 live audit with evidence

## Result

- canonical ADT declaration / constructor behavior is locked by dedicated fixtures
- PCC-5B remains fixture/evidence packaging, not a new ADT architecture
- basic match coverage remains PCC-5C
- negative diagnostics remain PCC-5D
- #477 remains open

## Out of scope

- match-specific broadening
- negative diagnostics fixtures
- parser changes
- typecheck changes
- lowering changes
- SemCode changes
- verifier changes
- VM/runtime changes
- Option / Result
- records
- collections
- README/examples promotion

## Validation

- `cargo test -q --test pcc5_adt_acceptance`
- `cargo test -q --test snake_benchmark_gap_matrix snake_benchmark_positive_surface_passes_end_to_end`
- `git diff --check`
- `git status`
