### PR TITLE
cli(project-model): add minimal project-root dump-ast route

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -846,12 +846,18 @@ fn edit_distance(a: &str, b: &str) -> usize {
 
 fn cmd_dump_ast(args: &[String]) -> Result<(), String> {
     if args.len() != 1 {
-        return Err("usage: smc dump-ast <input.sm>".to_string());
+        return Err("usage: smc dump-ast <input.sm|project-root>".to_string());
     }
     let input = args[0].as_str();
-    let src = read_source_with_package_admission(Path::new(input))?;
+    let input_path = Path::new(input);
+    let root = if input_path.is_dir() {
+        resolve_project_root_check_entry(input_path)?
+    } else {
+        input_path.to_path_buf()
+    };
+    let src = read_source_with_package_admission(&root)?;
     let parser_profile = cli_profile();
-    let ast_key = ast_pack_key(Path::new(input), &src)?;
+    let ast_key = ast_pack_key(&root, &src)?;
     let ast_pack = cache_ast_file_for_key(ast_key)?;
     if let Some(cached) = load_text_pack(&ast_pack, PACK_KIND_AST)? {
         println!("{}", cached);

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -52,21 +52,34 @@ fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &
     );
     assert!(out.is_file(), "{context} did not write requested output");
     cli_ok(
-        vec!["verify".to_string(), out_arg],
+        vec!["verify".to_string(), out_arg.clone()],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg],
+        &format!("{context} run-smc failed"),
     );
     out
 }
 
-fn cli_compile_project_root_err(dir: &std::path::Path, out_name: &str, context: &str) -> String {
+fn cli_compile_project_root_err_no_overwrite(
+    dir: &std::path::Path,
+    out_name: &str,
+    context: &str,
+) -> String {
     let input = normalize_path(dir);
     let out = dir.join(out_name);
     let out_arg = normalize_path(&out);
+    std::fs::write(&out, "sentinel").expect("write sentinel");
     let err = cli_err(
         vec!["compile".to_string(), input, "-o".to_string(), out_arg],
         context,
     );
-    assert!(!out.exists(), "{context} unexpectedly wrote output");
+    let content = std::fs::read_to_string(&out).expect("read out file");
+    assert_eq!(
+        content, "sentinel",
+        "{context} overwrote existing file on compilation failure"
+    );
     err
 }
 
@@ -123,6 +136,19 @@ fn cli_compile_dot_ok(dir: &std::path::Path, out_name: &str, context: &str) -> P
     cli_ok(
         vec!["verify".to_string(), normalize_path(&out)],
         &format!("{context} produced unverifiable SemCode"),
+    );
+    let output2 = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("run-smc")
+        .arg(out_name)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc run-smc: {err}"));
+    assert!(
+        output2.status.success(),
+        "{context} run-smc failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output2.status.code(),
+        String::from_utf8_lossy(&output2.stdout),
+        String::from_utf8_lossy(&output2.stderr)
     );
     out
 }
@@ -557,7 +583,7 @@ name = "app"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "invalid-out.smc",
         "smc compile for invalid manifest project root",
@@ -638,7 +664,7 @@ entry = "examples/missing.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "missing-out.smc",
         "smc compile for missing entry file project root",
@@ -720,7 +746,7 @@ entry = "../escape.sm"
     )
     .expect("write manifest");
 
