### PR TITLE
PR-CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
@@ -66,3 +66,13 @@ No capability matrix entry is promoted to full release-frozen status by this PR.
 [ ] Is host state unchanged on denial?
 [ ] Is this actually out-of-PCC?
 ```
+
+## CTF-WP6 Project-Root Capability Notes
+
+CTF-WP6 states the boundary for future project-root support before PCC-9I implementation.
+
+Reading admitted project files is tooling input, not language host capability.
+
+Project-root support must not introduce network IO, registry access, remote package fetch, or telemetry.
+
+No project-root capability widening is added by WP6.

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -24,7 +24,7 @@ It prevents uncontrolled jump from docs-sync to release claims.
 | CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | done | determinism freeze |
 | CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP / future PCC-7 follow-up | planned | collections freeze |
 | CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | done | trap freeze |
-| CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | PCC-9I / CTF follow-up | planned | project model freeze |
+| CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | CTF-WP6 | done | project model freeze |
 | CTF-BL-007 | 7hell report shape | define stable qualification report surface | readiness needs stable qualification output | 7HELL-WP / CTF follow-up | planned | readiness |
 | CTF-BL-008 | Capability denial replay | replay denied-effect behavior once capability surfaces widen | capability denial must be deterministic | future CTF-E | deferred | capability freeze |
 | CTF-BL-009 | SymbolId / hot-path audit | verify PCC value/name surfaces do not regress into string hot paths | freeze-candidate names need hot-path discipline | future CTF-WP/E | planned | runtime performance/trust |
@@ -137,11 +137,36 @@ Rules:
 - `frozen` requires at least E2 and usually E3/E4 for execution-sensitive surfaces.
 - release-facing freeze requires E5 or explicit waiver.
 
+## CTF-WP6 Evidence
+
+CTF-WP6 defines project-root trust policy before PCC-9I implementation.
+
+Covered:
+
+- verifier-first route for future project-root commands;
+- deterministic manifest / entry / path policy;
+- project diagnostics policy;
+- capability / effect boundary;
+- future golden trace requirements;
+- future PCC-9I split.
+
+Boundaries:
+
+- no project-root implementation;
+- no semantic.toml parser;
+- no smc new;
+- no package registry;
+- no dependency resolver;
+- no workspace;
+- no remote packages;
+- no CTF closure;
+- no release readiness.
+
 ## Prioritized Next PRs
 
 ```text
-CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I
 7HELL-WP1 — docs(7hell): define qualification report contract
+PCC-9I1 — cli(project-model): add project-root check entrypoint
 ```
 
 Make clear:

--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -167,3 +167,11 @@ FM-035 is unchanged by this PR.
 [x] FM-036 can be treated as frozen for PCC readiness
 [x] FM-035 is left untouched
 ```
+
+## CTF-WP6 Project-Root Determinism Notes
+
+CTF-WP6 defines future evidence requirements for project-root determinism before PCC-9I implementation.
+
+Project-root discovery, `semantic.toml`, `src/main.sm`, `smc new`, and project-level 7hell remain open until separately evidenced.
+
+WP6 does not add project-root determinism artifacts.

--- a/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
@@ -130,3 +130,11 @@ Boundaries:
 - no package registry / remote dependency trace.
 
 Future CTF-E2 / CTF-E3 still own replay and trap taxonomy evidence.
+
+## CTF-WP6 Project-Root Golden Trace Notes
+
+CTF-WP6 defines the trust policy for future project-root behavior, but it does not add trace artifacts.
+
+Future PCC-9I work may add positive project-root check / run traces, project diagnostics traces, and project-root replay traces when behavior is implemented and stable.
+
+Project manifest helper traces are still not project-root execution traces.

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -25,6 +25,8 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`
 - Evidence backlog / promotion waypoint: `CTF-WP5 — define CTF evidence backlog and freeze-candidate promotion rules`
+- Project-root trust policy: `docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md`
+- Project-root trust waypoint: `CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files
@@ -38,6 +40,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 | `verifier_first_policy.md` | Does public execution still require admission before VM run? |
 | `golden_trace_policy.md` | Does the change require new or updated golden traces? |
 | `capability_effect_denial_matrix.md` | Did host/effect/capability behavior change? |
