### PR TITLE
cli(project-model): add minimal project-root hash-smc route

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -1732,7 +1732,7 @@ fn cmd_hash_ir(args: &[String]) -> Result<(), String> {
 fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
     if args.is_empty() {
         return Err(
-            "usage: smc hash-smc <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--trace-cache]"
+            "usage: smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--trace-cache]"
                 .to_string(),
         );
     }
@@ -1765,23 +1765,28 @@ fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
         }
         i += 1;
     }
-    let src = read_source_with_package_admission(Path::new(input))?;
+    let input_path = Path::new(input);
+    let root = if input_path.is_dir() {
+        resolve_project_root_check_entry(input_path)?
+    } else {
+        input_path.to_path_buf()
+    };
+    let src = read_source_with_package_admission(&root)?;
     let prev_graph_hash = read_graph_hash(Path::new(CACHE_GRAPH_FILE));
-    let graph_hash_now = if let Ok(snapshot) = ModuleGraphSnapshot::read_from_root(Path::new(input))
-    {
+    let graph_hash_now = if let Ok(snapshot) = ModuleGraphSnapshot::read_from_root(&root) {
         let hash = snapshot.hash(CACHE_SCHEMA_VERSION);
         let _ = snapshot.write_to(Path::new(CACHE_GRAPH_FILE), CACHE_SCHEMA_VERSION);
         Some(hash)
     } else {
         None
     };
-    let exb_key = smc_pack_key(Path::new(input), &src, profile, opt, debug_symbols)?;
+    let exb_key = smc_pack_key(&root, &src, profile, opt, debug_symbols)?;
     if trace_cache_enabled && prev_graph_hash.is_some() && prev_graph_hash != graph_hash_now {
         trace_cache(
             true,
             CacheEvent::Invalidate,
             CacheReason::GraphChanged,
-            Path::new(input),
+            &root,
             "GRAPH",
             &format!("{:016x}", exb_key),
         );
@@ -1793,7 +1798,7 @@ fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
                 trace_cache_enabled,
                 CacheEvent::Hit,
                 CacheReason::Reused,
-                Path::new(input),
+                &root,
                 "SMCP",
                 &format!("{:016x}", exb_key),
             );
@@ -1804,7 +1809,7 @@ fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
                 trace_cache_enabled,
                 CacheEvent::Miss,
                 reason,
-                Path::new(input),
+                &root,
                 "SMCP",
                 &format!("{:016x}", exb_key),
             );
