### PR TITLE
PR-CTF-WP4 — docs(core-trust-freeze): update golden trace and capability denial policy after PCC

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
@@ -15,8 +15,9 @@ PCC is mainly a practical language-core phase. It should not silently widen host
 |---|---|---|---|
 | Pure computation | allowed | sm-* | Must remain deterministic. |
 | Debug / trace output | internal only unless scoped | smc-cli / CTF | Must not become language output accidentally. |
-| `to_text` / formatting | planned | PCC-8 | Public stdlib, not debug_render. |
-| Assertion failure | planned | PCC-8 | Trap / diagnostic policy required. |
+| `to_text` / formatting | bounded admitted surface | PCC-8 / CTF | Admitted helper scope only; not universal reflection. |
+| `assert` failure | admitted trap / diagnostic surface | PCC-8 / CTF | Not a host effect. |
+| `print(text)` | admitted helper output | PCC-8 / CTF | CLI-visible output; must not become unreviewed host IO/capability widening. |
 | File IO | out-of-pcc | future capability scope | Not part of practical core. |
 | Network IO | out-of-pcc | future capability scope | Not part of practical core. |
 | Host gate read | out-of-pcc unless already stable | prom-abi / prom-cap | No widening in PCC. |
@@ -33,6 +34,26 @@ PCC is mainly a practical language-core phase. It should not silently widen host
 4. Local audit is not telemetry and not public language output.
 5. Capability denial must be deterministic and reportable.
 6. A denied effect must not partially mutate host state.
+
+## CTF-WP4 PCC-4..PCC-9 Capability / Effect Denial Sync
+
+PCC-4..PCC-7 are pure language / value surfaces and do not add host effects.
+
+PCC-8 stdlib helper surface remains bounded:
+
+- `assert` is a trap / diagnostic behavior, not a host effect;
+- `print(text)` is admitted helper output but must not become unreviewed host IO / capability widening;
+- `to_text` is admitted-types-only conversion, not reflection;
+- `debug_render` remains internal-only tooling;
+- unsupported `to_text` remains rejected.
+
+PCC-9 project model baseline is tooling / project-adjacent documentation and fixture evidence, not runtime host effect expansion.
+
+No package registry, dependency resolver, remote packages, network IO, filesystem capability, or host ABI behavior is introduced by PCC-9 closeout.
+
+Local audit is not telemetry.
+
+No capability matrix entry is promoted to full release-frozen status by this PR.
 
 ## PR review checklist
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
@@ -198,6 +198,16 @@ CTF-WP3 updates:
 
 CTF-WP3 does not close CTF and does not claim release readiness.
 
+## CTF-WP4 Follow-up
+
+CTF-WP4 updates:
+
+- golden trace policy after PCC-4..PCC-9;
+- capability/effect denial matrix after PCC feature-surface closeout.
+
+CTF-WP4 does not add golden trace artifacts.
+CTF-WP4 does not close CTF and does not claim release readiness.
+
 CTF touched: docs only
 
 Reason: docs-only trust-surface sync; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace change

--- a/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
@@ -74,3 +74,38 @@ runtime config, if execution is involved
 [ ] Did 7hell report shape change?
 [ ] Are trace changes intentional and explained?
 ```
+
+## CTF-WP4 PCC-4..PCC-9 Golden Trace Sync
+
+PCC-4..PCC-9 added fixture-backed evidence, but fixtures are not automatically golden traces.
+
+CTF-WP4 does not add trace artifacts.
+
+CTF-WP4 defines which surfaces should be considered for future golden trace mapping.
+
+Golden trace work remains follow-up unless already present.
+
+| PCC | Surface | Existing evidence | Golden trace implication | WP4 status |
+| --- | --- | --- | --- | --- |
+| PCC-4 | Records | positive + negative record fixtures | candidate for syntax / type / lowering / SemCode / verifier trace mapping | follow-up candidate |
+| PCC-5 | ADT + basic match | positive + negative ADT / match fixtures | candidate for type / lowering / verifier / VM trace mapping | follow-up candidate |
+| PCC-6 | Option / Result | positive + negative standard-form fixtures | candidate for ADT-like trace mapping | follow-up candidate |
+| PCC-7 | Collections v0 | Sequence / Map positive + diagnostics / trap fixtures | candidate for VM trap / determinism trace mapping | follow-up required for collection trap / replay traces |
+| PCC-8 | Stdlib helpers | helper positive + diagnostics / trap fixtures | candidate for assert trap, helper diagnostics, to_text boundary traces | follow-up candidate |
+| PCC-9 | Project Model baseline | Semantic.package positive + diagnostics fixtures | candidate for CLI / project-adjacent diagnostic trace mapping | follow-up candidate |
+
+Trace boundary notes:
+
+- Golden trace freeze is not required for every PCC fixture immediately.
+- Golden traces should be added only when a behavior becomes release-facing or freeze-candidate enough to protect byte, result, or diagnostic stability.
+- Compile-time diagnostics traces and VM runtime traces must not be mixed.
+- Project-model manifest helper traces are not project-root execution traces.
+- 7hell report traces remain future work.
+- Project-level 7hell remains open.
+- Map missing-key / iteration / quota policy remain open, so golden traces for those edges must not be claimed.
+
+```text
+CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces
+```
+
+Do not implement CTF-E1 in this PR.

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -17,6 +17,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Current sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
 - Runtime / trap follow-up: `CTF-WP2 — RuntimeValue and trap registry sync after PCC`
 - Determinism / verifier-first follow-up: `CTF-WP3 — determinism and verifier-first policy sync after PCC`
+- Golden trace / capability follow-up: `CTF-WP4 — golden trace and capability/effect denial policy sync after PCC`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -599,6 +599,7 @@ Roadmap artifacts:
 - CTF sync waypoint: `docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md`
 - CTF follow-up: `CTF-WP2 — docs(core-trust-freeze): update runtime value and trap registry after PCC`
 - CTF follow-up: `CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC`
+- CTF follow-up: `CTF-WP4 — docs(core-trust-freeze): update golden trace and capability denial policy after PCC`
 
 PCC-9 is closed for the current admitted manifest / project-adjacent baseline.
 The current evidence is bounded to the existing package-manifest baseline and


### PR DESCRIPTION
Docs-only CTF sync after PCC-4..PCC-9 bounded closeout. Maps fixture-backed PCC surfaces to future golden-trace consideration and tightens capability/effect denial wording without adding trace artifacts, runtime behavior, or release claims.