+| `project_root_trust_policy.md` | Does future project-root support preserve verifier-first trust? |
 
 ## PR requirement
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md
@@ -1,0 +1,253 @@
+# CTF Project-Root Trust Policy
+
+Status: active policy
+Owner: language maturity / execution contract
+Scope: trust policy before PCC-9I project-root implementation
+Non-goal: implementation, project-root readiness, CTF closure, or release readiness
+
+## 1. Purpose
+
+This document defines the trust policy for future project-root support before implementation.
+
+It prevents project-root support from bypassing verifier-first execution.
+
+It prevents manifest and project tooling from becoming hidden capability or host-effect widening.
+
+It keeps `semantic.toml`, `src/main.sm`, and `smc new` as future implementation work until separately admitted.
+
+It does not implement behavior.
+
+## 2. Current Baseline vs Target Contract
+
+| Item | Current state | Target / future state | Trust note |
+| --- | --- | --- | --- |
+| single-file `.sm` | existing baseline | remains supported | must not be broken by project-root work |
+| `Semantic.package` | admitted lower-level manifest baseline | may remain internal / transition baseline | current evidence only |
+| `semantic.toml` | target contract name | future parser / loader | not implemented by WP6 |
+| `src/main.sm` | target default entry convention | future discovery | not implemented by WP6 |
+| `smc check <project-root>` | target command | future PCC-9I implementation | must preserve check -> compile -> verify route |
+| `smc run <project-root>` | target command | future PCC-9I implementation | must preserve verifier-first route |
+| `smc new` | optional follow-up | future skeleton generator | must not create executable trust without check / verify |
+| package registry | out of scope | out of scope | no remote fetch |
+| dependency resolver | out of scope | out of scope | no version solving |
+| workspace | out of scope | out of scope | no multi-package trust model |
+
+## 3. Trust Invariants
+
+```text
+Invariant 1:
+Project-root execution must not bypass single-file semantic analysis, lowering, SemCode emission, verifier admission, or VM execution contracts.
+
+Invariant 2:
+Project-root run must be verifier-first:
+project source -> check -> compile -> verify -> run.
+
+Invariant 3:
+Manifest parsing must be deterministic and path-normalized.
+
+Invariant 4:
+Project-root discovery must not depend on accidental process cwd.
+
+Invariant 5:
+Entry paths must not escape project root.
+
+Invariant 6:
+Directory traversal, if introduced, must be deterministic and sorted.
+
+Invariant 7:
+Project-root support must not introduce host IO capabilities beyond reading explicitly admitted project files.
+
+Invariant 8:
+No network, package registry, remote dependency, or telemetry behavior is admitted.
+
+Invariant 9:
+Project helper tests are not public execution evidence.
+
+Invariant 10:
+Project-root implementation PRs must update CTF status before claiming readiness.
+```
+
+## 4. Verifier-First Route
+
+```text
+project root
+  -> manifest discovery
+  -> manifest parse
+  -> entry resolution
+  -> source load
+  -> semantic check
+  -> compile / lower
+  -> SemCode emit
+  -> verifier admission
+  -> verified run
+```
+
+Any future public project-root run path must go through this route.
+
+`smc check <project-root>` may stop before SemCode or VM, but must not become execution evidence.
+
+`smc run <project-root>` must not run unchecked source.
+
+Any direct helper must be test-only or internal and clearly marked.
+
+## 5. Determinism Requirements
+
+| Surface | Determinism requirement | Evidence required before readiness |
+| --- | --- | --- |
+| manifest lookup | same project root resolves same manifest | test + trace |
+| manifest parse | same file parses to same manifest model | test |
+| entry resolution | same manifest resolves same entry path | test |
+| path normalization | platform path differences normalized | test |
+| directory traversal | sorted deterministic order if used | test |
+| import resolution | same imports resolve same modules | replay / golden trace |
+| diagnostics | same invalid layout gives stable diagnostic category | diagnostics test |
+| project-root run | same project produces same SemCode / verifier / VM result | replay / golden trace |
+| smc new | same input creates same skeleton | test before admission |
+
+Explicitly:
+
+- `semantic.toml` determinism is not claimed yet.
+- `src/main.sm` discovery determinism is not claimed yet.
+- `smc new` determinism is not claimed yet.
+- project-level 7hell determinism is not claimed yet.
+
+## 6. Diagnostics Policy
+
+Diagnostics categories, not exact codes:
+
+- missing manifest;
+- malformed manifest;
+- unsupported manifest version / shape;
+- missing package name;
+- missing entry;
+- entry path escapes project root;
+- entry path points to directory;
+- entry file missing;
+- invalid project root;
+- unsupported workspace field;
+- unsupported dependency field;
+- unresolved local dependency;
+- import path escape;
+- nondeterministic module root.
+
+Rules:
+
+- Do not invent exact codes unless already stable.
+- Diagnostics must classify as project-diagnostic, not VM trap.
+- Project diagnostics must not be mislabeled as verifier rejection unless actual SemCode verification is involved.
+- Compile/check diagnostics must stay separate from VM traps.
+
+## 7. Capability / Effect Boundary
+
+- Reading project files is a tooling or compiler input operation, not a language-level host capability.
+- Project-root support must not introduce network IO.
+- Project-root support must not introduce package registry access.
+- Project-root support must not introduce remote dependency fetch.
+- Project-root support must not introduce telemetry.
+- Local audit is not telemetry.
+- `smc new` file creation, if implemented later, must be a CLI or tooling effect with explicit user command, not language runtime effect.
+- Workbench / UI integration remains out of scope.
+
+## 8. Golden Trace Requirements
+
+Future PCC-9I implementation must add trace and evidence when behavior becomes public.
+
+Suggested future trace set:
+
+- positive minimal project check trace;
+- positive minimal project run trace;
+- missing manifest diagnostic trace;
+- malformed manifest diagnostic trace;
+- entry path escape diagnostic trace;
+- missing entry diagnostic trace;
+- project-root SemCode / verifier trace;
+- project-root replay determinism trace.
+
+No trace artifacts are added by CTF-WP6.
+
+Project manifest helper traces are not project-root execution traces.
+
+7hell report traces remain future work.
+
+## 9. Required CTF Note for Future PCC-9I PRs
+
+```text
+CTF touched:
+  - docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md
+  - docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
+  - docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+  - docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md
+  - docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md
+
+Reason:
+  Project-root behavior changes trust surface.
+
+CTF status impact:
+  - no status change
+  - audit-needed -> freeze-candidate
+  - freeze-candidate -> evidence-backed
+  - demotion required
+```
+
+## 10. PCC-9I Implementation Split
+
+```text
+PCC-9I1 — cli(project-model): add project-root check entrypoint
+PCC-9I2 — cli(project-model): add project-root run entrypoint
+PCC-9I3 — project-model: add minimal semantic.toml parser / loader
+PCC-9I4 — cli(project-model): add smc new minimal skeleton
+PCC-9I5 — project-model: enforce deterministic module-root and entry policy
+PCC-9I6 — diagnostics(project-model): stabilize project layout diagnostics
+PCC-9I7 — test(project-model): add project-root positive / negative fixtures
+PCC-9I8 — test(core-trust-freeze): add project-root determinism / golden trace coverage
+```
+
+Boundary:
+
+- `PCC-9I1` and `PCC-9I2` may depend on `PCC-9I3`.
+- No package manager.
+- No registry.
+- No workspace.
+- No remote packages.
+
+## 11. Stop Conditions for Future Implementation PRs
+
+Future implementation PRs must stop if:
+
+1. project-root run would bypass verifier;
+2. semantic.toml parser requires broad TOML support beyond minimal shape;
+3. file discovery depends on cwd accidentally;
+4. path normalization is platform-unstable;
+5. directory traversal is unsorted;
+6. entry path escape cannot be rejected;
+7. import resolution requires workspace / registry semantics;
+8. smc new would generate non-deterministic output;
+9. diagnostics require new unstable exact codes;
+10. implementation would introduce network or host IO.
+
+## 12. Final Verdict
+
+```text
+CTF-WP6 defines the trust policy required before PCC-9I project-root implementation.
+It does not implement project-root behavior.
+It does not close CTF.
+It does not claim release readiness.
+```
+
+## 13. Acceptance Checklist
+
+```markdown
+- [ ] current baseline vs target contract documented
+- [ ] verifier-first route defined
+- [ ] determinism requirements defined
+- [ ] diagnostics policy defined
+- [ ] capability/effect boundary defined
+- [ ] golden trace requirements defined
+- [ ] future PCC-9I split proposed
+- [ ] stop conditions defined
+- [ ] no project-root implementation added
+- [ ] no semantic.toml parser added
+- [ ] no smc new added
+- [ ] no CTF closure claimed
+- [ ] no release readiness claimed
+```

