### PR TITLE
PR-7HELL-S3 — cli(7hell): add stage result wiring for syntax/type diagnostics

### DIFF
--- a/src/bin/smc.rs
+++ b/src/bin/smc.rs
@@ -8,6 +8,27 @@ enum SevenHellOutputMode {
     Json,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SevenHellDiagnosticKind {
+    SyntaxDiagnostic,
+    CheckDiagnostic,
+    BoundaryDenial,
+}
+
+impl SevenHellDiagnosticKind {
+    fn as_human(self) -> &'static str {
+        match self {
+            Self::SyntaxDiagnostic => "syntax-diagnostic",
+            Self::CheckDiagnostic => "check-diagnostic",
+            Self::BoundaryDenial => "boundary-denial",
+        }
+    }
+
+    fn as_json(self) -> &'static str {
+        self.as_human()
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SevenHellStageStatus {
     Pass,
@@ -63,8 +84,26 @@ struct SevenHellStageReport {
     name: &'static str,
     key: &'static str,
     status: SevenHellStageStatus,
-    summary: &'static str,
+    summary: String,
     blocked_by: Option<&'static str>,
+    diagnostic_ids: Vec<String>,
+}
+
+struct SevenHellDiagnosticSource {
+    file: String,
+    line: Option<u32>,
+    column: Option<u32>,
+}
+
+struct SevenHellDiagnostic {
+    id: String,
+    stage: &'static str,
+    kind: SevenHellDiagnosticKind,
+    code: String,
+    category: &'static str,
+    message_needle: String,
+    severity: &'static str,
+    source: SevenHellDiagnosticSource,
 }
 
 struct SevenHellReport {
@@ -72,6 +111,7 @@ struct SevenHellReport {
     target_normalized: String,
     result: SevenHellResult,
     stages: [SevenHellStageReport; 7],
+    diagnostics: Vec<SevenHellDiagnostic>,
     boundary: &'static str,
 }
 
@@ -137,14 +177,14 @@ fn execute_7hell_single_file(target: &str, output_mode: SevenHellOutputMode) -> 
     let report = match fs::read_to_string(Path::new(target)) {
         Ok(source) => match smc_cli::CliPipeline::semantic_check_source(&source) {
             Ok(_) => build_passed_7hell_report(target_display),
-            Err(_) => build_failed_7hell_report(
-                target_display,
-                "single-file check failed; diagnostic wiring reserved for 7HELL-S3",
-            ),
+            Err(error_text) => {
+                let diagnostic = diagnostic_from_check_error(&error_text, &target_display);
+                build_failed_7hell_report(target_display, diagnostic)
+            }
         },
         Err(_) => build_failed_7hell_report(
-            target_display,
-            "input file could not be read; single-file check skipped",
+            target_display.clone(),
+            boundary_denial_diagnostic(&target_display),
         ),
     };
     let success = matches!(report.result, SevenHellResult::Incomplete);
@@ -196,6 +236,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::Pass,
                 "single-file check accepted",
                 None,
+                vec![],
             ),
             stage_report(
                 2,
@@ -204,6 +245,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::Pass,
                 "single-file check accepted",
                 None,
+                vec![],
             ),
             stage_report(
                 3,
@@ -212,6 +254,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::NotImplemented,
                 "7HELL-S2 does not lower",
                 None,
+                vec![],
             ),
             stage_report(
                 4,
@@ -220,6 +263,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::NotImplemented,
                 "7HELL-S2 does not verify",
                 None,
+                vec![],
             ),
             stage_report(
                 5,
@@ -228,6 +272,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::NotImplemented,
                 "7HELL-S2 does not run VM",
                 None,
+                vec![],
             ),
             stage_report(
                 6,
@@ -236,6 +281,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::NotImplemented,
                 "7HELL-S2 does not execute practical stage",
                 None,
+                vec![],
             ),
             stage_report(
                 7,
@@ -244,13 +290,19 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 SevenHellStageStatus::NotImplemented,
                 "7HELL-S2 does not wire diagnostics",
                 None,
+                vec![],
             ),
         ],
+        diagnostics: Vec::new(),
         boundary: "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure",
     }
 }
 
