### PR TITLE
PR-PCC-6D — option-result: lock negative diagnostics fixtures

### DIFF
--- a/docs/roadmap/language_maturity/pcc6_option_result_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc6_option_result_live_audit.md
@@ -35,15 +35,16 @@ standard-form baseline across the practical stack:
   `option_result_standard_forms_scope.md`.
 - Dedicated PCC-6 positive Option fixture packaging now exists.
 - Dedicated PCC-6 positive Result fixture packaging now exists.
-- Dedicated negative PCC-6 fixture packaging is still missing.
+- Dedicated negative PCC-6 fixture packaging now exists.
 
 Audit verdict:
 
 ```text
 The narrow first-wave Option / Result baseline is already present in main.
 PCC-6 does not need a new architecture seam before fixture packaging.
-PCC-6B covers the Option side; PCC-6C now covers the Result side.
-Negative PCC-6 fixture packaging remains to be added.
+PCC-6B covers the Option side; PCC-6C covers the Result side; PCC-6D covers
+the negative diagnostics side.
+PCC-6 closeout remains to be synced.
 ```
 
 CTF touched: none
@@ -62,13 +63,13 @@ SymbolId, capability, or trace change.
 | typecheck | Option payload validation | confirmed-working | yes | keep as fixture-backed evidence |
 | typecheck | Result payload validation | confirmed-working | yes | keep as fixture-backed evidence |
 | typecheck | match arm payload binding | confirmed-working | yes | keep as fixture-backed evidence |
-| exhaustiveness | Option / Result match policy | confirmed-partial | partial | dedicated Result-specific qualification / negative packaging still missing |
+| exhaustiveness | Option / Result match policy | confirmed-working | yes | keep match-policy diagnostics stable |
 | lowering | Option / Result constructor / match lowering | confirmed-working | yes | keep as fixture-backed evidence |
 | SemCode | stable representation | confirmed-working | yes | keep opcode mapping and verifier coverage stable |
 | verifier | validates emitted form | confirmed-working | yes | keep bytecode checks stable |
 | VM | executes Option / Result path | confirmed-working | yes | keep runtime carrier behavior stable |
 | diagnostics | clear Option / Result errors | confirmed-working | yes | keep diagnostic needles stable |
-| tests | positive / negative coverage | confirmed-partial | partial | dedicated negative PCC-6 fixture packaging is still missing |
+| tests | positive / negative coverage | confirmed-working | yes | keep dedicated PCC-6 evidence synced for closeout |
 | docs | standard-form boundary | documented-only | partial | keep scope boundary synced with live evidence |
 
 ## 4. Risk List
@@ -83,8 +84,8 @@ Observed risks are narrow, not architectural:
 - Match ergonomics must remain canonical unless separately scoped.
 - Option / Result should reuse the existing ADT-style carrier path where the
   current design says so.
-- Dedicated negative PCC-6 fixture packaging may still be missing even if the
-  baseline implementation already exists.
+- Dedicated PCC-6 closeout evidence may still be missing even if the baseline
+  implementation already exists.
 
 ## 5. Recommended PCC-6 Split
 
@@ -135,6 +136,7 @@ not widen the PR into general generics or host ABI work.
 - [x] PCC-6 split proposed
 - [x] PCC-6B positive Option fixtures added
 - [x] PCC-6C positive Result fixtures added
+- [x] PCC-6D negative diagnostics fixtures added
 - [x] no code changed
 
 ## 8. PCC-6B Evidence
@@ -179,5 +181,33 @@ Validation:
 
 PCC-6C does not add new Result semantics.
 PCC-6C does not turn Result into exception handling.
