### PR TITLE
PR-7HELL-E2 — test(7hell): add type diagnostic snapshot coverage

### DIFF
--- a/tests/7hell_e1_report_snapshots.rs
+++ b/tests/7hell_e1_report_snapshots.rs
@@ -79,6 +79,30 @@ fn syntax_invalid_json_snapshot() {
 }
 
 #[test]
+fn type_invalid_json_snapshot() {
+    let input = fixture("tests/fixtures/7hell_e1/type_invalid.sm");
+    let output = smc_output(&["seven-hell", &input, "--json"]);
+    assert!(
+        !output.status.success(),
+        "command unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\"stage\": \"type\""));
+    assert!(stdout.contains("\"kind\": \"check-diagnostic\""));
+    assert!(stdout.contains("\"code\": \"E0201\""));
+    assert!(!stdout.contains("\"kind\": \"vm-trap\""));
+    assert!(!stdout.contains("\"kind\": \"verifier-rejection\""));
+    assert!(!stdout.contains("\"kind\": \"project-diagnostic\""));
+    assert_snapshot(
+        &repo_path("tests/fixtures/7hell_e1/snapshots/type_invalid_json.json"),
+        &stdout,
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.is_empty(), "unexpected stderr: {}", stderr);
+}
+
+#[test]
 fn project_flag_rejected() {
     let output = smc_output(&["7hell", "--project", "."]);
     assert!(!output.status.success(), "command unexpectedly succeeded");

--- a/tests/fixtures/7hell_e1/snapshots/type_invalid_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/type_invalid_json.json
@@ -1,0 +1,109 @@
+{
+  "schema": "semantic.7hell.report.v0",
+  "tool": "smc 7hell",
+  "target": {
+    "kind": "single-file",
+    "display": "tests/fixtures/7hell_e1/type_invalid.sm",
+    "normalized": "tests/fixtures/7hell_e1/type_invalid.sm"
+  },
+  "profile": "default",
+  "result": "fail",
+  "stages": [
+    {
+      "index": 1,
+      "name": "Syntax Hell",
+      "key": "syntax",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 2,
+      "name": "Type Hell",
+      "key": "type",
+      "status": "fail",
+      "summary": "code: E0201; category: type; summary: if condition must be bool; explicit compare is required for quad",
+      "diagnostic_ids": ["D001"],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 3,
+      "name": "Lowering Hell",
+      "key": "lowering",
+      "status": "blocked",
+      "summary": "blocked by earlier stage failure",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "type"
+    },
+    {
+      "index": 4,
+      "name": "Verifier Hell",
+      "key": "verifier",
+      "status": "blocked",
+      "summary": "blocked by earlier stage failure",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "lowering"
+    },
+    {
+      "index": 5,
+      "name": "VM Hell",
+      "key": "vm",
+      "status": "blocked",
+      "summary": "blocked by earlier stage failure",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "verifier"
+    },
+    {
+      "index": 6,
+      "name": "Practical Hell",
+      "key": "practical",
+      "status": "blocked",
+      "summary": "blocked by earlier stage failure",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "vm"
+    },
+    {
+      "index": 7,
+      "name": "User Pain / Diagnostics Hell",
+      "key": "diagnostics",
+      "status": "not_implemented",
+      "summary": "diagnostic wiring reserved for 7HELL-S3",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    }
+  ],
+  "diagnostics": [
+    {
+      "id": "D001",
+      "stage": "type",
+      "kind": "check-diagnostic",
+      "code": "E0201",
+      "category": "type",
+      "message_needle": "if condition must be bool; explicit compare is required for quad",
+      "severity": "error",
+      "source": {
+        "file": "tests/fixtures/7hell_e1/type_invalid.sm",
+        "line": 1,
+        "column": 1
+      }
+    }
+  ],
+  "evidence": [],
+  "ctf": [],
+  "boundaries": [
+    {
+      "id": "B001",
+      "scope": "7hell-s2-single-file",
+      "status": "s2-single-file-check-only",
+      "reason": "S4 downstream placeholder discipline only; no lower, SemCode emit, verifier, VM run, project-root, CI gate, release readiness, or CTF closure"
+    }
+  ]
+}

--- a/tests/fixtures/7hell_e1/type_invalid.sm
+++ b/tests/fixtures/7hell_e1/type_invalid.sm
@@ -1,0 +1,5 @@
+fn main() {
+    if 1 {
+        return;
+    }
+}


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-E2 type diagnostic snapshot tests only; no runtime value, trap, determinism, verifier, SymbolId, capability, or trace behavior change

7hell touched:
  - tests/7hell_e1_report_snapshots.rs
  - tests/fixtures/7hell_e1/type_invalid.sm
  - tests/fixtures/7hell_e1/snapshots/type_invalid_json.json

Reason:
  Add snapshot coverage for type-check diagnostic output in 7hell reports.

7hell status impact:
  - type diagnostic report shape becomes test-backed
  - no command behavior change
  - no compile/lower/SemCode/verifier/VM behavior
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure
