### PR TITLE
PR-CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -21,7 +21,7 @@ It prevents uncontrolled jump from docs-sync to release claims.
 | ---------- | ---- | ------------- | ---------- | ------------ | ------ | ------------ |
 | CTF-BL-001 | Golden trace selection | choose representative PCC fixture surfaces for trace promotion | PCC fixtures are not golden traces | CTF-E1 | done | trace freeze |
 | CTF-BL-002 | Golden trace artifacts | add selected source/type/IR/SemCode/verifier/VM trace samples | protect byte/result/diagnostic stability | CTF-E1 | done | trace freeze |
-| CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | planned | determinism freeze |
+| CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | done | determinism freeze |
 | CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP / future PCC-7 follow-up | planned | collections freeze |
 | CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | planned | trap freeze |
 | CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | PCC-9I / CTF follow-up | planned | project model freeze |
@@ -68,6 +68,35 @@ Boundaries:
 - no semantic.toml trace;
 - no package registry / remote dependency trace.
 
+## CTF-E2 Evidence
+
+CTF-E2 adds collection determinism replay evidence for selected admitted PCC-7 collection fixtures.
+
+Covered:
+
+- Sequence indexing replay;
+- Sequence iteration replay;
+- Sequence mutation replay;
+- Map insert/lookup replay;
+- Map persistent update replay.
+
+Replay artifacts are checked in under:
+
+- `tests/fixtures/core_trust_freeze/replay/ctf_e2/`;
+- `tests/ctf_e2_collection_replay.rs`.
+
+Boundaries:
+
+- no Map missing-key policy;
+- no Map iteration policy;
+- no collection memory/quota policy;
+- no project-root determinism;
+- no semantic.toml determinism;
+- no smc new determinism;
+- no 7hell report determinism;
+- no CTF closure;
+- no release readiness.
+
 ## Evidence Classes
 
 | Evidence class | Meaning | Example |
@@ -88,7 +117,6 @@ Rules:
 ## Prioritized Next PRs
 
 ```text
-CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage
 CTF-E3 — test(core-trust-freeze): add trap taxonomy regression coverage
 CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I
 7HELL-WP1 — docs(7hell): define qualification report contract
@@ -96,7 +124,6 @@ CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC
 
 Make clear:
 
-- CTF-E2 should focus on admitted collection baseline only, not open Map policy edges.
 - CTF-E3 should distinguish compile-time diagnostics from VM traps.
 
 ## Out of Scope

--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -61,6 +61,23 @@ They do provide bounded determinism evidence for current admitted fixture-backed
 
 Future widening still requires new CTF review.
 
+## CTF-E2 Collection Replay Evidence
+
+CTF-E2 adds E4-style replay evidence for selected admitted PCC-7 collection surfaces.
+
+Replay evidence covers only:
+
+- selected Sequence baseline behavior;
+- selected admitted Map insert/lookup and persistent update baseline behavior.
+
+This does not close:
+
+- Map missing-key behavior;
+- Map iteration policy;
+- collection memory/quota determinism;
+- broad collections freeze;
+- release readiness.
+
 ## 5. Planned / non-admitted surfaces
 
 These determinism-sensitive families are intentionally not frozen for the
@@ -73,8 +90,8 @@ current PCC core-readiness gate:
 | Records | Current record literal/access/update fixture surface only. | PCC-4 | PCC-4 closeout | PCC-4 | freeze-candidate | typecheck, emit, VM |
 | ADT + basic match | Current constructors + basic match fixtures only. | PCC-5 | PCC-5 closeout | PCC-5 | freeze-candidate | typecheck, emit, VM |
 | Option / Result | Standard forms only. | PCC-6 | PCC-6 closeout | PCC-6 | freeze-candidate | typecheck, emit, VM |
-| Sequence | Current Sequence operations covered by PCC-7B/D. | PCC-7 | PCC-7 closeout | PCC-7 | freeze-candidate | typecheck, emit, VM |
-| Map | Admitted baseline only; missing-key, iteration policy, and quota remain open. | PCC-7 | PCC-7 closeout | PCC-7 | audit-needed / freeze-candidate | typecheck, emit, VM |
+| Sequence | Current Sequence operations covered by PCC-7B/D and selected replay evidence. | PCC-7 | PCC-7 closeout + CTF-E2 | PCC-7 | evidence-backed for selected admitted replay surfaces | typecheck, emit, VM |
+| Map | Admitted baseline only; missing-key, iteration policy, and quota remain open, with selected replay evidence for insert / lookup and persistent update. | PCC-7 | PCC-7 closeout + CTF-E2 | PCC-7 | evidence-backed for selected admitted baseline only / audit-needed overall | typecheck, emit, VM |
 | Stdlib helpers | `assert` / `print` / `to_text` admitted helper surface only. | PCC-8 | PCC-8 closeout | PCC-8 | freeze-candidate | typecheck, emit, VM |
 | Project model manifest baseline | Current `Semantic.package` helper baseline only. | PCC-9 | PCC-9 closeout | PCC-9 | freeze-candidate | CLI |
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -19,6 +19,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Determinism / verifier-first follow-up: `CTF-WP3 — determinism and verifier-first policy sync after PCC`
 - Golden trace / capability follow-up: `CTF-WP4 — golden trace and capability/effect denial policy sync after PCC`
 - Golden trace evidence: `CTF-E1 — selected PCC golden trace coverage`
+- Collection replay evidence: `CTF-E2 — collection determinism replay coverage`
 - Waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -601,6 +601,7 @@ Roadmap artifacts:
 - CTF follow-up: `CTF-WP3 — docs(core-trust-freeze): update determinism and verifier-first evidence after PCC`
 - CTF follow-up: `CTF-WP4 — docs(core-trust-freeze): update golden trace and capability denial policy after PCC`
 - CTF evidence: `CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces`
+- CTF evidence: `CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage`
 - CTF waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`

