### PR TITLE
docs(status): add post-fmt status audit snapshot

### DIFF
--- a/docs/roadmap/status_audit_post_fmt_baseline.md
+++ b/docs/roadmap/status_audit_post_fmt_baseline.md
@@ -1,0 +1,106 @@
+# Status Audit Snapshot after README Refresh and fmt Baseline Cleanup
+
+Status: audit snapshot  
+Scope: post-merge status / release-reading snapshot  
+Mode: docs / roadmap audit  
+Non-goal: implementation, release widening, CI gate, or CTF closure
+
+## 1. Background
+
+This snapshot records the repository status after the following merged PRs:
+
+- `#758` - README status refresh
+- `#760` - formatting baseline cleanup
+
+The purpose is to keep the release-facing reading and the status-reading
+documents aligned with current `main` without widening the public contract.
+
+## 2. Current reading
+
+The current release-facing posture remains unchanged:
+
+- published stable remains `v1.1.1`
+- the current `main` line remains `landed on main, not yet promised`
+- the repository is still **not** being described as `public release`
+- the current limited-release posture remains governed by the existing release
+  documentation, not by the formatting cleanup
+
+Current high-level repository reading:
+
+- `#758` removed stale README wording about an open M-Hello PR
+- `#760` normalized the formatting baseline without widening semantics or the
+  public contract
+- `main` remains the active development line
+- the next recommended focus is CTF synchronization, not a new feature wave
+
+## 3. Status snapshot
+
+| Item | Current status | Notes |
+|---|---|---|
+| Open PR count | 0 | No open PRs remain after the latest merges. |
+| Current development line | active | `main` remains the live integration line. |
+| Public stable line | unchanged | Published stable remains `v1.1.1`. |
+| Limited release posture | unchanged | No release-facing widening was introduced by the fmt cleanup. |
+| README status wording | refreshed | Stale open-PR wording was removed in `#758`. |
+| Formatting baseline | normalized | `#760` aligns the repo with current rustfmt output. |
+| Local CI gate | green | `scripts/local_ci.ps1` passed on the current snapshot. |
+| GitHub latest `main` run | success | Latest push run for `#760` completed successfully. |
+| Next focus | CTF sync | Runtime value, trap, determinism, and capability-policy docs are the next safe lane. |
+
+## 4. Why fmt cleanup does not widen the public contract
+
+`#760` only normalizes repository formatting. It does not:
+
+- add new runtime behavior;
+- change verifier admission;
+- change VM execution;
+- add project-root behavior;
+- widen the public stable line;
+- promote landed-on-`main` work into a new release promise.
+
+The cleanup is therefore a maintenance step, not a release-claim change.
+
+## 5. Gate summary
+
+The local workflow-equivalent gate is currently green:
+
+- `pwsh -File scripts/local_ci.ps1`
+- `git diff --check`
+
+The latest GitHub `main` push run for `#760` also completed successfully.
+
+## 6. Next recommended focus
+
+The next safe package is CTF synchronization, starting with the post-PCC /
+post-7hell trust-lane documents:
+
+- runtime value registry
+- trap taxonomy
+- determinism matrix
+- verifier-first policy
+- golden trace policy
+- capability / effect denial matrix
+
+This should remain a documentation and trust-lane sync, not a behavior change.
+
+## 7. CTF statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only status snapshot after `#758` and `#760`. It does not
+change runtime value semantics, VM trap semantics, verifier behavior,
+capability/audit behavior, trace policy, project-root behavior, release gates,
+or CTF closure behavior.
+
+## 8. Status impact
+
+- current post-merge status is recorded
+- the public-status reading remains conservative
+- `main` is still an active development line, not a blanket stable promise
+- `#760` does not widen the public contract
+- local CI is green on this snapshot
+- next focus is CTF sync
+- no implementation or behavior change is introduced
+- no release readiness claim is added
+- no CTF closure is claimed


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only post-merge status snapshot after #758 (README refresh) and #760 (fmt baseline cleanup). No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gates, or CTF closure behavior change.

7hell touched:
  - none

Reason:
Record the current release/status truth after the README refresh and formatting baseline cleanup, confirm that the public contract was not widened, and point the next safe focus at CTF synchronization.

Status impact:
  - current post-merge status recorded
  - open PR count is 0
  - main remains the active development line, not a blanket stable promise
  - fmt cleanup does not widen the public contract
  - local CI is green on this snapshot
  - next focus is CTF sync
  - no release readiness claim
  - no CTF closure

Research / CI note:
This is a docs-only audit snapshot. GitHub Actions was intentionally skipped for this commit; local CI was used as the pre-admission gate.

Checks:
  - pwsh -File scripts/local_ci.ps1
  - git diff --check