### PR TITLE
infra(ci): add Semantic.package fixture to local CI smoke

### DIFF
--- a/scripts/local_ci.ps1
+++ b/scripts/local_ci.ps1
@@ -44,6 +44,8 @@ $TempRoot = if ($env:TEMP) {
 $ManifestPath = Join-Path $TempRoot "semantic_v1_release_bundle_manifest.json"
 $ProjectRootSmokeFixture = Join-Path $RepoRoot "examples/qualification/pcc9_project_root_minimal"
 $ProjectRootSmokeTempDir = Join-Path $TempRoot "semantic_project_root_local_ci_smoke"
+$PackageBaselineSmokeFixture = Join-Path $RepoRoot "examples/qualification/pcc9_project_root_package_baseline"
+$PackageBaselineSmokeTempDir = Join-Path $TempRoot "semantic_project_root_package_baseline_local_ci_smoke"
 $ExeSuffix = if ($IsWindows) { ".exe" } else { "" }
 $SmcBinary = Join-Path $RepoRoot "target/debug/smc$ExeSuffix"
 
@@ -88,6 +90,21 @@ Invoke-LocalCiStep "canonical project-root fixture smoke" {
     & $SmcBinary compile $ProjectRootSmokeFixture -o $ProjectRootSmokeOut
     & $SmcBinary verify $ProjectRootSmokeOut
     & $SmcBinary run-smc $ProjectRootSmokeOut
+}
+
+Invoke-LocalCiStep "package-baseline project-root fixture smoke" {
+    if (Test-Path $PackageBaselineSmokeTempDir) {
+        Remove-Item -Recurse -Force $PackageBaselineSmokeTempDir
+    }
+    New-Item -ItemType Directory -Force -Path $PackageBaselineSmokeTempDir | Out-Null
+
+    $PackageBaselineSmokeOut = Join-Path $PackageBaselineSmokeTempDir "out-package-baseline.smc"
+
+    & $SmcBinary check $PackageBaselineSmokeFixture
+    & $SmcBinary run $PackageBaselineSmokeFixture
+    & $SmcBinary compile $PackageBaselineSmokeFixture -o $PackageBaselineSmokeOut
+    & $SmcBinary verify $PackageBaselineSmokeOut
+    & $SmcBinary run-smc $PackageBaselineSmokeOut
 }
 
 Invoke-LocalCiStep "smc 7hell human smoke" {


### PR DESCRIPTION
summary:
- Extend local CI smoke to cover the canonical `Semantic.package` project-root fixture in addition to the existing `semantic.toml` fixture.

changed files:
- scripts/local_ci.ps1

fixture path added to local CI:
- `examples/qualification/pcc9_project_root_package_baseline/`

local CI smoke commands added:
- `smc check <package-baseline-fixture>`
- `smc run <package-baseline-fixture>`
- `smc compile <package-baseline-fixture> -o <temp/out-package-baseline.smc>`
- `smc verify <temp/out-package-baseline.smc>`
- `smc run-smc <temp/out-package-baseline.smc>`

artifact output path:
- `%TEMP%\semantic_project_root_package_baseline_local_ci_smoke\out-package-baseline.smc`

explicit non-goals:
- no production code changes
- no CLI behavior changes
- no project-root resolver changes
- no manifest format changes
- no docs/spec changes
- no GitHub Actions changes
- no `.claude/` changes
- no generated `.smc` artifacts committed

CTF touched: none
Reason: this PR only extends local CI smoke coverage for a canonical project-root fixture. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched: none
Reason: this package is project-root local CI smoke coverage, not 7hell qualification behavior.

local checks run:
- `cargo fmt --all --check` (passed)
- `cargo test -q --test pcc9_project_model_acceptance` (passed)
- `cargo test -q --test public_api_contracts` (passed)
- `cargo test --all-targets --quiet` (passed)
- `pwsh -File scripts/local_ci.ps1` (passed)
- `git diff --check` (passed)

confirmation:
- no production code changed
- no CLI behavior changed
- no generated `.smc` artifacts are committed
- `.claude/` is not included
- `git log --oneline origin/main..HEAD` shows exactly one commit: `infra(ci): add Semantic.package fixture to local CI smoke`
- `git diff --name-only origin/main..HEAD` shows only `scripts/local_ci.ps1`