--- a/tests/ctf_e2_collection_replay.rs
+++ b/tests/ctf_e2_collection_replay.rs
@@ -1,0 +1,319 @@
+use std::fs;
+use std::path::PathBuf;
+
+use semantic_language::{
+    frontend::{compile_program_to_ir, compile_program_to_semcode},
+    semantics::check_source,
+    semcode_verify::verify_semcode,
+};
+use sm_vm::run_verified_semcode;
+
+const REPLAY_COUNT: usize = 5;
+const UPDATE_ENV: &str = "SM_UPDATE_CTF_E2_REPLAYS";
+
+#[derive(Clone, Copy)]
+struct ReplayCase {
+    replay_id: &'static str,
+    pcc: &'static str,
+    surface: &'static str,
+    source_fixture: &'static str,
+    artifact_file: &'static str,
+    replay_class: &'static [&'static str],
+    expected_status: &'static str,
+    boundary: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplayRun {
+    run_index: usize,
+    check_status: &'static str,
+    source_hash: String,
+    ir_shape_hash: String,
+    semcode_hash: String,
+    verifier_status: &'static str,
+    vm_status: &'static str,
+}
+
+const TRACE_CASES: &[ReplayCase] = &[
+    ReplayCase {
+        replay_id: "CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001",
+        pcc: "PCC-7",
+        surface: "Sequence indexing",
+        source_fixture: "tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm",
+        artifact_file: "CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001.replay.json",
+        replay_class: &["check", "ir", "semcode", "verifier", "vm"],
+        expected_status: "accept",
+        boundary: "current admitted PCC-7 Sequence baseline only; no Map policy widening",
+    },
+    ReplayCase {
+        replay_id: "CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001",
+        pcc: "PCC-7",
+        surface: "Sequence iteration",
+        source_fixture: "tests/fixtures/pcc7_sequence/positive_sequence_iteration.sm",
+        artifact_file: "CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json",
+        replay_class: &["check", "ir", "semcode", "verifier", "vm"],
+        expected_status: "accept",
+        boundary: "current admitted PCC-7 Sequence baseline only; no Map iteration policy widening",
+    },
+    ReplayCase {
+        replay_id: "CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001",
+        pcc: "PCC-7",
+        surface: "Sequence mutation",
+        source_fixture: "tests/fixtures/pcc7_sequence/positive_sequence_push_prepend.sm",
+        artifact_file: "CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json",
+        replay_class: &["check", "ir", "semcode", "verifier", "vm"],
+        expected_status: "accept",
+        boundary: "current admitted PCC-7 Sequence baseline only; no collection quota widening",
+    },
+    ReplayCase {
+        replay_id: "CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001",
+        pcc: "PCC-7",
+        surface: "Map insert/lookup",
+        source_fixture: "tests/fixtures/pcc7_map/positive_map_basic_insert_lookup.sm",
+        artifact_file: "CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001.replay.json",
+        replay_class: &["check", "ir", "semcode", "verifier", "vm"],
+        expected_status: "accept",
+        boundary: "current admitted PCC-7 Map baseline only; missing-key and iteration remain open",
+    },
+    ReplayCase {
+        replay_id: "CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001",
+        pcc: "PCC-7",
+        surface: "Map persistent update",
+        source_fixture: "tests/fixtures/pcc7_map/positive_map_persistent_update.sm",
+        artifact_file: "CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001.replay.json",
+        replay_class: &["check", "ir", "semcode", "verifier", "vm"],
+        expected_status: "accept",
+        boundary: "current admitted PCC-7 Map baseline only; quota, iteration, and missing-key remain open",
+    },
+];
+
+fn repo_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read_text(rel: &str) -> String {
+    let raw = fs::read_to_string(repo_path(rel))
+        .unwrap_or_else(|err| panic!("read failed for {rel}: {err}"));
+    normalize_newlines(&raw)
+}
+
+fn normalize_newlines(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    let mut hash = OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn hash_hex(text: &str) -> String {
+    format!("{:016x}", fnv1a64(text.as_bytes()))
+}
+
+fn hash_hex_bytes(bytes: &[u8]) -> String {
+    format!("{:016x}", fnv1a64(bytes))
+}
+
+fn replay_dir() -> PathBuf {
+    repo_path("tests/fixtures/core_trust_freeze/replay/ctf_e2")
+}
+
+fn replay_manifest_path() -> PathBuf {
+    replay_dir().join("manifest.md")
+}
+
+fn replay_artifact_path(case: &ReplayCase) -> PathBuf {
+    replay_dir().join(case.artifact_file)
+}
+
+fn update_mode() -> bool {
+    std::env::var(UPDATE_ENV)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn write_text(path: &PathBuf, text: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!("create_dir_all failed for {}: {err}", parent.display())
+        });
+    }
+    fs::write(path, text).unwrap_or_else(|err| panic!("write failed for {}: {err}", path.display()));
+}
+
+fn assert_text_file(path: &PathBuf, got: &str) {
+    let got = normalize_newlines(got);
+    if update_mode() {
+        write_text(path, &got);
+        return;
+    }
+    let expected = normalize_newlines(
+        &fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("read failed for {}: {err}", path.display())),
+    );
+    assert_eq!(expected, got, "replay artifact drifted at {}", path.display());
+}
+
+fn json_escape(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 8);
+    for ch in text.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn render_manifest() -> String {
+    let mut out = String::new();
+    out.push_str("# CTF-E2 Collection Replay Manifest\n");
+    out.push_str("Status: checked-in replay selection\n");
+    out.push_str("Owner: language maturity / execution contract\n");
+    out.push_str("Scope: admitted PCC-7 collection replay evidence only\n");
+    out.push_str("Non-goal: collection policy changes, project-root determinism, or release freeze\n\n");
+    out.push_str("| replay_id | pcc | surface | source_fixture | artifact | expected_status |\n");
+    out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+    for case in TRACE_CASES {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} |\n",
+            case.replay_id,
+            case.pcc,
+            case.surface,
+            case.source_fixture,
+            case.artifact_file,
+            case.expected_status
+        ));
+    }
+    out
+}
+
+fn run_case_once(case: &ReplayCase) -> ReplayRun {
+    let src = read_text(case.source_fixture);
+    let _sema = check_source(&src).expect("semantic check");
+    let ir = compile_program_to_ir(&src).expect("compile ir");
+    let semcode = compile_program_to_semcode(&src).expect("compile semcode");
+    verify_semcode(&semcode).expect("verify semcode");
+    run_verified_semcode(&semcode).expect("run verified semcode");
+
+    let source_hash = hash_hex(&src);
+    let mut ir_signatures = Vec::with_capacity(ir.len());
+    for func in &ir {
+        ir_signatures.push(format!("{}:{}", func.name, func.instrs.len()));
+    }
+    ir_signatures.sort();
+    let ir_shape_hash = hash_hex(&ir_signatures.join("|"));
+    let semcode_hash = hash_hex_bytes(&semcode);
+
+    ReplayRun {
+        run_index: 0,
+        check_status: "accept",
+        source_hash,
+        ir_shape_hash,
+        semcode_hash,
+        verifier_status: "accept",
+        vm_status: "ok",
+    }
+}
+
+fn collect_runs(case: &ReplayCase) -> Vec<ReplayRun> {
+    let mut runs = Vec::with_capacity(REPLAY_COUNT);
+    for run_index in 1..=REPLAY_COUNT {
+        let mut run = run_case_once(case);
+        run.run_index = run_index;
+        runs.push(run);
+    }
+    runs
+}
+
+fn runs_all_equal(runs: &[ReplayRun]) -> bool {
+    if runs.is_empty() {
+        return true;
+    }
+    runs.iter().all(|run| {
+        run.check_status == runs[0].check_status
+            && run.source_hash == runs[0].source_hash
+            && run.ir_shape_hash == runs[0].ir_shape_hash
+            && run.semcode_hash == runs[0].semcode_hash
+            && run.verifier_status == runs[0].verifier_status
+            && run.vm_status == runs[0].vm_status
+    })
+}
+
+fn render_runs(runs: &[ReplayRun]) -> String {
+    let mut out = String::new();
+    out.push_str("[\n");
+    for (idx, run) in runs.iter().enumerate() {
+        out.push_str(&format!(
+            "  {{\n    \"run_index\": {},\n    \"check_status\": \"{}\",\n    \"source_hash\": \"{}\",\n    \"ir_shape_hash\": \"{}\",\n    \"semcode_hash\": \"{}\",\n    \"verifier_status\": \"{}\",\n    \"vm_status\": \"{}\"\n  }}",
+            run.run_index,
+            run.check_status,
+            run.source_hash,
+            run.ir_shape_hash,
+            run.semcode_hash,
+            run.verifier_status,
+            run.vm_status
+        ));
+        if idx + 1 != runs.len() {
+            out.push(',');
+        }
+        out.push('\n');
+    }
+    out.push_str("]\n");
+    out
+}
+
+fn render_replay_artifact(case: &ReplayCase) -> String {
+    let src = read_text(case.source_fixture);
+    let source_hash = hash_hex(&src);
+    let runs = collect_runs(case);
+    assert!(
+        runs_all_equal(&runs),
+        "replay drifted for {}",
+        case.replay_id
+    );
+    let summary_hash = hash_hex(&render_runs(&runs));
+    let trace_class = case
+        .replay_class
+        .iter()
+        .map(|entry| format!("\"{}\"", json_escape(entry)))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "{{\n  \"replay_id\": \"{}\",\n  \"pcc\": \"{}\",\n  \"surface\": \"{}\",\n  \"source_fixture\": \"{}\",\n  \"replay_class\": [{}],\n  \"replay_count\": {},\n  \"expected_status\": \"{}\",\n  \"source_hash\": \"{}\",\n  \"summary_hash\": \"{}\",\n  \"verifier_status\": \"accept\",\n  \"vm_status\": \"ok\",\n  \"all_runs_equal\": true,\n  \"boundary\": \"{}\",\n  \"runs\": {}\n}}\n",
+        json_escape(case.replay_id),
+        json_escape(case.pcc),
+        json_escape(case.surface),
+        json_escape(case.source_fixture),
+        trace_class,
+        REPLAY_COUNT,
+        case.expected_status,
+        source_hash,
+        summary_hash,
+        json_escape(case.boundary),
+        render_runs(&runs),
+    )
+}
+
+#[test]
+fn ctf_e2_collection_replay_matches_checked_in_selection() {
+    assert_text_file(&replay_manifest_path(), &render_manifest());
+
+    for case in TRACE_CASES {
+        let artifact = render_replay_artifact(case);
+        assert_text_file(&replay_artifact_path(case), &artifact);
+    }
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001.replay.json
@@ -1,0 +1,63 @@
+{
+  "replay_id": "CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001",
+  "pcc": "PCC-7",
+  "surface": "Map insert/lookup",
+  "source_fixture": "tests/fixtures/pcc7_map/positive_map_basic_insert_lookup.sm",
+  "replay_class": ["check", "ir", "semcode", "verifier", "vm"],
+  "replay_count": 5,
+  "expected_status": "accept",
+  "source_hash": "2b2fe057d0e062a2",
+  "summary_hash": "2678c8fbde9e4690",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "all_runs_equal": true,
+  "boundary": "current admitted PCC-7 Map baseline only; missing-key and iteration remain open",
+  "runs": [
+  {
+    "run_index": 1,
+    "check_status": "accept",
+    "source_hash": "2b2fe057d0e062a2",
+    "ir_shape_hash": "60abb4f62a3c7f22",
+    "semcode_hash": "6f442fbf0ced8a28",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 2,
+    "check_status": "accept",
+    "source_hash": "2b2fe057d0e062a2",
+    "ir_shape_hash": "60abb4f62a3c7f22",
+    "semcode_hash": "6f442fbf0ced8a28",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 3,
+    "check_status": "accept",
+    "source_hash": "2b2fe057d0e062a2",
+    "ir_shape_hash": "60abb4f62a3c7f22",
+    "semcode_hash": "6f442fbf0ced8a28",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 4,
+    "check_status": "accept",
+    "source_hash": "2b2fe057d0e062a2",
+    "ir_shape_hash": "60abb4f62a3c7f22",
+    "semcode_hash": "6f442fbf0ced8a28",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 5,
+    "check_status": "accept",
+    "source_hash": "2b2fe057d0e062a2",
+    "ir_shape_hash": "60abb4f62a3c7f22",
+    "semcode_hash": "6f442fbf0ced8a28",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  }
+]
+
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001.replay.json
@@ -1,0 +1,63 @@
+{
+  "replay_id": "CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001",
+  "pcc": "PCC-7",
+  "surface": "Map persistent update",
+  "source_fixture": "tests/fixtures/pcc7_map/positive_map_persistent_update.sm",
+  "replay_class": ["check", "ir", "semcode", "verifier", "vm"],
+  "replay_count": 5,
+  "expected_status": "accept",
+  "source_hash": "ee62b165d2605a8d",
+  "summary_hash": "0eaf7b87e0059c47",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "all_runs_equal": true,
+  "boundary": "current admitted PCC-7 Map baseline only; quota, iteration, and missing-key remain open",
+  "runs": [
+  {
+    "run_index": 1,
+    "check_status": "accept",
+    "source_hash": "ee62b165d2605a8d",
+    "ir_shape_hash": "60b5bdf62a44e2f2",
+    "semcode_hash": "3bf7695b30da268c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 2,
+    "check_status": "accept",
+    "source_hash": "ee62b165d2605a8d",
+    "ir_shape_hash": "60b5bdf62a44e2f2",
+    "semcode_hash": "3bf7695b30da268c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 3,
+    "check_status": "accept",
+    "source_hash": "ee62b165d2605a8d",
+    "ir_shape_hash": "60b5bdf62a44e2f2",
+    "semcode_hash": "3bf7695b30da268c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 4,
+    "check_status": "accept",
+    "source_hash": "ee62b165d2605a8d",
+    "ir_shape_hash": "60b5bdf62a44e2f2",
+    "semcode_hash": "3bf7695b30da268c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 5,
+    "check_status": "accept",
+    "source_hash": "ee62b165d2605a8d",
+    "ir_shape_hash": "60b5bdf62a44e2f2",
+    "semcode_hash": "3bf7695b30da268c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  }
+]
+
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001.replay.json
@@ -1,0 +1,63 @@
+{
+  "replay_id": "CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001",
+  "pcc": "PCC-7",
+  "surface": "Sequence indexing",
+  "source_fixture": "tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm",
+  "replay_class": ["check", "ir", "semcode", "verifier", "vm"],
+  "replay_count": 5,
+  "expected_status": "accept",
+  "source_hash": "2881ddd5433113ef",
+  "summary_hash": "2cf4e40166940dd4",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "all_runs_equal": true,
+  "boundary": "current admitted PCC-7 Sequence baseline only; no Map policy widening",
+  "runs": [
+  {
+    "run_index": 1,
+    "check_status": "accept",
+    "source_hash": "2881ddd5433113ef",
+    "ir_shape_hash": "60b2c1f62a42b3e7",
+    "semcode_hash": "78f164c2dc9f1111",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 2,
+    "check_status": "accept",
+    "source_hash": "2881ddd5433113ef",
+    "ir_shape_hash": "60b2c1f62a42b3e7",
+    "semcode_hash": "78f164c2dc9f1111",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 3,
+    "check_status": "accept",
+    "source_hash": "2881ddd5433113ef",
+    "ir_shape_hash": "60b2c1f62a42b3e7",
+    "semcode_hash": "78f164c2dc9f1111",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 4,
+    "check_status": "accept",
+    "source_hash": "2881ddd5433113ef",
+    "ir_shape_hash": "60b2c1f62a42b3e7",
+    "semcode_hash": "78f164c2dc9f1111",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 5,
+    "check_status": "accept",
+    "source_hash": "2881ddd5433113ef",
+    "ir_shape_hash": "60b2c1f62a42b3e7",
+    "semcode_hash": "78f164c2dc9f1111",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  }
+]
+
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json
@@ -1,0 +1,63 @@
+{
+  "replay_id": "CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001",
+  "pcc": "PCC-7",
+  "surface": "Sequence iteration",
+  "source_fixture": "tests/fixtures/pcc7_sequence/positive_sequence_iteration.sm",
+  "replay_class": ["check", "ir", "semcode", "verifier", "vm"],
+  "replay_count": 5,
+  "expected_status": "accept",
+  "source_hash": "4cc5edb44a9c8f32",
+  "summary_hash": "a96c664aa1af91c0",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "all_runs_equal": true,
+  "boundary": "current admitted PCC-7 Sequence baseline only; no Map iteration policy widening",
+  "runs": [
+  {
+    "run_index": 1,
+    "check_status": "accept",
+    "source_hash": "4cc5edb44a9c8f32",
+    "ir_shape_hash": "ce7adee40a6f3732",
+    "semcode_hash": "1c23e431a66f8383",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 2,
+    "check_status": "accept",
+    "source_hash": "4cc5edb44a9c8f32",
+    "ir_shape_hash": "ce7adee40a6f3732",
+    "semcode_hash": "1c23e431a66f8383",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 3,
+    "check_status": "accept",
+    "source_hash": "4cc5edb44a9c8f32",
+    "ir_shape_hash": "ce7adee40a6f3732",
+    "semcode_hash": "1c23e431a66f8383",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 4,
+    "check_status": "accept",
+    "source_hash": "4cc5edb44a9c8f32",
+    "ir_shape_hash": "ce7adee40a6f3732",
+    "semcode_hash": "1c23e431a66f8383",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 5,
+    "check_status": "accept",
+    "source_hash": "4cc5edb44a9c8f32",
+    "ir_shape_hash": "ce7adee40a6f3732",
+    "semcode_hash": "1c23e431a66f8383",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  }
+]
+
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json
@@ -1,0 +1,63 @@
+{
+  "replay_id": "CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001",
+  "pcc": "PCC-7",
+  "surface": "Sequence mutation",
+  "source_fixture": "tests/fixtures/pcc7_sequence/positive_sequence_push_prepend.sm",
+  "replay_class": ["check", "ir", "semcode", "verifier", "vm"],
+  "replay_count": 5,
+  "expected_status": "accept",
+  "source_hash": "f52f7952bcd12bb0",
+  "summary_hash": "fc57a2cbfda46e02",
+  "verifier_status": "accept",
+  "vm_status": "ok",
+  "all_runs_equal": true,
+  "boundary": "current admitted PCC-7 Sequence baseline only; no collection quota widening",
+  "runs": [
+  {
+    "run_index": 1,
+    "check_status": "accept",
+    "source_hash": "f52f7952bcd12bb0",
+    "ir_shape_hash": "60a52af62a3728f6",
+    "semcode_hash": "23b4b75ec7e15d3c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 2,
+    "check_status": "accept",
+    "source_hash": "f52f7952bcd12bb0",
+    "ir_shape_hash": "60a52af62a3728f6",
+    "semcode_hash": "23b4b75ec7e15d3c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 3,
+    "check_status": "accept",
+    "source_hash": "f52f7952bcd12bb0",
+    "ir_shape_hash": "60a52af62a3728f6",
+    "semcode_hash": "23b4b75ec7e15d3c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 4,
+    "check_status": "accept",
+    "source_hash": "f52f7952bcd12bb0",
+    "ir_shape_hash": "60a52af62a3728f6",
+    "semcode_hash": "23b4b75ec7e15d3c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  },
+  {
+    "run_index": 5,
+    "check_status": "accept",
+    "source_hash": "f52f7952bcd12bb0",
+    "ir_shape_hash": "60a52af62a3728f6",
+    "semcode_hash": "23b4b75ec7e15d3c",
+    "verifier_status": "accept",
+    "vm_status": "ok"
+  }
+]
+
+}

--- a/tests/fixtures/core_trust_freeze/replay/ctf_e2/manifest.md
+++ b/tests/fixtures/core_trust_freeze/replay/ctf_e2/manifest.md
@@ -1,0 +1,13 @@
+# CTF-E2 Collection Replay Manifest
+Status: checked-in replay selection
+Owner: language maturity / execution contract
+Scope: admitted PCC-7 collection replay evidence only
+Non-goal: collection policy changes, project-root determinism, or release freeze
+
+| replay_id | pcc | surface | source_fixture | artifact | expected_status |
+| --- | --- | --- | --- | --- | --- |
+| CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001 | PCC-7 | Sequence indexing | tests/fixtures/pcc7_sequence/positive_sequence_indexing.sm | CTF-E2-PCC7-SEQUENCE-INDEXING-REPLAY-001.replay.json | accept |
+| CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001 | PCC-7 | Sequence iteration | tests/fixtures/pcc7_sequence/positive_sequence_iteration.sm | CTF-E2-PCC7-SEQUENCE-ITERATION-REPLAY-001.replay.json | accept |
+| CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001 | PCC-7 | Sequence mutation | tests/fixtures/pcc7_sequence/positive_sequence_push_prepend.sm | CTF-E2-PCC7-SEQUENCE-MUTATION-REPLAY-001.replay.json | accept |
+| CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001 | PCC-7 | Map insert/lookup | tests/fixtures/pcc7_map/positive_map_basic_insert_lookup.sm | CTF-E2-PCC7-MAP-INSERT-LOOKUP-REPLAY-001.replay.json | accept |
+| CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001 | PCC-7 | Map persistent update | tests/fixtures/pcc7_map/positive_map_persistent_update.sm | CTF-E2-PCC7-MAP-PERSISTENT-UPDATE-REPLAY-001.replay.json | accept |


### PR DESCRIPTION
CTF touched:
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
  - docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
  - docs/roadmap/language_maturity/core_trust_freeze/index.md
  - docs/roadmap/language_maturity/practical_core_completion_v0_3.md
  - tests/ctf_e2_collection_replay.rs
  - tests/fixtures/core_trust_freeze/replay/ctf_e2/

Reason:
  Adds E4-style repeated-run evidence for selected admitted PCC-7 collection baselines.

CTF status impact:
  - CTF-BL-003 planned -> done
  - selected Sequence replay surfaces become evidence-backed
  - selected admitted Map baseline replay surfaces become evidence-backed
  - no broad collections freeze
  - no CTF closure
  - no release-readiness claim
