### PR TITLE
infra(ci): cleanup project-root local CI smoke temp dirs

### DIFF
--- a/scripts/local_ci.ps1
+++ b/scripts/local_ci.ps1
@@ -90,6 +90,10 @@ Invoke-LocalCiStep "canonical project-root fixture smoke" {
     & $SmcBinary compile $ProjectRootSmokeFixture -o $ProjectRootSmokeOut
     & $SmcBinary verify $ProjectRootSmokeOut
     & $SmcBinary run-smc $ProjectRootSmokeOut
+
+    if (Test-Path $ProjectRootSmokeTempDir) {
+        Remove-Item -Recurse -Force $ProjectRootSmokeTempDir
+    }
 }
 
 Invoke-LocalCiStep "package-baseline project-root fixture smoke" {
@@ -105,6 +109,10 @@ Invoke-LocalCiStep "package-baseline project-root fixture smoke" {
     & $SmcBinary compile $PackageBaselineSmokeFixture -o $PackageBaselineSmokeOut
     & $SmcBinary verify $PackageBaselineSmokeOut
     & $SmcBinary run-smc $PackageBaselineSmokeOut
+
+    if (Test-Path $PackageBaselineSmokeTempDir) {
+        Remove-Item -Recurse -Force $PackageBaselineSmokeTempDir
+    }
 }
 
 Invoke-LocalCiStep "smc 7hell human smoke" {


### PR DESCRIPTION
summary:
- Clean up the local CI-owned temp directories used by the two project-root smoke fixtures after successful smoke execution.

changed files:
- scripts/local_ci.ps1

temp dirs cleaned up:
- `%TEMP%\semantic_project_root_local_ci_smoke`
- `%TEMP%\semantic_project_root_package_baseline_local_ci_smoke`

confirmation that pre-run cleanup remains intact:
- the existing pre-run `Remove-Item` guards remain in place for both smoke temp dirs before directory creation.

confirmation that failures are not masked:
- cleanup runs only after the smoke commands complete successfully; if a smoke command fails, the step fails normally and local CI stops via `Invoke-LocalCiStep`.

explicit non-goals:
- no production code changes
- no CLI behavior changes
- no project-root resolver changes
- no tests changes
- no docs changes
- no GitHub Actions changes
- no generated `.smc` artifacts committed
- no `.claude/` changes
- no broad formatting or cleanup

CTF touched: none
Reason: this PR only cleans up local CI-owned project-root smoke temp directories after successful smoke execution. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, project-root resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched: none
Reason: this package is local CI hygiene work, not 7hell qualification behavior.

local checks run:
- `cargo fmt --all --check` (passed)
- `cargo test -q --test pcc9_project_model_acceptance` (passed)
- `cargo test -q --test public_api_contracts` (passed)
- `cargo test --all-targets --quiet` (passed)
- `pwsh -File scripts/local_ci.ps1` (passed)
- `git diff --check` (passed)

confirmation:
- no production code changed
- no CLI behavior changed
- no generated `.smc` artifacts are committed
- `.claude/` is not included
- `git log --oneline origin/main..HEAD` shows exactly one commit: `infra(ci): cleanup project-root local CI smoke temp dirs`
- `git diff --name-only origin/main..HEAD` shows only `scripts/local_ci.ps1`
