### PR TITLE
PR-CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -19,8 +19,8 @@ It prevents uncontrolled jump from docs-sync to release claims.
 
 | Backlog ID | Area | Evidence need | Why needed | Candidate PR | Status | Blocking for |
 | ---------- | ---- | ------------- | ---------- | ------------ | ------ | ------------ |
-| CTF-BL-001 | Golden trace selection | choose representative PCC fixture surfaces for trace promotion | PCC fixtures are not golden traces | CTF-E1 | planned | trace freeze |
-| CTF-BL-002 | Golden trace artifacts | add selected source/type/IR/SemCode/verifier/VM trace samples | protect byte/result/diagnostic stability | CTF-E1 | planned | trace freeze |
+| CTF-BL-001 | Golden trace selection | choose representative PCC fixture surfaces for trace promotion | PCC fixtures are not golden traces | CTF-E1 | done | trace freeze |
+| CTF-BL-002 | Golden trace artifacts | add selected source/type/IR/SemCode/verifier/VM trace samples | protect byte/result/diagnostic stability | CTF-E1 | done | trace freeze |
 | CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | planned | determinism freeze |
 | CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP / future PCC-7 follow-up | planned | collections freeze |
 | CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | planned | trap freeze |
@@ -39,6 +39,34 @@ Status values allowed:
 - `done`
 
 Do not mark any backlog item done unless the evidence already exists and is linked.
+
+## CTF-E1 Evidence
+
+CTF-E1 adds the first selected golden trace coverage for PCC fixture-backed surfaces.
+
+Covered:
+
+- Records trace candidate;
+- ADT / match trace candidate;
+- Option trace candidate;
+- Sequence trace candidate;
+- Stdlib helper boundary trace candidate.
+
+Trace artifacts are checked in under:
+
+- `tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/`;
+- `tests/ctf_e1_golden_traces.rs`.
+
+Boundaries:
+
+- not all PCC fixtures are golden traces;
+- no release readiness claim;
+- no CTF closure;
+- no 7hell report trace;
+- no Map missing-key / iteration / quota trace;
+- no project-root execution trace;
+- no semantic.toml trace;
+- no package registry / remote dependency trace.
 
 ## Evidence Classes
 
@@ -60,7 +88,6 @@ Rules:
 ## Prioritized Next PRs
 
 ```text
-CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces
 CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage
 CTF-E3 — test(core-trust-freeze): add trap taxonomy regression coverage
 CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I
@@ -69,8 +96,6 @@ CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC
 
 Make clear:
 
-- CTF-E1 should not cover every feature.
-- CTF-E1 should select representative traces first.
 - CTF-E2 should focus on admitted collection baseline only, not open Map policy edges.
 - CTF-E3 should distinguish compile-time diagnostics from VM traps.
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -122,7 +122,7 @@ Make clear:
 - [ ] no item overclaimed as done without evidence
 - [ ] no CTF closure claimed
 - [ ] no release readiness claimed
-- [ ] no code changed
-- [ ] no tests or fixtures changed
-- [ ] no trace artifacts added
+- [ ] no unrelated code changed
+- [ ] no unrelated tests or fixtures changed
+- [ ] no unreviewed trace artifacts added
 ```

--- a/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
@@ -104,8 +104,29 @@ Trace boundary notes:
 - Project-level 7hell remains open.
 - Map missing-key / iteration / quota policy remain open, so golden traces for those edges must not be claimed.
 
-```text
-CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces
-```
+## CTF-E1 Selected Golden Trace Coverage
 
-Do not implement CTF-E1 in this PR.
+CTF-E1 promotes only selected PCC fixture-backed surfaces into golden trace evidence.
+
+The first evidence set is representative, not exhaustive:
+
+- PCC-4 Records;
+- PCC-5 ADT + basic match;
+- PCC-6 Option;
+- PCC-7 Sequence;
+- PCC-8 stdlib helper boundary.
+
+CTF-E1 adds checked-in golden trace artifacts for selected surfaces only.
+
+Boundaries:
+
+- not all PCC fixtures are golden traces;
+- no release-facing freeze;
+- no CTF closure;
+- no Map missing-key / iteration / quota trace;
+- no 7hell report trace;
+- no project-root execution trace;
+- no semantic.toml trace;
+- no package registry / remote dependency trace.
+
+Future CTF-E2 / CTF-E3 still own replay and trap taxonomy evidence.

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -18,6 +18,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Runtime / trap follow-up: `CTF-WP2 — RuntimeValue and trap registry sync after PCC`
 - Determinism / verifier-first follow-up: `CTF-WP3 — determinism and verifier-first policy sync after PCC`
 - Golden trace / capability follow-up: `CTF-WP4 — golden trace and capability/effect denial policy sync after PCC`
