### PR TITLE
docs(core-trust-freeze): define capability denial replay evidence

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/capability_denial_replay.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/capability_denial_replay.md
@@ -1,0 +1,87 @@
+# CTF-E4 - Capability Denial Replay
+
+Status: draft replay plan
+Owner: language maturity / execution contract
+Parent lane: `docs/roadmap/language_maturity/core_trust_freeze/index.md`
+Scope: denied-effect replay evidence after PCC and current CTF sync wave
+Non-goal: implementation, capability widening, release readiness, CI gate, or CTF closure
+
+## Purpose
+
+CTF-E4 defines the replay evidence shape for denied capability and denied effect behavior.
+
+The aim is to keep capability denial deterministic, reportable, and distinguishable from verifier rejection and VM traps as the platform surface widens.
+
+This document does not add replay artifacts.
+
+It does not widen host capability behavior.
+
+It does not claim release readiness.
+
+## Replay Boundary
+
+Capability denial replay should cover the surfaces that can be mistaken for host effect widening:
+
+| Surface | Replay question | Expected boundary |
+| --- | --- | --- |
+| `print(text)` | Does the same denied input produce the same denial classification? | capability / effect boundary only |
+| `to_text` / formatting | Does text formatting remain admitted without host widening? | admitted type formatting only |
+| `debug_render` | Does internal rendering stay internal-only? | no host-visible output |
+| file IO | Does denied file access stay denied deterministically? | capability denial, not trap class drift |
+| network IO | Does denied network access stay denied deterministically? | capability denial, not trap class drift |
+| host gate read/write | Do host gate reads and writes remain denied where appropriate? | capability boundary only |
+| pulse emit | Do pulse emissions remain effect-gated? | denied-effect classification |
+| UI event/frame effects | Do UI-adjacent effects remain outside the core trust lane? | no host widening |
+| audit emission | Does internal audit emission stay separate from host output? | audit surface only |
+
+Replay evidence should confirm:
+
+- the same denied input yields the same denial classification;
+- denial reasons remain in the capability/effect boundary, not VM trap naming;
+- no host mutation occurs;
+- no hidden stdout, file, network, or telemetry channel appears;
+- admitted input remains admitted across unrelated PCC or 7hell changes;
+- capability denial remains distinct from verifier rejection and VM traps.
+
+## Replay Shape
+
+CTF-E4 is a plan for replay evidence, not a trap taxonomy change.
+
+Future evidence should be able to show:
+
+- input surface;
+- denied capability or effect;
+- replayable denial classification;
+- stable denial reason text;
+- no host-effect widening;
+- no trap reclassification.
+
+## Current Status
+
+Capability denial replay is now explicitly planned as the next trust-evidence boundary.
+
+Denied-effect behavior remains a determinism and reportability goal.
+
+No command behavior changes are introduced by this document.
+
+No execution behavior changes are introduced by this document.
+
+## CTF Statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only replay plan for capability denial evidence. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gates, or CTF closure behavior.
+
+## Status Impact
+
+- capability denial replay is explicitly planned;
+- denied-effect behavior remains deterministic and reportable as a goal;
+- no command behavior change;
+- no execution behavior change;
+- no verifier behavior change;
+- no VM behavior change;
+- no project-root behavior;
+- no CI gate;
+- no release readiness claim;
+- no CTF closure.

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -26,7 +26,7 @@ It prevents uncontrolled jump from docs-sync to release claims.
 | CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | done | trap freeze |
 | CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | CTF-WP6 | done | project model freeze |
 | CTF-BL-007 | 7hell report shape | define stable qualification report surface | readiness needs stable qualification output | 7HELL-WP1 | done | readiness |
-| CTF-BL-008 | Capability denial replay | replay denied-effect behavior once capability surfaces widen | capability denial must be deterministic | future CTF-E | deferred | capability freeze |
+| CTF-BL-008 | Capability denial replay | replay denied-effect behavior once capability surfaces widen | capability denial must be deterministic | CTF-E4 | ready-for-task | capability freeze |
 | CTF-BL-009 | SymbolId / hot-path audit | verify PCC value/name surfaces do not regress into string hot paths | freeze-candidate names need hot-path discipline | future CTF-WP/E | planned | runtime performance/trust |
 
 Status values allowed:
@@ -119,6 +119,31 @@ Boundaries:
 - no new trap class is promoted to frozen without existing evidence;
 - no CTF closure;
 - no release readiness.
