### PR TITLE
test(project-model): add project-root stale artifact protection matrix

### DIFF
--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -52,21 +52,34 @@ fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &
     );
     assert!(out.is_file(), "{context} did not write requested output");
     cli_ok(
-        vec!["verify".to_string(), out_arg],
+        vec!["verify".to_string(), out_arg.clone()],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg],
+        &format!("{context} run-smc failed"),
     );
     out
 }
 
-fn cli_compile_project_root_err(dir: &std::path::Path, out_name: &str, context: &str) -> String {
+fn cli_compile_project_root_err_no_overwrite(
+    dir: &std::path::Path,
+    out_name: &str,
+    context: &str,
+) -> String {
     let input = normalize_path(dir);
     let out = dir.join(out_name);
     let out_arg = normalize_path(&out);
+    std::fs::write(&out, "sentinel").expect("write sentinel");
     let err = cli_err(
         vec!["compile".to_string(), input, "-o".to_string(), out_arg],
         context,
     );
-    assert!(!out.exists(), "{context} unexpectedly wrote output");
+    let content = std::fs::read_to_string(&out).expect("read out file");
+    assert_eq!(
+        content, "sentinel",
+        "{context} overwrote existing file on compilation failure"
+    );
     err
 }
 
@@ -123,6 +136,19 @@ fn cli_compile_dot_ok(dir: &std::path::Path, out_name: &str, context: &str) -> P
     cli_ok(
         vec!["verify".to_string(), normalize_path(&out)],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    let output2 = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("run-smc")
+        .arg(out_name)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc run-smc: {err}"));
+    assert!(
+        output2.status.success(),
+        "{context} run-smc failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output2.status.code(),
+        String::from_utf8_lossy(&output2.stdout),
+        String::from_utf8_lossy(&output2.stderr)
     );
     out
 }
@@ -557,7 +583,7 @@ name = "app"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "invalid-out.smc",
         "smc compile for invalid manifest project root",
@@ -638,7 +664,7 @@ entry = "examples/missing.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "missing-out.smc",
         "smc compile for missing entry file project root",
@@ -720,7 +746,7 @@ entry = "../escape.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "escape-out.smc",
         "smc compile for escaped entry project root",

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -83,6 +83,54 @@ fn cli_compile_project_root_err_no_overwrite(
     err
 }
 
+fn assert_stale_artifact_protected<F>(
+    dir: &std::path::Path,
+    out_name: &str,
+    mutate: F,
+    context: &str,
+) where
+    F: FnOnce(&std::path::Path),
+{
+    let out = cli_compile_project_root_ok(dir, out_name, &format!("{context} (initial compile)"));
+    let original_bytes = std::fs::read(&out).unwrap_or_else(|err| {
+        panic!(
+            "{context}: failed to read original bytes of {}: {err}",
+            out.display()
+        )
+    });
+    mutate(dir);
+    let input = normalize_path(dir);
+    let out_arg = normalize_path(&out);
+    let _err = cli_err(
+        vec![
+            "compile".to_string(),
+            input,
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("{context} (failing compile expected)"),
+    );
+    assert!(out.is_file(), "{context}: out.smc was deleted");
+    let current_bytes = std::fs::read(&out).unwrap_or_else(|err| {
+        panic!(
+            "{context}: failed to read current bytes of {}: {err}",
+            out.display()
+        )
+    });
+    assert_eq!(
+        original_bytes, current_bytes,
+        "{context}: out.smc was overwritten or modified on compilation failure"
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("{context}: verification failed for original artifact after failed compile"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg],
+        &format!("{context}: run-smc failed for original artifact after failed compile"),
+    );
+}
+
 fn cli_check_dot_ok(dir: &std::path::Path, context: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_smc"))
         .arg("check")
@@ -921,6 +969,173 @@ module_root src
 
     let resolved = resolve_package_import_path(&importer, "math::core.sm").expect("resolve");
     assert_eq!(normalize_path(&resolved), normalize_path(&dep));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_semantic_toml_becomes_malformed() {
+    let dir = mk_temp_dir("pcc9_stale_malformed");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package
+name = "app"
+"#,
+            )
+            .expect("write malformed toml");
+        },
+        "malformed semantic.toml protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_package_name_missing() {
+    let dir = mk_temp_dir("pcc9_stale_missing_package_name");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+
+[project]
+entry = "src/main.sm"
+"#,
+            )
+            .expect("write missing package name toml");
+        },
+        "missing package name protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_empty() {
+    let dir = mk_temp_dir("pcc9_stale_empty_entry");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = ""
+"#,
+            )
+            .expect("write empty entry toml");
+        },
+        "empty entry protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_missing_file() {
+    let dir = mk_temp_dir("pcc9_stale_missing_file");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "src/missing.sm"
+"#,
+            )
+            .expect("write missing entry file toml");
+        },
+        "missing entry file protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_path_escapes() {
+    let dir = mk_temp_dir("pcc9_stale_path_escape");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+            )
+            .expect("write path escape toml");
+        },
+        "path escape protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_semantic_toml_preferred_over_package_manifest_and_semantic_toml_invalid(
+) {
+    let dir = mk_temp_dir("pcc9_stale_preferred_invalid");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("examples").join("main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+            )
+            .expect("write invalid toml");
+        },
+        "semantic.toml priority invalid protection",
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
This PR adds test-only acceptance coverage proving that failed project-root compile attempts do not delete, modify, or overwrite an existing valid `.smc` output artifact.

## Changed Files
- `tests/pcc9_project_model_acceptance.rs`

## Tests Added
A dedicated reusable test helper `assert_stale_artifact_protected` was added to `tests/pcc9_project_model_acceptance.rs`, along with the following 6 scenario test cases:
1. `pcc9_stale_artifact_protected_when_semantic_toml_becomes_malformed`
2. `pcc9_stale_artifact_protected_when_package_name_missing`
3. `pcc9_stale_artifact_protected_when_project_entry_empty`
4. `pcc9_stale_artifact_protected_when_project_entry_missing_file`
5. `pcc9_stale_artifact_protected_when_project_entry_path_escapes`
6. `pcc9_stale_artifact_protected_when_semantic_toml_preferred_over_package_manifest_and_semantic_toml_invalid`

## Explicit Non-goals
- No CLI features or commands added.
- No compiler, verifier, VM, SemCode format, runtime, capability, audit, CTF, or 7hell behavior changed.

## Artifact Safety Statement
Failed compile attempts do not overwrite, delete, or modify existing valid output artifacts. The pre-existing `.smc` remains byte-identical, verifies successfully, and executes properly.

## CTF Touched
CTF touched: none

Reason:
This PR adds acceptance coverage for stale artifact preservation on failed project-root compile attempts. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, release gates, or CTF closure.

## 7hell Touched
7hell touched: none

Reason:
This package is project-model CLI acceptance coverage, not 7hell qualification behavior.

## Local Checks Run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

## .claude/ Modified
No. No `.claude/` files or CI workflow files have been added, modified, or included.
