### PR TITLE
PR-PCC-8B — docs(stdlib): freeze public helper contract and debug_render boundary

### DIFF
--- a/docs/roadmap/language_maturity/pcc8_stdlib_live_audit.md
+++ b/docs/roadmap/language_maturity/pcc8_stdlib_live_audit.md
@@ -14,8 +14,9 @@ It is docs-only. It does not add helper behavior.
 
 ## 2. Current Known Status
 
-Current `main` already shows a narrow helper-adjacent surface, but it is not
-yet frozen as a public stdlib contract:
+Current `main` already shows a narrow helper-adjacent surface, and PCC-8B now
+freezes the public helper boundary in a separate contract doc, but the
+implementation / fixture side is still not ready:
 
 - `assert` is already used as a runtime-visible failure surface and appears in
   canonical fixtures, but no dedicated PCC-8 helper contract is frozen yet.
@@ -28,8 +29,8 @@ yet frozen as a public stdlib contract:
   `to_text` substitute.
 - The stdlib roadmap docs already describe the intended first-wave families
   (`assert`, math helpers, text helpers, `to_text`, sequence helpers, map
-  helpers, Option / Result helpers), but the public helper list is still a
-  roadmap contract rather than a frozen public API contract.
+  helpers, Option / Result helpers), and PCC-8B now freezes the public helper
+  contract boundary without claiming implementation completion.
 - Sequence / map / Option / Result helper behavior is already backed by
   earlier PCC fixture suites, but PCC-8 still lacks dedicated packaging for the
   stdlib boundary itself.
@@ -40,8 +41,8 @@ yet frozen as a public stdlib contract:
 
 | Layer            | Required for PCC-8                               | Current state | Ready? | Next action |
 | ---------------- | ------------------------------------------------ | ------------- | ------ | ----------- |
-| surface          | public helper list                               | documented-only | no | freeze the public helper list and keep it separate from internal tooling |
-| surface          | helper naming / canonical call form              | documented-only | no | keep `debug_render` internal and preserve canonical helper spellings |
+| surface          | public helper list                               | confirmed-partial | no | keep the public contract frozen but avoid claiming implementation completion |
+| surface          | helper naming / canonical call form              | confirmed-partial | no | keep `debug_render` internal and preserve canonical helper spellings |
 | assert           | assert behavior                                  | confirmed-partial | no | freeze helper contract and failure wording |
 | print            | text-only print behavior                         | confirmed-partial | no | document text-only boundary and non-text rejection wording |
 | to_text          | admitted basic types                             | confirmed-partial | no | freeze admitted types and canonical call sites |
@@ -60,11 +61,35 @@ yet frozen as a public stdlib contract:
 | verifier         | verifies helper form                             | confirmed-partial | no | keep verifier-first admission intact for helper-like execution paths |
 | VM/runtime       | executes helper form                             | confirmed-partial | no | preserve deterministic runtime behavior for helper paths |
 | determinism      | deterministic helper behavior                    | confirmed-partial | no | keep helper output / trap behavior stable across runs |
-| docs             | public stdlib contract                           | documented-only | no | freeze the public helper contract before implementation packaging |
+| docs             | public stdlib contract                           | confirmed-partial | no | keep the public contract frozen and separate from implementation completion |
 | examples         | canonical examples avoid internal debug helpers  | documented-only | no | keep canonical examples free of `debug_render` and other internal helpers |
 | tests            | positive / negative coverage                     | confirmed-partial | no | add dedicated PCC-8 packaging after the contract boundary is frozen |
 
-## 4. Risk List
+## 4. PCC-8B Evidence
+
+PCC-8B freezes the public helper contract and debug_render boundary.
+
+Covered:
+
+- public helper family classification;
+- debug_render internal-only boundary;
+- to_text admitted-types boundary;
+- unsupported to_text rejection boundary;
+- print text-only boundary;
+- helper failure behavior policy;
+- capability / host boundary;
+- canonical examples rule.
+
+Validation:
+
+- `git diff --check`
+
+PCC-8B does not add tests or implementation.
+PCC-8C remains positive fixture packaging.
+PCC-8D remains diagnostics / trap fixture packaging.
+PCC-8E remains closeout.
+
+## 5. Risk List
 
 Include at least:
 
@@ -79,7 +104,7 @@ Include at least:
 - public helper list must be explicit.
 - canonical examples must not rely on internal debug formatting.
 
-## 5. Recommended PCC-8 Split
+## 6. Recommended PCC-8 Split
 
 Default split:
 
@@ -100,7 +125,7 @@ between B/C/D, for example:
 - PCC-8I4 helper diagnostics seam;
 - PCC-8I5 public helper contract docs seam.
 
-## 6. Out of Scope
+## 7. Out of Scope
 
 Explicitly list:
 
@@ -115,7 +140,7 @@ Explicitly list:
 - UI / Workbench;
 - README promotion.
 
-## 7. Acceptance Checklist
+## 8. Acceptance Checklist
 
 ```markdown
 - [ ] helper surface inspected
@@ -142,7 +167,7 @@ Explicitly list:
 - [ ] no code changed
 ```
 
-## 8. CTF Note
+## 9. CTF Note
 
 Because this is docs-only:
 

