### PR TITLE
PR-PCC-5C — test(match): lock basic ADT match fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
@@ -24,6 +24,7 @@ Current `main` already contains the ADT and basic match seam across the full pra
 - Diagnostics for invalid ADT and match shapes already exist.
 - Existing tests already exercise the surface end-to-end through the snake benchmark path.
 - PCC-5B adds a dedicated positive ADT acceptance fixture suite for declaration and constructor use.
+- PCC-5C adds a dedicated positive basic ADT match acceptance fixture suite.
 
 Audit verdict:
 
@@ -52,7 +53,7 @@ Reason: docs-only audit; no runtime value, trap, determinism, verifier, SymbolId
 | verifier | validates ADT/match bytecode | confirmed-working | yes | keep bytecode checks stable |
 | VM | executes ADT/match runtime values | confirmed-working | yes | keep runtime carrier behavior stable |
 | diagnostics | clear ADT/match errors | confirmed-working | yes | keep diagnostic needles stable |
-| tests | positive/negative coverage | confirmed-partial | partial | PCC-5B positive fixtures exist; PCC-5C/PCC-5D still needed for full lock |
+| tests | positive/negative coverage | confirmed-partial | partial | PCC-5B positive ADT fixtures exist; PCC-5C positive match fixtures exist; PCC-5D still needed for negative lock |
 
 ## 4. Risk List
 
@@ -88,8 +89,7 @@ Covered positive cases:
 
 - enum / ADT declaration;
 - unit-like constructor expression;
-- constructor value across a function boundary;
-- optional minimal constructor observation is deferred because stable equality is not admitted for the nominal enum shape in this slice.
+- constructor value across a function boundary.
 
 Validation:
 
@@ -100,6 +100,27 @@ Validation:
 PCC-5B does not close match coverage.
 Basic match fixture lock remains PCC-5C.
 Negative diagnostics remain PCC-5D.
+
+## PCC-5C Evidence
+
+PCC-5C adds dedicated positive basic ADT match acceptance fixtures.
+
+Covered positive cases:
+
+- basic match over a unit-like enum;
+- match expression assigned to a local value;
+- ADT value matched across a function boundary;
+- constructor returned from a function and matched.
+
+Validation:
+
+- `cargo test --test pcc5_match_acceptance`
+- `cargo test --test pcc5_adt_acceptance`
+- `git diff --check`
+
+PCC-5C does not add new match semantics.
+Negative diagnostics remain PCC-5D.
+PCC-5 closeout remains PCC-5E.
 
 ## 6. Out of Scope
 

--- a/tests/fixtures/pcc5_adt/pcc5_adt_constructor_function_boundary.sm
+++ b/tests/fixtures/pcc5_adt/pcc5_adt_constructor_function_boundary.sm
@@ -1,0 +1,19 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn choose_right() -> Direction {
+    return Direction::Right;
+}
+
+fn accept_direction(dir: Direction) -> Direction {
+    return dir;
+}
+
+fn main() {
+    let dir: Direction = accept_direction(choose_right());
+    return;
+}

--- a/tests/fixtures/pcc5_adt/pcc5_adt_declaration_only.sm
+++ b/tests/fixtures/pcc5_adt/pcc5_adt_declaration_only.sm
@@ -1,0 +1,9 @@
+enum Signal {
+    Red,
+    Green,
+    Blue,
+}
+
+fn main() {
+    return;
+}

--- a/tests/fixtures/pcc5_adt/pcc5_adt_unit_constructor.sm
+++ b/tests/fixtures/pcc5_adt/pcc5_adt_unit_constructor.sm
@@ -1,0 +1,11 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn main() {
+    let dir: Direction = Direction::Right;
+    return;
+}

--- a/tests/fixtures/pcc5_match/positive_match_constructor_from_function.sm
+++ b/tests/fixtures/pcc5_match/positive_match_constructor_from_function.sm
@@ -1,0 +1,23 @@
+enum Mode {
+    Idle,
+    Run,
+    Stop,
+}
+
+fn choose_mode() -> Mode {
+    return Mode::Stop;
+}
+
+fn mode_code(mode: Mode) -> text {
+    let code: text = match mode {
+        Mode::Idle => { "0" }
+        Mode::Run => { "1" }
+        Mode::Stop => { "2" }
+    };
+    return code;
+}
+
+fn main() {
+    assert(mode_code(choose_mode()) == "2");
+    return;
+}