+
+## CTF-E4 Evidence
+
+CTF-E4 adds denied-effect replay evidence for capability and effect surfaces that can be mistaken for host widening.
+
+Covered:
+
+- bounded `print(text)` replay;
+- `to_text` / formatting boundary replay;
+- `debug_render` internal-only replay boundary;
+- file IO denial replay;
+- network IO denial replay;
+- host gate read/write denial replay;
+- pulse emit denial replay;
+- UI event/frame denial replay;
+- audit emission internal-only replay.
+
+Boundaries:
+
+- no host widening;
+- no new IO path;
+- no registry or remote fetch replay;
+- no telemetry widening;
+- no release readiness;
+- no CTF closure.
 
 ## Evidence Classes
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md
@@ -148,13 +148,13 @@ No release-readiness claim may cite CTF-WP1..WP4 without a later CTF closeout / 
 
 ```text
 Decision:
-Move from CTF docs-sync waypoint into targeted evidence planning.
+Move from CTF docs-sync waypoint into targeted denied-effect replay evidence planning.
 
 Immediate next step:
-CTF-E1 — test(core-trust-freeze): add golden trace coverage for selected PCC fixture surfaces
+CTF-E4 — docs(core-trust-freeze): define capability denial replay evidence
 ```
 
-Alternative if we want one more docs-only step:
+Alternative if we want one more docs-only step before evidence:
 
 ```text
 CTF-WP5 — docs(core-trust-freeze): define CTF evidence backlog and freeze-candidate promotion rules
@@ -162,10 +162,10 @@ CTF-WP5 — docs(core-trust-freeze): define CTF evidence backlog and freeze-cand
 
 Default recommendation:
 
-- If we want to start hardening with tests: `CTF-E1`.
-- If we want one more control document before tests: `CTF-WP5`.
+- If we want to start hardening the trust lane with replay evidence: `CTF-E4`.
+- If we want one more control document before evidence work: `CTF-WP5`.
 
-The document should recommend `CTF-WP5` first if the project wants maximum control before adding trace artifacts.
+The document should recommend `CTF-E4` first if the project wants the next trust-evidence boundary rather than another backlog-only control step.
 
 ## Evidence Backlog Preview
 
@@ -175,6 +175,7 @@ The document should recommend `CTF-WP5` first if the project wants maximum contr
 | Golden trace artifacts | Need stable source / type / IR / SemCode / verifier / VM trace samples | CTF-E1 |
 | Collection determinism replay | Map / Sequence behavior needs replay evidence | CTF-E2 |
 | Trap taxonomy regression | Fixture-backed failure surfaces need stable trap / diagnostic mapping | CTF-E3 |
+| Capability denial replay | Denied-effect behavior needs replay evidence | CTF-E4 |
 | Project-root trust policy | Future project-root work must preserve verifier / determinism / capability boundaries | future PCC-9I / CTF follow-up |
 | 7hell report shape | Qualification output must become stable before readiness | 7HELL-WP / CTF-E follow-up |
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -21,6 +21,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Golden trace evidence: `CTF-E1 — selected PCC golden trace coverage`
 - Collection replay evidence: `CTF-E2 — collection determinism replay coverage`
 - Trap taxonomy evidence: `CTF-E3 — trap taxonomy regression coverage`
+- Capability denial replay evidence: `CTF-E4 — denied-effect replay coverage`
 - Waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`
@@ -49,6 +50,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 | `7hell_report_contract.md` | Does future 7hell reporting remain stable and deterministic? |
 | `7hell_diagnostics_boundary_decision.md` | Has Diagnostics Hell been classified without changing execution behavior? |
 | `7hell_diag_report_quality_seam_audit.md` | Has the future Diagnostics Hell report-quality seam been located safely? |
+| `capability_denial_replay.md` | Has denied-effect replay evidence been planned without widening capability behavior? |
 
 ## PR requirement
 


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only replay plan for capability denial evidence. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

7hell touched:
  - docs/roadmap/language_maturity/core_trust_freeze/capability_denial_replay.md
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md
  - docs/roadmap/language_maturity/core_trust_freeze/index.md

Reason:
Define the capability denial replay evidence boundary so denied-effect behavior stays deterministic and reportable without widening capability behavior.

7hell status impact:
  - capability denial replay explicitly planned
  - denied-effect behavior remains a replayable trust boundary
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Checks:
  - pwsh -File scripts/local_ci.ps1
  - git diff --check clean
