### PR TITLE
docs(core-trust-freeze): define Map open-edge policy

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
@@ -22,7 +22,7 @@ It prevents uncontrolled jump from docs-sync to release claims.
 | CTF-BL-001 | Golden trace selection | choose representative PCC fixture surfaces for trace promotion | PCC fixtures are not golden traces | CTF-E1 | done | trace freeze |
 | CTF-BL-002 | Golden trace artifacts | add selected source/type/IR/SemCode/verifier/VM trace samples | protect byte/result/diagnostic stability | CTF-E1 | done | trace freeze |
 | CTF-BL-003 | Collection determinism replay | repeated-run evidence for Sequence/Map admitted baseline | collection determinism is bounded but not deeply replay-backed | CTF-E2 | done | determinism freeze |
-| CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP / future PCC-7 follow-up | planned | collections freeze |
+| CTF-BL-004 | Map open-edge policy | decide missing-key / iteration / quota evidence boundary | Map remains bounded-open | CTF-WP8 | ready-for-task | collections freeze |
 | CTF-BL-005 | Trap taxonomy regression | map fixture-backed failure surfaces to stable trap/diagnostic categories | avoid compile diagnostics vs VM trap confusion | CTF-E3 | done | trap freeze |
 | CTF-BL-006 | Project-root trust policy | define trust impact before project-root check/run implementation | project-root remains open | CTF-WP6 | done | project model freeze |
 | CTF-BL-007 | 7hell report shape | define stable qualification report surface | readiness needs stable qualification output | 7HELL-WP1 | done | readiness |

--- a/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md
@@ -100,6 +100,7 @@ Open determinism notes:
 - map missing-key behavior remains unresolved;
 - map iteration policy remains unresolved;
 - collection memory/quota determinism remains open;
+- Map open-edge policy is recorded in `map_open_edge_policy.md`;
 - project-root discovery remains open;
 - semantic.toml parse/load determinism remains open;
 - src/main.sm discovery remains open;

--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -34,6 +34,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - 7hell PCC stage mapping: `docs/roadmap/language_maturity/7hell_pcc4_pcc9_stage_mapping.md`
 - 7hell initial fixture selection: `docs/roadmap/language_maturity/7hell_initial_fixture_selection.md`
 - SymbolId hot-path audit: `docs/roadmap/language_maturity/core_trust_freeze/symbolid_hot_path_audit.md`
+- Map open-edge policy: `docs/roadmap/language_maturity/core_trust_freeze/map_open_edge_policy.md`
 - PCC waypoint review: `docs/roadmap/language_maturity/pcc_waypoint_review_after_pcc4_pcc9.md`
 
 ## Files
@@ -53,6 +54,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 | `7hell_diag_report_quality_seam_audit.md` | Has the future Diagnostics Hell report-quality seam been located safely? |
 | `capability_denial_replay.md` | Has denied-effect replay evidence been planned without widening capability behavior? |
 | `symbolid_hot_path_audit.md` | Have names and symbols been audited to stay off the runtime hot path? |
+| `map_open_edge_policy.md` | Have Map missing-key / iteration / quota edges been kept explicitly open? |
 
 ## PR requirement
 

