### PR TITLE
test(project-model): add PCC9 project-root surface inventory guard

### DIFF
--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -3104,3 +3104,80 @@ fn pcc9_project_root_package_baseline_fixture_rejects_artifact_only_commands_on_
         "smc run-smc must reject package baseline project-root fixture input",
     );
 }
+
+#[test]
+fn pcc9_project_root_surface_inventory_guard() {
+    let fixture_roots = [
+        (
+            "semantic.toml canonical project-root fixture",
+            canonical_project_root_fixture(),
+            true,
+            false,
+        ),
+        (
+            "Semantic.package fallback project-root fixture",
+            package_baseline_project_root_fixture(),
+            false,
+            true,
+        ),
+    ];
+
+    let admitted_project_root_commands = [
+        "check",
+        "run",
+        "compile",
+        "dump-ast",
+        "dump-ir",
+        "dump-bytecode",
+        "hash-ast",
+        "hash-ir",
+        "hash-smc",
+    ];
+    let artifact_only_commands = ["disasm", "verify", "run-smc"];
+
+    assert_eq!(
+        admitted_project_root_commands,
+        [
+            "check",
+            "run",
+            "compile",
+            "dump-ast",
+            "dump-ir",
+            "dump-bytecode",
+            "hash-ast",
+            "hash-ir",
+            "hash-smc",
+        ],
+        "admitted project-root command surface changed unexpectedly",
+    );
+    assert_eq!(
+        artifact_only_commands,
+        ["disasm", "verify", "run-smc"],
+        "artifact-only command boundary changed unexpectedly",
+    );
+
+    for (label, root, has_semantic_toml, has_package_manifest) in fixture_roots {
+        assert!(
+            root.is_dir(),
+            "{label} root must exist as a directory: {}",
+            root.display()
+        );
+        assert_eq!(
+            root.join("semantic.toml").is_file(),
+            has_semantic_toml,
+            "{label} semantic.toml expectation failed at {}",
+            root.display()
+        );
+        assert_eq!(
+            root.join(PACKAGE_MANIFEST_FILE_NAME).is_file(),
+            has_package_manifest,
+            "{label} Semantic.package expectation failed at {}",
+            root.display()
+        );
+        assert!(
+            root.join("src").join("main.sm").is_file(),
+            "{label} must contain src/main.sm at {}",
+            root.display()
+        );
+    }
+}


### PR DESCRIPTION
Summary:
- Add a PCC9 project-root surface inventory guard that records the admitted project-root command surface, artifact-only boundary, and canonical fixture identities.

Changed files:
- tests/pcc9_project_model_acceptance.rs

Inventory guard summary:
- The new test explicitly records the canonical `semantic.toml` fixture root and the canonical `Semantic.package` fallback fixture root.
- It validates manifest identity expectations with file-existence checks.
- It records the admitted PCC9 project-root commands and the artifact-only boundary commands as static arrays.

Canonical fixture paths:
- examples/qualification/pcc9_project_root_minimal/
- examples/qualification/pcc9_project_root_package_baseline/

Admitted project-root command surface:
- check
- run
- compile
- dump-ast
- dump-ir
- dump-bytecode
- hash-ast
- hash-ir
- hash-smc

Artifact-only command boundary:
- disasm
- verify
- run-smc

Explicit non-goals:
- no production code changes
- no CLI behavior changes
- no project-root resolver changes
- no manifest format changes
- no docs/spec changes
- no fixture file changes
- no package registry / workspace support
- no `.claude/`
- no snapshots
- no CI workflow changes

CTF touched statement:
- none

Reason:
This PR only adds a test-only PCC9 project-root surface inventory guard. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, project-root resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched statement:
- none

Reason:
This package is project-root acceptance inventory coverage, not 7hell qualification behavior.

Local checks run:
- cargo fmt --all --check
- cargo test -q --test pcc9_project_model_acceptance
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

Confirmation:
- .claude/ is not included
- no generated .smc artifacts are committed
- git log --oneline origin/main..HEAD shows exactly one commit: a6645f0 test(project-model): add PCC9 project-root surface inventory guard
- git diff --name-only origin/main..HEAD shows only tests/pcc9_project_model_acceptance.rs