-    let err = cli_compile_project_root_err(
+    let err = cli_compile_project_root_err_no_overwrite(
         &dir,
         "escape-out.smc",
         "smc compile for escaped entry project root",

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -83,6 +83,54 @@ fn cli_compile_project_root_err_no_overwrite(
     err
 }
 
+fn assert_stale_artifact_protected<F>(
+    dir: &std::path::Path,
+    out_name: &str,
+    mutate: F,
+    context: &str,
+) where
+    F: FnOnce(&std::path::Path),
+{
+    let out = cli_compile_project_root_ok(dir, out_name, &format!("{context} (initial compile)"));
+    let original_bytes = std::fs::read(&out).unwrap_or_else(|err| {
+        panic!(
+            "{context}: failed to read original bytes of {}: {err}",
+            out.display()
+        )
+    });
+    mutate(dir);
+    let input = normalize_path(dir);
+    let out_arg = normalize_path(&out);
+    let _err = cli_err(
+        vec![
+            "compile".to_string(),
+            input,
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("{context} (failing compile expected)"),
+    );
+    assert!(out.is_file(), "{context}: out.smc was deleted");
+    let current_bytes = std::fs::read(&out).unwrap_or_else(|err| {
+        panic!(
+            "{context}: failed to read current bytes of {}: {err}",
+            out.display()
+        )
+    });
+    assert_eq!(
+        original_bytes, current_bytes,
+        "{context}: out.smc was overwritten or modified on compilation failure"
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("{context}: verification failed for original artifact after failed compile"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg],
+        &format!("{context}: run-smc failed for original artifact after failed compile"),
+    );
+}
+
 fn cli_check_dot_ok(dir: &std::path::Path, context: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_smc"))
         .arg("check")
@@ -921,6 +969,173 @@ module_root src
 
     let resolved = resolve_package_import_path(&importer, "math::core.sm").expect("resolve");
     assert_eq!(normalize_path(&resolved), normalize_path(&dep));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_semantic_toml_becomes_malformed() {
+    let dir = mk_temp_dir("pcc9_stale_malformed");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package
+name = "app"
+"#,
+            )
+            .expect("write malformed toml");
+        },
+        "malformed semantic.toml protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_package_name_missing() {
+    let dir = mk_temp_dir("pcc9_stale_missing_package_name");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+
+[project]
+entry = "src/main.sm"
+"#,
+            )
+            .expect("write missing package name toml");
+        },
+        "missing package name protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_empty() {
+    let dir = mk_temp_dir("pcc9_stale_empty_entry");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = ""
+"#,
+            )
+            .expect("write empty entry toml");
+        },
+        "empty entry protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_missing_file() {
+    let dir = mk_temp_dir("pcc9_stale_missing_file");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "src/missing.sm"
+"#,
+            )
+            .expect("write missing entry file toml");
+        },
+        "missing entry file protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_project_entry_path_escapes() {
+    let dir = mk_temp_dir("pcc9_stale_path_escape");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+            )
+            .expect("write path escape toml");
+        },
+        "path escape protection",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_stale_artifact_protected_when_semantic_toml_preferred_over_package_manifest_and_semantic_toml_invalid(
+) {
+    let dir = mk_temp_dir("pcc9_stale_preferred_invalid");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("examples").join("main.sm"));
+    write_source(&dir.join("src").join("main.sm"));
+
+    assert_stale_artifact_protected(
+        &dir,
+        "out.smc",
+        |d| {
+            std::fs::write(
+                d.join("semantic.toml"),
+                r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+            )
+            .expect("write invalid toml");
+        },
+        "semantic.toml priority invalid protection",
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -1139,3 +1139,207 @@ entry = "../escape.sm"
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+fn cli_dump_ast_ok(input_path: &std::path::Path, context: &str) -> String {
+    let input = normalize_path(input_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("dump-ast")
+        .arg(input)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn cli_dump_ast_dot_ok(dir: &std::path::Path, context: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("dump-ast")
+        .arg(".")
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn cli_dump_ast_err(input_path: &std::path::Path, context: &str) -> String {
+    let input = normalize_path(input_path);
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("dump-ast")
+        .arg(input)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        !output.status.success(),
+        "{context} expected failure but got success\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+#[test]
+fn pcc9_dump_ast_semantic_toml_explicit_entry() {
+    let dir = mk_temp_dir("pcc9_dump_ast_explicit");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry_file = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn explicit_main() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_ok(&dir, "dump-ast with semantic.toml explicit entry");
+    assert!(
+        ast.contains("explicit_main"),
+        "AST should contain explicit_main: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_semantic_toml_default_entry() {
+    let dir = mk_temp_dir("pcc9_dump_ast_default");
+    write_semantic_toml(&dir, None);
+    let entry_file = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn default_main() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_ok(&dir, "dump-ast with semantic.toml default entry");
+    assert!(
+        ast.contains("default_main"),
+        "AST should contain default_main: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_semantic_toml_nested_entry() {
+    let dir = mk_temp_dir("pcc9_dump_ast_nested");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    let entry_file = dir.join("examples").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn nested_main() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_ok(&dir, "dump-ast with semantic.toml nested entry");
+    assert!(
+        ast.contains("nested_main"),
+        "AST should contain nested_main: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_prefers_semantic_toml_over_package_manifest() {
+    let dir = mk_temp_dir("pcc9_dump_ast_preferred");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    let toml_entry = dir.join("examples").join("main.sm");
+    std::fs::create_dir_all(toml_entry.parent().unwrap()).expect("mkdir");
+    std::fs::write(&toml_entry, "fn toml_main() { return; }\n").expect("write file");
+
+    let pkg_entry = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(pkg_entry.parent().unwrap()).expect("mkdir");
+    std::fs::write(&pkg_entry, "fn pkg_main() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_ok(&dir, "dump-ast prefers semantic.toml over Semantic.package");
+    assert!(
+        ast.contains("toml_main"),
+        "AST should contain toml_main: {ast}"
+    );
+    assert!(
+        !ast.contains("pkg_main"),
+        "AST should not contain pkg_main: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_package_baseline_fallback() {
+    let dir = mk_temp_dir("pcc9_dump_ast_package_baseline");
+    write_package_manifest_baseline(&dir);
+    let entry_file = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn pkg_fallback() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_ok(&dir, "dump-ast fallback to Semantic.package");
+    assert!(
+        ast.contains("pkg_fallback"),
+        "AST should contain pkg_fallback: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_dot_works_from_root() {
+    let dir = mk_temp_dir("pcc9_dump_ast_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry_file = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn dot_main() { return; }\n").expect("write file");
+
+    let ast = cli_dump_ast_dot_ok(&dir, "dump-ast . from project root");
+    assert!(
+        ast.contains("dot_main"),
+        "AST should contain dot_main: {ast}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_invalid_semantic_toml_fails_without_fallback() {
+    let dir = mk_temp_dir("pcc9_dump_ast_invalid_toml");
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write malformed toml");
+    write_package_manifest_baseline(&dir);
+    let entry_file = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(entry_file.parent().unwrap()).expect("mkdir");
+    std::fs::write(&entry_file, "fn pkg_main() { return; }\n").expect("write file");
+
+    let err = cli_dump_ast_err(&dir, "dump-ast with invalid semantic.toml");
+    assert!(!err.is_empty(), "expected error output");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_missing_entry_file_fails_without_fallback() {
+    let dir = mk_temp_dir("pcc9_dump_ast_missing_file");
+    write_semantic_toml(&dir, Some("src/missing.sm"));
+
+    let err = cli_dump_ast_err(&dir, "dump-ast with missing entry file");
+    assert!(!err.is_empty(), "expected error output");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_dump_ast_path_escape_fails_without_fallback() {
+    let dir = mk_temp_dir("pcc9_dump_ast_path_escape");
+    write_semantic_toml(&dir, Some("../escape.sm"));
+
+    let err = cli_dump_ast_err(&dir, "dump-ast with path escape entry");
+    assert!(!err.is_empty(), "expected error output");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary
This PR adds minimal project-root support for `smc dump-ast <project-root>` and `smc dump-ast .` by reusing the existing project manifest entry resolution.

## Changed Files
- `crates/smc-cli/src/app.rs`
- `tests/pcc9_project_model_acceptance.rs`

## Behavior Added
- `smc dump-ast <project-root>` and `smc dump-ast .` are supported and map to the resolved manifest entry.

## Tests Added
A set of 9 comprehensive acceptance tests were added to `tests/pcc9_project_model_acceptance.rs`:
- Positive cases covering explicit entry, default entry, nested entry, manifest preference, fallback to baseline, and relative `.` route from the project root.
- Negative cases covering invalid/malformed TOML, missing entry file, and path escape entry attempts (all fail deterministically without fallback).

## Explicit Non-goals
- No dump-ir, dump-bytecode, hash-ast, hash-ir, hash-smc, disasm, or other commands have been introduced or modified for project roots.
- No changes to AST format.

## CTF Touched
CTF touched: none

Reason:
This PR adds a minimal project-root CLI route for `smc dump-ast` using existing project entry resolution. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, AST format, release gates, or CTF closure.

## 7hell Touched
7hell touched: none

Reason:
This package is project-model CLI inspection routing, not 7hell qualification behavior.

## Local Checks Run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

## .claude/ Modified
No. No `.claude/` files or CI workflow files have been added, modified, or included.
