### PR TITLE
PCC-5D — test(adt): lock negative ADT/match diagnostics fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc5_adt_match_live_audit.md
@@ -25,6 +25,7 @@ Current `main` already contains the ADT and basic match seam across the full pra
 - Existing tests already exercise the surface end-to-end through the snake benchmark path.
 - PCC-5B adds a dedicated positive ADT acceptance fixture suite for declaration and constructor use.
 - PCC-5C adds a dedicated positive basic ADT match acceptance fixture suite.
+- PCC-5D adds a dedicated negative ADT and basic match diagnostics fixture suite.
 
 Audit verdict:
 
@@ -53,7 +54,7 @@ Reason: docs-only audit; no runtime value, trap, determinism, verifier, SymbolId
 | verifier | validates ADT/match bytecode | confirmed-working | yes | keep bytecode checks stable |
 | VM | executes ADT/match runtime values | confirmed-working | yes | keep runtime carrier behavior stable |
 | diagnostics | clear ADT/match errors | confirmed-working | yes | keep diagnostic needles stable |
-| tests | positive/negative coverage | confirmed-partial | partial | PCC-5B positive ADT fixtures exist; PCC-5C positive match fixtures exist; PCC-5D still needed for negative lock |
+| tests | positive/negative coverage | confirmed-working | yes | PCC-5B positive ADT fixtures exist; PCC-5C positive match fixtures exist; PCC-5D negative lock exists |
 
 ## 4. Risk List
 
@@ -122,6 +123,32 @@ PCC-5C does not add new match semantics.
 Negative diagnostics remain PCC-5D.
 PCC-5 closeout remains PCC-5E.
 
+## PCC-5D Evidence
+
+PCC-5D adds dedicated negative ADT and basic match diagnostics fixtures.
+
+Covered negative cases:
+
+- unknown ADT / enum type;
+- unknown constructor / variant;
+- constructor assigned to wrong ADT type;
+- constructor payload type mismatch;
+- constructor payload arity mismatch;
+- match arm with unknown variant;
+- match arm result type mismatch;
+- non-exhaustive match missing a declared variant.
+
+Validation:
+
+- `cargo test --test pcc5_adt_diagnostics`
+- `cargo test --test pcc5_adt_acceptance`
+- `cargo test --test pcc5_match_acceptance`
+- `git diff --check`
+
+PCC-5D does not add new ADT or match semantics.
+PCC-5D does not redesign exhaustiveness.
+PCC-5 closeout remains PCC-5E.
+
 ## 6. Out of Scope
 
 - records
@@ -150,6 +177,8 @@ PCC-5 closeout remains PCC-5E.
 - [x] VM runtime inspected
 - [x] diagnostics inspected
 - [x] tests inspected