-fn build_failed_7hell_report(target_display: String, summary: &'static str) -> SevenHellReport {
+fn build_failed_7hell_report(target_display: String, diagnostic: SevenHellDiagnostic) -> SevenHellReport {
+    let failure_on_type = diagnostic.stage == "type";
+    let mut diagnostics = Vec::new();
+    let diag_id = diagnostic.id.clone();
+    diagnostics.push(diagnostic);
     SevenHellReport {
         target_display: target_display.clone(),
         target_normalized: target_display,
@@ -260,17 +312,35 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 1,
                 "Syntax Hell",
                 "syntax",
-                SevenHellStageStatus::Fail,
-                summary,
+                if failure_on_type {
+                    SevenHellStageStatus::Pass
+                } else {
+                    SevenHellStageStatus::Fail
+                },
+                if failure_on_type {
+                    "single-file check accepted".to_string()
+                } else {
+                    failure_stage_summary(&diagnostics[0])
+                },
                 None,
+                if failure_on_type { vec![] } else { vec![diag_id.clone()] },
             ),
             stage_report(
                 2,
                 "Type Hell",
                 "type",
-                SevenHellStageStatus::Blocked,
-                "blocked by syntax check failure",
-                Some("syntax"),
+                if failure_on_type {
+                    SevenHellStageStatus::Fail
+                } else {
+                    SevenHellStageStatus::Blocked
+                },
+                if failure_on_type {
+                    failure_stage_summary(&diagnostics[0])
+                } else {
+                    "blocked by syntax check failure".to_string()
+                },
+                if failure_on_type { None } else { Some("syntax") },
+                if failure_on_type { vec![diag_id.clone()] } else { vec![] },
             ),
             stage_report(
                 3,
@@ -279,6 +349,7 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 SevenHellStageStatus::Blocked,
                 "blocked by earlier stage failure",
                 Some("type"),
+                vec![],
             ),
             stage_report(
                 4,
@@ -287,6 +358,7 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 SevenHellStageStatus::Blocked,
                 "blocked by earlier stage failure",
                 Some("lowering"),
+                vec![],
             ),
             stage_report(
                 5,
@@ -295,6 +367,7 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 SevenHellStageStatus::Blocked,
                 "blocked by earlier stage failure",
                 Some("verifier"),
+                vec![],
             ),
             stage_report(
                 6,
@@ -303,6 +376,7 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 SevenHellStageStatus::Blocked,
                 "blocked by earlier stage failure",
                 Some("vm"),
+                vec![],
             ),
             stage_report(
                 7,
@@ -311,8 +385,10 @@ fn build_failed_7hell_report(target_display: String, summary: &'static str) -> S
                 SevenHellStageStatus::NotImplemented,
                 "diagnostic wiring reserved for 7HELL-S3",
                 None,
+                vec![],
             ),
         ],
+        diagnostics,
         boundary: "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure",
     }
 }