--- a/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md
@@ -93,3 +93,11 @@ Any future SemCode/opcode/helper expansion must update verifier-first policy or 
 [ ] Does 7hell verify before run?
 [ ] Are debug helpers kept out of the language surface?
 ```
+
+## CTF-WP6 Project-Root Trust Route
+
+CTF-WP6 defines the trust route for future project-root behavior before PCC-9I implementation.
+
+Future project-root run paths must preserve verifier-first admission and must not use project helper tests as execution evidence.
+
+No project-root implementation is added by WP6.

--- a/docs/roadmap/language_maturity/pcc9_project_model_contract.md
+++ b/docs/roadmap/language_maturity/pcc9_project_model_contract.md
@@ -187,3 +187,5 @@ Possible narrow implementation seams after the freeze:
 - `PCC-9I6 — diagnostics(project-model): stabilize project layout errors`
 
 Do not implement these in PCC-9B.
+
+CTF-WP6 owns the trust-policy definition for future PCC-9I implementation, but it does not widen this contract or claim project-root readiness.

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -603,6 +603,7 @@ Roadmap artifacts:
 - CTF evidence: `CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces`
 - CTF evidence: `CTF-E2 — test(core-trust-freeze): add collection determinism replay coverage`
 - CTF evidence: `CTF-E3 — test(core-trust-freeze): add trap taxonomy regression coverage`
+- CTF waypoint: `CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I`
 - CTF waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - CTF backlog / promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`


### PR DESCRIPTION
CTF touched:\n  - docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md\n  - docs/roadmap/language_maturity/core_trust_freeze/index.md\n  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md\n  - docs/roadmap/language_maturity/core_trust_freeze/verifier_first_policy.md\n  - docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md\n  - docs/roadmap/language_maturity/core_trust_freeze/golden_trace_policy.md\n  - docs/roadmap/language_maturity/core_trust_freeze/capability_effect_denial_matrix.md\n  - docs/roadmap/language_maturity/pcc9_project_model_contract.md\n  - docs/roadmap/language_maturity/practical_core_completion_v0_3.md\n\nReason:\n  Define the trust policy required before any PCC-9I project-root implementation work starts.\n\nCTF status impact:\n  - CTF-BL-006 planned -> done, for policy definition only\n  - no project-root implementation\n  - no semantic.toml parser\n  - no smc new\n  - no CTF closure\n  - no release readiness claim