### PR TITLE
test(project-model): add canonical Semantic.package fallback fixture

### DIFF
--- a/examples/qualification/pcc9_project_root_package_baseline/Semantic.package
+++ b/examples/qualification/pcc9_project_root_package_baseline/Semantic.package
@@ -1,0 +1,4 @@
+format 1
+package pcc9_project_root_package_baseline
+manifest_dir .
+module_root src

--- a/examples/qualification/pcc9_project_root_package_baseline/src/main.sm
+++ b/examples/qualification/pcc9_project_root_package_baseline/src/main.sm
@@ -1,0 +1,3 @@
+fn main() {
+    return;
+}

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -24,6 +24,12 @@ fn canonical_project_root_fixture() -> PathBuf {
     ))
 }
 
+fn package_baseline_project_root_fixture() -> PathBuf {
+    PathBuf::from(repo_path(
+        "examples/qualification/pcc9_project_root_package_baseline",
+    ))
+}
+
 fn collect_fixture_tree_entries(
     dir: &std::path::Path,
     root: &std::path::Path,
@@ -72,6 +78,27 @@ fn assert_canonical_project_root_fixture_clean(context: &str) {
     assert_eq!(
         files,
         vec!["semantic.toml".to_string(), "src/main.sm".to_string(),],
+        "{context} fixture tree contained unexpected files: {:?}",
+        files
+    );
+    assert_eq!(
+        dirs,
+        vec!["src".to_string()],
+        "{context} fixture tree contained unexpected directories: {:?}",
+        dirs
+    );
+}
+
+fn assert_package_baseline_project_root_fixture_clean(context: &str) {
+    let root = package_baseline_project_root_fixture();
+    let mut files = Vec::new();
+    let mut dirs = Vec::new();
+    collect_fixture_tree_entries(&root, &root, &mut files, &mut dirs);
+    files.sort();
+    dirs.sort();
+    assert_eq!(
+        files,
+        vec!["Semantic.package".to_string(), "src/main.sm".to_string(),],
         "{context} fixture tree contained unexpected files: {:?}",
         files
     );
@@ -2933,5 +2960,147 @@ fn pcc9_project_root_smoke_fixture_rejects_artifact_only_commands_on_project_roo
         "run-smc",
         &root,
         "smc run-smc must reject canonical project-root fixture input",
+    );
+}
+
+#[test]
+fn pcc9_project_root_package_baseline_fixture_accepts_admitted_surface() {
+    let root = package_baseline_project_root_fixture();
+    assert_package_baseline_project_root_fixture_clean(
+        "package baseline project-root fixture before checks",
+    );
+    assert_no_semcode_artifacts(&root, "package baseline project-root fixture");
+
+    cli_check_project_root_ok(&root, "smc check for package baseline project-root fixture");
+    cli_run_project_root_ok(&root, "smc run for package baseline project-root fixture");
+
+    let ast = cli_dump_ast_ok(
+        &root,
+        "smc dump-ast for package baseline project-root fixture",
+    );
+    assert!(
+        ast.contains("main"),
+        "dump-ast output should mention main: {ast}"
+    );
+    let ir = cli_dump_ir_ok(
+        &root,
+        "smc dump-ir for package baseline project-root fixture",
+    );
+    assert!(
+        ir.contains("main"),
+        "dump-ir output should mention main: {ir}"
+    );
+    let bytecode = cli_dump_bytecode_ok(
+        &root,
+        "smc dump-bytecode for package baseline project-root fixture",
+    );
+    assert!(
+        bytecode.contains("0000:"),
+        "dump-bytecode output should contain offset 0000: {bytecode}"
+    );
+
+    let ast_hash = cli_hash_ast_project_root_output(
+        &root,
+        "smc hash-ast for package baseline project-root fixture",
+    );
+    assert_eq!(
+        ast_hash,
+        cli_hash_ast_project_root_output(
+            &root,
+            "smc hash-ast for package baseline project-root fixture second run"
+        ),
+        "hash-ast must be deterministic across repeated runs"
+    );
+    let ir_hash = cli_hash_ir_project_root_output(
+        &root,
+        "smc hash-ir for package baseline project-root fixture",
+    );
+    assert_eq!(
+        ir_hash,
+        cli_hash_ir_project_root_output(
+            &root,
+            "smc hash-ir for package baseline project-root fixture second run"
+        ),
+        "hash-ir must be deterministic across repeated runs"
+    );
+    let smc_hash = cli_hash_smc_project_root_output(
+        &root,
+        "smc hash-smc for package baseline project-root fixture",
+    );
+    assert_eq!(
+        smc_hash,
+        cli_hash_smc_project_root_output(
+            &root,
+            "smc hash-smc for package baseline project-root fixture second run"
+        ),
+        "hash-smc must be deterministic across repeated runs"
+    );
+
+    let artifacts_dir = mk_temp_dir("pcc9_project_root_package_baseline_fixture_artifacts");
+    let out = cli_compile_project_root_to(
+        &root,
+        &artifacts_dir,
+        "out.smc",
+        "smc compile package baseline project-root fixture to temp output",
+    );
+    assert!(
+        out.starts_with(&artifacts_dir),
+        "compile output should stay under temp artifact dir: {}",
+        out.display()
+    );
+    assert_eq!(
+        out.parent(),
+        Some(artifacts_dir.as_path()),
+        "compile output should be written directly into the temp artifact dir"
+    );
+    cli_ok(
+        vec!["verify".to_string(), normalize_path(&out)],
+        "smc verify for package baseline project-root artifact",
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), normalize_path(&out)],
+        "smc run-smc for package baseline project-root artifact",
+    );
+    let disasm = cli_disasm_artifact_output(
+        &out,
+        "smc disasm for package baseline project-root artifact",
+    );
+    assert!(
+        !disasm.trim().is_empty(),
+        "smc disasm for package baseline project-root artifact returned empty output"
+    );
+    assert_eq!(
+        disasm,
+        cli_disasm_artifact_output(
+            &out,
+            "smc disasm for package baseline project-root artifact second run"
+        ),
+        "smc disasm for package baseline project-root artifact must be deterministic"
+    );
+    assert_package_baseline_project_root_fixture_clean(
+        "package baseline project-root fixture after checks",
+    );
+    assert_no_semcode_artifacts(&root, "package baseline project-root fixture after checks");
+
+    let _ = std::fs::remove_dir_all(&artifacts_dir);
+}
+
+#[test]
+fn pcc9_project_root_package_baseline_fixture_rejects_artifact_only_commands_on_project_root() {
+    let root = package_baseline_project_root_fixture();
+    assert_artifact_only_command_rejects_project_root_input(
+        "disasm",
+        &root,
+        "smc disasm must reject package baseline project-root fixture input",
+    );
+    assert_artifact_only_command_rejects_project_root_input(
+        "verify",
+        &root,
+        "smc verify must reject package baseline project-root fixture input",
+    );
+    assert_artifact_only_command_rejects_project_root_input(
+        "run-smc",
+        &root,
+        "smc run-smc must reject package baseline project-root fixture input",
     );
 }