@@ -322,17 +398,26 @@ fn stage_report(
     name: &'static str,
     key: &'static str,
     status: SevenHellStageStatus,
-    summary: &'static str,
+    summary: impl Into<String>,
     blocked_by: Option<&'static str>,
+    diagnostic_ids: Vec<String>,
 ) -> SevenHellStageReport {
     SevenHellStageReport {
         index,
         name,
         key,
         status,
-        summary,
+        summary: summary.into(),
         blocked_by,
+        diagnostic_ids,
     }
+}
+
+fn failure_stage_summary(diagnostic: &SevenHellDiagnostic) -> String {
+    format!(
+        "code: {}; category: {}; summary: {}",
+        diagnostic.code, diagnostic.category, diagnostic.message_needle
+    )
 }
 
 fn render_7hell_report(report: &SevenHellReport, output_mode: SevenHellOutputMode) -> String {
@@ -359,6 +444,31 @@ fn render_human_7hell_report(report: &SevenHellReport) -> String {
             out.push_str(&format!("  blocked_by: {}\n", blocked_by));
         }
         out.push_str(&format!("  summary: {}\n", stage.summary));
+        if !stage.diagnostic_ids.is_empty() {
+            out.push_str(&format!(
+                "  diagnostic_ids: {}\n",
+                stage.diagnostic_ids.join(", ")
+            ));
+        }
+    }
+    if !report.diagnostics.is_empty() {
+        out.push_str("\ndiagnostics:\n");
+        for diagnostic in &report.diagnostics {
+            out.push_str(&format!(
+                "  - {} stage={} kind={} code={} category={} summary={} source={}{}\n",
+                diagnostic.id,
+                diagnostic.stage,
+                diagnostic.kind.as_human(),
+                diagnostic.code,
+                diagnostic.category,
+                diagnostic.message_needle,
+                diagnostic.source.file,
+                match (diagnostic.source.line, diagnostic.source.column) {
+                    (Some(line), Some(col)) => format!(":{}:{}", line, col),
+                    _ => String::new(),
+                }
+            ));
+        }
     }
     out.push_str(&format!("\nresult: {}\n", report.result.as_human()));
     out.push_str(&format!("boundary: {}\n", report.boundary));
@@ -375,25 +485,152 @@ fn render_json_7hell_report(report: &SevenHellReport) -> String {
             Some(value) => format!("\"{}\"", json_escape(value)),
             None => "null".to_string(),
         };
+        let diagnostic_ids = render_json_string_array(&stage.diagnostic_ids);
         stages.push_str(&format!(
-            "    {{\n      \"index\": {},\n      \"name\": \"{}\",\n      \"key\": \"{}\",\n      \"status\": \"{}\",\n      \"summary\": \"{}\",\n      \"diagnostic_ids\": [],\n      \"evidence_ids\": [],\n      \"blocked_by\": {}\n    }}",
+            "    {{\n      \"index\": {},\n      \"name\": \"{}\",\n      \"key\": \"{}\",\n      \"status\": \"{}\",\n      \"summary\": \"{}\",\n      \"diagnostic_ids\": {},\n      \"evidence_ids\": [],\n      \"blocked_by\": {}\n    }}",
             stage.index,
             json_escape(stage.name),
             json_escape(stage.key),
             stage.status.as_json(),
-            json_escape(stage.summary),
+            json_escape(&stage.summary),
+            diagnostic_ids,
             blocked_by
         ));
     }
 
+    let diagnostics = render_json_diagnostics(&report.diagnostics);
+
     format!(
-        "{{\n  \"schema\": \"semantic.7hell.report.v0\",\n  \"tool\": \"smc 7hell\",\n  \"target\": {{\n    \"kind\": \"single-file\",\n    \"display\": \"{}\",\n    \"normalized\": \"{}\"\n  }},\n  \"profile\": \"default\",\n  \"result\": \"{}\",\n  \"stages\": [\n{}\n  ],\n  \"diagnostics\": [],\n  \"evidence\": [],\n  \"ctf\": [],\n  \"boundaries\": [\n    {{\n      \"id\": \"B001\",\n      \"scope\": \"7hell-s2-single-file\",\n      \"status\": \"s2-single-file-check-only\",\n      \"reason\": \"{}\"\n    }}\n  ]\n}}\n",
+        "{{\n  \"schema\": \"semantic.7hell.report.v0\",\n  \"tool\": \"smc 7hell\",\n  \"target\": {{\n    \"kind\": \"single-file\",\n    \"display\": \"{}\",\n    \"normalized\": \"{}\"\n  }},\n  \"profile\": \"default\",\n  \"result\": \"{}\",\n  \"stages\": [\n{}\n  ],\n  \"diagnostics\": {},\n  \"evidence\": [],\n  \"ctf\": [],\n  \"boundaries\": [\n    {{\n      \"id\": \"B001\",\n      \"scope\": \"7hell-s2-single-file\",\n      \"status\": \"s2-single-file-check-only\",\n      \"reason\": \"{}\"\n    }}\n  ]\n}}\n",
         json_escape(&report.target_display),
         json_escape(&report.target_normalized),
         report.result.as_json(),
         stages,
+        diagnostics,
         json_escape(report.boundary)
     )