@@ -2487,7 +2492,7 @@ fn usage() -> String {
         "  smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
         "  smc hash-ast <input.sm|project-root>",
         "  smc hash-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
-        "  smc hash-smc <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
+        "  smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
         "  smc snapshots [--update]",
         "  smc features",
         "  smc explain <error-code|--list>",

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -50,7 +50,7 @@ Current accepted usage forms are:
 - `smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]`
 - `smc hash-ast <input.sm|project-root>`
 - `smc hash-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
-- `smc hash-smc <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
+- `smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
 - `smc snapshots [--update]`
 - `smc features`
 - `smc explain <error-code|--list>`
@@ -134,6 +134,7 @@ Current rule:
 - project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route
 - project-root `smc hash-ast` uses the same bounded project entry resolution and emits the existing AST hash for the resolved source file
 - project-root `smc hash-ir` uses the same bounded project entry resolution and emits the existing IR hash for the resolved source file
+- project-root `smc hash-smc` uses the same bounded project entry resolution and emits the existing SemCode hash for the resolved source or artifact path
 - widening package resolution, helper import loading, or source-root admission is a public CLI and source-boundary change
 
 ## Tooling Helper Rule

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -104,6 +104,31 @@ fn cli_hash_ir_file_output(path: &std::path::Path, context: &str) -> String {
     cli_stdout(vec!["hash-ir".to_string(), normalize_path(path)], context)
 }
 
+fn cli_hash_smc_project_root_output(dir: &std::path::Path, context: &str) -> String {
+    let input = normalize_path(dir);
+    cli_stdout(vec!["hash-smc".to_string(), input], context)
+}
+
+fn cli_hash_smc_project_root_output_dot(dir: &std::path::Path, context: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_smc"))
+        .arg("hash-smc")
+        .arg(".")
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to spawn smc: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn cli_hash_smc_file_output(path: &std::path::Path, context: &str) -> String {
+    cli_stdout(vec!["hash-smc".to_string(), normalize_path(path)], context)
+}
 fn cli_compile_project_root_ok(dir: &std::path::Path, out_name: &str, context: &str) -> PathBuf {
     let input = normalize_path(dir);
     let out = dir.join(out_name);
@@ -1130,6 +1155,24 @@ fn assert_hash_ir_project_root_matches_entry(
     );
 }
 
+fn assert_hash_smc_project_root_matches_entry(
+    dir: &std::path::Path,
+    entry: &std::path::Path,
+    context: &str,
+) {
+    let root_hash = cli_hash_smc_project_root_output(dir, &format!("{context} (project root)"));
+    let file_hash = cli_hash_smc_file_output(entry, &format!("{context} (resolved file)"));
+    assert_eq!(
+        root_hash, file_hash,
+        "{context}: project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        root_hash,
+        cli_hash_smc_project_root_output(dir, &format!("{context} (second run)")),
+        "{context}: project-root hash must be deterministic across repeated runs"
+    );
+}
+
 #[test]
 fn pcc9_project_root_hash_ir_semantic_toml_explicit_entry() {
     let dir = mk_temp_dir("pcc9_project_root_hash_ir_explicit_entry");
@@ -1326,6 +1369,202 @@ entry = "../escape.sm"
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+#[test]
+fn pcc9_project_root_hash_smc_semantic_toml_explicit_entry() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_explicit_entry");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    assert_hash_smc_project_root_matches_entry(
+        &dir,
+        &entry,
+        "smc hash-smc with semantic.toml explicit entry",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_semantic_toml_default_entry() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_default_entry");
+    write_semantic_toml(&dir, None);
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    assert_hash_smc_project_root_matches_entry(
+        &dir,
+        &entry,
+        "smc hash-smc with semantic.toml default entry",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_semantic_toml_nested_entry() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_nested_entry");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    let entry = dir.join("examples").join("main.sm");
+    write_source(&entry);
+
+    assert_hash_smc_project_root_matches_entry(
+        &dir,
+        &entry,
+        "smc hash-smc with semantic.toml nested entry",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_prefers_semantic_toml_over_package_manifest() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_preferred");
+    write_semantic_toml(&dir, Some("examples/main.sm"));
+    write_package_manifest_baseline(&dir);
+    let semantic_entry = dir.join("examples").join("main.sm");
+    let package_entry = dir.join("src").join("main.sm");
+    std::fs::create_dir_all(semantic_entry.parent().unwrap()).expect("mkdir semantic entry");
+    std::fs::create_dir_all(package_entry.parent().unwrap()).expect("mkdir package entry");
+    std::fs::write(
+        &semantic_entry,
+        "fn main() { return; }\nfn toml_main() { return; }\n",
+    )
+    .expect("write semantic entry");
+    std::fs::write(
+        &package_entry,
+        "fn main() { return; }\nfn pkg_main() { return; }\n",
+    )
+    .expect("write package entry");
+
+    assert_hash_smc_project_root_matches_entry(
+        &dir,
+        &semantic_entry,
+        "smc hash-smc prefers semantic.toml over Semantic.package",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_package_baseline_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_package_baseline");
+    write_package_manifest_baseline(&dir);
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    assert_hash_smc_project_root_matches_entry(
+        &dir,
+        &entry,
+        "smc hash-smc fallback to Semantic.package",
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_dot_works_from_root() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_dot");
+    write_semantic_toml(&dir, Some("src/main.sm"));
+    let entry = dir.join("src").join("main.sm");
+    write_source(&entry);
+
+    let root_hash =
+        cli_hash_smc_project_root_output(&dir, "smc hash-smc for absolute project root");
+    let dot_hash = cli_hash_smc_project_root_output_dot(&dir, "smc hash-smc dot from project root");
+    let file_hash = cli_hash_smc_file_output(&entry, "smc hash-smc for resolved entry");
+    assert_eq!(
+        root_hash, file_hash,
+        "project-root hash must match resolved file hash"
+    );
+    assert_eq!(
+        dot_hash, file_hash,
+        "smc hash-smc . must match resolved file hash"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_rejects_invalid_semantic_toml_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_invalid_syntax");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package
+name = "app"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-smc".to_string(), input.clone()],
+        &format!("smc hash-smc for invalid manifest project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("malformed"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_rejects_missing_entry_file_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_missing_entry_file");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "examples/missing.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-smc".to_string(), input.clone()],
+        &format!("smc hash-smc for missing entry file project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("missing file"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn pcc9_project_root_hash_smc_rejects_path_escape_without_fallback() {
+    let dir = mk_temp_dir("pcc9_project_root_hash_smc_path_escape");
+    write_package_manifest_baseline(&dir);
+    write_source(&dir.join("src").join("main.sm"));
+    std::fs::write(
+        dir.join("semantic.toml"),
+        r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+    )
+    .expect("write manifest");
+
+    let input = normalize_path(&dir);
+    let err = cli_err(
+        vec!["hash-smc".to_string(), input.clone()],
+        &format!("smc hash-smc for escaped entry project root {input}"),
+    );
+    assert!(err.contains("semantic.toml"), "{err}");
+    assert!(err.contains("must not escape the project root"), "{err}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
 #[test]
 fn pcc9_project_root_run_rejects_path_escape_without_fallback() {
     let dir = mk_temp_dir("pcc9_project_root_run_path_escape");


### PR DESCRIPTION
summary
- Add minimal `smc hash-smc <project-root>` and `smc hash-smc .` route on top of the existing project-root manifest resolver.
- Preserve the existing SemCode hash algorithm and output format.

changed files
- `crates/smc-cli/src/app.rs`
- `docs/spec/cli.md`
- `tests/pcc9_project_model_acceptance.rs`

behavior added
- Project-root `hash-smc` resolves `semantic.toml` when present.
- `smc hash-smc .` works from inside the project root.
- Existing `Semantic.package` baseline remains supported when `semantic.toml` is absent.
- Invalid manifest, missing entry file, and path-escape cases fail deterministically through existing diagnostics.
- Hash output remains the existing SemCode hash for the resolved source/artifact path.

tests added
- Positive project-root `hash-smc` coverage for explicit `semantic.toml` entry, default entry, nested entry, and `semantic.toml` preference over `Semantic.package`.
- Positive baseline coverage for `Semantic.package` when `semantic.toml` is absent.
- `smc hash-smc .` coverage from project root.
- Negative coverage for invalid manifest syntax, missing entry file, and path escape.
- Determinism checks across repeated runs and comparison to the resolved entry file hash.

explicit non-goals
- Do not implement `smc run` changes.
- Do not implement `smc compile` changes.
- Do not implement `hash-ast`, `hash-ir`, `disasm`, `verify`, `run-smc`, package registry, dependency resolver, workspace support, or multi-package discovery.
- Do not change parser, lowering, verifier, VM, runtime, SemCode format, capability, audit, or trace behavior.
- Do not widen release claims.
- Do not touch `.claude/`.

determinism statement
- `smc hash-smc <project-root>` must return the same hash for the same resolved entry source or artifact path, and it must match the hash produced by `smc hash-smc <resolved-entry-file>` for that same source.

verifier-first note
- Project-root `hash-smc` resolves the admitted entrypoint and then uses the existing SemCode hashing path; it does not bypass admission boundaries or introduce a separate execution route.

CTF touched
- none

Reason:
This PR adds a minimal project-root CLI route for `smc hash-smc` using the existing admitted source resolution path. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, hash-smc algorithm, release gates, or CTF closure.

7hell touched
- none

Reason:
This package is project-model CLI hash routing, not 7hell qualification behavior.

local checks run
- `cargo fmt --all --check`
- `cargo test -q --test pcc9_project_model_acceptance`
- `cargo test -q --test public_api_contracts`
- `cargo test --all-targets --quiet`
- `pwsh -File scripts/local_ci.ps1`
- `git diff --check`

`.claude/` is not included.
