### PR TITLE
cli(project-model): add minimal project-root run route

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -2378,10 +2378,16 @@ fn render_controlled_observation_envelope(
 
 fn cmd_run(args: &[String]) -> Result<(), String> {
     if args.len() != 1 {
-        return Err("usage: smc run <input.sm>".to_string());
+        return Err("usage: smc run <input.sm|project-root>".to_string());
     }
     let input = args[0].as_str();
-    let src = read_source_with_package_admission(Path::new(input))?;
+    let input_path = Path::new(input);
+    let root = if input_path.is_dir() {
+        resolve_project_root_check_entry(input_path)?
+    } else {
+        input_path.to_path_buf()
+    };
+    let src = read_source_with_package_admission(&root)?;
     let bytes = compile_program_to_semcode(&src).map_err(|e| e.to_string())?;
     let envelope = render_controlled_observation_envelope(&bytes)?;
     for line in envelope.rendered_lines {
@@ -2451,7 +2457,7 @@ fn usage() -> String {
         "  smc explain <error-code|--list>",
         "  smc repl",
         "  smc verify <input.smc>",
-        "  smc run <input.sm>",
+        "  smc run <input.sm|project-root>",
         "  smc run-smc <input.smc>",
         "  smc disasm <input.smc>",
     ]

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -56,7 +56,7 @@ Current accepted usage forms are:
 - `smc explain <error-code|--list>`
 - `smc repl`
 - `smc verify <input.smc>`
-- `smc run <input.sm>`
+- `smc run <input.sm|project-root>`
 - `smc run-smc <input.smc>`
 - `smc disasm <input.smc>`
 
@@ -112,7 +112,7 @@ Current output rules:
 
 Current execution-facing commands follow this split:
 
-- `smc run <input.sm>` compiles source input and executes the produced in-memory SemCode path
+- `smc run <input.sm|project-root>` resolves source input, then compiles and executes the produced in-memory SemCode path
 - `smc verify <input.smc>` performs verifier admission without execution
 - `smc run-smc <input.smc>` executes compiled SemCode through the verified artifact path
 
@@ -130,6 +130,7 @@ Current rule:
 - source-reading commands inherit the current executable bundle admission boundary
 - `smc check` also accepts a bounded admitted project-root entrypoint through `Semantic.package` + `src/main.sm`
 - project-root `smc check` also resolves a minimal `semantic.toml` manifest when present
+- project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route
 - widening package resolution, helper import loading, or source-root admission is a public CLI and source-boundary change
 
 ## Tooling Helper Rule

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -32,9 +32,30 @@ fn cli_check_project_root_ok(dir: &std::path::Path, context: &str) {
     cli_ok(vec!["check".to_string(), input], context);
 }
 
+fn cli_run_project_root_ok(dir: &std::path::Path, context: &str) {
+    let input = normalize_path(dir);
+    cli_ok(vec!["run".to_string(), input], context);
+}
+
 fn cli_check_dot_ok(dir: &std::path::Path, context: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_smc"))
         .arg("check")
+        .arg(".")
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn cli_run_dot_ok(dir: &std::path::Path, context: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("run")
         .arg(".")
         .current_dir(dir)
         .output()
@@ -156,10 +177,7 @@ fn write_source(path: &std::path::Path) {
     std::fs::write(path, "fn main() { return; }\n").expect("write source");
 }
 
-fn full_project_root_package_baseline_check_path() {
-    let dir = mk_temp_dir("pcc9_project_root_package_acceptance");
-    let src_dir = dir.join("src");
-    std::fs::create_dir_all(&src_dir).expect("mkdir src");
+fn write_package_manifest_baseline(dir: &std::path::Path) {
     std::fs::write(
         dir.join(PACKAGE_MANIFEST_FILE_NAME),
         r#"
@@ -169,7 +187,14 @@ manifest_dir .
 module_root src
 "#,
     )
-    .expect("write manifest");
+    .expect("write package manifest");
+}
+
+fn full_project_root_package_baseline_check_path() {
+    let dir = mk_temp_dir("pcc9_project_root_package_acceptance");
+    let src_dir = dir.join("src");
+    std::fs::create_dir_all(&src_dir).expect("mkdir src");
+    write_package_manifest_baseline(&dir);
     std::fs::write(src_dir.join("main.sm"), "fn main() { return; }\n").expect("write entry");
 
     let input = normalize_path(&dir);
@@ -177,6 +202,16 @@ module_root src
         vec!["check".to_string(), input.clone()],
         &format!("smc check for package baseline project root {input}"),
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+fn full_project_root_package_baseline_run_path() {
+    let dir = mk_temp_dir("pcc9_project_root_package_run_acceptance");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run for package baseline project root");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -197,12 +232,28 @@ fn pcc9_project_root_package_baseline_still_passes_check_entrypoint() {
 }
 
 #[test]
+fn pcc9_project_root_package_baseline_still_runs_entrypoint() {
+    full_project_root_package_baseline_run_path();
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_explicit_entry_passes_check() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry");
     write_semantic_toml(&dir, Some("src/main.sm"));
     write_source(&dir.join("src").join("main.sm"));
 
     cli_check_project_root_ok(&dir, "smc check for semantic.toml explicit entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_explicit_entry_runs() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry_run");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run for semantic.toml explicit entry");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -219,6 +270,17 @@ fn pcc9_project_root_semantic_toml_default_entry_passes_check() {
 }
 
 #[test]
+fn pcc9_project_root_semantic_toml_default_entry_runs() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_default_entry_run");
+    write_semantic_toml(&dir, None);
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run for semantic.toml default entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_nested_entry_passes_check() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry");
     write_semantic_toml(&dir, Some("examples/main.sm"));
@@ -230,25 +292,39 @@ fn pcc9_project_root_semantic_toml_nested_entry_passes_check() {
 }
 
 #[test]
+fn pcc9_project_root_semantic_toml_nested_entry_runs() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry_run");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run for semantic.toml nested entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_preferred");
     write_semantic_toml(&dir, Some("examples/main.sm"));
-    std::fs::write(
-        dir.join(PACKAGE_MANIFEST_FILE_NAME),
-        r#"
-format 1
-package app
-manifest_dir .
-module_root src
-"#,
-    )
-    .expect("write package manifest");
+    write_package_manifest_baseline(&dir);
     write_source(&dir.join("examples").join("main.sm"));
 
     cli_check_project_root_ok(
         &dir,
         "smc check prefers semantic.toml over Semantic.package",
     );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_run() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_preferred_run");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run prefers semantic.toml over Semantic.package");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -261,6 +337,18 @@ fn pcc9_project_root_check_dot_matches_absolute_project_root() {
 
     cli_check_project_root_ok(&dir, "smc check for absolute project root");
     cli_check_dot_ok(&dir, "smc check dot from project root");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_run_dot_matches_absolute_project_root() {
+    let dir = mk_temp_dir("pcc9_project_root_run_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_run_project_root_ok(&dir, "smc run for absolute project root");
+    cli_run_dot_ok(&dir, "smc run dot from project root");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -281,6 +369,31 @@ name = "app"
     let err = cli_err(
         vec!["check".to_string(), input.clone()],
         &format!("smc check for invalid manifest project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("malformed"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_run_rejects_invalid_semantic_toml_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_run_invalid_syntax");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for invalid manifest project root {input}"),
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("malformed"), "{err}");
@@ -314,6 +427,34 @@ entry = "src/main.sm"
 }
 
 #[test]
+fn pcc9_project_root_run_rejects_missing_entry_file_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_run_missing_entry_file");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "examples/missing.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for missing entry file project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing file"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_rejects_empty_package_name() {
     let dir = mk_temp_dir("pcc9_project_root_empty_package_name");
     std::fs::write(
@@ -335,6 +476,34 @@ entry = "src/main.sm"
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("empty [package].name"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_run_rejects_path_escape_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_run_path_escape");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["run".to_string(), input.clone()],
+        &format!("smc run for escaped entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("must not escape the project root"), "{err}");
 
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

Adds the minimal `smc run <project-root>` / `smc run .` route on top of the existing project-root `smc check` entry resolution.

The run command now resolves directory input through the existing project manifest path, then continues through the existing source run pipeline. This is intentionally limited to routing and acceptance coverage.

## Changed Files

- `crates/smc-cli/src/app.rs`
- `tests/pcc9_project_model_acceptance.rs`
- `docs/spec/cli.md`

## Behavior Added

- `smc run <project-root>` resolves `semantic.toml` when present.
- `semantic.toml` supports the already-admitted shape: `[package].name` and optional `[project].entry`.
- Omitted `[project].entry` defaults to `src/main.sm`.
- Nested entries such as `examples/main.sm` resolve inside the project root.
- `semantic.toml` remains preferred when both `semantic.toml` and `Semantic.package` exist.
- Existing `Semantic.package` baseline remains supported when `semantic.toml` is absent.
- `smc run .` works from inside the project root.
- Invalid manifests, missing entry files, and path-escape entries fail through the existing deterministic project-root diagnostics without falling back to unrelated files.

## Tests Added

- `semantic.toml` explicit entry runs successfully.
- Omitted `semantic.toml` entry runs through the default `src/main.sm` entry.
- Nested `semantic.toml` entry runs successfully.
- `semantic.toml` wins over `Semantic.package` for the run route.
- `Semantic.package` baseline still runs when `semantic.toml` is absent.
- `smc run .` works from the project root.
- Run route rejects invalid `semantic.toml` without fallback.
- Run route rejects missing entry file without fallback.
- Run route rejects path escape without fallback.

## Explicit Non-Goals

- Do not implement `smc new`.
- Do not implement package registry behavior.
- Do not implement dependency resolver behavior.
- Do not implement workspace support.
- Do not implement multi-package discovery.
- Do not add host IO behavior.
- Do not change verifier behavior.
- Do not change VM semantics.
- Do not change capability/audit behavior.
- Do not widen release claims.
- Do not claim CTF closure.

## Verifier-First Note

The project-root run route only resolves a project root to an entry source file. Execution remains on the existing source run pipeline: source is compiled to SemCode, admitted by `verify_semcode` in the controlled observation envelope, and then executed by the existing VM collection path. This PR does not add a separate unchecked execution path.

## CTF Touched

CTF touched: none

Reason: This PR adds a minimal project-root CLI route for `smc run` using the existing project entry resolution and existing verifier-first run pipeline. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, release gates, or CTF closure.

## 7hell Touched

7hell touched: none

Reason: This package is project-model CLI execution routing, not 7hell qualification behavior.

## Local Checks Run

- `cargo fmt --all --check` passed.
- `cargo test -q --test pcc9_project_model_acceptance` passed.
- `cargo test -q --test public_api_contracts` passed.
- `cargo test --all-targets --quiet` passed.
- `pwsh -File scripts/local_ci.ps1` passed.
- `git diff --check` passed.

## .claude/

`.claude/` is not included in this PR.