### PR TITLE
test(cli): add source/artifact role helpers for PCC acceptance

### DIFF
--- a/tests/pcc5_match_acceptance.rs
+++ b/tests/pcc5_match_acceptance.rs
@@ -1,72 +1,19 @@
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = std::env::temp_dir()
-        .join("semantic-tests")
-        .join("pcc5-match")
-        .join(format!(
-            "{}_{}_{}_{}",
-            prefix,
-            std::process::id(),
-            TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc5_match_acceptance");
-    let out = dir.join("out.smc");
-    std::fs::create_dir_all(
-        out.parent()
-            .expect("out.smc should always have an output directory"),
-    )
-    .expect("mkdir out parent");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc5-match", "smc_pcc5_match_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc7_sequence_acceptance.rs
+++ b/tests/pcc7_sequence_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc7_sequence_acceptance");
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg.clone()],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc7-sequence", "smc_pcc7_sequence_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/support/cli_artifact_support.rs
+++ b/tests/support/cli_artifact_support.rs
@@ -1,0 +1,115 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceFixturePath(PathBuf);
+
+#[derive(Debug)]
+pub(crate) struct SemCodeArtifactPath {
+    root: PathBuf,
+    path: PathBuf,
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+impl SourceFixturePath {
+    pub(crate) fn cli_arg(&self) -> String {
+        normalize_path(&self.0)
+    }
+}
+
+impl SemCodeArtifactPath {
+    pub(crate) fn cli_arg(&self) -> String {
+        normalize_path(&self.path)
+    }
+}
+
+impl Drop for SemCodeArtifactPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+pub(crate) fn source_fixture(path: impl Into<PathBuf>) -> SourceFixturePath {
+    SourceFixturePath(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path.into()))
+}
+
+pub(crate) fn temp_semcode_artifact(scope: &str, fixture_name: &str) -> SemCodeArtifactPath {
+    let root = std::env::temp_dir()
+        .join("semantic-tests")
+        .join(scope)
+        .join(format!(
+            "{}_{}_{}_{}",
+            fixture_name,
+            std::process::id(),
+            TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+    std::fs::create_dir_all(&root).expect("mkdir");
+    SemCodeArtifactPath {
+        path: root.join("out.smc"),
+        root,
+    }
+}
+
+pub(crate) fn check_source(source: &SourceFixturePath) {
+    cli_ok(
+        vec!["check".to_string(), source.cli_arg()],
+        "smc check for source fixture",
+    );
+}
+
+pub(crate) fn run_source(source: &SourceFixturePath) {
+    cli_ok(
+        vec!["run".to_string(), source.cli_arg()],
+        "smc run for source fixture",
+    );
+}
+
+pub(crate) fn compile_source_to_artifact(
+    source: &SourceFixturePath,
+    artifact: &SemCodeArtifactPath,
+) {
+    std::fs::create_dir_all(
+        artifact
+            .path
+            .parent()
+            .expect("SemCode artifact should always have a parent"),
+    )
+    .expect("mkdir artifact parent");
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            source.cli_arg(),
+            "-o".to_string(),
+            artifact.cli_arg(),
+        ],
+        "smc compile for source fixture",
+    );
+}
+
+pub(crate) fn verify_artifact(artifact: &SemCodeArtifactPath) {
+    cli_ok(
+        vec!["verify".to_string(), artifact.cli_arg()],
+        "smc verify for SemCode artifact",
+    );
+}
+
+pub(crate) fn run_smc_artifact(artifact: &SemCodeArtifactPath) {
+    cli_ok(
+        vec!["run-smc".to_string(), artifact.cli_arg()],
+        "smc run-smc for SemCode artifact",
+    );
+}


### PR DESCRIPTION
Summary
- Add a small shared test helper layer that makes source fixture paths and SemCode artifact paths explicit in PCC acceptance tests.

Changed files
- tests/support/cli_artifact_support.rs
- tests/pcc5_match_acceptance.rs
- tests/pcc7_sequence_acceptance.rs

Helper API summary
- `SourceFixturePath` for source fixtures
- `SemCodeArtifactPath` for compiled SemCode artifacts
- `source_fixture(...)`
- `temp_semcode_artifact(...)`
- `check_source(...)`
- `run_source(...)`
- `compile_source_to_artifact(...)`
- `verify_artifact(...)`
- `run_smc_artifact(...)`

Converted tests
- `tests/pcc5_match_acceptance.rs`
- `tests/pcc7_sequence_acceptance.rs`

Source/artifact role confirmation
- Source fixtures and compiled artifacts now have separate explicit wrapper types.
- `verify_artifact` only accepts a SemCode artifact wrapper.
- `compile_source_to_artifact` clearly takes source first, artifact second.

Behavior confirmation
- pcc7 verify still uses compiled `out.smc`.
- pcc5 temp artifact isolation remains under isolated temp directories.

Exact non-goals
- No production code changes.
- No CLI behavior changes.
- No verifier/VM/runtime/SemCode changes.
- No docs changes.
- No snapshots.
- No `.claude/` changes.
- No broad refactor.

CTF touched: none
7hell touched: none

Local checks run
- cargo fmt --all --check
- cargo test -q --test pcc7_sequence_acceptance
- cargo test -q --test pcc5_match_acceptance
- cargo test -q --test pcc1_control_flow_diagnostics
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

Confirmation
- `.claude/` is not included.