### PR TITLE
cli(project-model): add project-root check fixture matrix

### DIFF
--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use smc_cli::{
@@ -24,6 +25,27 @@ fn read_fixture(rel: &str) -> String {
 
 fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_check_project_root_ok(dir: &std::path::Path, context: &str) {
+    let input = normalize_path(dir);
+    cli_ok(vec!["check".to_string(), input], context);
+}
+
+fn cli_check_dot_ok(dir: &std::path::Path, context: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("check")
+        .arg(".")
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn cli_err(args: Vec<String>, context: &str) -> String {
@@ -107,6 +129,33 @@ entry = "src/main.sm"
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+fn write_semantic_toml(dir: &std::path::Path, entry: Option<&str>) {
+    let manifest = match entry {
+        Some(entry) => format!(
+            r#"
+[package]
+name = "app"
+
+[project]
+entry = "{entry}"
+"#
+        ),
+        None => r#"
+[package]
+name = "app"
+"#
+        .to_string(),
+    };
+    std::fs::write(dir.join("semantic.toml"), manifest).expect("write semantic.toml");
+}
+
+fn write_source(path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir source parent");
+    }
+    std::fs::write(path, "fn main() { return; }\n").expect("write source");
+}
+
 fn full_project_root_package_baseline_check_path() {
     let dir = mk_temp_dir("pcc9_project_root_package_acceptance");
     let src_dir = dir.join("src");
@@ -145,6 +194,75 @@ fn pcc9_project_root_baseline_passes_check_entrypoint() {
 #[test]
 fn pcc9_project_root_package_baseline_still_passes_check_entrypoint() {
     full_project_root_package_baseline_check_path();
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_explicit_entry_passes_check() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_check_project_root_ok(&dir, "smc check for semantic.toml explicit entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_default_entry_passes_check() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_default_entry");
+    write_semantic_toml(&dir, None);
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_check_project_root_ok(&dir, "smc check for semantic.toml default entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_nested_entry_passes_check() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_check_project_root_ok(&dir, "smc check for semantic.toml nested entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_preferred");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    std::fs::write(
+        dir.join(PACKAGE_MANIFEST_FILE_NAME),
+        r#"
+format 1
+package app
+manifest_dir .
+module_root src
+"#,
+    )
+    .expect("write package manifest");
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_check_project_root_ok(
+        &dir,
+        "smc check prefers semantic.toml over Semantic.package",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_check_dot_matches_absolute_project_root() {
+    let dir = mk_temp_dir("pcc9_project_root_check_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_check_project_root_ok(&dir, "smc check for absolute project root");
+    cli_check_dot_ok(&dir, "smc check dot from project root");
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds positive acceptance coverage for the existing project-root `smc check` path after the semantic.toml loader and diagnostics hardening work.

This is a test-only package. It does not widen the project model or add new CLI functionality.

## Changed Files

- `tests/pcc9_project_model_acceptance.rs`

## Positive Scenarios Added

- `semantic.toml` with `[package].name` and `[project].entry = "src/main.sm"` passes `smc check <project-root>`.
- `semantic.toml` with omitted `[project].entry` defaults to `src/main.sm`.
- `semantic.toml` with nested `[project].entry = "examples/main.sm"` resolves inside the project root.
- `semantic.toml` remains preferred when both `semantic.toml` and `Semantic.package` exist.
- Existing `Semantic.package` baseline remains covered when `semantic.toml` is absent.
- `smc check .` from the project root is covered against the same successful project-root route as an absolute project-root path.

## Explicit Non-Goals

- Do not implement `smc run .`.
- Do not implement package registry behavior.
- Do not implement dependency resolver behavior.
- Do not implement workspace support.
- Do not implement multi-package discovery.
- Do not implement `smc new`.
- Do not change runtime value semantics.
- Do not change VM trap semantics.
- Do not change verifier behavior.
- Do not change capability/audit behavior.
- Do not widen release claims.
- Do not claim CTF closure.

## CTF Touched

CTF touched: none

Reason: This PR adds positive acceptance coverage for the existing project-root `smc check` route. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, release gates, or CTF closure.

## 7hell Touched

7hell touched: none

Reason: This package is project-model CLI acceptance coverage, not 7hell qualification behavior.

## Local Checks Run

- `cargo fmt --all --check` passed.
- `cargo test -q --test pcc9_project_model_acceptance` passed.
- `cargo test -q --test public_api_contracts` passed.
- `cargo test --all-targets --quiet` passed as part of `pwsh -File scripts/local_ci.ps1`.
- `pwsh -File scripts/local_ci.ps1` passed.
- `git diff --check` passed.

Note: earlier standalone `cargo test --all-targets --quiet` runs encountered unrelated transient acceptance-test artifact failures; the affected tests passed in isolation, and the full local CI script subsequently passed its all-targets gate.

## .claude/

`.claude/` is not included in this PR.