--- a/docs/roadmap/language_maturity/pcc8_stdlib_public_contract.md
+++ b/docs/roadmap/language_maturity/pcc8_stdlib_public_contract.md
@@ -1,0 +1,103 @@
+# PCC-8 Stdlib v0 Public Helper Contract
+
+Status: contract freeze
+Owner: language maturity stream
+Scope: public helper boundary before PCC-8 fixture packaging
+Non-goal: implementation changes
+
+## 1. Purpose
+
+This document freezes the first-wave public helper boundary before PCC-8C and
+PCC-8D tests.
+
+It does not add helper behavior. It only states which helpers are public,
+which are internal, and which remain deferred.
+
+## 2. Public Helper Families For Stdlib v0
+
+The first-wave public families are contract categories, not implementation
+promises:
+
+- assert family
+- print family
+- to_text family for admitted basic types
+- text helpers already admitted by prior PCC phases
+- sequence helpers already admitted by PCC-7 fixture-backed surface
+- map helpers already admitted by PCC-7 fixture-backed surface
+- Option / Result helper surface only where already admitted by PCC-6
+- math helpers remain proposed and not yet fixture-backed unless evidence
+  exists
+
+## 3. Public / Internal / Deferred Classification
+
+| Helper / family               | Public in Stdlib v0?                | Status                                       | Boundary |
+| ----------------------------- | ----------------------------------- | -------------------------------------------- | -------- |
+| assert                        | yes                                 | partial / evidence-backed                    | deterministic runtime failure surface |
+| print(text)                   | yes                                 | partial / evidence-backed                    | text-only, no arbitrary debug rendering |
+| print(non-text)               | no                                  | rejected                                     | must remain diagnostic-stable |
+| to_text(admitted basic types) | yes                                 | partial / evidence-backed                    | explicit admitted set only |
+| to_text(record)               | no                                  | rejected                                     | no universal reflection |
+| to_text(ADT)                  | no unless already admitted          | deferred                                     | no implicit debug formatting |
+| to_text(collection)           | no unless already admitted          | deferred                                     | no generic structural rendering |
+| debug_render                   | no                                  | internal-only                                | not language semantics, not public stdlib |
+| text concat / equality / len   | yes if already admitted              | fixture-backed by PCC-3 / benchmark evidence | keep bounded |
+| sequence helpers               | yes if already admitted              | fixture-backed by PCC-7                      | no memory / quota expansion |
+| map helpers                    | yes if already admitted              | fixture-backed by PCC-7                      | no missing-key policy expansion |
+| Option / Result helpers        | only admitted standard-form surface  | fixture-backed by PCC-6                      | no exception semantics |
+| math helpers                   | proposed                             | not closed                                   | require later fixture evidence |
+
+## 4. debug_render Boundary
+
+`debug_render` is internal tooling.
+
+It is not part of Semantic language semantics.
+It is not a public stdlib helper.
+It must not appear in canonical examples as a substitute for `to_text`.
+It must not be used to justify public formatting or reflection behavior.
+It may be used only by internal diagnostics and tooling where already
+admitted.
+
+## 5. to_text Boundary
+
+`to_text` is not universal reflection.
+
+It only applies to explicitly admitted types.
+Unsupported types must reject with stable diagnostics.
+Record, ADT, and collection `to_text` behavior must not be inferred from debug
+rendering.
+Any expansion requires explicit PCC-8 or post-PCC work.
+
+## 6. Failure Behavior
+
+Freeze policy shape:
+
+- helper misuse must be diagnostic-stable or trap-stable;
+- assert false must remain deterministic;
+- print non-text must reject if current contract says text-only;
+- unsupported to_text must reject;
+- helper failures must not depend on host state.
+
+## 7. Capability / Host Boundary
+
+Stdlib helpers must not bypass capability gates.
+
+print / output behavior must remain within the admitted runtime boundary.
+
+No host ABI widening is introduced by this contract.
+No IO expansion is introduced by this contract.
+
+## 8. Canonical Examples Rule
+
+Canonical examples may use public helpers only.
+
+Canonical examples must not rely on debug_render.
+README or public docs must not present internal tooling helpers as language
+helpers.
+
+## 9. Follow-up Split
+
+```text
+PCC-8C — test(stdlib): lock positive basic helper fixtures
+PCC-8D — test(stdlib): lock helper diagnostics and runtime traps
+PCC-8E — docs(stdlib): close PCC-8 with evidence sync and roadmap status update
+```

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -561,10 +561,12 @@ DoD:
 Live audit:
 
 - `docs/roadmap/language_maturity/pcc8_stdlib_live_audit.md`
+- `docs/roadmap/language_maturity/pcc8_stdlib_public_contract.md`
 
-PCC-8 remains a live audit. The public helper contract is not frozen yet, and
-`debug_render` remains internal tooling rather than a replacement for
-`to_text`.
+PCC-8 remains a live audit. The public helper contract is frozen in
+`pcc8_stdlib_public_contract.md`, but implementation / fixture packaging is
+still open. `debug_render` remains internal tooling rather than a replacement
+for `to_text`.
 
 ## 17. PCC-9 — Project Model v0
 


### PR DESCRIPTION
Docs-only PCC-8B contract freeze for Stdlib v0.\n\nScope: pcc8_stdlib_public_contract.md, pcc8_stdlib_live_audit.md, practical_core_completion_v0_3.md.\n\nThis freezes the public helper boundary and keeps debug_render internal. PCC-8 remains open for later fixture packaging.