### PR TITLE
PR-PCC-6E — docs(option-result): close PCC-6 with evidence sync and roadmap status update

### DIFF
--- a/docs/roadmap/language_maturity/pcc6_option_result_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc6_option_result_live_audit.md
@@ -1,6 +1,6 @@
 # PCC-6 Option / Result Live Audit
 
-Status: live audit
+Status: PCC-6 closed / evidence synced
 Owner: language maturity stream
 Scope: Option / Result readiness before PCC-6 implementation or fixture work
 Non-goal: code changes
@@ -44,7 +44,7 @@ The narrow first-wave Option / Result baseline is already present in main.
 PCC-6 does not need a new architecture seam before fixture packaging.
 PCC-6B covers the Option side; PCC-6C covers the Result side; PCC-6D covers
 the negative diagnostics side.
-PCC-6 closeout remains to be synced.
+PCC-6E now closes the track for the current Practical Core scope.
 ```
 
 CTF touched: none
@@ -137,6 +137,12 @@ not widen the PR into general generics or host ABI work.
 - [x] PCC-6B positive Option fixtures added
 - [x] PCC-6C positive Result fixtures added
 - [x] PCC-6D negative diagnostics fixtures added
+- [x] PCC-6E closeout evidence synced
+- [x] PCC-6 roadmap status updated
+- [x] feature matrix Option / Result rows confirmed
+- [x] no Option / Result architecture redesign
+- [x] no general generics introduced
+- [x] no host ABI widening introduced
 - [x] no code changed
 
 ## 8. PCC-6B Evidence
@@ -211,3 +217,34 @@ PCC-6D does not add general generics.
 PCC-6D does not turn Result into exception handling.
 PCC-6D does not redesign exhaustiveness.
 PCC-6 closeout remains PCC-6E.
+
+## 11. PCC-6E Closeout
+
+PCC-6E closes the current Option / Result practical-core track.
+
+Evidence chain:
+
+- PCC-6A — docs audit / scope correction
+- PCC-6B — positive Option standard-form fixtures
+- PCC-6C — positive Result standard-form fixtures
+- PCC-6D — negative Option / Result diagnostics fixtures
+- PCC-6E — closeout / roadmap sync
+
+Final verdict:
+
+```text
+PCC-6 Option / Result is closed for the current Practical Core scope.
+```
+
+Evidence-backed surface:
+
+- `Option(T)` is evidence-backed.
+- `Result(T, E)` is evidence-backed.
+- `Option::Some(value)` / `Option::None` are evidence-backed.
+- `Result::Ok(value)` / `Result::Err(error)` are evidence-backed.
+- explicit match payload binding is evidence-backed.
+- invalid Option / Result programs reject with stable diagnostics.
+- invalid Option / Result programs do not reach a verified execution path.
+- no new architecture seam was required.
+- no general generics, hidden prelude injection, exception semantics, or host
+  ABI widening were introduced.

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -469,6 +469,18 @@ DoD:
 [ ] diagnostics for invalid payload usage are stable
 ```
 
+PCC-6 closeout note:
+
+- PCC-6 is closed for the current Practical Core scope.
+- Evidence lives in `pcc6_option_result_live_audit.md`.
+- Dedicated test suites now cover positive Option standard-form fixtures,
+  positive Result standard-form fixtures, and negative Option / Result
+  diagnostics.
+- Further aggregate work remains assigned to later PCC phases:
+  - `PCC-7` Collections v0
+  - `PCC-8` Stdlib v0
+  - `PCC-9` Project Model v0
+
 ## 15. PCC-7 — Collections v0
 
 Scope:


### PR DESCRIPTION
## Summary\n\nCloses PCC-6 Option / Result for the current Practical Core scope by syncing the final evidence trail and roadmap status.\n\nThis PR is docs-only and does not change code, tests, fixtures, parser, typecheck, lowering, SemCode, verifier, VM, or runtime behavior.\n\n## Scope\n\n- updates PCC-6 live audit status to closed / evidence synced\n- adds PCC-6E closeout evidence and verdict\n- adds a PCC-6 closeout note to Practical Core completion\n- keeps feature matrix and implementation files unchanged\n\n## Result\n\n- PCC-6 A/B/C/D/E evidence chain is explicit\n- PCC-6 is closed for the current Practical Core scope\n- Option / Result standard-form coverage remains evidence-backed\n- no new architecture seam is introduced\n\n## Validation\n\n- git diff --check\n- git diff --name-only origin/main...HEAD\n- git status