--- a/docs/roadmap/language_maturity/core_trust_freeze/map_open_edge_policy.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/map_open_edge_policy.md
@@ -1,0 +1,93 @@
+# CTF-WP8 - Map Open-Edge Policy
+
+Status: policy draft
+Owner: language maturity / execution contract
+Parent lane: `docs/roadmap/language_maturity/core_trust_freeze/index.md`
+Scope: Map missing-key / iteration / quota evidence boundary after PCC and current CTF sync wave
+Non-goal: implementation, collections widening, release readiness, CI gate, or CTF closure
+
+## Purpose
+
+CTF-WP8 defines the open-edge policy for `Map<K,V>`.
+
+The admitted Map baseline already has selected replay evidence for insert/lookup and persistent update.
+
+This policy records the remaining open edges so Map does not drift from bounded baseline into accidental broad collections freeze.
+
+This document does not add Map runtime behavior.
+
+It does not close Map policy edges.
+
+It does not claim release readiness.
+
+## Current Baseline
+
+The current Map evidence is bounded to the admitted baseline only.
+
+Covered today:
+
+- insert / lookup replay evidence;
+- persistent update replay evidence;
+- selected admitted Map baseline behavior.
+
+Not covered today:
+
+- missing-key behavior;
+- iteration policy;
+- memory / quota policy.
+
+## Open-Edge Policy
+
+| Map edge | Current status | Policy note | Required later evidence |
+| --- | --- | --- | --- |
+| missing-key behavior | open | stays outside the admitted baseline until separately evidenced | deterministic failure / diagnostic evidence |
+| iteration policy | open | stays outside the admitted baseline until separately evidenced | deterministic replay or trace evidence |
+| memory / quota policy | open | remains a later collections-trust concern | quota / trap / diagnostic evidence |
+
+Policy rules:
+
+1. Map may remain evidence-backed for selected admitted baseline surfaces.
+2. Missing-key, iteration, and quota behavior must not be quietly promoted into freeze-candidate or frozen status.
+3. Any future Map widening must name which edge is being admitted.
+4. Project-root, registry, and remote-dependency behavior remain separate trust surfaces.
+5. Golden traces for Map edges must not be claimed until the edge is explicitly opened and evidenced.
+
+## Boundary Statement
+
+Map remains bounded-open overall.
+
+The current baseline is sufficient for the selected replay-backed surfaces, but it is not a broad collections freeze.
+
+This policy keeps the open edges visible instead of letting them disappear into the admitted baseline.
+
+## Required Future Evidence Shape
+
+Before a Map edge can move beyond `audit-needed`, future evidence should specify:
+
+- the exact edge;
+- the exact input class;
+- whether the behavior is a value result, diagnostic, or trap;
+- whether repeated runs remain deterministic;
+- whether the behavior stays within the current capability / effect boundary;
+- whether the evidence is replay, trace, or ordinary test evidence.
+
+## CTF Statement
+
+CTF touched: none
+
+Reason:
+This is a docs-only policy for Map open edges. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gates, or CTF closure behavior.
+
+## Status Impact
+
+- Map open-edge policy is explicitly recorded;
+- missing-key / iteration / quota remain open;
+- selected admitted baseline evidence remains unchanged;
+- no command behavior change;
+- no execution behavior change;
+- no verifier behavior change;
+- no VM behavior change;
+- no project-root behavior;
+- no CI gate;
+- no release readiness claim;
+- no CTF closure.

--- a/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
@@ -28,7 +28,7 @@ Use the following table during PCC live audit and post-7hell trust synchronizati
 | `Option(T)` | freeze-candidate | PCC-6 | Current standard-form Option only. |
 | `Result(T,E)` | freeze-candidate | PCC-6 | Current standard-form Result only. |
 | `Sequence<T>` | freeze-candidate | PCC-7 | Current admitted Sequence fixture-backed surface only. |
-| `Map<K,V>` | freeze-candidate | PCC-7 | Current admitted Map baseline only; missing-key / iteration / quota policy remains open. |
+| `Map<K,V>` | freeze-candidate | PCC-7 | Current admitted Map baseline only; missing-key / iteration / quota policy remains open. See `map_open_edge_policy.md`. |
 | controlled observation carrier / event | out-of-pcc | M-Hello / 7hell | Narrow controlled-observation evidence exists, but this is not general stdout and not a general runtime value family in this trust lane. |
 | project manifest metadata | audit-needed | PCC-9 | Current Semantic.package manifest baseline only; not a runtime value unless later represented in VM/runtime. |
 | closure values | out-of-pcc unless audited | post-PCC / current-main audit | Do not widen in PCC unless explicitly pulled in. |
@@ -83,7 +83,7 @@ Boundary notes:
 - ADT: current constructors / basic match only;
 - Option / Result: standard forms only, no exception semantics;
 - Sequence: current positive / negative fixture-backed operations only;
-- Map: current baseline only; missing-key behavior, iteration policy, and memory/quota remain open;
+- Map: current baseline only; missing-key behavior, iteration policy, and memory/quota remain open; see `map_open_edge_policy.md`;
 - text / to_text: no universal reflection; debug_render remains internal-only;
 - controlled observation carrier / event: narrow verified-observation evidence exists, but it is not a general stdout family and stays separate from raw observation text;
 - Project Model: Semantic.package baseline is project-adjacent evidence, not a runtime value family unless runtime representation is later introduced.


### PR DESCRIPTION
CTF touched: none

Reason:
Docs-only policy for Map open edges. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

7hell touched:
  - docs/roadmap/language_maturity/core_trust_freeze/map_open_edge_policy.md
  - docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md
  - docs/roadmap/language_maturity/core_trust_freeze/index.md
  - docs/roadmap/language_maturity/core_trust_freeze/runtime_value_registry.md
  - docs/roadmap/language_maturity/core_trust_freeze/determinism_matrix.md

Reason:
Define the Map missing-key / iteration / quota boundary so the admitted Map baseline remains bounded-open instead of drifting into an unreviewed collections freeze.

7hell status impact:
  - Map open-edge policy explicitly recorded
  - missing-key / iteration / quota remain open
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no project-root behavior
  - no CI gate
  - no release readiness claim
  - no CTF closure

Checks:
  - pwsh -File scripts/local_ci.ps1
  - git diff --check clean
