### PR TITLE
cli(project-model): add minimal project-root compile route

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -107,7 +107,7 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
 fn cmd_compile(args: &[String]) -> Result<(), String> {
     if args.len() < 3 {
         return Err(
-            "usage: smc compile <input.sm> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
+            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
                 .to_string(),
         );
     }
@@ -153,7 +153,13 @@ fn cmd_compile(args: &[String]) -> Result<(), String> {
     }
     let out = out.ok_or_else(|| "missing -o <out.smc>".to_string())?;
     let t0 = Instant::now();
-    let src = read_source_with_package_admission(Path::new(input))?;
+    let input_path = Path::new(input);
+    let root = if input_path.is_dir() {
+        resolve_project_root_check_entry(input_path)?
+    } else {
+        input_path.to_path_buf()
+    };
+    let src = read_source_with_package_admission(&root)?;
     let t_read = Instant::now();
     let parser_profile = cli_profile();
     let bytes = compile_program_to_semcode_with_options_debug(&src, profile, opt, debug_symbols)
@@ -2441,7 +2447,7 @@ fn cmd_disasm(args: &[String]) -> Result<(), String> {
 fn usage() -> String {
     [
         "Semantic Language toolchain v0",
-        "  smc compile <input.sm> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]",
+        "  smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]",
         "  smc check <input.sm|project-root> [--no-cache] [--trace-cache] [--metrics] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc watch <input.sm> [--metrics] [--color auto|always|never]",

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -40,7 +40,7 @@ The admitted `smc` command surface is currently:
 
 Current accepted usage forms are:
 
-- `smc compile <input.sm> -o|--out <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--metrics]`
+- `smc compile <input.sm|project-root> -o|--out <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--metrics]`
 - `smc check <input.sm|project-root> [--no-cache] [--trace-cache] [--metrics] [--deny warnings|<CODE>] [--color auto|always|never]`
 - `smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]`
 - `smc watch <input.sm> [--metrics] [--color auto|always|never]`
@@ -123,11 +123,12 @@ Public rule:
 
 ## Source Admission Rule
 
-Commands that ingest source input through `<input.sm>` operate through the current package-admission and helper-module loading rules rather than unrestricted filesystem execution.
+Commands that ingest source input through `<input.sm>` or admitted project-root forms operate through the current package-admission and helper-module loading rules rather than unrestricted filesystem execution.
 
 Current rule:
 
 - source-reading commands inherit the current executable bundle admission boundary
+- project-root `smc compile` uses the bounded project entry resolution, then writes the SemCode artifact only to the requested `-o|--out` path
 - `smc check` also accepts a bounded admitted project-root entrypoint through `Semantic.package` + `src/main.sm`
 - project-root `smc check` also resolves a minimal `semantic.toml` manifest when present
 - project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -37,6 +37,39 @@ fn cli_run_project_root_ok(dir: &std::path::Path, context: &str) {
     cli_ok(vec!["run".to_string(), input], context);
 }
 
+fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &str) -> PathBuf {
+    let input = normalize_path(dir);
+    let out = dir.join(out_name);
+    let out_arg = normalize_path(&out);
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            input,
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        context,
+    );
+    assert!(out.is_file(), "{context} did not write requested output");
+    cli_ok(
+        vec!["verify".to_string(), out_arg],
+        &format!("{context} produced unverifiable SemCode"),
+    );
+    out
+}
+
+fn cli_compile_project_root_err(dir: &std::path::Path, out_name: &str, context: &str) -> String {
+    let input = normalize_path(dir);
+    let out = dir.join(out_name);
+    let out_arg = normalize_path(&out);
+    let err = cli_err(
+        vec!["compile".to_string(), input, "-o".to_string(), out_arg],
+        context,
+    );
+    assert!(!out.exists(), "{context} unexpectedly wrote output");
+    err
+}
+
 fn cli_check_dot_ok(dir: &std::path::Path, context: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_smc"))
         .arg("check")
@@ -67,6 +100,31 @@ fn cli_run_dot_ok(dir: &std::path::Path, context: &str) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn cli_compile_dot_ok(dir: &std::path::Path, out_name: &str, context: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("compile")
+        .arg(".")
+        .arg("-o")
+        .arg(out_name)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let out = dir.join(out_name);
+    assert!(out.is_file(), "{context} did not write requested output");
+    cli_ok(
+        vec!["verify".to_string(), normalize_path(&out)],
+        &format!("{context} produced unverifiable SemCode"),
+    );
+    out
 }
 
 fn cli_err(args: Vec<String>, context: &str) -> String {
@@ -216,6 +274,20 @@ fn full_project_root_package_baseline_run_path() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+fn full_project_root_package_baseline_compile_path() {
+    let dir = mk_temp_dir("pcc9_project_root_package_compile_acceptance");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_compile_project_root_ok(
+        &dir,
+        "package-out.smc",
+        "smc compile for package project root",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn pcc9_single_file_baseline_passes_full_cli_path() {
     full_cli_path("tests/fixtures/pcc9_project_model/single_file_baseline/main.sm");
@@ -237,6 +309,11 @@ fn pcc9_project_root_package_baseline_still_runs_entrypoint() {
 }
 
 #[test]
+fn pcc9_project_root_package_baseline_still_compiles_entrypoint() {
+    full_project_root_package_baseline_compile_path();
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_explicit_entry_passes_check() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry");
     write_semantic_toml(&dir, Some("src/main.sm"));
@@ -254,6 +331,17 @@ fn pcc9_project_root_semantic_toml_explicit_entry_runs() {
     write_source(&dir.join("src").join("main.sm"));
 
     cli_run_project_root_ok(&dir, "smc run for semantic.toml explicit entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_explicit_entry_compiles() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry_compile");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_compile_project_root_ok(&dir, "explicit-out.smc", "smc compile for explicit entry");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -281,6 +369,17 @@ fn pcc9_project_root_semantic_toml_default_entry_runs() {
 }
 
 #[test]
+fn pcc9_project_root_semantic_toml_default_entry_compiles() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_default_entry_compile");
+    write_semantic_toml(&dir, None);
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_compile_project_root_ok(&dir, "default-out.smc", "smc compile for default entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_nested_entry_passes_check() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry");
     write_semantic_toml(&dir, Some("examples/main.sm"));
@@ -298,6 +397,17 @@ fn pcc9_project_root_semantic_toml_nested_entry_runs() {
     write_source(&dir.join("examples").join("main.sm"));
 
     cli_run_project_root_ok(&dir, "smc run for semantic.toml nested entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_nested_entry_compiles() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry_compile");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_compile_project_root_ok(&dir, "nested-out.smc", "smc compile for nested entry");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -330,6 +440,22 @@ fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_run() 
 }
 
 #[test]
+fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_compile() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_preferred_compile");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("examples").join("main.sm"));
+
+    cli_compile_project_root_ok(
+        &dir,
+        "preferred-out.smc",
+        "smc compile prefers semantic.toml over Semantic.package",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_check_dot_matches_absolute_project_root() {
     let dir = mk_temp_dir("pcc9_project_root_check_dot");
     write_semantic_toml(&dir, Some("src/main.sm"));
@@ -349,6 +475,22 @@ fn pcc9_project_root_run_dot_matches_absolute_project_root() {
 
     cli_run_project_root_ok(&dir, "smc run for absolute project root");
     cli_run_dot_ok(&dir, "smc run dot from project root");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_compile_dot_writes_requested_output() {
+    let dir = mk_temp_dir("pcc9_project_root_compile_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    cli_compile_project_root_ok(
+        &dir,
+        "absolute-out.smc",
+        "smc compile absolute project root",
+    );
+    cli_compile_dot_ok(&dir, "dot-out.smc", "smc compile dot from project root");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -394,6 +536,31 @@ name = "app"
     let err = cli_err(
         vec!["run".to_string(), input.clone()],
         &format!("smc run for invalid manifest project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("malformed"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_compile_rejects_invalid_semantic_toml_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_compile_invalid_syntax");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write manifest");
+
+    let err = cli_compile_project_root_err(
+        &dir,
+        "invalid-out.smc",
+        "smc compile for invalid manifest project root",
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("malformed"), "{err}");
@@ -455,6 +622,34 @@ entry = "examples/missing.sm"
 }
 
 #[test]
+fn pcc9_project_root_compile_rejects_missing_entry_file_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_compile_missing_entry_file");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "examples/missing.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let err = cli_compile_project_root_err(
+        &dir,
+        "missing-out.smc",
+        "smc compile for missing entry file project root",
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing file"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_rejects_empty_package_name() {
     let dir = mk_temp_dir("pcc9_project_root_empty_package_name");
     std::fs::write(
@@ -501,6 +696,34 @@ entry = "../escape.sm"
     let err = cli_err(
         vec!["run".to_string(), input.clone()],
         &format!("smc run for escaped entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("must not escape the project root"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_compile_rejects_path_escape_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_compile_path_escape");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let err = cli_compile_project_root_err(
+        &dir,
+        "escape-out.smc",
+        "smc compile for escaped entry project root",
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("must not escape the project root"), "{err}");


### PR DESCRIPTION
## Summary

Adds the minimal `smc compile <project-root> -o <output.smc>` / `smc compile . -o <output.smc>` route on top of the existing project-root entry resolution.

The compile command now resolves directory input through the existing project manifest path, then continues through the existing source compile pipeline. This is intentionally limited to routing, artifact placement checks, and acceptance coverage.

## Changed Files

- `crates/smc-cli/src/app.rs`
- `tests/pcc9_project_model_acceptance.rs`
- `docs/spec/cli.md`

## Behavior Added

- `smc compile <project-root> -o <output.smc>` resolves `semantic.toml` when present.
- `semantic.toml` supports the already-admitted shape: `[package].name` and optional `[project].entry`.
- Omitted `[project].entry` defaults to `src/main.sm`.
- Nested entries such as `examples/main.sm` resolve inside the project root.
- `semantic.toml` remains preferred when both `semantic.toml` and `Semantic.package` exist.
- Existing `Semantic.package` baseline remains supported when `semantic.toml` is absent.
- `smc compile . -o <output.smc>` works from inside the project root.
- Invalid manifests, missing entry files, and path-escape entries fail through the existing deterministic project-root diagnostics without falling back to unrelated files.
- Successful project-root compile cases write the artifact to the requested `-o` path and verify the produced `.smc` artifact.

## Tests Added

- `semantic.toml` explicit entry compiles successfully.
- Omitted `semantic.toml` entry compiles through the default `src/main.sm` entry.
- Nested `semantic.toml` entry compiles successfully.
- `semantic.toml` wins over `Semantic.package` for the compile route.
- `Semantic.package` baseline still compiles when `semantic.toml` is absent.
- `smc compile . -o dot-out.smc` works from the project root.
- Successful project-root compile cases assert the requested `.smc` artifact exists and verifies.
- Compile route rejects invalid `semantic.toml` without fallback or output artifact.
- Compile route rejects missing entry file without fallback or output artifact.
- Compile route rejects path escape without fallback or output artifact.

## Explicit Non-Goals

- Do not implement `smc new`.
- Do not implement package registry behavior.
- Do not implement dependency resolver behavior.
- Do not implement workspace support.
- Do not implement multi-package discovery.
- Do not change SemCode format.
- Do not change verifier behavior.
- Do not change VM semantics.
- Do not change runtime value semantics.
- Do not change capability/audit behavior.
- Do not add host IO behavior beyond the existing compile output path behavior.
- Do not widen release claims.
- Do not claim CTF closure.

## Safety / Admission Note

This PR only routes project-root input to an entry source file before compilation. It does not change SemCode admission, verifier behavior, VM execution, runtime behavior, or capability/audit behavior. Output artifact writes remain limited to the requested `-o|--out` path.

## CTF Touched

CTF touched: none

Reason: This PR adds a minimal project-root CLI route for `smc compile` using the existing project entry resolution and existing source compile pipeline. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, release gates, SemCode format, or CTF closure.

## 7hell Touched

7hell touched: none

Reason: This package is project-model CLI compilation routing, not 7hell qualification behavior.

## Local Checks Run

- `cargo fmt --all --check` passed.
- `cargo test -q --test pcc9_project_model_acceptance` passed.
- `cargo test -q --test public_api_contracts` passed.
- `cargo test --all-targets --quiet` passed.
- `pwsh -File scripts/local_ci.ps1` passed.
- `git diff --check` passed.

## .claude/

`.claude/` is not included in this PR.