### PR TITLE
cli(project-model): harden semantic.toml diagnostics

### DIFF
--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -781,7 +781,6 @@ fn resolve_manifest_context(
 
 #[derive(Debug)]
 struct ParsedSemanticTomlManifest {
-    manifest: PackageManifest,
     entry: String,
 }
 
@@ -938,7 +937,7 @@ fn parse_semantic_toml_manifest(
             )
         }
     })?;
-    Ok(ParsedSemanticTomlManifest { manifest, entry })
+    Ok(ParsedSemanticTomlManifest { entry })
 }
 fn resolve_relative_import_path(base: &Path, spec: &str) -> PathBuf {
     let path = append_default_module_extension(spec);

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -781,6 +781,7 @@ fn resolve_manifest_context(
 
 #[derive(Debug)]
 struct ParsedSemanticTomlManifest {
+    manifest: PackageManifest,
     entry: String,
 }
 
@@ -937,7 +938,7 @@ fn parse_semantic_toml_manifest(
             )
         }
     })?;
-    Ok(ParsedSemanticTomlManifest { entry })
+    Ok(ParsedSemanticTomlManifest { manifest, entry })
 }
 fn resolve_relative_import_path(base: &Path, spec: &str) -> PathBuf {
     let path = append_default_module_extension(spec);

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -446,7 +446,16 @@ pub(crate) fn resolve_project_root_check_entry(root: &Path) -> Result<PathBuf, S
             .map_err(|e| format!("failed to read '{}': {}", semantic_toml.display(), e))?;
         let project_manifest = parse_semantic_toml_manifest(&semantic_toml, &source)
             .map_err(|e| format!("failed to parse '{}': {}", semantic_toml.display(), e))?;
-        return Ok(root.join(project_manifest.entry));
+        let entry_path = root.join(&project_manifest.entry);
+        if !entry_path.is_file() {
+            return Err(format!(
+                "semantic.toml manifest '{}' entry '{}' resolves to missing file '{}'",
+                semantic_toml.display(),
+                project_manifest.entry,
+                entry_path.display()
+            ));
+        }
+        return Ok(entry_path);
     }
 
     let package_manifest = root.join(PACKAGE_MANIFEST_FILE_NAME);
@@ -461,7 +470,6 @@ pub(crate) fn resolve_project_root_check_entry(root: &Path) -> Result<PathBuf, S
         PACKAGE_MANIFEST_FILE_NAME
     ))
 }
-
 pub fn resolve_package_import_path(
     importer_module: &Path,
     spec: &str,
@@ -879,12 +887,21 @@ fn parse_semantic_toml_manifest(
         }
     }
 
-    let package_name = parsed
-        .package_name
-        .ok_or_else(|| "semantic.toml missing [package].name".to_string())?;
+    let package_name = parsed.package_name.ok_or_else(|| {
+        format!(
+            "semantic.toml manifest '{}' is missing required [package].name",
+            manifest_path.display()
+        )
+    })?;
     let entry = parsed
         .project_entry
         .unwrap_or_else(|| "src/main.sm".to_string());
+    if entry.trim().is_empty() {
+        return Err(format!(
+            "semantic.toml manifest '{}' has empty [project].entry",
+            manifest_path.display()
+        ));
+    }
     let entry_path = Path::new(&entry);
     let module_root = entry_path
         .parent()
@@ -897,22 +914,32 @@ fn parse_semantic_toml_manifest(
             }
         })
         .unwrap_or_else(|| ".".to_string());
-    let _ = manifest_path;
-    Ok(ParsedSemanticTomlManifest {
-        manifest: PackageManifest::new(
-            PackageIdentity {
-                name: package_name,
-                root: PackageRoot {
-                    manifest_dir: ".".to_string(),
-                    module_root,
-                },
+    let manifest = PackageManifest::new(
+        PackageIdentity {
+            name: package_name,
+            root: PackageRoot {
+                manifest_dir: ".".to_string(),
+                module_root,
             },
-            Vec::new(),
-        ),
-        entry,
-    })
+        },
+        Vec::new(),
+    );
+    validate_package_manifest_baseline(&manifest).map_err(|e| {
+        if e.code == PackageManifestValidationCode::EmptyPackageName {
+            format!(
+                "semantic.toml manifest '{}' has empty [package].name",
+                manifest_path.display()
+            )
+        } else {
+            format!(
+                "semantic.toml manifest '{}' is invalid: {}",
+                manifest_path.display(),
+                e
+            )
+        }
+    })?;
+    Ok(ParsedSemanticTomlManifest { manifest, entry })
 }
