### PR TITLE
infra(ci): restore cargo fmt check after baseline cleanup

### DIFF
--- a/scripts/local_ci.ps1
+++ b/scripts/local_ci.ps1
@@ -6,16 +6,12 @@ Set-StrictMode -Version Latest
 # This script provides a repeatable local pre-admission signal. It does not
 # replace GitHub Actions and must not be treated as a release gate by itself.
 #
-# Intentionally excluded for now:
-# cargo fmt --check
+# Formatting gate:
+# cargo fmt --all --check
 #
-# Reason:
-# Existing formatting baseline drift causes unrelated failures. Formatting
-# baseline normalization must be handled by a separate dedicated PR.
-#
-# This script does not run cargo fmt. Do not use formatting as part of behavior
-# PRs until the formatting baseline is normalized. After any manual formatting
-# attempt, inspect `git diff --name-only` and revert unrelated churn.
+# This script includes formatting because the baseline has been normalized.
+# Do not use formatting as a substitute for behavior checks. After any manual
+# formatting attempt, inspect `git diff --name-only` and revert unrelated churn.
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 Set-Location $RepoRoot
@@ -63,6 +59,10 @@ Invoke-LocalCiStep "cargo test --all-targets --quiet" {
 
 Invoke-LocalCiStep "cargo check --no-default-features --quiet" {
     cargo check --no-default-features --quiet
+}
+
+Invoke-LocalCiStep "cargo fmt --all --check" {
+    cargo fmt --all --check
 }
 
 Invoke-LocalCiStep "verify release bundle process" {


### PR DESCRIPTION
CTF touched: none

Reason:
Infra-only local CI update. Restores cargo fmt --all --check to the local gate after formatting baseline cleanup. No runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, project-root behavior, release gate, or CTF closure behavior change.

Files touched:
  - scripts/local_ci.ps1

Reason:
Reinstate the formatting gate in the repo-owned local workflow-equivalent checker so the normalized formatting baseline remains enforced before push/PR.

Status impact:
  - local_ci now includes cargo fmt --all --check
  - no command behavior change
  - no execution behavior change
  - no verifier behavior change
  - no VM behavior change
  - no project-root behavior
  - no CI gate widening beyond formatting enforcement
  - no release readiness claim
  - no CTF closure

Checks:
  - pwsh -File scripts/local_ci.ps1
  - cargo fmt --all --check
  - git diff --check