+- [x] PCC-5D negative fixture suite added
+- [x] invalid ADT/match diagnostics locked
 - [x] risks documented
 - [x] PCC-5 split proposed
 - [x] no code changed

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_payload_arity_mismatch.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_payload_arity_mismatch.sm
@@ -1,0 +1,9 @@
+enum Probe {
+    Value(i32),
+    Pair(i32, bool),
+}
+
+fn main() {
+    let probe: Probe = Probe::Pair(1);
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_payload_type_mismatch.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_payload_type_mismatch.sm
@@ -1,0 +1,9 @@
+enum Probe {
+    Value(i32),
+    Pair(i32, bool),
+}
+
+fn main() {
+    let probe: Probe = Probe::Value(true);
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_wrong_adt_type.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_constructor_wrong_adt_type.sm
@@ -1,0 +1,14 @@
+enum Direction {
+    Up,
+    Right,
+}
+
+enum Signal {
+    Red,
+    Green,
+}
+
+fn main() {
+    let signal: Signal = Direction::Right;
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_match_missing_variant.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_match_missing_variant.sm
@@ -1,0 +1,14 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+}
+
+fn main() {
+    let dir: Direction = Direction::Right;
+    let code: i32 = match dir {
+        Direction::Up => { 1 }
+        Direction::Right => { 2 }
+    };
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_match_result_type_mismatch.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_match_result_type_mismatch.sm
@@ -1,0 +1,13 @@
+enum Direction {
+    Up,
+    Right,
+}
+
+fn main() {
+    let dir: Direction = Direction::Right;
+    let code: i32 = match dir {
+        Direction::Up => { 1 }
+        Direction::Right => { true }
+    };
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_match_unknown_variant.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_match_unknown_variant.sm
@@ -1,0 +1,13 @@
+enum Direction {
+    Up,
+    Right,
+}
+
+fn main() {
+    let dir: Direction = Direction::Right;
+    let code: i32 = match dir {
+        Direction::Up => { 1 }
+        Direction::Left => { 2 }
+    };
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_unknown_adt_type.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_unknown_adt_type.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let dir: MissingDirection = MissingDirection::Right;
+    return;
+}

--- a/tests/fixtures/pcc5_adt_diagnostics/negative_unknown_constructor.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_unknown_constructor.sm
@@ -1,0 +1,9 @@
+enum Direction {
+    Up,
+    Right,
+}
+
+fn main() {
+    let dir: Direction = Direction::Left;
+    return;
+}

--- a/tests/pcc5_adt_diagnostics.rs
+++ b/tests/pcc5_adt_diagnostics.rs
@@ -1,0 +1,156 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_path(rel: &str) -> String {
+    repo_path(&format!("tests/fixtures/pcc5_adt_diagnostics/{rel}"))
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join(format!(
+            "{}_{}_{}",
+            prefix,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn assert_adt_check_error(rel: &str, code: &str, needle: &str) {
+    let input = fixture_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains(&format!("Error [{code}]")),
+        "expected diagnostic code {code} for {rel}, got: {err}"
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+    );
+}
+
+fn assert_invalid_adt_source_does_not_verify(rel: &str, code: &str, needle: &str) {
+    assert_adt_check_error(rel, code, needle);
+
+    let input = fixture_path(rel);
+    let dir = mk_temp_dir("pcc5_adt_diagnostics_invalid");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let compile_res = smc_cli::run(vec![
+        "compile".to_string(),
+        input.clone(),
+        "-o".to_string(),
+        out_arg.clone(),
+    ]);
+
+    match compile_res {
+        Ok(()) => {
+            let bytes = std::fs::read(&out).unwrap_or_else(|err| {
+                panic!("compile succeeded but emitted artifact for {input} was not readable: {err}")
+            });
+            assert!(
+                !bytes.is_empty(),
+                "compile succeeded but emitted artifact for {input} was empty"
+            );
+            let verify_err = cli_err(
+                vec!["verify".to_string(), out_arg.clone()],
+                &format!("smc verify for {out_arg}"),
+            );
+            assert!(
+                verify_err.contains("Error ["),
+                "expected verify to reject invalid ADT artifact for {rel}, got: {verify_err}"
+            );
+        }
+        Err(err) => {
+            assert!(
+                err.contains(&format!("Error [{code}]")) || err.contains(needle),
+                "expected compile failure to mention {code} or '{needle}' for {rel}, got: {err}"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc5_adt_unknown_type_and_constructor_diagnostics_are_stable() {
+    for (rel, code, needle) in [
+        (
+            "negative_unknown_adt_type.sm",
+            "E0201",
+            "unknown record type 'MissingDirection'",
+        ),
+        (
+            "negative_unknown_constructor.sm",
+            "E0201",
+            "enum 'Direction' has no variant named 'Left'",
+        ),
+        (
+            "negative_constructor_wrong_adt_type.sm",
+            "E0201",
+            "type mismatch in let 'signal'",
+        ),
+    ] {
+        assert_invalid_adt_source_does_not_verify(rel, code, needle);
+    }
+}
+
+#[test]
+fn pcc5_adt_payload_constructor_diagnostics_are_stable() {
+    for (rel, code, needle) in [
+        (
+            "negative_constructor_payload_type_mismatch.sm",
+            "E0201",
+            "type mismatch in enum constructor 'Probe::Value' payload item 0: I32 vs Bool",
+        ),
+        (
+            "negative_constructor_payload_arity_mismatch.sm",
+            "E0201",
+            "enum constructor 'Probe::Pair' expects 2 payload items, got 1",
+        ),
+    ] {
+        assert_invalid_adt_source_does_not_verify(rel, code, needle);
+    }
+}
+
+#[test]
+fn pcc5_match_unknown_variant_and_result_diagnostics_are_stable() {
+    for (rel, code, needle) in [
+        (
+            "negative_match_unknown_variant.sm",
+            "E0201",
+            "enum 'Direction' has no variant named 'Left' in match pattern",
+        ),
+        (
+            "negative_match_result_type_mismatch.sm",
+            "E0201",
+            "match expression branch type mismatch: expected I32, got Bool",
+        ),
+        (
+            "negative_match_missing_variant.sm",
+            "E0201",
+            "non-exhaustive match expression for enum 'Direction'; missing variants: Down",
+        ),
+    ] {
+        assert_invalid_adt_source_does_not_verify(rel, code, needle);
+    }
+}


### PR DESCRIPTION
## Summary

Adds dedicated negative ADT and basic match diagnostics fixtures for PCC-5.

This PR does not implement ADT or match semantics, parser changes, typecheck changes, lowering changes, SemCode changes, verifier changes, VM changes, or runtime changes.

## Issue

Refs #477.
Does not close #477.

## Scope

- adds `tests/pcc5_adt_diagnostics.rs`
- adds `tests/fixtures/pcc5_adt_diagnostics/*.sm`
- locks stable diagnostics for invalid ADT and basic match programs
- keeps negative fixture coverage separate from PCC-5B and PCC-5C positive suites
- updates the PCC-5 live audit with PCC-5D evidence

## Result

- invalid ADT / match sources are rejected with stable diagnostics
- invalid ADT / match sources do not reach a verified execution path
- PCC-5D negative diagnostics are now evidence-backed
- PCC-5 remains open for closeout documentation only

## Out of scope

- ADT architecture redesign
- new match semantics
- exhaustiveness redesign
- parser changes
- typecheck changes
- lowering changes
- SemCode changes
- verifier changes
- VM changes
- runtime changes
- records
- collections
- Option / Result work
- host ABI widening
- UI / Workbench / Studio
- README promotion
- closing #477

## Validation

- `cargo test -q --test pcc5_adt_diagnostics`
- `cargo test -q --test pcc5_adt_acceptance`
- `cargo test -q --test pcc5_match_acceptance`
- `cargo test -q --test snake_benchmark_gap_matrix snake_benchmark_positive_surface_passes_end_to_end`
- `cargo test -q --test public_api_contracts`
- `git diff --check`