### PR TITLE
test(pcc5): stabilize match artifact path handling

### DIFF
--- a/tests/pcc5_match_acceptance.rs
+++ b/tests/pcc5_match_acceptance.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn repo_path(rel: &str) -> String {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -13,12 +16,14 @@ fn cli_ok(args: Vec<String>, context: &str) {
 }
 
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
+    let dir = std::env::temp_dir()
+        .join("semantic-tests")
+        .join("pcc5-match")
         .join(format!(
-            "{}_{}_{}",
+            "{}_{}_{}_{}",
             prefix,
             std::process::id(),
+            TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("clock")
@@ -41,6 +46,11 @@ fn check_run_compile_verify(rel: &str) {
 
     let dir = mk_temp_dir("smc_pcc5_match_acceptance");
     let out = dir.join("out.smc");
+    std::fs::create_dir_all(
+        out.parent()
+            .expect("out.smc should always have an output directory"),
+    )
+    .expect("mkdir out parent");
     let out_arg = out.to_string_lossy().replace('\\', "/");
     cli_ok(
         vec![


### PR DESCRIPTION
Summary
- Stabilize the pcc5 match acceptance path by moving compile outputs out of repo-local `target/...` into an isolated temp root.

Changed files
- tests/pcc5_match_acceptance.rs

Root cause
- The helper used `CARGO_MANIFEST_DIR/target/.../out.smc`, which is fragile on Windows during broad test runs and can fail with `failed to write ... out.smc: The system cannot find the path specified. (os error 3)`.

Exact failure mode fixed
- Repo-local disposable artifact output under `target/...` with no isolated temp root and no explicit parent-dir creation for the output artifact.

Fix summary
- Use `std::env::temp_dir()/semantic-tests/pcc5-match/<unique-id>/`.
- Add a monotonic counter to avoid temp-dir collisions.
- Create the `out.smc` parent directory before `smc compile` writes the file.
- Keep cleanup scoped to the test-owned directory.

Confirmation
- pcc1 did not reproduce on clean `origin/main`.
- No production code changed.
- No CLI behavior changed.
- No generated `.smc` artifacts are committed.
- `.claude/` is not included.
- `git log --oneline origin/main..HEAD` shows exactly one commit.
- `git diff --name-only origin/main..HEAD` is within allowed scope.

Local checks run
- cargo fmt --all --check
- cargo test -q --test pcc5_match_acceptance
- cargo test -q --test pcc1_control_flow_diagnostics
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

CTF touched: none
7hell touched: none