### PR TITLE
PR-7HELL-DIAG-DECISION — docs(7hell): decide Diagnostics Hell boundary before implementation

### DIFF
--- a/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
+++ b/docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
@@ -7,6 +7,7 @@ Non-goal: implementation, S8, release readiness, CI gate, or CTF closure
 
 Related:
 
+- `7hell_diagnostics_boundary_decision.md`
 - `7hell_qualification_contract.md`
 - `7hell_waypoint_review_after_s1_s7_e1_e5.md`
 - `roadmap_wave_2_7hell_update.md`
@@ -21,7 +22,8 @@ Current bounded status:
 - Implementation work packages S1..S7 are completed in the bounded current scope.
 - Evidence packages E1..E5 are completed.
 - WR2 has been recorded.
-- This does not mean all 7hell stages are complete: Diagnostics Hell / User Pain remains not implemented and still requires a separate boundary decision.
+- This does not mean all 7hell stages are complete: Diagnostics Hell / User Pain remains not implemented.
+- The Diagnostics Hell boundary decision is recorded in `7hell_diagnostics_boundary_decision.md`.
 - `7hell` is still not a release gate.
 - `7hell` is still not a CI gate.
 - `7hell` is still not CTF closure.
@@ -46,7 +48,7 @@ only pattern this document records.
 | Verifier Hell | active / rejection snapshot-backed | S5 + E3 | #730, #731, #732, #740 | selected single-file fixtures only, no verifier behavior change |
 | VM Hell | active / trap snapshot-backed | S6 + E4 | #733, #734, #735, #740 | silent verified single-file VM execution only, no host-visible output |
 | Practical Hell | active / failure snapshot-backed | S7 + E5 | #736, #737, #738, #739, #740 | uses non-rendering practical envelope, no raw observation text, no host-visible output |
-| Diagnostics Hell / User Pain | not implemented / decision required | none yet | pending next decision only | must not be implemented before deciding whether it is a standalone S8 stage, a report-quality layer, or a future PCC diagnostics track |
+| Diagnostics Hell / User Pain | not implemented / boundary decided | decision record only | `7hell_diagnostics_boundary_decision.md` | classified as a report-quality layer applied across existing failure reports; implementation remains future work |
 
 ## 3. Recent PR pattern
 
@@ -61,16 +63,17 @@ for future Diagnostics/User-Pain work:
 
 Any future Diagnostics Hell work must follow that same pattern.
 
-## 4. Next decision: Diagnostics Hell boundary
+## 4. Diagnostics Hell boundary decision
 
-Before implementation begins, Diagnostics Hell must be classified as one of:
+The boundary decision is recorded in:
 
-- A. Standalone `7HELL-S8` stage
-- B. Report-quality layer applied across all failure reports
-- C. Future PCC diagnostics track, not part of the current 7hell wave
+- `7hell_diagnostics_boundary_decision.md`
 
-This document does not choose among those options.
-That decision is still required before any Diagnostics Hell implementation work.
+Diagnostics Hell / User Pain is classified as a report-quality layer applied
+across existing failure reports.
+
+Diagnostics Hell remains not implemented.
+The next safe work package is audit-only.
 
 ## 5. Explicit non-goals
 

