### PR TITLE
cli(project-model): add minimal project-root hash-ast route

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -1613,12 +1613,18 @@ fn load_cache_entry(path: &Path, expected_fp: u64) -> Result<Option<CacheEntry>,
 
 fn cmd_hash_ast(args: &[String]) -> Result<(), String> {
     if args.len() != 1 {
-        return Err("usage: smc hash-ast <input.sm>".to_string());
+        return Err("usage: smc hash-ast <input.sm|project-root>".to_string());
     }
     let input = args[0].as_str();
-    let src = read_source_with_package_admission(Path::new(input))?;
+    let input_path = Path::new(input);
+    let root = if input_path.is_dir() {
+        resolve_project_root_check_entry(input_path)?
+    } else {
+        input_path.to_path_buf()
+    };
+    let src = read_source_with_package_admission(&root)?;
     let parser_profile = cli_profile();
-    let ast_key = ast_pack_key(Path::new(input), &src)?;
+    let ast_key = ast_pack_key(&root, &src)?;
     let ast_pack = cache_ast_file_for_key(ast_key)?;
     let text = if let Some(cached) = load_text_pack(&ast_pack, PACK_KIND_AST)? {
         cached
@@ -2473,7 +2479,7 @@ fn usage() -> String {
         "  smc dump-ast <input.sm>",
         "  smc dump-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
         "  smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
-        "  smc hash-ast <input.sm>",
+        "  smc hash-ast <input.sm|project-root>",
         "  smc hash-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
         "  smc hash-smc <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
         "  smc snapshots [--update]",

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -48,7 +48,7 @@ Current accepted usage forms are:
 - `smc dump-ast <input.sm>`
 - `smc dump-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
 - `smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]`
-- `smc hash-ast <input.sm>`
+- `smc hash-ast <input.sm|project-root>`
 - `smc hash-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
 - `smc hash-smc <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
 - `smc snapshots [--update]`
@@ -132,6 +132,7 @@ Current rule:
 - `smc check` also accepts a bounded admitted project-root entrypoint through `Semantic.package` + `src/main.sm`
 - project-root `smc check` also resolves a minimal `semantic.toml` manifest when present
 - project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route
+- project-root `smc hash-ast` uses the same bounded project entry resolution and emits the existing AST hash for the resolved source file
 - widening package resolution, helper import loading, or source-root admission is a public CLI and source-boundary change
 
 ## Tooling Helper Rule

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -27,6 +27,21 @@ fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
 }
 
+fn cli_stdout(args: Vec<String>, context: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
 fn cli_check_project_root_ok(dir: &std::path::Path, context: &str) {
     let input = normalize_path(dir);
     cli_ok(vec!["check".to_string(), input], context);
@@ -35,6 +50,32 @@ fn cli_check_project_root_ok(dir: &std::path::Path, context: &str) {
 fn cli_run_project_root_ok(dir: &std::path::Path, context: &str) {
     let input = normalize_path(dir);
     cli_ok(vec!["run".to_string(), input], context);
+}
+
+fn cli_hash_ast_project_root_output(dir: &std::path::Path, context: &str) -> String {
+    let input = normalize_path(dir);
+    cli_stdout(vec!["hash-ast".to_string(), input], context)
+}
+
+fn cli_hash_ast_project_root_output_dot(dir: &std::path::Path, context: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("hash-ast")
+        .arg(".")
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn cli_hash_ast_file_output(path: &std::path::Path, context: &str) -> String {
+    cli_stdout(vec!["hash-ast".to_string(), normalize_path(path)], context)
 }
 
 fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &str) -> PathBuf {
@@ -348,6 +389,31 @@ fn full_project_root_package_baseline_run_path() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+fn full_project_root_package_baseline_hash_ast_path() {
+    let dir = mk_temp_dir("pcc9_project_root_package_hash_ast_acceptance");
+    write_package_manifest_baseline(&dir);
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_ast_project_root_output(&dir, "smc hash-ast for package baseline project root");
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for resolved package entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_ast_project_root_output(
+            &dir,
+            "smc hash-ast for package baseline project root second run"
+        ),
+        "project-root hash must be deterministic across repeated runs"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 fn full_project_root_package_baseline_compile_path() {
     let dir = mk_temp_dir("pcc9_project_root_package_compile_acceptance");
     write_package_manifest_baseline(&dir);
@@ -383,6 +449,11 @@ fn pcc9_project_root_package_baseline_still_runs_entrypoint() {
 }
 
 #[test]
+fn pcc9_project_root_package_baseline_still_hashes_entrypoint() {
+    full_project_root_package_baseline_hash_ast_path();
+}
+
+#[test]
 fn pcc9_project_root_package_baseline_still_compiles_entrypoint() {
     full_project_root_package_baseline_compile_path();
 }
@@ -405,6 +476,32 @@ fn pcc9_project_root_semantic_toml_explicit_entry_runs() {
     write_source(&dir.join("src").join("main.sm"));
 
     cli_run_project_root_ok(&dir, "smc run for semantic.toml explicit entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_explicit_entry_hashes() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_explicit_entry_hash");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_ast_project_root_output(&dir, "smc hash-ast for semantic.toml explicit entry");
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for explicit resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_ast_project_root_output(
+            &dir,
+            "smc hash-ast for semantic.toml explicit entry second run"
+        ),
+        "project-root hash must be deterministic across repeated runs"
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -443,6 +540,32 @@ fn pcc9_project_root_semantic_toml_default_entry_runs() {
 }
 
 #[test]
+fn pcc9_project_root_semantic_toml_default_entry_hashes() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_default_entry_hash");
+    write_semantic_toml(&dir, None);
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_ast_project_root_output(&dir, "smc hash-ast for semantic.toml default entry");
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for default resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_ast_project_root_output(
+            &dir,
+            "smc hash-ast for semantic.toml default entry second run"
+        ),
+        "project-root hash must be deterministic across repeated runs"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_default_entry_compiles() {
     let dir = mk_temp_dir("pcc9_project_root_semantic_default_entry_compile");
     write_semantic_toml(&dir, None);
@@ -471,6 +594,32 @@ fn pcc9_project_root_semantic_toml_nested_entry_runs() {
     write_source(&dir.join("examples").join("main.sm"));
 
     cli_run_project_root_ok(&dir, "smc run for semantic.toml nested entry");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_nested_entry_hashes() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_nested_entry_hash");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    let entry = dir.join("examples").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_ast_project_root_output(&dir, "smc hash-ast for semantic.toml nested entry");
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for nested resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_ast_project_root_output(
+            &dir,
+            "smc hash-ast for semantic.toml nested entry second run"
+        ),
+        "project-root hash must be deterministic across repeated runs"
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -509,6 +658,35 @@ fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_run() 
     write_source(&dir.join("examples").join("main.sm"));
 
     cli_run_project_root_ok(&dir, "smc run prefers semantic.toml over Semantic.package");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_semantic_toml_is_preferred_over_package_manifest_for_hash_ast() {
+    let dir = mk_temp_dir("pcc9_project_root_semantic_preferred_hash");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    let entry = dir.join("examples").join("main.sm");
+    write_source(&entry);
+
+    let root_hash = cli_hash_ast_project_root_output(
+        &dir,
+        "smc hash-ast prefers semantic.toml over Semantic.package",
+    );
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for preferred resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_ast_project_root_output(
+            &dir,
+            "smc hash-ast prefers semantic.toml over Semantic.package second run"
+        ),
+        "project-root hash must be deterministic across repeated runs"
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -554,6 +732,29 @@ fn pcc9_project_root_run_dot_matches_absolute_project_root() {
 }
 
 #[test]
+fn pcc9_project_root_hash_ast_dot_matches_absolute_project_root() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_ast_project_root_output(&dir, "smc hash-ast for absolute project root");
+    let dot_hash = cli_hash_ast_project_root_output_dot(&dir, "smc hash-ast dot from project root");
+    let file_hash = cli_hash_ast_file_output(&entry, "smc hash-ast for absolute resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        dot_hash, file_hash,
+        "smc hash-ast . must match resolved file hash"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_compile_dot_writes_requested_output() {
     let dir = mk_temp_dir("pcc9_project_root_compile_dot");
     write_semantic_toml(&dir, Some("src/main.sm"));
@@ -565,6 +766,31 @@ fn pcc9_project_root_compile_dot_writes_requested_output() {
         "smc compile absolute project root",
     );
     cli_compile_dot_ok(&dir, "dot-out.smc", "smc compile dot from project root");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_ast_rejects_invalid_semantic_toml_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_invalid_syntax");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-ast".to_string(), input.clone()],
+        &format!("smc hash-ast for invalid manifest project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("malformed"), "{err}");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -588,6 +814,34 @@ name = "app"
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("malformed"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_ast_rejects_missing_entry_file_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_missing_entry_file");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "examples/missing.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-ast".to_string(), input.clone()],
+        &format!("smc hash-ast for missing entry file project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing file"), "{err}");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -643,6 +897,34 @@ name = "app"
 }
 
 #[test]
+fn pcc9_project_root_hash_ast_rejects_path_escape_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_path_escape");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-ast".to_string(), input.clone()],
+        &format!("smc hash-ast for escaped entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("must not escape the project root"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pcc9_project_root_semantic_toml_rejects_missing_package_name() {
     let dir = mk_temp_dir("pcc9_project_root_missing_package_name");
     std::fs::write(
@@ -660,6 +942,33 @@ entry = "src/main.sm"
     let err = cli_err(
         vec!["check".to_string(), input.clone()],
         &format!("smc check for missing package name project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing required [package].name"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_ast_rejects_missing_package_name_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_missing_package_name");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+
+[project]
+entry = "src/main.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-ast".to_string(), input.clone()],
+        &format!("smc hash-ast for missing package name project root {input}"),
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("missing required [package].name"), "{err}");
@@ -745,6 +1054,34 @@ entry = "src/main.sm"
     );
     assert!(err.contains("semantic.toml"), "{err}");
     assert!(err.contains("empty [package].name"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_ast_rejects_empty_entry_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_ast_empty_entry");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = ""
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-ast".to_string(), input.clone()],
+        &format!("smc hash-ast for empty entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("empty [project].entry"), "{err}");
 
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
summary
- Add minimal `smc hash-ast <project-root>` and `smc hash-ast .` route on top of the existing project-root manifest resolver.
- Preserve the existing AST hash algorithm and output format.

changed files
- `crates/smc-cli/src/app.rs`
- `docs/spec/cli.md`
- `tests/pcc9_project_model_acceptance.rs`

behavior added
- Project-root `hash-ast` resolves `semantic.toml` when present.
- `smc hash-ast .` works from inside the project root.
- Existing `Semantic.package` baseline remains supported when `semantic.toml` is absent.
- Invalid manifest, missing entry file, and path-escape cases fail deterministically through existing diagnostics.
- Hash output remains the existing AST hash for the resolved source file.

tests added
- Positive project-root `hash-ast` coverage for explicit `semantic.toml` entry, default entry, nested entry, and `semantic.toml` preference over `Semantic.package`.
- Positive baseline coverage for `Semantic.package` when `semantic.toml` is absent.
- `smc hash-ast .` coverage from project root.
- Negative coverage for invalid manifest syntax, missing entry file, path escape, missing package name, and empty entry.
- Determinism checks across repeated runs.

explicit non-goals
- Do not implement `smc run` changes.
- Do not implement `smc compile` changes.
- Do not implement package registry, dependency resolver, workspace support, or multi-package discovery.
- Do not change parser, verifier, VM, runtime, capability, audit, or trace behavior.
- Do not widen release claims.
- Do not touch `.claude/`.

verifier-first note
- Project-root `hash-ast` resolves the admitted entrypoint and then uses the existing source hashing path; it does not bypass existing admission boundaries or introduce a separate execution route.

CTF touched
- none

Reason:
This PR adds minimal project-root CLI coverage for `smc hash-ast` using the existing admitted source resolution path. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, release gates, or CTF closure.

7hell touched
- none

Reason:
This package is project-model CLI hashing coverage, not 7hell qualification behavior.

local checks run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

`.claude/` is not included.