-Negative diagnostics remain PCC-6D.
+PCC-6 closeout remains PCC-6E.
+
+## 10. PCC-6D Evidence
+
+PCC-6D adds dedicated negative Option / Result diagnostics fixtures.
+
+Covered negative cases:
+
+- Option constructor payload mismatch;
+- Option constructor assigned to wrong declared type;
+- Option match exhaustiveness boundary;
+- Option match arm result type mismatch;
+- Result::Ok payload mismatch;
+- Result::Err payload mismatch;
+- Result constructor assigned to wrong declared type;
+- Result match exhaustiveness boundary;
+- Result match arm result type mismatch.
+
+Validation:
+
+- `cargo test --test pcc6_option_result_diagnostics`
+- `cargo test --test pcc6_option_acceptance`
+- `cargo test --test pcc6_result_acceptance`
+- `git diff --check`
+
+PCC-6D does not add new Option / Result semantics.
+PCC-6D does not add general generics.
+PCC-6D does not turn Result into exception handling.
+PCC-6D does not redesign exhaustiveness.
 PCC-6 closeout remains PCC-6E.

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_constructor_wrong_declared_type.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_constructor_wrong_declared_type.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: i32 = Option::Some(7);
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_match_arm_result_type_mismatch.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_match_arm_result_type_mismatch.sm
@@ -1,0 +1,8 @@
+fn main() {
+    let opt: Option(i32) = Option::Some(7);
+    let value: i32 = match opt {
+        Option::Some(v) => { v }
+        Option::None => { false }
+    };
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_match_missing_none.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_match_missing_none.sm
@@ -1,0 +1,10 @@
+fn unwrap(opt: Option(i32)) -> i32 {
+    let value: i32 = match opt {
+        Option::Some(v) => { v }
+    };
+    return value;
+}
+
+fn main() {
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_some_payload_type_mismatch.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_some_payload_type_mismatch.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let opt: Option(i32) = Option::Some(true);
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_result_constructor_wrong_declared_type.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_result_constructor_wrong_declared_type.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: i32 = Result::Ok(7);
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_result_err_payload_type_mismatch.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_result_err_payload_type_mismatch.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let res: Result(i32, text) = Result::Err(5);
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_result_match_arm_result_type_mismatch.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_result_match_arm_result_type_mismatch.sm
@@ -1,0 +1,8 @@
+fn main() {
+    let res: Result(i32, text) = Result::Ok(7);
+    let value: i32 = match res {
+        Result::Ok(v) => { v }
+        Result::Err(e) => { false }
+    };
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_result_match_missing_err.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_result_match_missing_err.sm
@@ -1,0 +1,10 @@
+fn unwrap(res: Result(i32, text)) -> i32 {
+    let value: i32 = match res {
+        Result::Ok(v) => { v }
+    };
+    return value;
+}
+
+fn main() {
+    return;
+}

--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_result_ok_payload_type_mismatch.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_result_ok_payload_type_mismatch.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let res: Result(i32, text) = Result::Ok(true);
+    return;
+}

--- a/tests/pcc6_option_result_diagnostics.rs
+++ b/tests/pcc6_option_result_diagnostics.rs
@@ -1,0 +1,171 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn fixture_path(rel: &str) -> String {
+    repo_path(&format!("tests/fixtures/pcc6_option_result_diagnostics/{rel}"))
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn assert_option_result_check_error(rel: &str, code: &str, needle: &str) {
+    let input = fixture_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+    assert!(
+        err.contains(&format!("Error [{code}]")),
+        "expected diagnostic code {code} for {rel}, got: {err}"
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+    );
+}
+
+fn assert_invalid_option_result_source_does_not_verify(rel: &str, code: &str, needle: &str) {
+    assert_option_result_check_error(rel, code, needle);
+
+    let input = fixture_path(rel);
+    let dir = mk_temp_dir("pcc6_option_result_diagnostics_invalid");
+    let out = dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let compile_res = smc_cli::run(vec![
+        "compile".to_string(),
+        input.clone(),
+        "-o".to_string(),
+        out_arg.clone(),
+    ]);
+
+    match compile_res {
+        Ok(()) => {
+            let bytes = std::fs::read(&out).unwrap_or_else(|err| {
+                panic!("compile succeeded but emitted artifact for {input} was not readable: {err}")
+            });
+            assert!(
+                !bytes.is_empty(),
+                "compile succeeded but emitted artifact for {input} was empty"
+            );
+            let verify_err = cli_err(
+                vec!["verify".to_string(), out_arg.clone()],
+                &format!("smc verify for {out_arg}"),
+            );
+            assert!(
+                verify_err.contains("Error ["),
+                "expected verify to reject invalid option/result artifact for {rel}, got: {verify_err}"
+            );
+        }
+        Err(err) => {
+            assert!(
+                err.contains(&format!("Error [{code}]")) || err.contains(needle),
+                "expected compile failure to mention {code} or '{needle}' for {rel}, got: {err}"
+            );
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc6_option_some_payload_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_some_payload_type_mismatch.sm",
+        "E0201",
+        "type mismatch in Option::Some payload",
+    );
+}
+
+#[test]
+fn pcc6_option_constructor_wrong_declared_type_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_constructor_wrong_declared_type.sm",
+        "E0201",
+        "type mismatch in let",
+    );
+}
+
+#[test]
+fn pcc6_option_match_missing_none_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_match_missing_none.sm",
+        "E0201",
+        "non-exhaustive match expression for Option(T); missing variants: None",
+    );
+}
+
+#[test]
+fn pcc6_option_match_arm_result_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_match_arm_result_type_mismatch.sm",
+        "E0201",
+        "match expression branch type mismatch",
+    );
+}
+
+#[test]
+fn pcc6_result_ok_payload_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_result_ok_payload_type_mismatch.sm",
+        "E0201",
+        "type mismatch in Result::Ok payload",
+    );
+}
+
+#[test]
+fn pcc6_result_err_payload_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_result_err_payload_type_mismatch.sm",
+        "E0201",
+        "type mismatch in Result::Err payload",
+    );
+}
+
+#[test]
+fn pcc6_result_constructor_wrong_declared_type_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_result_constructor_wrong_declared_type.sm",
+        "E0201",
+        "Result::Ok currently requires contextual Result(T, E) type in v0",
+    );
+}
+
+#[test]
+fn pcc6_result_match_missing_err_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_result_match_missing_err.sm",
+        "E0201",
+        "non-exhaustive match expression for Result(T, E); missing variants: Err",
+    );
+}
+
+#[test]
+fn pcc6_result_match_arm_result_type_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_result_match_arm_result_type_mismatch.sm",
+        "E0201",
+        "match expression branch type mismatch",
+    );
+}


### PR DESCRIPTION
## Summary\n\nAdds a dedicated PCC-6 negative diagnostics suite for Option / Result standard forms and syncs the PCC-6 live audit evidence.\n\n## Scope\n\n- adds negative Option / Result fixtures under tests/fixtures/pcc6_option_result_diagnostics/\n- adds tests/pcc6_option_result_diagnostics.rs\n- updates docs/roadmap/language_maturity/pcc6_option_result_live_audit.md with PCC-6D evidence\n\n## Result\n\n- invalid Option / Result programs are rejected with stable diagnostics\n- invalid Option / Result programs do not reach a verified execution path\n- positive Option and Result suites remain intact\n- no parser, typecheck, lowering, SemCode, verifier, VM, or runtime code changed\n\n## Validation\n\n- cargo test -q --test pcc6_option_result_diagnostics\n- cargo test -q --test pcc6_option_acceptance\n- cargo test -q --test pcc6_result_acceptance\n- cargo test -q --test snake_benchmark_gap_matrix snake_benchmark_positive_surface_passes_end_to_end\n- git diff --check\n\n## Notes\n\nPCC-6D is test/docs only. It does not add new Option / Result semantics, general generics, hidden prelude injection, exception semantics, or host ABI widening.