--- a/tests/fixtures/pcc5_match/positive_match_function_boundary.sm
+++ b/tests/fixtures/pcc5_match/positive_match_function_boundary.sm
@@ -1,0 +1,19 @@
+enum Mode {
+    Idle,
+    Run,
+    Stop,
+}
+
+fn mode_code(mode: Mode) -> text {
+    let code: text = match mode {
+        Mode::Idle => { "0" }
+        Mode::Run => { "1" }
+        Mode::Stop => { "2" }
+    };
+    return code;
+}
+
+fn main() {
+    assert(mode_code(Mode::Run) == "1");
+    return;
+}

--- a/tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm
+++ b/tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm
@@ -1,0 +1,21 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn label(dir: Direction) -> text {
+    let out: text = match dir {
+        Direction::Up => { "Up" }
+        Direction::Right => { "Right" }
+        Direction::Down => { "Down" }
+        Direction::Left => { "Left" }
+    };
+    return out;
+}
+
+fn main() {
+    assert(label(Direction::Right) == "Right");
+    return;
+}

--- a/tests/pcc5_match_acceptance.rs
+++ b/tests/pcc5_match_acceptance.rs
@@ -13,17 +13,15 @@ fn cli_ok(args: Vec<String>, context: &str) {
 }
 
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target").join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }
@@ -39,7 +37,7 @@ fn check_run_compile_verify(rel: &str) {
         &format!("smc run for {input}"),
     );
 
-    let dir = mk_temp_dir("smc_pcc5_adt_acceptance");
+    let dir = mk_temp_dir("smc_pcc5_match_acceptance");
     let out = dir.join("out.smc");
     let out_arg = out.to_string_lossy().replace('\\', "/");
     cli_ok(
@@ -60,16 +58,16 @@ fn check_run_compile_verify(rel: &str) {
 }
 
 #[test]
-fn pcc5_adt_declaration_only_fixture_passes_full_cli_path() {
-    check_run_compile_verify("tests/fixtures/pcc5_adt/pcc5_adt_declaration_only.sm");
+fn pcc5_match_unit_enum_label_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm");
 }
 
 #[test]
-fn pcc5_adt_unit_constructor_fixture_passes_full_cli_path() {
-    check_run_compile_verify("tests/fixtures/pcc5_adt/pcc5_adt_unit_constructor.sm");
+fn pcc5_match_function_boundary_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_match/positive_match_function_boundary.sm");
 }
 
 #[test]
-fn pcc5_adt_constructor_function_boundary_fixture_passes_full_cli_path() {
-    check_run_compile_verify("tests/fixtures/pcc5_adt/pcc5_adt_constructor_function_boundary.sm");
+fn pcc5_match_constructor_from_function_fixture_passes_full_cli_path() {
+    check_run_compile_verify("tests/fixtures/pcc5_match/positive_match_constructor_from_function.sm");
 }


### PR DESCRIPTION
## Summary

Locks canonical basic ADT match acceptance fixtures for PCC-5.

This PR is test + docs only. It does not change parser, typecheck, lowering, SemCode, verifier, VM, CLI, or runtime behavior.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds dedicated PCC-5 basic match acceptance fixtures
- validates basic ADT match through the full CLI path
- keeps positive ADT declaration / constructor regression coverage in place
- updates the PCC-5 live audit with evidence

## Result

- basic ADT match behavior is locked by dedicated fixtures
- PCC-5C remains positive-match packaging, not new match semantics
- negative diagnostics remain PCC-5D
- #477 remains open

## Out of scope

- negative diagnostics fixtures
- parser changes
- typecheck changes
- lowering changes
- SemCode changes
- verifier changes
- VM/runtime changes
- exhaustiveness redesign
- advanced pattern matching
- Option / Result
- records
- collections
- README/examples promotion

## Validation

- `cargo test -q --test pcc5_match_acceptance`
- `cargo test -q --test pcc5_adt_acceptance`
- `cargo test -q --test snake_benchmark_gap_matrix snake_benchmark_positive_surface_passes_end_to_end`
- `git diff --check`
- `git status`
