### PR TITLE
test(project-model): add project-root compile artifact chain

### DIFF
--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -52,21 +52,34 @@ fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &
     );
     assert!(out.is_file(), "{context} did not write requested output");
     cli_ok(
-        vec!["verify".to_string(), out_arg],
+        vec!["verify".to_string(), out_arg.clone()],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg],
+        &format!("{context} run-smc failed"),
     );
     out
 }
 
-fn cli_compile_project_root_err(dir: &std::path::Path, out_name: &str, context: &str) -> String {
+fn cli_compile_project_root_err_no_overwrite(
+    dir: &std::path::Path,
+    out_name: &str,
+    context: &str,
+) -> String {
     let input = normalize_path(dir);
     let out = dir.join(out_name);
     let out_arg = normalize_path(&out);
+    std::fs::write(&out, "sentinel").expect("write sentinel");
     let err = cli_err(
         vec!["compile".to_string(), input, "-o".to_string(), out_arg],
         context,
     );
-    assert!(!out.exists(), "{context} unexpectedly wrote output");
+    let content = std::fs::read_to_string(&out).expect("read out file");
+    assert_eq!(
+        content, "sentinel",
+        "{context} overwrote existing file on compilation failure"
+    );
     err
 }
 
@@ -123,6 +136,19 @@ fn cli_compile_dot_ok(dir: &std::path::Path, out_name: &str, context: &str) -> P
     cli_ok(
         vec!["verify".to_string(), normalize_path(&out)],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    let output2 = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("run-smc")
+        .arg(out_name)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc run-smc: {err}"));
+    assert!(
+        output2.status.success(),
+        "{context} run-smc failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output2.status.code(),
+        String::from_utf8_lossy(&output2.stdout),
+        String::from_utf8_lossy(&output2.stderr)
     );
     out
 }
@@ -557,7 +583,7 @@ name = "app"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "invalid-out.smc",
         "smc compile for invalid manifest project root",
@@ -638,7 +664,7 @@ entry = "examples/missing.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "missing-out.smc",
         "smc compile for missing entry file project root",
@@ -720,7 +746,7 @@ entry = "../escape.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "escape-out.smc",
         "smc compile for escaped entry project root",


### PR DESCRIPTION
## Summary
This PR adds comprehensive integration test coverage for the project-root compile artifact acceptance chain. It proves that the `.smc` bytecode compiled from a project-root is fully valid, verifies against the verifier, and executes successfully via the existing VM routing of `run-smc` CLI entrypoint without changing any compiler, verifier, or runtime VM behaviors.

## Changed Files
- `tests/pcc9_project_model_acceptance.rs`

## Tests Added
The existing test suite in `tests/pcc9_project_model_acceptance.rs` has been updated to chain compile, verify, and run-smc:
1. `pcc9_project_root_semantic_toml_explicit_entry_compiles` - verified compile -> verify -> run-smc chain.
2. `pcc9_project_root_semantic_toml_default_entry_compiles` - verified default `src/main.sm` compile -> verify -> run-smc chain.
3. `pcc9_project_root_semantic_toml_nested_entry_compiles` - verified nested `examples/main.sm` compile -> verify -> run-smc.
4. `pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_compile` - verified TOML preference over baseline manifest and subsequent verify -> run-smc chain.
5. `pcc9_project_root_package_baseline_still_compiles_entrypoint` - verified baseline compile -> verify -> run-smc chain.
6. `pcc9_project_root_compile_dot_writes_requested_output` - verified compile dot -> verify -> run-smc chain via spawned CLI.
7. Verified negative no-overwrite checks on compilation failures (`pcc9_project_root_compile_rejects_invalid_semantic_toml_without_fallback`, `pcc9_project_root_compile_rejects_missing_entry_file_without_fallback`, `pcc9_project_root_compile_rejects_path_escape_without_fallback`).

## Explicit Non-goals
- No new CLI commands or routing options have been introduced.
- No changes to SemCode format.
- No verifier bypass or runtime VM modifications.
- No changes to workspace or workspace dependency resolution logic.

## Safety Rules Followed
- No repo-wide cleanup or mass deletions have been executed.
- Modifying only the target test suite file inside the allowed scope.
- Pre-existing files at target output path are preserved and not overwritten on compilation failure.

## CTF Touched
CTF touched: none

Reason:
This PR adds acceptance coverage for the existing project-root compile artifact chain. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, release gates, or CTF closure.

## 7hell Touched
7hell touched: none

Reason:
This package is project-model CLI acceptance coverage, not 7hell qualification behavior.

## Local Checks Run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

## .claude/ Modified
No. No `.claude/` files or CI workflow files have been added, modified, or included.