+}
+
+fn render_json_string_array(values: &[String]) -> String {
+    let mut out = String::from("[");
+    for (idx, value) in values.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        out.push('"');
+        out.push_str(&json_escape(value));
+        out.push('"');
+    }
+    out.push(']');
+    out
+}
+
+fn render_json_diagnostics(diagnostics: &[SevenHellDiagnostic]) -> String {
+    if diagnostics.is_empty() {
+        return "[]".to_string();
+    }
+    let mut out = String::from("[\n");
+    for (idx, diagnostic) in diagnostics.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(",\n");
+        }
+        let line = match diagnostic.source.line {
+            Some(line) => line.to_string(),
+            None => "null".to_string(),
+        };
+        let column = match diagnostic.source.column {
+            Some(column) => column.to_string(),
+            None => "null".to_string(),
+        };
+        out.push_str(&format!(
+            "    {{\n      \"id\": \"{}\",\n      \"stage\": \"{}\",\n      \"kind\": \"{}\",\n      \"code\": \"{}\",\n      \"category\": \"{}\",\n      \"message_needle\": \"{}\",\n      \"severity\": \"{}\",\n      \"source\": {{\n        \"file\": \"{}\",\n        \"line\": {},\n        \"column\": {}\n      }}\n    }}",
+            json_escape(&diagnostic.id),
+            json_escape(diagnostic.stage),
+            diagnostic.kind.as_json(),
+            json_escape(&diagnostic.code),
+            json_escape(diagnostic.category),
+            json_escape(&diagnostic.message_needle),
+            json_escape(diagnostic.severity),
+            json_escape(&diagnostic.source.file),
+            line,
+            column
+        ));
+    }
+    out.push_str("\n  ]");
+    out
+}
+
+fn diagnostic_from_check_error(error_text: &str, target_display: &str) -> SevenHellDiagnostic {
+    let first_line = error_text.lines().next().unwrap_or(error_text);
+    let code = extract_error_code(first_line).unwrap_or_else(|| "unknown".to_string());
+    let message_needle = extract_error_message(first_line).unwrap_or_else(|| "check failed".to_string());
+    let (line, column) = extract_error_location(first_line);
+
+    let (stage, kind, category) = match code.as_str() {
+        "E0201" => ("type", SevenHellDiagnosticKind::CheckDiagnostic, "type"),
+        "E0000" => ("syntax", SevenHellDiagnosticKind::SyntaxDiagnostic, "syntax"),
+        c if c.starts_with('E') => ("syntax", SevenHellDiagnosticKind::SyntaxDiagnostic, "syntax"),
+        _ => ("syntax", SevenHellDiagnosticKind::CheckDiagnostic, "check"),
+    };
+
+    SevenHellDiagnostic {
+        id: "D001".to_string(),
+        stage,
+        kind,
+        code,
+        category,
+        message_needle,
+        severity: "error",
+        source: SevenHellDiagnosticSource {
+            file: target_display.to_string(),
+            line,
+            column,
+        },
+    }
+}
+
+fn boundary_denial_diagnostic(target_display: &str) -> SevenHellDiagnostic {
+    SevenHellDiagnostic {
+        id: "D001".to_string(),
+        stage: "syntax",
+        kind: SevenHellDiagnosticKind::BoundaryDenial,
+        code: "E0239".to_string(),
+        category: "boundary",
+        message_needle: "input file could not be read".to_string(),
+        severity: "error",
+        source: SevenHellDiagnosticSource {
+            file: target_display.to_string(),
+            line: None,
+            column: None,
+        },
+    }
+}
+
+fn extract_error_code(line: &str) -> Option<String> {
+    let start = line.find('[')? + 1;
+    let end = line[start..].find(']')? + start;
+    Some(line[start..end].to_string())
+}
+
+fn extract_error_message(line: &str) -> Option<String> {
+    let after_colon = line.find("]: ")? + 3;
+    let tail = &line[after_colon..];
+    if let Some(pos) = tail.rfind(" at line ") {
+        Some(tail[..pos].trim().to_string())
+    } else {
+        Some(tail.trim().to_string())
+    }
+}
+
+fn extract_error_location(line: &str) -> (Option<u32>, Option<u32>) {
+    let Some(pos) = line.rfind(" at line ") else {
+        return (None, None);
+    };
+    let loc = &line[(pos + " at line ".len())..];
+    let mut split = loc.split(':');
+    let line = split.next().and_then(|v| v.parse::<u32>().ok());
+    let column = split.next().and_then(|v| v.parse::<u32>().ok());
+    (line, column)
 }
 
 fn json_escape(value: &str) -> String {
@@ -473,6 +710,7 @@ mod tests {
         assert!(rendered.contains("\"status\": \"pass\""));
         assert!(rendered.contains("\"blocked_by\": null"));
         assert!(rendered.contains("\"scope\": \"7hell-s2-single-file\""));
+        assert!(rendered.contains("\"diagnostics\": []"));
     }
 
     #[test]
@@ -514,11 +752,44 @@ fn main() {
         assert!(outcome.rendered.contains("\"result\": \"fail\""));
         assert!(outcome.rendered.contains("\"status\": \"fail\""));
         assert!(outcome.rendered.contains("\"status\": \"blocked\""));
-        assert!(outcome.rendered.contains(
-            "single-file check failed; diagnostic wiring reserved for 7HELL-S3"
-        ));
+        assert!(outcome.rendered.contains("\"diagnostics\": ["));
+        assert!(outcome.rendered.contains("\"id\": \"D001\""));
+        assert!(outcome.rendered.contains("\"kind\": \"syntax-diagnostic\""));
+        assert!(outcome.rendered.contains("\"category\": \"syntax\""));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn syntax_failure_includes_stable_diagnostic_summary() {
+        let dir = mk_temp_dir("smc_7hell_s2_display");
+        let entry = dir.join("program.sm");
+        std::fs::write(&entry, "fn main(").expect("write source");
+
+        let outcome = execute_7hell_single_file(&entry.to_string_lossy(), SevenHellOutputMode::Human);
+        assert!(outcome.rendered.contains("Syntax Hell"));
+        assert!(outcome.rendered.contains("FAIL"));
+        assert!(outcome.rendered.contains("code: E0000"));
+        assert!(outcome.rendered.contains("category: syntax"));
+        assert!(outcome.rendered.contains("summary:"));
+        assert!(!outcome.rendered.contains(&*entry.to_string_lossy()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn type_failure_populates_check_diagnostic() {
+        let outcome = execute_7hell_single_file(
+            "tests/fixtures/pcc3_text/negative_to_text_record.sm",
+            SevenHellOutputMode::Json,
+        );
+        assert!(!outcome.success);
+        assert!(outcome.rendered.contains("\"stage\": \"type\""));
+        assert!(outcome.rendered.contains("\"kind\": \"check-diagnostic\""));
+        assert!(outcome.rendered.contains("\"code\": \"E0201\""));
+        assert!(outcome.rendered.contains("\"category\": \"type\""));
+        assert!(outcome.rendered.contains("\"result\": \"fail\""));
+        assert!(outcome.rendered.contains("\"diagnostics\": ["));
     }
 
     #[test]


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-S3 diagnostic report wiring only; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace behavior change

7hell touched:
  - src/bin/smc.rs

Reason:
  Add stable Syntax/Type diagnostic object wiring for single-file 7hell check failures.

7hell status impact:
  - diagnostics[] may be populated for Syntax/Type check failures
  - Syntax/Type stage failure classification becomes more explicit
  - downstream stages remain blocked or not_implemented
  - result remains incomplete on successful Syntax/Type only
  - no compile/lower/SemCode/verifier/VM behavior
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure
