### PR TITLE
test(pcc6): stabilize option acceptance artifact output paths

### DIFF
--- a/tests/pcc6_option_acceptance.rs
+++ b/tests/pcc6_option_acceptance.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 fn repo_path(rel: &str) -> String {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -8,22 +8,19 @@ fn repo_path(rel: &str) -> String {
         .replace('\\', "/")
 }
 
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
 fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
 }
 
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = std::env::temp_dir().join("semantic-tests").join(format!(
+        "{}_{}_{}",
+        prefix,
+        std::process::id(),
+        TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }
@@ -41,6 +38,9 @@ fn check_run_compile_verify(rel: &str) {
 
     let dir = mk_temp_dir("smc_pcc6_option_acceptance");
     let out = dir.join("out.smc");
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent).expect("mkdir artifact parent");
+    }
     let out_arg = out.to_string_lossy().replace('\\', "/");
     cli_ok(
         vec![


### PR DESCRIPTION
Summary:
- Stabilize pcc6 option acceptance artifact output paths on Windows by moving temp artifact directories out of the repo `target/` tree and creating the artifact parent directory explicitly before compile.

Changed files:
- tests/pcc6_option_acceptance.rs

Root cause found:
- The pcc6 acceptance helper used a repo-local `target/...` temp directory and relied on the compile output path being available under that tree during broad Windows test runs. The isolated pcc6 runs were stable, but the local Windows failure surfaced during the broad `cargo test --all-targets --quiet` phase in `scripts/local_ci.ps1`, which is consistent with a fragile temp/output-path strategy rather than a production CLI bug.

Exact fix applied:
- Move pcc6 artifact temp directories to `std::env::temp_dir()/semantic-tests/...` instead of `repo/target/...`.
- Add a monotonic counter to guarantee unique temp directories.
- Ensure the parent directory for `out.smc` exists before invoking `smc compile`.

Commands run:
- cargo fmt --all --check
- cargo test -q --test pcc6_option_acceptance
- cargo test -q --test pcc6_option_acceptance
- cargo test -q --test pcc6_option_acceptance -- --test-threads=1
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check
- git log --oneline origin/main..HEAD
- git diff --name-only origin/main..HEAD

Local check results:
- cargo fmt --all --check: passed
- cargo test -q --test pcc6_option_acceptance: passed
- cargo test -q --test pcc6_option_acceptance: passed
- cargo test -q --test pcc6_option_acceptance -- --test-threads=1: passed
- cargo test -q --test public_api_contracts: passed
- cargo test --all-targets --quiet: passed
- pwsh -File scripts/local_ci.ps1: passed
- git diff --check: passed

Non-goals:
- no production code changes
- no CLI behavior changes
- no SemCode/verifier/VM/runtime changes
- no PCC9 changes
- no docs
- no `.claude/`
- no generated `.smc` artifacts committed

CTF touched statement:
- none

Reason:
This PR only stabilizes pcc6 option acceptance test artifact paths. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, project-root resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched statement:
- none

Reason:
This package is pcc6 test reliability work, not 7hell qualification behavior.

Confirmation:
- .claude/ is not included
- git log --oneline origin/main..HEAD shows exactly one commit: 1120255 test(pcc6): stabilize option acceptance artifact output paths
- git diff --name-only origin/main..HEAD shows only tests/pcc6_option_acceptance.rs