### PR DESCRIPTION
Summary:
- Add a canonical Semantic.package fallback fixture and acceptance coverage for the legacy project-root baseline.

Changed files:
- examples/qualification/pcc9_project_root_package_baseline/Semantic.package
- examples/qualification/pcc9_project_root_package_baseline/src/main.sm
- tests/pcc9_project_model_acceptance.rs

Fixture path:
- examples/qualification/pcc9_project_root_package_baseline/

Commands covered:
- smc check <project-root>
- smc run <project-root>
- smc compile <project-root> -o <temp/out.smc>
- smc verify <temp/out.smc>
- smc run-smc <temp/out.smc>
- smc dump-ast <project-root>
- smc dump-ir <project-root>
- smc dump-bytecode <project-root>
- smc hash-ast <project-root>
- smc hash-ir <project-root>
- smc hash-smc <project-root>
- smc disasm / verify / run-smc rejection on project-root input

Semantic.package fallback statement:
- The fixture intentionally uses the legacy `Semantic.package` baseline and omits `semantic.toml`, proving that the admitted project-root routes still support the older manifest shape.

Artifact-only boundary statement:
- `smc disasm`, `smc verify`, and `smc run-smc` remain artifact-only and reject project-root input in this coverage.

Fixture cleanliness statement:
- The fixture tree is asserted to contain only `Semantic.package`, `src/main.sm`, and `src/`.
- No `.smc` artifacts or local output/cache directories are allowed inside the fixture tree.
- Compile output is written to a temp test directory only.

Explicit non-goals:
- no production code changes
- no CLI behavior changes
- no project-root resolver changes
- no docs/spec changes
- no parser/lowering/verifier/VM/runtime/SemCode changes
- no package registry / workspace support
- no `.claude/`
- no snapshots
- no CI workflow changes

CTF touched statement:
- none

Reason:
This PR adds a canonical Semantic.package fallback fixture and acceptance coverage only. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, project-root resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched statement:
- none

Reason:
This package is project-model fixture/acceptance coverage, not 7hell qualification behavior.

Local checks run:
- cargo fmt --all --check
- cargo test -q --test pcc9_project_model_acceptance
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

Confirmation:
- .claude/ is not included
- no generated .smc artifacts are committed
- git log --oneline origin/main..HEAD shows exactly one commit: 5d8d1b6 test(project-model): add canonical Semantic.package fallback fixture
