### PR TITLE
docs(readme): refresh current M-Hello status

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ The stable public contract lives in `docs/spec/*` and the release/status languag
 The active implementation focus is **M-Hello**:
 
 ```text
-#477 — M-Hello: admit minimal verified Hello World observation surface
-#673 — PR-M-HELLO-12A-5: cli: render controlled observation envelope
+M-Hello — admit minimal verified Hello World observation surface
+M-Hello — cli: render controlled observation envelope
 ```
 
 This track is deliberately narrow. It is not adding general stdout or broad I/O. It is building one verified observation path:
@@ -153,7 +153,7 @@ Recent M-Hello work has moved the observation path through the required lower la
 - controlled observation audit policy;
 - CLI rendering envelope for `smc run` and `smc run-smc`.
 
-The current open PR keeps source-run and verified-artifact routes separate and renders only after verifier admission, VM collection, capability allow, and audit decision.
+The current M-Hello track keeps source-run and verified-artifact routes separate and renders only after verifier admission, VM collection, capability allow, and audit decision.
 
 ### Current guarantees / design posture
 


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only status refresh after the recent 7hell / local CI merges. Removes stale open-PR wording from README and keeps the M-Hello focus aligned with the current repository state.

Files touched:
- README.md

Behavior:
- no code changes
- no test changes
- no snapshot changes
- no workflow changes
- no release-readiness claim widening

Checks:
- git diff --check clean
