### PR TITLE
PR-CTF-WP5 — docs(core-trust-freeze): define CTF evidence backlog and freeze-candidate promotion rules

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -1,0 +1,103 @@
+# CTF Evidence Backlog
+
+Status: active backlog
+Owner: language maturity / execution contract
+Scope: evidence backlog after PCC-4..PCC-9 and CTF-WP1..WP4
+Non-goal: implementation, trace artifact addition, release readiness, or CTF closure
+
+## Purpose
+
+This document converts the CTF-WR1 evidence backlog preview into an actionable backlog.
+
+It does not add evidence artifacts.
+
+It defines what evidence is needed next.
+
+It prevents uncontrolled jump from docs-sync to release claims.
+
+## Evidence Backlog Table
+
+| Backlog ID | Area | Evidence need | Why needed | Candidate PR | Status | Blocking for |
+| ---------- | ---- | ------------- | ---------- | ------------ | ------ | ------------ |
+| CTF-BL-001 | Golden trace selection | choose representative PCC fixture surfaces for trace promotion | PCC fixtures are not golden traces | CTF-E1 | planned | trace freeze |
+| CTF-BL-002 | Golden trace artifacts | add selected source/type/IR/SemCode/verifier/VM trace samples | protect byte/result/diagnostic stability | CTF-E1 | planned | trace freeze |
+| CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | planned | determinism freeze |
+| CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP / future PCC-7 follow-up | planned | collections freeze |
+| CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | planned | trap freeze |
+| CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | PCC-9I / CTF follow-up | planned | project model freeze |
+| CTF-BL-007 | 7hell report shape | define stable qualification report surface | readiness needs stable qualification output | 7HELL-WP / CTF follow-up | planned | readiness |
+| CTF-BL-008 | Capability denial replay | replay denied-effect behavior once capability surfaces widen | capability denial must be deterministic | future CTF-E | deferred | capability freeze |
+| CTF-BL-009 | SymbolId / hot-path audit | verify PCC value/name surfaces do not regress into string hot paths | freeze-candidate names need hot-path discipline | future CTF-WP/E | planned | runtime performance/trust |
+
+Status values allowed:
+
+- `planned`
+- `ready-for-task`
+- `in-progress`
+- `blocked`
+- `deferred`
+- `done`
+
+Do not mark any backlog item done unless the evidence already exists and is linked.
+
+## Evidence Classes
+
+| Evidence class | Meaning | Example |
+| -------------- | ------- | ------- |
+| E0-doc | documented claim only | policy docs |
+| E1-code | implementation exists | code path exists |
+| E2-test | ordinary test evidence | cargo test / integration test |
+| E3-trace | golden trace / snapshot evidence | stable trace artifact |
+| E4-replay | repeated-run determinism evidence | replay harness |
+| E5-release-gate | release qualification gate | 7hell/readiness gate |
+
+Rules:
+
+- `freeze-candidate` can be supported by E0/E1/E2 depending on scope.
+- `frozen` requires at least E2 and usually E3/E4 for execution-sensitive surfaces.
+- release-facing freeze requires E5 or explicit waiver.
+
+## Prioritized Next PRs
+
+```text
+CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces
+CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage
+CTF-E3 — test(core-trust-freeze): add trap taxonomy regression coverage
+CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I
+7HELL-WP1 — docs(7hell): define qualification report contract
+```
+
+Make clear:
+
+- CTF-E1 should not cover every feature.
+- CTF-E1 should select representative traces first.
+- CTF-E2 should focus on admitted collection baseline only, not open Map policy edges.
+- CTF-E3 should distinguish compile-time diagnostics from VM traps.
+
+## Out of Scope
+
+- release readiness;
+- CTF closure;
+- new language features;
+- project-root implementation;
+- semantic.toml parser;
+- smc new;
+- package registry;
+- remote dependencies;
+- Workbench / UI;
+- host IO widening;
+- runtime behavior changes.
+
+## Acceptance Checklist
+
+```markdown
+- [ ] backlog IDs defined
+- [ ] evidence classes defined
+- [ ] next PR order proposed
+- [ ] no item overclaimed as done without evidence
+- [ ] no CTF closure claimed
+- [ ] no release readiness claimed
+- [ ] no code changed
+- [ ] no tests or fixtures changed
+- [ ] no trace artifacts added
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md
@@ -204,6 +204,17 @@ The project should now move into targeted evidence planning before any release-r
 - [ ] no golden trace artifacts added
 ```
 
+## CTF-WP5 Follow-up
+
+CTF-WP5 defines:
+
+- CTF evidence backlog;
+- freeze-candidate promotion rules;
+- evidence classes;
+- next evidence PR order.
+
+CTF-WP5 does not close CTF and does not claim release readiness.
+
 CTF touched: docs only
 
 Reason: CTF waypoint review after WP1..WP4 sync; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace behavior change

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_wp1_pcc4_pcc9_sync.md
@@ -210,6 +210,17 @@ CTF-WP4 does not close CTF and does not claim release readiness.
 
 CTF-WR1 reviews the first trust-sync wave after WP1..WP4.
 
