### PR TITLE
PR-7HELL-S4 — cli(7hell): add verifier / VM stage placeholders with explicit blocked states

### DIFF
--- a/src/bin/smc.rs
+++ b/src/bin/smc.rs
@@ -252,7 +252,7 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 "Lowering Hell",
                 "lowering",
                 SevenHellStageStatus::NotImplemented,
-                "7HELL-S2 does not lower",
+                "lowering stage not implemented in 7HELL-S4",
                 None,
                 vec![],
             ),
@@ -260,27 +260,27 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 4,
                 "Verifier Hell",
                 "verifier",
-                SevenHellStageStatus::NotImplemented,
-                "7HELL-S2 does not verify",
-                None,
+                SevenHellStageStatus::Blocked,
+                "blocked until lowering/SemCode emission is available",
+                Some("lowering"),
                 vec![],
             ),
             stage_report(
                 5,
                 "VM Hell",
                 "vm",
-                SevenHellStageStatus::NotImplemented,
-                "7HELL-S2 does not run VM",
-                None,
+                SevenHellStageStatus::Blocked,
+                "blocked until verifier admission is available",
+                Some("verifier"),
                 vec![],
             ),
             stage_report(
                 6,
                 "Practical Hell",
                 "practical",
-                SevenHellStageStatus::NotImplemented,
-                "7HELL-S2 does not execute practical stage",
-                None,
+                SevenHellStageStatus::Blocked,
+                "blocked until VM execution is available",
+                Some("vm"),
                 vec![],
             ),
             stage_report(
@@ -288,13 +288,13 @@ fn build_passed_7hell_report(target_display: String) -> SevenHellReport {
                 "User Pain / Diagnostics Hell",
                 "diagnostics",
                 SevenHellStageStatus::NotImplemented,
-                "7HELL-S2 does not wire diagnostics",
+                "7HELL-S4 does not wire diagnostics",
                 None,
                 vec![],
             ),
         ],
         diagnostics: Vec::new(),
-        boundary: "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure",
+        boundary: "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure",
     }
 }
 
@@ -389,7 +389,7 @@ fn build_failed_7hell_report(target_display: String, diagnostic: SevenHellDiagno
             ),
         ],
         diagnostics,
-        boundary: "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure",
+        boundary: "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure",
     }
 }
 
@@ -691,10 +691,10 @@ mod tests {
         assert!(rendered.contains("[1/7] Syntax Hell"));
         assert!(rendered.contains("[2/7] Type Hell"));
         assert!(rendered.contains("PASS"));
-        assert!(rendered.contains("NOT_IMPLEMENTED"));
+        assert!(rendered.contains("BLOCKED"));
         assert!(rendered.contains("result: INCOMPLETE"));
         assert!(rendered.contains(
-            "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure"
+            "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure"
         ));
         assert!(!rendered.contains("result: PASS"));
     }
@@ -708,7 +708,8 @@ mod tests {
         assert!(rendered.contains("\"key\": \"syntax\""));
         assert!(rendered.contains("\"key\": \"diagnostics\""));
         assert!(rendered.contains("\"status\": \"pass\""));
-        assert!(rendered.contains("\"blocked_by\": null"));
+        assert!(rendered.contains("\"status\": \"blocked\""));
+        assert!(rendered.contains("\"blocked_by\": \"lowering\""));
         assert!(rendered.contains("\"scope\": \"7hell-s2-single-file\""));
         assert!(rendered.contains("\"diagnostics\": []"));
     }
@@ -731,11 +732,11 @@ fn main() {
         assert!(outcome.success);
         assert!(outcome.rendered.contains("Syntax Hell"));
         assert!(outcome.rendered.contains("PASS"));
-        assert!(outcome.rendered.contains("NOT_IMPLEMENTED"));
+        assert!(outcome.rendered.contains("BLOCKED"));
         assert!(outcome.rendered.contains("result: INCOMPLETE"));
         assert!(!outcome.rendered.contains("result: PASS"));
         assert!(outcome.rendered.contains(
-            "boundary: S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure"
+            "boundary: S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure"
         ));
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/tests/7hell_e1_report_snapshots.rs
+++ b/tests/7hell_e1_report_snapshots.rs
@@ -75,20 +75,13 @@ fn syntax_invalid_json_snapshot() {
         &String::from_utf8_lossy(&output.stdout),
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.is_empty(),
-        "unexpected stderr: {}",
-        stderr
-    );
+    assert!(stderr.is_empty(), "unexpected stderr: {}", stderr);
 }
 
 #[test]
 fn project_flag_rejected() {
     let output = smc_output(&["7hell", "--project", "."]);
-    assert!(
-        !output.status.success(),
-        "command unexpectedly succeeded"
-    );
+    assert!(!output.status.success(), "command unexpectedly succeeded");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("unknown flag '--project'"),

--- a/tests/fixtures/7hell_e1/snapshots/syntax_invalid_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/syntax_invalid_json.json
@@ -103,7 +103,7 @@
       "id": "B001",
       "scope": "7hell-s2-single-file",
       "status": "s2-single-file-check-only",
-      "reason": "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure"
+      "reason": "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure"
     }
   ]
 }

