### PR TITLE
PR-7HELL-E4 — test(7hell): add VM trap snapshot coverage

### DIFF
--- a/tests/7hell_e1_report_snapshots.rs
+++ b/tests/7hell_e1_report_snapshots.rs
@@ -103,6 +103,36 @@ fn type_invalid_json_snapshot() {
 }
 
 #[test]
+fn vm_trap_assert_false_json_snapshot() {
+    let input = fixture("tests/fixtures/7hell_e1/vm_trap_assert_false.sm");
+    let output = smc_output(&["seven-hell", &input, "--json"]);
+    assert!(
+        !output.status.success(),
+        "command unexpectedly succeeded: {}",
+        normalize(&String::from_utf8_lossy(&output.stdout))
+    );
+
+    let stdout = normalize(&String::from_utf8_lossy(&output.stdout));
+    assert!(stdout.contains("\"stage\": \"vm\""));
+    assert!(stdout.contains("\"kind\": \"vm-trap\""));
+    assert!(stdout.contains("\"code\": \"AssertionFailed\""));
+    assert!(stdout.contains("\"result\": \"fail\""));
+    assert!(stdout.contains("\"key\": \"practical\""));
+    assert!(stdout.contains("\"blocked_by\": \"vm\""));
+    assert!(!stdout.contains("\"kind\": \"verifier-rejection\""));
+    assert!(!stdout.contains("\"kind\": \"project-diagnostic\""));
+    assert!(!stdout.contains("\"result\": \"pass\""));
+
+    assert_snapshot(
+        &repo_path("tests/fixtures/7hell_e1/snapshots/vm_trap_assert_false_json.json"),
+        &stdout,
+    );
+
+    let stderr = normalize(&String::from_utf8_lossy(&output.stderr));
+    assert!(stderr.is_empty(), "unexpected stderr: {}", stderr);
+}
+
+#[test]
 fn project_flag_rejected() {
     let output = smc_output(&["7hell", "--project", "."]);
     assert!(!output.status.success(), "command unexpectedly succeeded");

--- a/tests/fixtures/7hell_e1/snapshots/vm_trap_assert_false_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/vm_trap_assert_false_json.json
@@ -1,0 +1,109 @@
+{
+  "schema": "semantic.7hell.report.v0",
+  "tool": "smc 7hell",
+  "target": {
+    "kind": "single-file",
+    "display": "tests/fixtures/7hell_e1/vm_trap_assert_false.sm",
+    "normalized": "tests/fixtures/7hell_e1/vm_trap_assert_false.sm"
+  },
+  "profile": "default",
+  "result": "fail",
+  "stages": [
+    {
+      "index": 1,
+      "name": "Syntax Hell",
+      "key": "syntax",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 2,
+      "name": "Type Hell",
+      "key": "type",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 3,
+      "name": "Lowering Hell",
+      "key": "lowering",
+      "status": "pass",
+      "summary": "SemCode emitted for verifier admission",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 4,
+      "name": "Verifier Hell",
+      "key": "verifier",
+      "status": "pass",
+      "summary": "SemCode verifier accepted program",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 5,
+      "name": "VM Hell",
+      "key": "vm",
+      "status": "fail",
+      "summary": "code: AssertionFailed; category: vm; summary: assertion failed",
+      "diagnostic_ids": ["D001"],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 6,
+      "name": "Practical Hell",
+      "key": "practical",
+      "status": "blocked",
+      "summary": "host-visible effects and practical qualification are outside 7HELL-S6",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": "vm"
+    },
+    {
+      "index": 7,
+      "name": "User Pain / Diagnostics Hell",
+      "key": "diagnostics",
+      "status": "not_implemented",
+      "summary": "7HELL-S6 does not wire diagnostics",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    }
+  ],
+  "diagnostics": [
+    {
+      "id": "D001",
+      "stage": "vm",
+      "kind": "vm-trap",
+      "code": "AssertionFailed",
+      "category": "vm",
+      "message_needle": "assertion failed",
+      "severity": "error",
+      "source": {
+        "file": "tests/fixtures/7hell_e1/vm_trap_assert_false.sm",
+        "line": null,
+        "column": null
+      }
+    }
+  ],
+  "evidence": [],
+  "ctf": [],
+  "boundaries": [
+    {
+      "id": "B001",
+      "scope": "7hell-single-file",
+      "status": "s6-silent-vm-stage-only",
+      "reason": "S6 silent VM-stage execution only; no host-visible output, project-root, cache route, temp .smc, CI gate, release readiness, or CTF closure"
+    }
+  ]
+}

--- a/tests/fixtures/7hell_e1/vm_trap_assert_false.sm
+++ b/tests/fixtures/7hell_e1/vm_trap_assert_false.sm
@@ -1,0 +1,4 @@
+fn main() {
+    assert(false);
+    return;
+}


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-E4 VM trap snapshot coverage only; no runtime value semantics, verifier behavior, capability/audit envelope, project-root, release gate, or CTF closure behavior change

7hell touched:
- tests/7hell_e1_report_snapshots.rs
- tests/fixtures/7hell_e1/vm_trap_assert_false.sm
- tests/fixtures/7hell_e1/snapshots/vm_trap_assert_false_json.json

Reason:
Add test-backed snapshot coverage for VM trap report shape after S6.

7hell status impact:
- VM trap report shape becomes test-backed
- no command behavior change
- no host-visible output
- no capability/audit envelope widening
- no project-root behavior
- no CI gate
- no release readiness claim
- no CTF closure