### PR TITLE
PR-7HELL-E3 — test(7hell): add verifier rejection snapshot coverage

### DIFF
--- a/src/bin/smc.rs
+++ b/src/bin/smc.rs
@@ -1050,6 +1050,35 @@ fn main() {
     }
 
     #[test]
+    fn verifier_reject_json_snapshot() {
+        let target = "tests/fixtures/7hell_e1/verifier_reject.synthetic.sm".to_string();
+        let report = sm_verify::RejectReport {
+            diagnostics: vec![sm_verify::VerificationDiagnostic {
+                code: sm_verify::VerificationCode::UnknownOpcode,
+                function: Some("main".to_string()),
+                offset: Some(0),
+                message: "unknown opcode 0xff".to_string(),
+            }],
+        };
+        let diagnostic = diagnostic_from_verifier_error(&report, &target);
+        let seven = build_verifier_failed_7hell_report(target.clone(), diagnostic);
+        let rendered = render_7hell_report(&seven, SevenHellOutputMode::Json);
+
+        assert!(rendered.contains("\"kind\": \"verifier-rejection\""));
+        assert!(rendered.contains("\"stage\": \"verifier\""));
+        assert!(rendered.contains("\"code\": \"UnknownOpcode\""));
+        assert!(!rendered.contains("\"kind\": \"vm-trap\""));
+        assert!(!rendered.contains("\"kind\": \"project-diagnostic\""));
+        assert!(!rendered.contains("\"result\": \"pass\""));
+
+        let snapshot = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/7hell_e1/snapshots/verifier_reject_json.json");
+        let expected = std::fs::read_to_string(&snapshot)
+            .unwrap_or_else(|err| panic!("read {}: {}", snapshot.display(), err));
+        assert_eq!(expected.replace("\r\n", "\n"), rendered.replace("\r\n", "\n"));
+    }
+
+    #[test]
     fn display_path_never_reveals_absolute_temp_path() {
         let dir = mk_temp_dir("smc_7hell_s2_display");
         let entry = dir.join("program.sm");

--- a/tests/fixtures/7hell_e1/snapshots/verifier_reject_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/verifier_reject_json.json
@@ -1,0 +1,109 @@
+{
+  "schema": "semantic.7hell.report.v0",
+  "tool": "smc 7hell",
+  "target": {
+    "kind": "single-file",
+    "display": "tests/fixtures/7hell_e1/verifier_reject.synthetic.sm",
+    "normalized": "tests/fixtures/7hell_e1/verifier_reject.synthetic.sm"
+  },
+  "profile": "default",
+  "result": "fail",
+  "stages": [
+    {
+      "index": 1,
+      "name": "Syntax Hell",
+      "key": "syntax",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 2,
+      "name": "Type Hell",
+      "key": "type",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 3,
+      "name": "Lowering Hell",
+      "key": "lowering",
+      "status": "pass",
+      "summary": "SemCode emitted for verifier admission",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 4,
+      "name": "Verifier Hell",
+      "key": "verifier",
+      "status": "fail",
+      "summary": "code: UnknownOpcode; category: verifier; summary: unknown opcode 0xff",
+      "diagnostic_ids": ["D001"],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 5,
+      "name": "VM Hell",
+      "key": "vm",
+      "status": "blocked",
+      "summary": "VM execution intentionally not implemented in 7HELL-S5",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "vm"
+    },
+    {
+      "index": 6,
+      "name": "Practical Hell",
+      "key": "practical",
+      "status": "blocked",
+      "summary": "blocked until VM execution is available",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "vm"
+    },
+    {
+      "index": 7,
+      "name": "User Pain / Diagnostics Hell",
+      "key": "diagnostics",
+      "status": "not_implemented",
+      "summary": "7HELL-S5 does not wire diagnostics",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    }
+  ],
+  "diagnostics": [
+    {
+      "id": "D001",
+      "stage": "verifier",
+      "kind": "verifier-rejection",
+      "code": "UnknownOpcode",
+      "category": "verifier",
+      "message_needle": "unknown opcode 0xff",
+      "severity": "error",
+      "source": {
+        "file": "tests/fixtures/7hell_e1/verifier_reject.synthetic.sm",
+        "line": null,
+        "column": null
+      }
+    }
+  ],
+  "evidence": [],
+  "ctf": [],
+  "boundaries": [
+    {
+      "id": "B001",
+      "scope": "7hell-single-file",
+      "status": "s5-verifier-stage-only",
+      "reason": "S5 verifier-stage execution only; no VM run, project-root, cache route, temp .smc, CI gate, release readiness, or CTF closure"
+    }
+  ]
+}


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-E3 verifier rejection snapshot coverage only; no runtime value, VM trap, SymbolId, capability, trace, project-root, or release-gate behavior change

7hell touched:

* src/bin/smc.rs test-only section
* tests/fixtures/7hell_e1/snapshots/verifier_reject_json.json

Reason:
Add test-backed snapshot coverage for existing verifier rejection report path.

7hell status impact:

* verifier rejection report shape becomes test-backed
* no command behavior change
* no VM execution
* no project-root behavior
* no CI gate
* no release readiness claim
* no CTF closure