### PR TITLE
docs(ctf): sync runtime value and trap registry after PCC

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
@@ -1,6 +1,6 @@
 # CTF-1 — RuntimeValue Registry
 
-Status: draft registry
+Status: post-PCC / post-7hell sync registry
 Parent lane: `core_trust_freeze/index.md`
 
 ## Purpose
@@ -11,7 +11,7 @@ It is not a full VM implementation document. It is a trust registry.
 
 ## Current registry shape
 
-Use the following table during PCC live audit.
+Use the following table during PCC live audit and post-7hell trust synchronization.
 
 | Runtime value family | Status | PCC owner | Notes |
 |---|---|---|---|
@@ -29,6 +29,7 @@ Use the following table during PCC live audit.
 | `Result(T,E)` | freeze-candidate | PCC-6 | Current standard-form Result only. |
 | `Sequence<T>` | freeze-candidate | PCC-7 | Current admitted Sequence fixture-backed surface only. |
 | `Map<K,V>` | freeze-candidate | PCC-7 | Current admitted Map baseline only; missing-key / iteration / quota policy remains open. |
+| controlled observation carrier / event | out-of-pcc | M-Hello / 7hell | Narrow controlled-observation evidence exists, but this is not general stdout and not a general runtime value family in this trust lane. |
 | project manifest metadata | audit-needed | PCC-9 | Current Semantic.package manifest baseline only; not a runtime value unless later represented in VM/runtime. |
 | closure values | out-of-pcc unless audited | post-PCC / current-main audit | Do not widen in PCC unless explicitly pulled in. |
 | host handles | out-of-pcc | separate runtime boundary scope | Do not mix into practical core. |
@@ -68,7 +69,7 @@ Any public conversion belongs to PCC-8 Stdlib v0.
 
 ## CTF-WP2 PCC-4..PCC-9 Runtime Value Sync
 
-PCC-4..PCC-9 closeouts did not add new runtime behavior in this PR.
+PCC-4..PCC-9 closeouts and the current 7hell / M-Hello wave did not add new runtime value families in this registry.
 
 WP2 records trust status based on existing PCC fixture evidence.
 
@@ -84,4 +85,5 @@ Boundary notes:
 - Sequence: current positive / negative fixture-backed operations only;
 - Map: current baseline only; missing-key behavior, iteration policy, and memory/quota remain open;
 - text / to_text: no universal reflection; debug_render remains internal-only;
+- controlled observation carrier / event: narrow verified-observation evidence exists, but it is not a general stdout family and stays separate from raw observation text;
 - Project Model: Semantic.package baseline is project-adjacent evidence, not a runtime value family unless runtime representation is later introduced.

--- a/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
@@ -1,6 +1,6 @@
 # CTF-2 — Trap Taxonomy
 
-Status: frozen for PCC core readiness
+Status: frozen for PCC core readiness and post-7hell sync
 Parent lane: `core_trust_freeze/index.md`
 
 ## 1. Purpose
@@ -9,7 +9,9 @@ This file freezes the current execution-failure surface that PCC practical core
 readiness depends on.
 
 The goal is not to forecast every future failure mode. The goal is to make the
-current failure surface explicit, stable, and reviewable before PCC-1 starts.
+current failure surface explicit, stable, and reviewable before PCC-1 starts,
+and to keep the post-7hell diagnostics/report-quality work separate from trap
+taxonomy widening.
 
 ## 2. Freeze status
 
@@ -52,6 +54,10 @@ None remain in the PCC-0F freeze set after this pass.
 
 If a future PCC PR introduces a new runtime-failure class, it starts here and
 must not be claimed as frozen until evidence exists.
+
+The current 7hell diagnostics/report-quality layer does not add a new trap
+class. It classifies report quality after execution and should remain separate
+from VM trap naming.
 
 ## CTF-WP2 PCC-4..PCC-9 Trap / Diagnostics Sync
 
@@ -133,6 +139,10 @@ the blocker set for FM-035 in this pass.
 That includes capability / UI capability / host-ABI denial surfaces that are
 owned by the capability and boundary documentation lanes.
 
+Controlled-observation denials remain boundary denials, not VM trap classes.
+They are evaluated in the observation/report layer and must not be renamed into
+the trap taxonomy unless a later PCC or CTF review explicitly promotes them.
+
 ## 7. Admission rule for new trap classes
 
 1. Name the class explicitly.
@@ -168,6 +178,9 @@ boundary docs, so they do not block the practical-core trap taxonomy freeze in
 this pass.
 
 FM-036 remains a separate blocker and is not changed by this PR.
+
+The post-7hell Diagnostics Hell report-quality layer does not change the frozen
+trap set or create a new VM failure family.
 
 ## 10. Acceptance checklist
 


### PR DESCRIPTION
CTF touched:
  - docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
  - docs/roadmap/language_maturity/core_trust_freeze/trap_taxonomy.md
Reason:
Post-PCC / post-7hell trust-lane sync only. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gates, or CTF closure behavior change.

7hell touched:
  - none

Reason:
Synchronize the runtime value registry and trap taxonomy after PCC and the current 7hell / M-Hello wave. The update keeps controlled-observation separate from stdout and keeps Diagnostics Hell/report-quality outside the VM trap taxonomy.

Status impact:
  - runtime value registry synced
  - trap taxonomy synced
  - controlled observation remains separate from general stdout
  - Diagnostics Hell/report-quality does not add a new trap class
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Research / CI note:
This is a docs-only trust-lane sync. Local CI was used as the pre-admission gate.

Checks:
  - pwsh -File scripts/local_ci.ps1
  - git diff --check