### PR TITLE
PR-7HELL-WR2 — docs(7hell): waypoint review after S1..S7 and E1..E5

### DIFF
--- a/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
+++ b/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
@@ -1,0 +1,102 @@
+# 7HELL Waypoint Review after S1..S7 and E1..E5
+
+Status: waypoint review
+Scope: 7hell command, report shape, stage execution, and snapshot evidence
+Non-goal: release readiness, CTF closure, project-root behavior, package/workspace behavior
+
+## 1. Current stage status
+
+| Stage | Status | What it is backed by | Current evidence |
+| --- | --- | --- | --- |
+| Stage 1 Syntax Hell | active | single-file check | syntax failure snapshot exists |
+| Stage 2 Type Hell | active | single-file check | type diagnostic snapshot exists |
+| Stage 3 Lowering Hell | active | SemCode emission before verifier | lowering is wired before verifier |
+| Stage 4 Verifier Hell | active | `verify_semcode` | verifier rejection snapshot exists |
+| Stage 5 VM Hell | active for silent verified single-file fixtures | `run_verified_semcode` | VM trap snapshot exists |
+| Stage 6 Practical Hell | active through non-rendering Practical qualification envelope | no raw text / no `rendered_lines` | Practical failure snapshot exists |
+| Stage 7 Diagnostics Hell | still `NOT_IMPLEMENTED` | reserved report slot only | not release-ready |
+
+The valid full S7 path currently reads:
+
+```text
+Syntax PASS
+Type PASS
+Lowering PASS
+Verifier PASS
+VM PASS
+Practical PASS
+Diagnostics NOT_IMPLEMENTED
+result INCOMPLETE
+```
+
+That `result: incomplete` remains correct because Diagnostics Hell is still not implemented and `7hell` is not a release gate.
+
+## 2. Evidence Ledger
+
+| Evidence | What it proves | What it does not prove | Boundary |
+| --- | --- | --- | --- |
+| E1 | first report snapshots exist | does not prove later stage execution | report shape only |
+| E2 | type diagnostic snapshot coverage exists | does not prove lowering/verifier/VM/practical behavior | syntax/type classification only |
+| E3 | verifier rejection snapshot coverage exists | does not prove VM or Practical qualification | verifier admission only |
+| E4 | VM trap snapshot coverage exists | does not prove host-visible observation behavior | silent verified VM path only |
+| E5 | Practical failure snapshot coverage exists | does not prove release readiness or final pass | non-rendering Practical failure path only |
+
+## 3. Guardrails preserved
+
+- no project-root behavior
+- no `semantic.toml`
+- no `src/main.sm` discovery
+- no `smc new`
+- no package registry
+- no workspace behavior
+- no temp `.smc` route
+- no cache route
+- no `cmd_run` / `cmd_run_smc` route inside `7hell`
+- no `render_controlled_observation_envelope` route inside `7hell`
+- no raw observation text in `7hell` JSON
+- no `rendered_lines` in `7hell` JSON
+- no host-visible output through `7hell`
+- no final PASS
+- no release readiness claim
+- no CTF closure claim
+
+## 4. Current result semantics
+
+Valid S7 path:
+
+- Syntax PASS
+- Type PASS
+- Lowering PASS
+- Verifier PASS
+- VM PASS
+- Practical PASS
+- Diagnostics NOT_IMPLEMENTED
+- result INCOMPLETE
+
+Failure paths:
+
+- syntax/type failure -> result FAIL
+- verifier rejection -> result FAIL
+- VM trap -> result FAIL
+- Practical failure -> result FAIL
+
+`result: incomplete` is still the correct success outcome for the current S7 path because Diagnostics Hell remains unimplemented.
+
+## 5. Remaining bounded work
+
+- `7HELL-S8-AUDIT` - audit(7hell): define Diagnostics Hell seam before execution
+- `7HELL-S8-SEAM` - optional, only if audit finds no safe seam
+- `7HELL-S8` - cli(7hell): add Diagnostics Hell summary if safe
+- `7HELL-E6` - test(7hell): diagnostics-stage snapshot coverage
+
+Do not jump to release readiness.
+Do not turn `7hell` into a CI gate yet.
+Do not add project-root before separate PCC-9I/project-root work.
+
+## 6. Decision
+
+Decision:
+`7HELL` has reached Practical qualification for single-file reports.
+This is not release readiness.
+This is not CTF closure.
+Next phase should focus on Diagnostics Hell and report usability, not project-root expansion.

--- a/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
+++ b/docs/roadmap/language_maturity/practical_core_completion_v0_3.md
@@ -212,6 +212,7 @@ Qualification report contract:
 
 7HELL-WP2 maps PCC-4..PCC-9 evidence into the 7hell stage model; this is a docs-only mapping and stage execution remains future work.
 7HELL-WP3 defines skeleton-to-runner transition rules before S2 implementation.
+7HELL-WR2 records the post-S1..S7 and E1..E5 waypoint review once E5 is merged.
 
 ## 7. CTF-0 — Core Trust Freeze directory
 


### PR DESCRIPTION
CTF touched: none
Reason: docs-only 7hell waypoint review; no runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root, release gate, or CTF closure behavior change

7hell touched:
  - docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
  - docs/roadmap/language_maturity/practical_core_completion_v0_3.md

Reason:
  Record waypoint review after 7HELL S1..S7 and E1..E5.

7hell status impact:
  - no command behavior change
  - no new execution behavior
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure
