### PR TITLE
PR-7HELL-STATUS-REFRESH-CLEAN — docs(7hell): refresh current stage matrix after S1..S7 and E1..E5

### DIFF
--- a/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
+++ b/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
@@ -1,0 +1,109 @@
+# 7HELL Current Status after WR2
+
+Status: post-WR2 status refresh
+Track: 7hell readiness / qualification contour
+Scope: current stage matrix after S1..S7 and E1..E5
+Non-goal: implementation, S8, release readiness, CI gate, or CTF closure
+
+Related:
+
+- `7hell_qualification_contract.md`
+- `7hell_waypoint_review_after_s1_s7_e1_e5.md`
+- `roadmap_wave_2_7hell_update.md`
+
+## 1. Current status summary
+
+`7hell` is now an active CLI qualification contour, not just a docs idea or
+skeleton.
+
+Current bounded status:
+
+- S1..S7 are completed in the bounded current scope.
+- E1..E5 are completed.
+- WR2 has been recorded.
+- `7hell` is still not a release gate.
+- `7hell` is still not a CI gate.
+- `7hell` is still not CTF closure.
+- `7hell` remains a readiness measurement contour.
+
+The current posture is therefore:
+
+```text
+AUDIT -> SEAM -> EXECUTION -> SNAPSHOT -> WAYPOINT
+```
+
+That sequence is the discipline used for the completed 7hell wave and is the
+only pattern this document records.
+
+## 2. Stage matrix
+
+| Stage | Current status | Evidence | Recent PRs | Notes / limits |
+| --- | --- | --- | --- | --- |
+| Syntax Hell | active / report-backed | S2/S3 + E1 snapshots | current S1..S7 wave, refreshed through #740 | single-file path only, no project-root behavior |
+| Type Hell | active / report-backed | S2/S3 + E2 snapshots | current S1..S7 wave, refreshed through #740 | single-file check path, no language widening |
+| Lowering Hell | covered through compile path / explicit status | S5 verifier-stage path requires compile-to-SemCode | current S1..S7 wave, refreshed through #740 | not a separate broad lowering qualification suite yet |
+| Verifier Hell | active / rejection snapshot-backed | S5 + E3 | #730, #731, #732, #740 | selected single-file fixtures only, no verifier behavior change |
+| VM Hell | active / trap snapshot-backed | S6 + E4 | #733, #734, #735, #740 | silent verified single-file VM execution only, no host-visible output |
+| Practical Hell | active / failure snapshot-backed | S7 + E5 | #736, #737, #738, #739, #740 | uses non-rendering practical envelope, no raw observation text, no host-visible output |
+| Diagnostics Hell / User Pain | not implemented / decision required | none yet | pending next decision only | must not be implemented before deciding whether it is a standalone S8 stage, a report-quality layer, or a future PCC diagnostics track |
+
+## 3. Recent PR pattern
+
+The latest 7hell work follows a bounded pattern that should remain the default
+for future Diagnostics/User-Pain work:
+
+- audit-only PR first;
+- seam exposure second where needed;
+- execution / wiring PR third;
+- snapshot coverage after the behavior shape exists;
+- waypoint review after the bounded group is complete.
+
+Any future Diagnostics Hell work must follow that same pattern.
+
+## 4. Next decision: Diagnostics Hell boundary
+
+Before implementation begins, Diagnostics Hell must be classified as one of:
+
+- A. Standalone `7HELL-S8` stage
+- B. Report-quality layer applied across all failure reports
+- C. Future PCC diagnostics track, not part of the current 7hell wave
+
+This document does not choose among those options.
+That decision is still required before any Diagnostics Hell implementation work.
+
+## 5. Explicit non-goals
+
+- no S8 implementation
+- no diagnostics quality scoring
+- no command behavior change
+- no new execution behavior
+- no project-root behavior
+- no CI gate
+- no release readiness claim
+- no CTF closure
+- no runtime value semantics change
+- no VM trap semantics change
+- no verifier behavior change
+- no capability or audit behavior change
+- no trace policy change
+
+## 6. CTF statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only status refresh after WR2. It does not change runtime value
+semantics, VM trap semantics, verifier behavior, capability/audit behavior,
+trace policy, project-root behavior, release gates, or CTF closure behavior.
+
+## 7. 7hell status impact
+
+- current 7hell stage matrix is refreshed
+- Practical Hell is recorded as active and snapshot-backed in the bounded current contour
+- Diagnostics Hell remains not implemented pending decision
+- no command behavior change
+- no new execution behavior
+- no project-root behavior
+- no CI gate
+- no release readiness claim
+- no CTF closure

--- a/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
+++ b/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
@@ -18,9 +18,10 @@ skeleton.
 
 Current bounded status:
 
-- S1..S7 are completed in the bounded current scope.
-- E1..E5 are completed.
+- Implementation work packages S1..S7 are completed in the bounded current scope.
+- Evidence packages E1..E5 are completed.
 - WR2 has been recorded.
+- This does not mean all 7hell stages are complete: Diagnostics Hell / User Pain remains not implemented and still requires a separate boundary decision.
 - `7hell` is still not a release gate.
 - `7hell` is still not a CI gate.
 - `7hell` is still not CTF closure.

--- a/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
+++ b/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
@@ -4,6 +4,10 @@ Status: waypoint review
 Scope: 7hell command, report shape, stage execution, and snapshot evidence
 Non-goal: release readiness, CTF closure, project-root behavior, package/workspace behavior
 
+Current post-WR2 status refresh:
+
+- `7hell_current_status_after_wr2.md`
+
 ## 1. Current stage status
 
 | Stage | Status | What it is backed by | Current evidence |
@@ -82,16 +86,17 @@ Failure paths:
 
 `result: incomplete` is still the correct success outcome for the current S7 path because Diagnostics Hell remains unimplemented.
 
-## 5. Remaining bounded work
+## 5. Remaining bounded decision
 
-- `7HELL-S8-AUDIT` - audit(7hell): define Diagnostics Hell seam before execution
-- `7HELL-S8-SEAM` - optional, only if audit finds no safe seam
-- `7HELL-S8` - cli(7hell): add Diagnostics Hell summary if safe
-- `7HELL-E6` - test(7hell): diagnostics-stage snapshot coverage
+Diagnostics Hell / User Pain remains undecided.
 
-Do not jump to release readiness.
-Do not turn `7hell` into a CI gate yet.
-Do not add project-root before separate PCC-9I/project-root work.
+Before implementation, decide whether it is:
+
+- A. standalone `7HELL-S8` stage;
+- B. report-quality layer across all failure reports;
+- C. future PCC diagnostics track outside the current 7hell wave.
+
+No S8 work should start before this decision is recorded.
 
 ## 6. Decision
 


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only 7hell status refresh recreated from the closed PR #741 on a clean branch from current main. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

7hell touched:
  - docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
  - docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md

Reason:
Record the current 7hell readiness/status matrix after S1..S7 and E1..E5, and preserve the next decision point before any Diagnostics Hell / User Pain implementation.

7hell status impact:
  - current stage matrix refreshed
  - Practical Hell recorded as active and snapshot-backed in bounded scope
  - Diagnostics Hell recorded as not implemented / decision required
  - no command behavior change
  - no new execution behavior
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Research / CI note:
This PR uses `[skip ci]` because GitHub Actions is currently blocked at the account level and the previous PR #741 already proved that Actions jobs fail before executing steps. This is not a release-readiness precedent and must not be used for code/runtime/verifier/VM/capability PRs.

Checks:
  - git diff --check clean