--- a/tests/fixtures/7hell_e1/snapshots/valid_human.txt
+++ b/tests/fixtures/7hell_e1/snapshots/valid_human.txt
@@ -8,15 +8,18 @@ profile: default
 [2/7] Type Hell                     PASS
   summary: single-file check accepted
 [3/7] Lowering Hell                 NOT_IMPLEMENTED
-  summary: 7HELL-S2 does not lower
-[4/7] Verifier Hell                 NOT_IMPLEMENTED
-  summary: 7HELL-S2 does not verify
-[5/7] VM Hell                       NOT_IMPLEMENTED
-  summary: 7HELL-S2 does not run VM
-[6/7] Practical Hell                NOT_IMPLEMENTED
-  summary: 7HELL-S2 does not execute practical stage
+  summary: lowering stage not implemented in 7HELL-S4
+[4/7] Verifier Hell                 BLOCKED
+  blocked_by: lowering
+  summary: blocked until lowering/SemCode emission is available
+[5/7] VM Hell                       BLOCKED
+  blocked_by: verifier
+  summary: blocked until verifier admission is available
+[6/7] Practical Hell                BLOCKED
+  blocked_by: vm
+  summary: blocked until VM execution is available
 [7/7] User Pain / Diagnostics Hell  NOT_IMPLEMENTED
-  summary: 7HELL-S2 does not wire diagnostics
+  summary: 7HELL-S4 does not wire diagnostics
 
 result: INCOMPLETE
-boundary: S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure
+boundary: S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure

--- a/tests/fixtures/7hell_e1/snapshots/valid_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/valid_json.json
@@ -34,7 +34,7 @@
       "name": "Lowering Hell",
       "key": "lowering",
       "status": "not_implemented",
-      "summary": "7HELL-S2 does not lower",
+      "summary": "lowering stage not implemented in 7HELL-S4",
       "diagnostic_ids": [],
       "evidence_ids": [],
       "blocked_by": null
@@ -43,38 +43,38 @@
       "index": 4,
       "name": "Verifier Hell",
       "key": "verifier",
-      "status": "not_implemented",
-      "summary": "7HELL-S2 does not verify",
+      "status": "blocked",
+      "summary": "blocked until lowering/SemCode emission is available",
       "diagnostic_ids": [],
       "evidence_ids": [],
-      "blocked_by": null
+      "blocked_by": "lowering"
     },
     {
       "index": 5,
       "name": "VM Hell",
       "key": "vm",
-      "status": "not_implemented",
-      "summary": "7HELL-S2 does not run VM",
+      "status": "blocked",
+      "summary": "blocked until verifier admission is available",
       "diagnostic_ids": [],
       "evidence_ids": [],
-      "blocked_by": null
+      "blocked_by": "verifier"
     },
     {
       "index": 6,
       "name": "Practical Hell",
       "key": "practical",
-      "status": "not_implemented",
-      "summary": "7HELL-S2 does not execute practical stage",
+      "status": "blocked",
+      "summary": "blocked until VM execution is available",
       "diagnostic_ids": [],
       "evidence_ids": [],
-      "blocked_by": null
+      "blocked_by": "vm"
     },
     {
       "index": 7,
       "name": "User Pain / Diagnostics Hell",
       "key": "diagnostics",
       "status": "not_implemented",
-      "summary": "7HELL-S2 does not wire diagnostics",
+      "summary": "7HELL-S4 does not wire diagnostics",
       "diagnostic_ids": [],
       "evidence_ids": [],
       "blocked_by": null
@@ -88,7 +88,7 @@
       "id": "B001",
       "scope": "7hell-s2-single-file",
       "status": "s2-single-file-check-only",
-      "reason": "S2 single-file check only; no compile, verify, VM run, project-root, CI gate, release readiness, or CTF closure"
+      "reason": "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure"
     }
   ]
 }


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-S4 downstream placeholder discipline only; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace behavior change

7hell touched:
  - src/bin/smc.rs
  - tests/7hell_e1_report_snapshots.rs
  - tests/fixtures/7hell_e1/

Reason:
  Make Lowering/Verifier/VM/Practical downstream placeholder states explicit without executing those stages.

7hell status impact:
  - Verifier/VM stages become explicit blocked placeholders when earlier required stages are unavailable
  - no compile/lower/SemCode/verifier/VM behavior
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure
