### PR TITLE
PR-7HELL-E5 — test(7hell): add Practical qualification failure/denial snapshot coverage

### DIFF
--- a/src/bin/smc.rs
+++ b/src/bin/smc.rs
@@ -1470,6 +1470,43 @@ fn main() {
     }
 
     #[test]
+    fn practical_failure_json_snapshot() {
+        let target = "tests/fixtures/7hell_e1/practical_failure.synthetic.sm".to_string();
+        let diagnostic = diagnostic_from_practical_error(
+            "controlled observation capability denied",
+            &target,
+        );
+        let report = build_practical_failed_7hell_report(target.clone(), diagnostic);
+        let rendered = render_7hell_report(&report, SevenHellOutputMode::Json);
+
+        assert!(rendered.contains("\"stage\": \"practical\""));
+        assert!(rendered.contains("\"kind\": \"practical-diagnostic\""));
+        assert!(rendered.contains("\"code\": \"PracticalQualificationFailed\""));
+        assert!(rendered.contains("\"category\": \"practical\""));
+        assert!(rendered.contains("\"result\": \"fail\""));
+        assert!(rendered.contains("\"key\": \"practical\""));
+        assert!(rendered.contains("\"status\": \"fail\""));
+        assert!(rendered.contains("\"key\": \"vm\""));
+        assert!(rendered.contains("\"status\": \"pass\""));
+        assert!(rendered.contains("\"key\": \"diagnostics\""));
+        assert!(rendered.contains("\"status\": \"not_implemented\""));
+        assert!(!rendered.contains("\"kind\": \"vm-trap\""));
+        assert!(!rendered.contains("\"kind\": \"verifier-rejection\""));
+        assert!(!rendered.contains("\"kind\": \"project-diagnostic\""));
+        assert!(!rendered.contains("rendered_lines"));
+        assert!(!rendered.contains("raw_text"));
+        assert!(!rendered.contains("stdout"));
+        assert!(!rendered.contains("Hello, World!"));
+        assert!(!rendered.contains("\"result\": \"pass\""));
+
+        let snapshot = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/7hell_e1/snapshots/practical_failure_json.json");
+        let expected = std::fs::read_to_string(&snapshot)
+            .unwrap_or_else(|err| panic!("read {}: {}", snapshot.display(), err));
+        assert_eq!(expected.replace("\r\n", "\n"), rendered.replace("\r\n", "\n"));
+    }
+
+    #[test]
     fn display_path_never_reveals_absolute_temp_path() {
         let dir = mk_temp_dir("smc_7hell_s2_display");
         let entry = dir.join("program.sm");

--- a/tests/fixtures/7hell_e1/snapshots/practical_failure_json.json
+++ b/tests/fixtures/7hell_e1/snapshots/practical_failure_json.json
@@ -1,0 +1,109 @@
+{
+  "schema": "semantic.7hell.report.v0",
+  "tool": "smc 7hell",
+  "target": {
+    "kind": "single-file",
+    "display": "tests/fixtures/7hell_e1/practical_failure.synthetic.sm",
+    "normalized": "tests/fixtures/7hell_e1/practical_failure.synthetic.sm"
+  },
+  "profile": "default",
+  "result": "fail",
+  "stages": [
+    {
+      "index": 1,
+      "name": "Syntax Hell",
+      "key": "syntax",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 2,
+      "name": "Type Hell",
+      "key": "type",
+      "status": "pass",
+      "summary": "single-file check accepted",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 3,
+      "name": "Lowering Hell",
+      "key": "lowering",
+      "status": "pass",
+      "summary": "SemCode emitted for verifier admission",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 4,
+      "name": "Verifier Hell",
+      "key": "verifier",
+      "status": "pass",
+      "summary": "SemCode verifier accepted program",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 5,
+      "name": "VM Hell",
+      "key": "vm",
+      "status": "pass",
+      "summary": "VM executed verified SemCode successfully",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 6,
+      "name": "Practical Hell",
+      "key": "practical",
+      "status": "fail",
+      "summary": "code: PracticalQualificationFailed; category: practical; summary: controlled observation capability denied",
+      "diagnostic_ids": ["D001"],
+      "evidence_ids": [],
+      "blocked_by": null
+    },
+    {
+      "index": 7,
+      "name": "User Pain / Diagnostics Hell",
+      "key": "diagnostics",
+      "status": "not_implemented",
+      "summary": "7HELL-S7 does not wire diagnostics",
+      "diagnostic_ids": [],
+      "evidence_ids": [],
+      "blocked_by": null
+    }
+  ],
+  "diagnostics": [
+    {
+      "id": "D001",
+      "stage": "practical",
+      "kind": "practical-diagnostic",
+      "code": "PracticalQualificationFailed",
+      "category": "practical",
+      "message_needle": "controlled observation capability denied",
+      "severity": "error",
+      "source": {
+        "file": "tests/fixtures/7hell_e1/practical_failure.synthetic.sm",
+        "line": null,
+        "column": null
+      }
+    }
+  ],
+  "evidence": [],
+  "ctf": [],
+  "boundaries": [
+    {
+      "id": "B001",
+      "scope": "7hell-single-file",
+      "status": "s7-practical-qualification-only",
+      "reason": "S7 non-rendering Practical qualification only; no raw observation text, host-visible output, project-root, cache route, temp .smc, CI gate, release readiness, or CTF closure"
+    }
+  ]
+}


### PR DESCRIPTION
CTF touched: none
Reason: 7HELL-E5 Practical failure snapshot coverage only; no runtime value semantics, VM trap semantics, verifier behavior, capability policy semantics, audit persistence, project-root, release gate, or CTF closure behavior change

7hell touched:
  - src/bin/smc.rs test-only section
  - tests/fixtures/7hell_e1/snapshots/practical_failure_json.json

Reason:
  Add test-backed snapshot coverage for Practical Hell failure report shape after S7.

7hell status impact:
  - Practical failure report shape becomes test-backed
  - no command behavior change
  - no production Practical qualification behavior change
  - no host-visible output
  - no raw observation text
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure
