### PR TITLE
docs(core-trust-freeze): define SymbolId hot-path audit

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -27,7 +27,7 @@ It prevents uncontrolled jump from docs-sync to release claims.
 | CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | CTF-WP6 | done | project model freeze |
 | CTF-BL-007 | 7hell report shape | define stable qualification report surface | readiness needs stable qualification output | 7HELL-WP1 | done | readiness |
 | CTF-BL-008 | Capability denial replay | replay denied-effect behavior once capability surfaces widen | capability denial must be deterministic | CTF-E4 | ready-for-task | capability freeze |
-| CTF-BL-009 | SymbolId / hot-path audit | verify PCC value/name surfaces do not regress into string hot paths | freeze-candidate names need hot-path discipline | future CTF-WP/E | planned | runtime performance/trust |
+| CTF-BL-009 | SymbolId / hot-path audit | verify PCC value/name surfaces do not regress into string hot paths | freeze-candidate names need hot-path discipline | CTF-WP7 | ready-for-task | runtime performance/trust |
 
 Status values allowed:
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -33,6 +33,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - 7hell Diagnostics Hell seam audit: `reports/7hell_diag_report_quality_seam_audit.md`
 - 7hell PCC stage mapping: `docs/roadmap/language_maturity/7hell_pcc4_pcc9_stage_mapping.md`
 - 7hell initial fixture selection: `docs/roadmap/language_maturity/7hell_initial_fixture_selection.md`
+- SymbolId hot-path audit: `docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files
@@ -51,6 +52,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 | `7hell_diagnostics_boundary_decision.md` | Has Diagnostics Hell been classified without changing execution behavior? |
 | `7hell_diag_report_quality_seam_audit.md` | Has the future Diagnostics Hell report-quality seam been located safely? |
 | `capability_denial_replay.md` | Has denied-effect replay evidence been planned without widening capability behavior? |
+| `symbolid_hot_path_audit.md` | Have names and symbols been audited to stay off the runtime hot path? |
 
 ## PR requirement
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md
@@ -1,0 +1,89 @@
+# CTF-WP7 - SymbolId Hot-Path Audit
+
+Status: audit plan
+Owner: language maturity / execution contract
+Parent lane: `docs/roadmap/language_maturity/core_trust_freeze/index.md`
+Scope: SymbolId and string hot-path audit after PCC and current CTF sync wave
+Non-goal: implementation, runtime widening, release readiness, CI gate, or CTF closure
+
+## Purpose
+
+CTF-WP7 defines the audit boundary for names, symbols, and hot-path lookup.
+
+The goal is to make sure practical language growth does not quietly reintroduce string-based execution paths where compact IDs or verified table indexes are required.
+
+This document does not add runtime behavior.
+
+It does not change any SymbolId semantics.
+
+It does not claim release readiness.
+
+## Audit Surface
+
+The audit should review the current public and internal name surfaces that can drift into runtime hot paths:
+
+| Surface | Audit question | Expected boundary |
+| --- | --- | --- |
+| source identifiers | Are source names resolved before runtime? | construction / diagnostics only |
+| type names | Are type names canonicalized before execution? | pre-runtime identity only |
+| SemCode function names | Are function names carried as verified references or table indexes? | verified table / compact ID |
+| runtime symbols | Is the runtime symbol table deterministic? | compact runtime symbol path |
+| debug names | Are debug names append-only and non-semantic? | debug-only map |
+| record fields | Are field identifiers stable and non-string-based in execution? | field ID / descriptor |
+| ADT variants | Are variants resolved through stable descriptors? | variant ID / descriptor |
+| Option / Result variants | Are variants canonicalized before runtime use? | canonical variant ID |
+| collection keys | Is key policy explicit and bounded? | explicit key policy |
+| manifest / package names | Do package and module names stay off the VM hot path? | project/tooling surface only |
+| import aliases | Are aliases resolved before execution? | pre-runtime resolution only |
+
+## Audit Questions
+
+The audit should answer:
+
+- does any runtime dispatch depend on user-facing strings where a compact ID already exists;
+- are debug names clearly separated from semantic identity;
+- are symbol-like lookups resolved before VM execution;
+- does the current registry still need additional rows;
+- does any PCC or CTF work widen the hot path into string-based dispatch;
+- does project-root naming stay a tooling concern rather than a VM concern.
+
+## Guardrails
+
+SymbolId hot-path review must not:
+
+- introduce new string-based execution behavior;
+- move semantic identity into debug output;
+- widen host capability or effect boundaries;
+- add project-root implementation;
+- add CTF closure claims;
+- add release readiness claims.
+
+## Current Status
+
+The current registry is still marked `audit-needed` for the most sensitive name surfaces.
+
+CTF-WP7 is the next safe place to document the audit boundary before any implementation follows.
+
+No code path changes are introduced by this document.
+
+No test or fixture changes are introduced by this document.
+
+## CTF Statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only audit plan for SymbolId / hot-path review. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gates, or CTF closure behavior.
+
+## Status Impact
+
+- SymbolId / string hot-path audit is explicitly planned;
+- name and symbol surfaces remain a trust boundary review item;
+- no command behavior change;
+- no execution behavior change;
+- no verifier behavior change;
+- no VM behavior change;
+- no project-root behavior;
+- no CI gate;
+- no release readiness claim;
+- no CTF closure.

--- a/docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md
@@ -40,3 +40,11 @@ PCC must not accidentally reintroduce string-based execution paths while adding 
 [ ] Are debug names clearly separated from semantic identity?
 [ ] Does this require a new registry row?
 ```
+
+## CTF-WP7 Follow-up
+
+The SymbolId hot-path audit boundary is recorded in:
+
+- `docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md`
+
+This registry remains a draft registry until the audit is completed and linked evidence is added.


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only audit plan for SymbolId / hot-path review. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

7hell touched:
  - docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
  - docs/roadmap/language_maturity/core_trust_freeze/index.md
  - docs/roadmap/language_maturity/core_trust_freeze/symbolid_migration.md

Reason:
Define the SymbolId / hot-path audit boundary so names and symbols stay off the runtime hot path and remain a trust-surface review item.

7hell status impact:
  - SymbolId / string hot-path audit explicitly planned
  - name and symbol surfaces remain a trust boundary review item
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Checks:
  - pwsh -File scripts/local_ci.ps1
  - git diff --check clean