-
 fn resolve_relative_import_path(base: &Path, spec: &str) -> PathBuf {
     let path = append_default_module_extension(spec);
     if path.is_absolute() {

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -26,6 +26,10 @@ fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
 }
 
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(context)
+}
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let base = std::env::temp_dir().join(format!(
         "{}_{}_{}",
@@ -103,6 +107,31 @@ entry = "src/main.sm"
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+fn full_project_root_package_baseline_check_path() {
+    let dir = mk_temp_dir("pcc9_project_root_package_acceptance");
+    let src_dir = dir.join("src");
+    std::fs::create_dir_all(&src_dir).expect("mkdir src");
+    std::fs::write(
+        dir.join(PACKAGE_MANIFEST_FILE_NAME),
+        r#"
+format 1
+package app
+manifest_dir .
+module_root src
+"#,
+    )
+    .expect("write manifest");
+    std::fs::write(src_dir.join("main.sm"), "fn main() { return; }\n").expect("write entry");
+
+    let input = normalize_path(&dir);
+    cli_ok(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for package baseline project root {input}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn pcc9_single_file_baseline_passes_full_cli_path() {
     full_cli_path("tests/fixtures/pcc9_project_model/single_file_baseline/main.sm");
@@ -111,6 +140,164 @@ fn pcc9_single_file_baseline_passes_full_cli_path() {
 #[test]
 fn pcc9_project_root_baseline_passes_check_entrypoint() {
     full_project_root_check_path();
+}
+
+#[test]
+fn pcc9_project_root_package_baseline_still_passes_check_entrypoint() {
+    full_project_root_package_baseline_check_path();
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_invalid_syntax() {
+    let dir = mk_temp_dir("pcc9_project_root_invalid_syntax");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for invalid manifest project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("malformed"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_missing_package_name() {
+    let dir = mk_temp_dir("pcc9_project_root_missing_package_name");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+
+[project]
+entry = "src/main.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for missing package name project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing required [package].name"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_empty_package_name() {
+    let dir = mk_temp_dir("pcc9_project_root_empty_package_name");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = ""
+
+[project]
+entry = "src/main.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for empty package name project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("empty [package].name"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_empty_entry() {
+    let dir = mk_temp_dir("pcc9_project_root_empty_entry");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = ""
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for empty entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("empty [project].entry"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_missing_entry_file() {
+    let dir = mk_temp_dir("pcc9_project_root_missing_entry_file");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "src/missing.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for missing entry file project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing file"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_rejects_path_escape() {
+    let dir = mk_temp_dir("pcc9_project_root_path_escape");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for escaped entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("must not escape the project root"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]


### PR DESCRIPTION
summary
Harden `semantic.toml` project-root diagnostics for `smc check <project-root>` without expanding the project model.

changed files
- `crates/smc-cli/src/package_manifest.rs`
- `tests/pcc9_project_model_acceptance.rs`

behavior added
- deterministic diagnostics for malformed `semantic.toml`
- rejection when `[package].name` is missing
- rejection when `[package].name` is empty
- rejection when `[project].entry` is empty
- rejection when the entry file is missing
- rejection when the entry path escapes the project root
- `Semantic.package` compatibility remains supported where already present

explicit non-goals
- no `smc run` project-root support
- no `smc new`
- no package registry
- no dependency resolver
- no workspace support
- no runtime / verifier / VM / capability / audit / trace widening
- no `.claude/` changes
- no removal of `Semantic.package` compatibility

CTF touched
none

Reason
This PR hardens project-root CLI manifest diagnostics for `semantic.toml`.
It does not change runtime value semantics, VM trap semantics, verifier behavior,
capability/audit behavior, trace policy, release gates, or CTF closure.

7hell touched
none

Reason
This package is project-model CLI diagnostics, not 7hell qualification behavior.

local checks run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

notes
- `.claude/` is present in the working tree but was not staged, committed, or included in the PR.
- The PR is intentionally kept draft until GitHub checks are visible and green on the current head SHA.
