### PR TITLE
PR-CTF-WP2 — docs(core-trust-freeze): update runtime value and trap registry after PCC

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
@@ -180,6 +180,15 @@ It identifies which CTF files are aligned and which require follow-up.
 - [ ] no tests or fixtures changed
 ```
 
+## CTF-WP2 Follow-up
+
+CTF-WP2 updates:
+
+- runtime value registry after PCC-4..PCC-9;
+- trap taxonomy notes after PCC diagnostics / trap fixture closeout.
+
+CTF-WP2 does not close CTF and does not claim release readiness.
+
 CTF touched: docs only
 
 Reason: docs-only trust-surface sync; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace change

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -15,6 +15,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 ## Waypoints
 
 - Current sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
+- Runtime / trap follow-up: `CTF-WP2 — RuntimeValue and trap registry sync after PCC`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files

--- a/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
@@ -22,13 +22,14 @@ Use the following table during PCC live audit.
 | `u32` | audit-needed | PCC-2 | Confirm arithmetic and conversion policy. |
 | `f64` | audit-needed | PCC-2 | Confirm deterministic profile and capability assumptions. |
 | `fx` | audit-needed | PCC-2 | Confirm fixed-point carrier and arithmetic scope. |
-| `text` | planned | PCC-3 | Literal / equality / concat / length only at PCC-3. |
-| `record` | planned | PCC-4 | Requires PCC-3.5 carrier note. |
-| `ADT` | planned | PCC-5 | Basic constructor + match path. |
-| `Option(T)` | planned | PCC-6 | Built on ADT / match assumptions. |
-| `Result(T,E)` | planned | PCC-6 | Built on ADT / match assumptions. |
-| `Sequence<T>` | planned | PCC-7 | Dynamic container; not record semantics. |
-| `Map<K,V>` | planned | PCC-7 | Dynamic container; key policy required. |
+| `text` | freeze-candidate | PCC-3 / PCC-8 | Literal / equality / concat / length and admitted helper/text surface only. |
+| `record` | freeze-candidate | PCC-4 | Current record seams / fixture-backed surface only. |
+| `ADT` | freeze-candidate | PCC-5 | Current constructor + basic match surface only. |
+| `Option(T)` | freeze-candidate | PCC-6 | Current standard-form Option only. |
+| `Result(T,E)` | freeze-candidate | PCC-6 | Current standard-form Result only. |
+| `Sequence<T>` | freeze-candidate | PCC-7 | Current admitted Sequence fixture-backed surface only. |
+| `Map<K,V>` | freeze-candidate | PCC-7 | Current admitted Map baseline only; missing-key / iteration / quota policy remains open. |
+| project manifest metadata | audit-needed | PCC-9 | Current Semantic.package manifest baseline only; not a runtime value unless later represented in VM/runtime. |
 | closure values | out-of-pcc unless audited | post-PCC / current-main audit | Do not widen in PCC unless explicitly pulled in. |
 | host handles | out-of-pcc | separate runtime boundary scope | Do not mix into practical core. |
 
@@ -64,3 +65,23 @@ debug_render is internal tooling only
 ```
 
 Any public conversion belongs to PCC-8 Stdlib v0.
+
+## CTF-WP2 PCC-4..PCC-9 Runtime Value Sync
+
+PCC-4..PCC-9 closeouts did not add new runtime behavior in this PR.
+
+WP2 records trust status based on existing PCC fixture evidence.
+
+`freeze-candidate` means protected from silent change, not full public release freeze.
+
+Broad ergonomics and future widening remain out of scope.
+
+Boundary notes:
+
+- record: current fields / literals / access fixture surface only;
+- ADT: current constructors / basic match only;
+- Option / Result: standard forms only, no exception semantics;
+- Sequence: current positive / negative fixture-backed operations only;
+- Map: current baseline only; missing-key behavior, iteration policy, and memory/quota remain open;
+- text / to_text: no universal reflection; debug_render remains internal-only;
+- Project Model: Semantic.package baseline is project-adjacent evidence, not a runtime value family unless runtime representation is later introduced.

--- a/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
@@ -53,6 +53,38 @@ None remain in the PCC-0F freeze set after this pass.
 If a future PCC PR introduces a new runtime-failure class, it starts here and
 must not be claimed as frozen until evidence exists.
 
+## CTF-WP2 PCC-4..PCC-9 Trap / Diagnostics Sync
+
+PCC-4, PCC-5, and PCC-6 diagnostics are compile/check-time diagnostics, not necessarily VM trap classes.
+
+PCC-7D introduced and locked collection runtime traps where applicable:
+
+- Sequence out-of-bounds indexing;
+- empty Sequence pop;
+- other currently evidenced runtime trap surfaces from PCC-7D.
+
+PCC-8D locked:
+
+- `assert(false)` deterministic runtime trap;
+- helper misuse diagnostics;
+- unsupported `to_text` diagnostics.
+
+PCC-9D locked manifest/project-adjacent diagnostics, not VM trap classes.
+
+No new trap class is introduced by CTF-WP2.
+
+Existing frozen classes remain unchanged unless explicit evidence requires a new freeze-candidate entry.
+
+These are PCC fixture-backed failure surfaces, but their final trap taxonomy class names require a separate CTF-E or CTF-WP follow-up before being promoted to frozen trap classes.
+
+PCC follow-up trap candidates:
+
+- Sequence out-of-bounds indexing;
+- empty Sequence pop;
+- collection baseline lookup / missing-key failures where still open;
+- helper misuse diagnostics that are not yet canonically named as VM traps;
+- manifest/project diagnostics from PCC-9D.
+
 ## 5. Planned / non-admitted classes
 
 None remain in the current PCC practical-core trap set.

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -596,7 +596,8 @@ Roadmap artifacts:
 - live audit: `docs/roadmap/language_maturity/pcc9_project_model_live_audit.md`
 - contract freeze: `docs/roadmap/language_maturity/pcc9_project_model_contract.md`
 - waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
- - CTF sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
+- CTF sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
+- CTF follow-up: `CTF-WP2 — docs(core-trust-freeze): update runtime value and trap registry after PCC`
 
 PCC-9 is closed for the current admitted manifest / project-adjacent baseline.
 The current evidence is bounded to the existing package-manifest baseline and


### PR DESCRIPTION
Docs-only CTF registry sync after PCC-4..PCC-9 bounded closeout. Updates the runtime value registry and trap taxonomy with bounded PCC fixture-backed evidence, keeps Map open edges explicit, and does not claim CTF closure or release readiness.