--- a/docs/roadmap/language_maturity/7hell_diagnostics_boundary_decision.md
+++ b/docs/roadmap/language_maturity/7hell_diagnostics_boundary_decision.md
@@ -1,0 +1,172 @@
+# 7HELL Diagnostics Hell Boundary Decision
+
+Status: decision record
+Scope: Diagnostics Hell / User Pain boundary
+Mode: research / readiness investigation
+Non-goal: implementation, release readiness, CI gate, CTF closure
+
+Related:
+
+- `7hell_current_status_after_wr2.md`
+- `7hell_waypoint_review_after_s1_s7_e1_e5.md`
+
+## 1. Background
+
+`7hell` has reached an active bounded qualification contour.
+
+Syntax, Type, Lowering, Verifier, VM, and Practical report paths are now present
+in bounded form. Practical Hell is active through a non-rendering practical
+envelope.
+
+Diagnostics Hell / User Pain remains not implemented.
+
+The post-WR2 status refresh preserved the Diagnostics Hell decision boundary
+instead of choosing a path prematurely. The open classification choices were:
+
+- A. Standalone `7HELL-S8` stage
+- B. Report-quality layer applied across all failure reports
+- C. Future PCC diagnostics track, not part of the current 7hell wave
+
+## 2. Decision
+
+Diagnostics Hell / User Pain is classified as:
+
+B. Report-quality layer applied across all failure reports.
+
+It is not a new execution stage.
+It is not a new VM/verifier/runtime path.
+It is not a project-root feature.
+It is not a release gate yet.
+
+## 3. Rationale
+
+Diagnostics Hell should evaluate the quality of reports already produced by
+prior stages.
+
+It should not create another execution path.
+It should not call check / compile / verify / run itself.
+It should not render host-visible program output.
+It should not expose raw observation text.
+It should inspect report structure and classify usability.
+It should be safe to add without touching VM, verifier, or runtime semantics.
+
+This keeps `7hell` as a measurement contour, not a hidden second runner.
+
+Execution stages produce facts.
+Diagnostics Hell evaluates whether those facts are understandable and safe to
+expose.
+
+## 4. Rejected alternatives
+
+| Option | Decision | Reason |
+| --- | --- | --- |
+| A. Standalone `7HELL-S8` stage | rejected for now | It risks implying a new execution stage and may blur the line between report evaluation and pipeline execution. |
+| B. Report-quality layer applied across all failure reports | accepted | It is the smallest safe boundary: evaluate report quality without changing execution behavior. |
+| C. Future PCC diagnostics track only | rejected as the sole answer | PCC diagnostics work is still needed later, but `7hell` already needs a minimal report-quality boundary now to prevent unreadable or misleading failure reports. |
+
+## 5. Boundary definition
+
+```text
+Diagnostics Hell =
+  report-quality assessment over existing 7hell stage results
+```
+
+Diagnostics Hell may read:
+
+- stage names
+- stage statuses
+- failure reason
+- diagnostic envelope
+- report-level messages
+- structured metadata already present in the report
+
+Diagnostics Hell must not:
+
+- call parser/check directly
+- call compiler/lowering directly
+- call verifier directly
+- call VM directly
+- call Practical envelope directly
+- perform host effects
+- inspect raw rendered program output
+- introduce new source execution behavior
+- mutate runtime state
+- create project-root behavior
+- become a release gate in this PR
+
+## 6. Minimal future acceptance shape
+
+Future Diagnostics Hell PASS / FAIL / INCOMPLETE logic should be defined at the
+report-quality layer.
+
+PASS:
+A failed or incomplete `7hell` report contains enough structured information for
+a developer to understand:
+
+- which stage failed or remained unavailable;
+- why it failed or remained unavailable;
+- whether the failure is due to syntax/type/verifier/VM/practical/report boundary;
+- whether there is no misleading release-readiness claim.
+
+FAIL:
+A report has a failure but lacks usable structured diagnostics, for example:
+
+- missing stage name;
+- missing failure reason;
+- ambiguous status;
+- raw panic-like text exposed as user-facing report;
+- contradictory readiness claim;
+- host-visible output leaked into `7hell` report;
+- report claims final readiness while a required stage is not implemented.
+
+INCOMPLETE:
+Diagnostics Hell itself has not yet been wired as an active report-quality
+evaluator.
+
+## 7. Current status after this decision
+
+After this PR:
+
+- Diagnostics Hell boundary is decided.
+- Diagnostics Hell implementation is still not present.
+- `7hell` remains not a CI gate.
+- `7hell` remains not a release gate.
+- no CTF closure is claimed.
+- next implementation work should be a separate audit PR.
+
+## 8. Next safe work package
+
+Next package:
+
+`PR-7HELL-DIAG-AUDIT` - audit(7hell): locate report-quality seam for
+Diagnostics Hell
+
+Purpose:
+Find where the `7hell` report can be evaluated for diagnostics/report quality
+without invoking new execution behavior.
+
+Do not implement this in the current PR.
+
+## 9. CTF statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only decision record for Diagnostics Hell / User Pain boundary.
+It does not change runtime value semantics, VM trap semantics, verifier
+behavior, capability/audit behavior, trace policy, project-root behavior,
+release gates, or CTF closure behavior.
+
+## 10. 7hell status impact
+
+- Diagnostics Hell boundary is decided as a report-quality layer.
+- no command behavior change
+- no execution behavior change
+- no verifier behavior change
+- no VM behavior change
+- no Practical envelope behavior change
+- no project-root behavior
+- no CI gate
+- no release readiness claim
+- no CTF closure
+- next safe work is audit-only

--- a/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
+++ b/docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md
@@ -7,6 +7,7 @@ Non-goal: release readiness, CTF closure, project-root behavior, package/workspa
 Current post-WR2 status refresh:
 
 - `7hell_current_status_after_wr2.md`
+- `7hell_diagnostics_boundary_decision.md`
 
 ## 1. Current stage status
 
@@ -88,15 +89,15 @@ Failure paths:
 
 ## 5. Remaining bounded decision
 
-Diagnostics Hell / User Pain remains undecided.
+The Diagnostics Hell / User Pain boundary decision is recorded in:
 
-Before implementation, decide whether it is:
+- `7hell_diagnostics_boundary_decision.md`
 
-- A. standalone `7HELL-S8` stage;
-- B. report-quality layer across all failure reports;
-- C. future PCC diagnostics track outside the current 7hell wave.
+Diagnostics Hell / User Pain is classified as a report-quality layer across all
+failure reports.
 
-No S8 work should start before this decision is recorded.
+Implementation remains future work.
+No S8 execution-stage work should start from this waypoint review.
 
 ## 6. Decision
 


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only decision record for Diagnostics Hell / User Pain boundary. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

7hell touched:
  - docs/roadmap/language_maturity/7hell_diagnostics_boundary_decision.md
  - docs/roadmap/language_maturity/7hell_current_status_after_wr2.md
  - docs/roadmap/language_maturity/7hell_waypoint_review_after_s1_s7_e1_e5.md

Reason:
Resolve the post-WR2 Diagnostics Hell boundary by classifying it as a report-quality layer applied across existing 7hell failure reports, not as a new execution stage.

7hell status impact:
  - Diagnostics Hell boundary decided
  - Diagnostics Hell implementation remains future work
  - next safe package is audit-only
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no Practical envelope behavior change
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Research / CI note:
This PR uses `[skip ci]` because GitHub Actions is currently blocked at the account level. This is docs-only research/status-control work and is not a release-readiness precedent.

Checks:
  - git diff --check clean