+- Golden trace evidence: `CTF-E1 — selected PCC golden trace coverage`
 - Waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -600,6 +600,7 @@ Roadmap artifacts:
 - CTF follow-up: `CTF-WP2 — docs(core-trust-freeze): update runtime value and trap registry after PCC`
 - CTF follow-up: `CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC`
 - CTF follow-up: `CTF-WP4 — docs(core-trust-freeze): update golden trace and capability denial policy after PCC`
+- CTF evidence: `CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces`
 - CTF waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`

--- a/tests/ctf_e1_golden_traces.rs
+++ b/tests/ctf_e1_golden_traces.rs
@@ -1,0 +1,263 @@
+use std::fs;
+use std::path::PathBuf;
+
+use semantic_language::{
+    frontend::{compile_program_to_ir, compile_program_to_semcode},
+    semantics::check_source,
+    semcode_verify::verify_semcode,
+};
+use sm_vm::run_verified_semcode;
+
+const UPDATE_ENV: &str = "SM_UPDATE_CTF_E1_TRACES";
+
+#[derive(Clone, Copy)]
+struct TraceCase {
+    trace_id: &'static str,
+    pcc: &'static str,
+    pcc_owner: &'static str,
+    surface: &'static str,
+    source_fixture: &'static str,
+    artifact_file: &'static str,
+    trace_class: &'static [&'static str],
+    stage: &'static str,
+    expected_status: &'static str,
+    runtime_config: &'static str,
+    notes: &'static str,
+}
+
+const TRACE_CASES: &[TraceCase] = &[
+    TraceCase {
+        trace_id: "CTF-E1-PCC4-RECORD-POSITIVE-001",
+        pcc: "PCC-4",
+        pcc_owner: "PCC-4",
+        surface: "Records",
+        source_fixture: "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+        artifact_file: "CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json",
+        trace_class: &["syntax", "type", "ir", "semcode", "verifier", "vm"],
+        stage: "selected",
+        expected_status: "accept",
+        runtime_config: "default",
+        notes: "Selected representative record fixture only; no project-root, Map, or 7hell coverage.",
+    },
+    TraceCase {
+        trace_id: "CTF-E1-PCC5-ADT-MATCH-POSITIVE-001",
+        pcc: "PCC-5",
+        pcc_owner: "PCC-5",
+        surface: "ADT + basic match",
+        source_fixture: "tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm",
+        artifact_file: "CTF-E1-PCC5-ADT-MATCH-POSITIVE-001.trace.json",
+        trace_class: &["syntax", "type", "ir", "semcode", "verifier", "vm"],
+        stage: "selected",
+        expected_status: "accept",
+        runtime_config: "default",
+        notes: "Selected basic ADT/match trace only; no broader pattern-matching freeze.",
+    },
+    TraceCase {
+        trace_id: "CTF-E1-PCC6-OPTION-POSITIVE-001",
+        pcc: "PCC-6",
+        pcc_owner: "PCC-6",
+        surface: "Option",
+        source_fixture: "tests/fixtures/pcc6_option/positive_option_some_match.sm",
+        artifact_file: "CTF-E1-PCC6-OPTION-POSITIVE-001.trace.json",
+        trace_class: &["syntax", "type", "ir", "semcode", "verifier", "vm"],
+        stage: "selected",
+        expected_status: "accept",
+        runtime_config: "default",
+        notes: "Selected standard-form Option trace only; Result remains covered by later evidence if needed.",
+    },
+    TraceCase {
+        trace_id: "CTF-E1-PCC7-SEQUENCE-POSITIVE-001",
+        pcc: "PCC-7",
+        pcc_owner: "PCC-7",
+        surface: "Sequence",
+        source_fixture: "tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm",
+        artifact_file: "CTF-E1-PCC7-SEQUENCE-POSITIVE-001.trace.json",
+        trace_class: &["syntax", "type", "ir", "semcode", "verifier", "vm"],
+        stage: "selected",
+        expected_status: "accept",
+        runtime_config: "default",
+        notes: "Selected Sequence baseline only; Map missing-key, iteration, and quota policy remain open.",
+    },
+    TraceCase {
+        trace_id: "CTF-E1-PCC8-STDLIB-HELPER-001",
+        pcc: "PCC-8",
+        pcc_owner: "PCC-8",
+        surface: "Stdlib helper boundary",
+        source_fixture: "tests/fixtures/pcc8_stdlib/positive_assert_true.sm",
+        artifact_file: "CTF-E1-PCC8-STDLIB-HELPER-001.trace.json",
+        trace_class: &["syntax", "type", "ir", "semcode", "verifier", "vm"],
+        stage: "selected",
+        expected_status: "accept",
+        runtime_config: "default",
+        notes: "Selected assert helper boundary only; no universal to_text or debug_render widening.",
+    },
+];
+
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read_text(rel: &str) -> String {
+    let raw = fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("read failed for {rel}: {err}"));
+    normalize_newlines(&raw)
+}
+
+fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    let mut hash = OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn hash_hex(text: &str) -> String {
+    format!("{:016x}", fnv1a64(text.as_bytes()))
+}
+
+fn hash_hex_bytes(bytes: &[u8]) -> String {
+    format!("{:016x}", fnv1a64(bytes))
+}
+
+fn trace_dir() -> PathBuf {
+    repo_path("tests/fixtures/core_trust_freeze/golden_traces/ctf_e1")
+}
+
+fn trace_manifest_path() -> PathBuf {
+    trace_dir().join("manifest.md")
+}
+
+fn trace_artifact_path(case: &TraceCase) -> PathBuf {
+    trace_dir().join(case.artifact_file)
+}
+
+fn update_mode() -> bool {
+    std::env::var(UPDATE_ENV)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn write_text(path: &PathBuf, text: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!("create_dir_all failed for {}: {err}", parent.display())
+        });
+    }
+    fs::write(path, text).unwrap_or_else(|err| panic!("write failed for {}: {err}", path.display()));
+}
+
+fn assert_text_file(path: &PathBuf, got: &str) {
+    let got = normalize_newlines(got);
+    if update_mode() {
+        write_text(path, &got);
+        return;
+    }
+    let expected = normalize_newlines(
+        &fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("read failed for {}: {err}", path.display())),
+    );
+    assert_eq!(expected, got, "trace artifact drifted at {}", path.display());
+}
+
+fn render_trace_manifest() -> String {
+    let mut out = String::new();
+    out.push_str("# CTF-E1 Golden Trace Manifest\n");
+    out.push_str("Status: checked-in trace selection\n");
+    out.push_str("Owner: language maturity / execution contract\n");
+    out.push_str("Scope: selected PCC fixture-backed golden traces only\n");
+    out.push_str("Non-goal: exhaustive coverage, project-root traces, or release freeze\n\n");
+    out.push_str("| trace_id | pcc | surface | source_fixture | artifact | expected_status |\n");
+    out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+    for case in TRACE_CASES {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} |\n",
+            case.trace_id,
+            case.pcc,
+            case.surface,
+            case.source_fixture,
+            case.artifact_file,
+            case.expected_status
+        ));
+    }
+    out
+}
+
+fn render_trace_artifact(case: &TraceCase) -> String {
+    let src = read_text(case.source_fixture);
+    let _sema = check_source(&src).expect("semantic check");
+    let ir = compile_program_to_ir(&src).expect("compile ir");
+    let semcode = compile_program_to_semcode(&src).expect("compile semcode");
+    verify_semcode(&semcode).expect("verify semcode");
+    run_verified_semcode(&semcode).expect("run verified semcode");
+
+    let source_hash = hash_hex(&src);
+    let mut ir_signatures = Vec::with_capacity(ir.len());
+    for func in &ir {
+        ir_signatures.push(format!("{}:{}", func.name, func.instrs.len()));
+    }
+    ir_signatures.sort();
+    let ir_hash = hash_hex(&ir_signatures.join("|"));
+    let semcode_hash = hash_hex_bytes(&semcode);
+    let trace_body = format!(
+        "{{\n  \"trace_id\": \"{}\",\n  \"pcc\": \"{}\",\n  \"pcc_owner\": \"{}\",\n  \"surface\": \"{}\",\n  \"source_fixture\": \"{}\",\n  \"trace_class\": [{}],\n  \"stage\": \"{}\",\n  \"expected_status\": \"{}\",\n  \"source_hash\": \"{}\",\n  \"ir_hash\": \"{}\",\n  \"semcode_hash\": \"{}\",\n  \"verifier_status\": \"accept\",\n  \"vm_status\": \"ok\",\n  \"runtime_config\": \"{}\",\n  \"notes\": \"{}\"\n}}\n",
+        case.trace_id,
+        case.pcc,
+        case.pcc_owner,
+        case.surface,
+        case.source_fixture,
+        case
+            .trace_class
+            .iter()
+            .map(|entry| format!("\"{entry}\""))
+            .collect::<Vec<_>>()
+            .join(", "),
+        case.stage,
+        case.expected_status,
+        source_hash,
+        ir_hash,
+        semcode_hash,
+        case.runtime_config,
+        case.notes,
+    );
+    let expected_output_hash = hash_hex(&trace_body);
+    format!(
+        "{{\n  \"trace_id\": \"{}\",\n  \"pcc\": \"{}\",\n  \"pcc_owner\": \"{}\",\n  \"surface\": \"{}\",\n  \"source_fixture\": \"{}\",\n  \"trace_class\": [{}],\n  \"stage\": \"{}\",\n  \"expected_status\": \"{}\",\n  \"source_hash\": \"{}\",\n  \"ir_hash\": \"{}\",\n  \"semcode_hash\": \"{}\",\n  \"verifier_status\": \"accept\",\n  \"vm_status\": \"ok\",\n  \"runtime_config\": \"{}\",\n  \"expected_output_hash\": \"{}\",\n  \"notes\": \"{}\"\n}}\n",
+        case.trace_id,
+        case.pcc,
+        case.pcc_owner,
+        case.surface,
+        case.source_fixture,
+        case
+            .trace_class
+            .iter()
+            .map(|entry| format!("\"{entry}\""))
+            .collect::<Vec<_>>()
+            .join(", "),
+        case.stage,
+        case.expected_status,
+        source_hash,
+        ir_hash,
+        semcode_hash,
+        case.runtime_config,
+        expected_output_hash,
+        case.notes,
+    )
+}
+
+#[test]
+fn ctf_e1_golden_traces_match_checked_in_selection() {
+    assert_text_file(&trace_manifest_path(), &render_trace_manifest());
+
+    for case in TRACE_CASES {
+        let artifact = render_trace_artifact(case);
+        assert_text_file(&trace_artifact_path(case), &artifact);
+    }
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json
@@ -1,0 +1,18 @@
+{
+  "trace_id": "CTF-E1-PCC4-RECORD-POSITIVE-001",
+  "pcc": "PCC-4",
+  "pcc_owner": "PCC-4",
+  "surface": "Records",
+  "source_fixture": "examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm",
+  "trace_class": ["syntax", "type", "ir", "semcode", "verifier", "vm"],
+  "stage": "selected",
+  "expected_status": "accept",
+  "source_hash": "ab07713734d22976",
+  "ir_hash": "b419ef35fb669085",
+  "semcode_hash": "3e052eda00ea9591",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "runtime_config": "default",
+  "expected_output_hash": "f86e5fe8a76915ad",
+  "notes": "Selected representative record fixture only; no project-root, Map, or 7hell coverage."
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC5-ADT-MATCH-POSITIVE-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC5-ADT-MATCH-POSITIVE-001.trace.json
@@ -1,0 +1,18 @@
+{
+  "trace_id": "CTF-E1-PCC5-ADT-MATCH-POSITIVE-001",
+  "pcc": "PCC-5",
+  "pcc_owner": "PCC-5",
+  "surface": "ADT + basic match",
+  "source_fixture": "tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm",
+  "trace_class": ["syntax", "type", "ir", "semcode", "verifier", "vm"],
+  "stage": "selected",
+  "expected_status": "accept",
+  "source_hash": "b674e2eb54322422",
+  "ir_hash": "f40e40b30590a1ac",
+  "semcode_hash": "35c781ffe8a81c83",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "runtime_config": "default",
+  "expected_output_hash": "c407777f917b26bd",
+  "notes": "Selected basic ADT/match trace only; no broader pattern-matching freeze."
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC6-OPTION-POSITIVE-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC6-OPTION-POSITIVE-001.trace.json
@@ -1,0 +1,18 @@
+{
+  "trace_id": "CTF-E1-PCC6-OPTION-POSITIVE-001",
+  "pcc": "PCC-6",
+  "pcc_owner": "PCC-6",
+  "surface": "Option",
+  "source_fixture": "tests/fixtures/pcc6_option/positive_option_some_match.sm",
+  "trace_class": ["syntax", "type", "ir", "semcode", "verifier", "vm"],
+  "stage": "selected",
+  "expected_status": "accept",
+  "source_hash": "86a1c92a6678acca",
+  "ir_hash": "60b5c1f62a44e9be",
+  "semcode_hash": "4aafda9e6d448d53",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "runtime_config": "default",
+  "expected_output_hash": "b0a5d3939d5819de",
+  "notes": "Selected standard-form Option trace only; Result remains covered by later evidence if needed."
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC7-SEQUENCE-POSITIVE-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC7-SEQUENCE-POSITIVE-001.trace.json
@@ -1,0 +1,18 @@
+{
+  "trace_id": "CTF-E1-PCC7-SEQUENCE-POSITIVE-001",
+  "pcc": "PCC-7",
+  "pcc_owner": "PCC-7",
+  "surface": "Sequence",
+  "source_fixture": "tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm",
+  "trace_class": ["syntax", "type", "ir", "semcode", "verifier", "vm"],
+  "stage": "selected",
+  "expected_status": "accept",
+  "source_hash": "2881ddd5433113ef",
+  "ir_hash": "60b2c1f62a42b3e7",
+  "semcode_hash": "78f164c2dc9f1111",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "runtime_config": "default",
+  "expected_output_hash": "8ce404860467cfdb",
+  "notes": "Selected Sequence baseline only; Map missing-key, iteration, and quota policy remain open."
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC8-STDLIB-HELPER-001.trace.json
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/CTF-E1-PCC8-STDLIB-HELPER-001.trace.json
@@ -1,0 +1,18 @@
+{
+  "trace_id": "CTF-E1-PCC8-STDLIB-HELPER-001",
+  "pcc": "PCC-8",
+  "pcc_owner": "PCC-8",
+  "surface": "Stdlib helper boundary",
+  "source_fixture": "tests/fixtures/pcc8_stdlib/positive_assert_true.sm",
+  "trace_class": ["syntax", "type", "ir", "semcode", "verifier", "vm"],
+  "stage": "selected",
+  "expected_status": "accept",
+  "source_hash": "7dd16913eee5d7ee",
+  "ir_hash": "aa750173e9bbe47f",
+  "semcode_hash": "ddba0b30bdabfdf7",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "runtime_config": "default",
+  "expected_output_hash": "7da46547c025309f",
+  "notes": "Selected assert helper boundary only; no universal to_text or debug_render widening."
+}

--- a/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/manifest.md
+++ b/tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/manifest.md
@@ -1,0 +1,13 @@
+# CTF-E1 Golden Trace Manifest
+Status: checked-in trace selection
+Owner: language maturity / execution contract
+Scope: selected PCC fixture-backed golden traces only
+Non-goal: exhaustive coverage, project-root traces, or release freeze
+
+| trace_id | pcc | surface | source_fixture | artifact | expected_status |
+| --- | --- | --- | --- | --- | --- |
+| CTF-E1-PCC4-RECORD-POSITIVE-001 | PCC-4 | Records | examples/qualification/g1_real_program_trial/data_audit_record_iterable/src/main.sm | CTF-E1-PCC4-RECORD-POSITIVE-001.trace.json | accept |
+| CTF-E1-PCC5-ADT-MATCH-POSITIVE-001 | PCC-5 | ADT + basic match | tests/fixtures/pcc5_match/positive_match_unit_enum_label.sm | CTF-E1-PCC5-ADT-MATCH-POSITIVE-001.trace.json | accept |
+| CTF-E1-PCC6-OPTION-POSITIVE-001 | PCC-6 | Option | tests/fixtures/pcc6_option/positive_option_some_match.sm | CTF-E1-PCC6-OPTION-POSITIVE-001.trace.json | accept |
+| CTF-E1-PCC7-SEQUENCE-POSITIVE-001 | PCC-7 | Sequence | tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm | CTF-E1-PCC7-SEQUENCE-POSITIVE-001.trace.json | accept |
+| CTF-E1-PCC8-STDLIB-HELPER-001 | PCC-8 | Stdlib helper boundary | tests/fixtures/pcc8_stdlib/positive_assert_true.sm | CTF-E1-PCC8-STDLIB-HELPER-001.trace.json | accept |


### PR DESCRIPTION
CTF touched:
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
  - docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
  - tests/ctf_e1_golden_traces.rs
  - tests/fixtures/core_trust_freeze/golden_traces/ctf_e1/

Reason:
  First selected E3 golden trace evidence after PCC-4..PCC-9 and CTF-WP1..WP5.

CTF status impact:
  - planned -> done for CTF-BL-001 and CTF-BL-002
  - evidence-backed for selected CTF-E1 trace artifacts only
  - no CTF closure
  - no release-facing frozen promotion