+## CTF-WP5 Follow-up
+
+CTF-WP5 defines:
+
+- CTF evidence backlog;
+- freeze-candidate promotion rules;
+- evidence classes;
+- next evidence PR order.
+
+CTF-WP5 does not close CTF and does not claim release readiness.
+
 CTF touched: docs only
 
 Reason: docs-only trust-surface sync; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace change

--- a/docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md
@@ -1,0 +1,125 @@
+# CTF Freeze-Candidate Promotion Rules
+
+Status: active policy
+Owner: language maturity / execution contract
+Scope: promotion rules for CTF entries after PCC/CTF sync
+Non-goal: release readiness or automatic freeze
+
+## Purpose
+
+This document defines how CTF entries move from `audit-needed` / `planned` / `freeze-candidate` toward stronger freeze states.
+
+It prevents docs-only PRs from silently creating release-facing freeze.
+
+It keeps CTF honest after PCC expansion.
+
+## Status Ladder
+
+| Status | Meaning | Allowed evidence |
+| ------ | ------- | ---------------- |
+| planned | belongs to a future phase | E0-doc |
+| audit-needed | exists or likely exists but needs review | E0/E1 |
+| documented-only | contract intent exists, behavior not proven | E0-doc |
+| freeze-candidate | behavior is bounded and should not change silently | E0 + E1/E2 preferred |
+| evidence-backed | tests/traces/replay support the behavior | E2/E3/E4 |
+| frozen | release-facing stable contract | E2 + E3/E4 or explicit waiver |
+| out-of-scope | not part of current plan | E0-doc |
+
+Do not use `frozen` casually.
+
+## Promotion Gates
+
+### planned → audit-needed
+
+Required:
+
+- surface identified;
+- owner known;
+- scope described.
+
+### audit-needed → freeze-candidate
+
+Required:
+
+- bounded scope;
+- current behavior described;
+- open edges listed;
+- no known contradictory evidence.
+
+### freeze-candidate → evidence-backed
+
+Required:
+
+- tests, traces, or replay evidence;
+- failure mode categorized;
+- determinism impact reviewed;
+- verifier-first impact reviewed if execution path exists.
+
+### evidence-backed → frozen
+
+Required:
+
+- evidence is linked;
+- release-facing contract is intended;
+- CTF owner approves;
+- overclaim risks reviewed;
+- compatibility / migration note if public behavior may matter.
+
+## Demotion Rule
+
+A CTF entry must be demoted if:
+
+- evidence is stale;
+- behavior changed;
+- scope widened;
+- tests were removed;
+- trace artifacts changed without explanation;
+- open edge invalidates the previous claim.
+
+Demotion targets:
+
+- frozen → evidence-backed
+- evidence-backed → freeze-candidate
+- freeze-candidate → audit-needed
+
+## Required CTF Note for Future PRs
+
+```text
+CTF touched:
+  - <file>
+Reason:
+  <why trust surface changed>
+
+CTF status impact:
+  - no status change
+  - planned -> audit-needed
+  - audit-needed -> freeze-candidate
+  - freeze-candidate -> evidence-backed
+  - evidence-backed -> frozen
+  - demotion required
+```
+
+## Prohibited Promotions
+
+Explicitly forbid:
+
+- docs-only PR promoting to release-facing `frozen` without evidence;
+- treating PCC closeout as CTF freeze;
+- treating fixtures as golden traces automatically;
+- treating compile-time diagnostics as VM traps;
+- treating project helper tests as public execution evidence;
+- treating `print(text)` as host IO without capability review;
+- treating `to_text` as reflection;
+- treating `debug_render` as public language output.
+
+## Review Checklist
+
+```markdown
+- [ ] status before and after stated
+- [ ] evidence class stated
+- [ ] open edges listed
+- [ ] owner known
+- [ ] overclaim risk reviewed
+- [ ] demotion considered
+- [ ] release claim avoided unless explicitly approved
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -19,6 +19,9 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Determinism / verifier-first follow-up: `CTF-WP3 — determinism and verifier-first policy sync after PCC`
 - Golden trace / capability follow-up: `CTF-WP4 — golden trace and capability/effect denial policy sync after PCC`
 - Waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
+- Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
+- Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`
+- Evidence backlog / promotion waypoint: `CTF-WP5 — define CTF evidence backlog and freeze-candidate promotion rules`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -601,6 +601,9 @@ Roadmap artifacts:
 - CTF follow-up: `CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC`
 - CTF follow-up: `CTF-WP4 — docs(core-trust-freeze): update golden trace and capability denial policy after PCC`
 - CTF waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
+- CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
+- CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`
+- CTF waypoint: `CTF-WP5 — docs(core-trust-freeze): define CTF evidence backlog and freeze-candidate promotion rules`
 
 PCC-9 is closed for the current admitted manifest / project-adjacent baseline.
 The current evidence is bounded to the existing package-manifest baseline and


### PR DESCRIPTION
Docs-only CTF control document. Converts the WP1..WP4 evidence backlog preview into an actionable backlog, defines promotion/demotion rules for CTF statuses, and keeps CTF closure and release readiness out of scope.