### PR TITLE
PR-CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
@@ -189,6 +189,15 @@ CTF-WP2 updates:
 
 CTF-WP2 does not close CTF and does not claim release readiness.
 
+## CTF-WP3 Follow-up
+
+CTF-WP3 updates:
+
+- determinism matrix after PCC-4..PCC-9;
+- verifier-first policy after PCC feature-surface closeout.
+
+CTF-WP3 does not close CTF and does not claim release readiness.
+
 CTF touched: docs only
 
 Reason: docs-only trust-surface sync; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace change

--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -51,6 +51,16 @@ None remain in the PCC core determinism freeze set after this pass.
 If a future PCC PR introduces a new determinism-sensitive behavior, it starts
 here and must not be called frozen until evidence exists.
 
+## CTF-WP3 PCC-4..PCC-9 Determinism Sync
+
+PCC-4..PCC-9 closeouts do not freeze broad feature families.
+
+They do provide bounded determinism evidence for current admitted fixture-backed surfaces.
+
+`freeze-candidate` means protected from silent change, not release freeze.
+
+Future widening still requires new CTF review.
+
 ## 5. Planned / non-admitted surfaces
 
 These determinism-sensitive families are intentionally not frozen for the
@@ -60,8 +70,24 @@ current PCC core-readiness gate:
 |---|---|---|---|---|---|---|
 | Numeric behavior | Arithmetic and numeric result/trap rules that belong to later language phases. | PCC-2 | docs / roadmap only | PCC-2 | planned | typecheck, emit, VM |
 | Text behavior | Text operations and text-result stability. | PCC-3 | docs / roadmap only | PCC-3 | planned | typecheck, emit, VM |
-| Records / ADT / collections / stdlib | Later language-surface determinism families. | PCC-4+ / PCC-5+ / PCC-7+ / PCC-8+ | docs / roadmap only | later PCC phases | planned | typecheck, emit, VM |
-| Project model / packaging | Project-level orchestration and packaging order. | PCC-9 | docs / roadmap only | PCC-9 | planned | CLI |
+| Records | Current record literal/access/update fixture surface only. | PCC-4 | PCC-4 closeout | PCC-4 | freeze-candidate | typecheck, emit, VM |
+| ADT + basic match | Current constructors + basic match fixtures only. | PCC-5 | PCC-5 closeout | PCC-5 | freeze-candidate | typecheck, emit, VM |
+| Option / Result | Standard forms only. | PCC-6 | PCC-6 closeout | PCC-6 | freeze-candidate | typecheck, emit, VM |
+| Sequence | Current Sequence operations covered by PCC-7B/D. | PCC-7 | PCC-7 closeout | PCC-7 | freeze-candidate | typecheck, emit, VM |
+| Map | Admitted baseline only; missing-key, iteration policy, and quota remain open. | PCC-7 | PCC-7 closeout | PCC-7 | audit-needed / freeze-candidate | typecheck, emit, VM |
+| Stdlib helpers | `assert` / `print` / `to_text` admitted helper surface only. | PCC-8 | PCC-8 closeout | PCC-8 | freeze-candidate | typecheck, emit, VM |
+| Project model manifest baseline | Current `Semantic.package` helper baseline only. | PCC-9 | PCC-9 closeout | PCC-9 | freeze-candidate | CLI |
+
+Open determinism notes:
+
+- map missing-key behavior remains unresolved;
+- map iteration policy remains unresolved;
+- collection memory/quota determinism remains open;
+- project-root discovery remains open;
+- semantic.toml parse/load determinism remains open;
+- src/main.sm discovery remains open;
+- smc new output determinism remains open;
+- project-level 7hell determinism remains open.
 
 ## 6. Out-of-scope surfaces
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -16,6 +16,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 
 - Current sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
 - Runtime / trap follow-up: `CTF-WP2 — RuntimeValue and trap registry sync after PCC`
+- Determinism / verifier-first follow-up: `CTF-WP3 — determinism and verifier-first policy sync after PCC`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files

--- a/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
@@ -48,6 +48,40 @@ debug_render must not be used by canonical examples
 
 `to_text` belongs to PCC-8 Stdlib v0 and must have a public type contract.
 
+## CTF-WP3 PCC-4..PCC-9 Verifier-First Sync
+
+PCC positive execution fixtures must continue to pass through check/compile/verify/run-smc where applicable.
+
+Manifest/project helper tests are not public execution paths and must not be used as verifier bypass evidence.
+
+Stdlib helper behavior must not create a host/capability bypass.
+
+`print(text)` must not become an unreviewed host effect.
+
+`debug_render` remains internal-only.
+
+`to_text` remains admitted-types-only and must not become reflection.
+
+Project-root check/run, when implemented, must enter the same verifier-first route:
+
+```text
+project source -> check -> compile -> verify -> run
+```
+
+`smc new` must not create executable trust without check/verify.
+
+Any future SemCode/opcode/helper expansion must update verifier-first policy or state why not.
+
+| Surface | Verifier-first implication | WP3 status |
+| --- | --- | --- |
+| Records | execution fixtures must verify before run | sync note |
+| ADT / match | lowering / branching must remain admitted before VM run | sync note |
+| Option / Result | standard forms do not bypass verifier | sync note |
+| Collections | collection ops / traps must remain verified execution behavior | sync note |
+| Stdlib helpers | helper calls must not widen host effects | sync note |
+| Project model | helper / manifest tests are not verifier bypass evidence | sync note |
+| Project-root future commands | must use verifier-first route | follow-up required |
+
 ## Review checklist
 
 ```text

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -598,6 +598,7 @@ Roadmap artifacts:
 - waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 - CTF sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
 - CTF follow-up: `CTF-WP2 — docs(core-trust-freeze): update runtime value and trap registry after PCC`
+- CTF follow-up: `CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC`
 
 PCC-9 is closed for the current admitted manifest / project-adjacent baseline.
 The current evidence is bounded to the existing package-manifest baseline and


### PR DESCRIPTION
Docs-only CTF sync after PCC-4..PCC-9 bounded closeout. Tightens determinism matrix and verifier-first policy around fixture-backed PCC surfaces, keeps Map open edges explicit, and does not claim CTF closure or release readiness.