### PR TITLE
test(cli): use typed source/artifact helpers in remaining full CLI path tests

### DIFF
--- a/tests/pcc4_records_acceptance.rs
+++ b/tests/pcc4_records_acceptance.rs
@@ -1,60 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
-        prefix,
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
-
-fn write_fixture(dir: &std::path::Path, name: &str, source: &str) -> String {
-    let path = dir.join(name);
-    std::fs::write(&path, source).expect("write PCC-4 fixture");
-    path.to_string_lossy().replace('\\', "/")
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, temp_semcode_artifact, temp_source_file,
+    verify_artifact,
+};
 
 fn check_run_compile_verify_source(name: &str, source: &str) {
-    let dir = mk_temp_dir("smc_pcc4_records_acceptance");
-    let input = write_fixture(&dir, name, source);
+    let source = temp_source_file("pcc4-records", name, source);
+    check_source(&source);
+    run_source(&source);
 
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
-
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc4-records", "smc_pcc4_records_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc5_adt_acceptance.rs
+++ b/tests/pcc5_adt_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc5_adt_acceptance");
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc5-adt", "smc_pcc5_adt_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc6_option_acceptance.rs
+++ b/tests/pcc6_option_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join("semantic-tests").join(format!(
-        "{}_{}_{}",
-        prefix,
-        std::process::id(),
-        TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed)
-    ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc6_option_acceptance");
-    let out = dir.join("out.smc");
-    if let Some(parent) = out.parent() {
-        std::fs::create_dir_all(parent).expect("mkdir artifact parent");
-    }
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc6-option", "smc_pcc6_option_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc6_result_acceptance.rs
+++ b/tests/pcc6_result_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc6_result_acceptance");
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc6-result", "smc_pcc6_result_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc7_map_acceptance.rs
+++ b/tests/pcc7_map_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc7_map_acceptance");
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc7-map", "smc_pcc7_map_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/pcc8_stdlib_acceptance.rs
+++ b/tests/pcc8_stdlib_acceptance.rs
@@ -1,62 +1,19 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    check_source, compile_source_to_artifact, run_source, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 fn check_run_compile_verify(rel: &str) {
-    let input = repo_path(rel);
-    cli_ok(
-        vec!["check".to_string(), input.clone()],
-        &format!("smc check for {input}"),
-    );
-    cli_ok(
-        vec!["run".to_string(), input.clone()],
-        &format!("smc run for {input}"),
-    );
+    let source = source_fixture(rel);
+    check_source(&source);
+    run_source(&source);
 
-    let dir = mk_temp_dir("smc_pcc8_stdlib_acceptance");
-    let out = dir.join("out.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg],
-        &format!("smc verify for {input}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    let artifact = temp_semcode_artifact("pcc8-stdlib", "smc_pcc8_stdlib_acceptance");
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
 }
 
 #[test]

--- a/tests/support/cli_artifact_support.rs
+++ b/tests/support/cli_artifact_support.rs
@@ -8,6 +8,12 @@ static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub(crate) struct SourceFixturePath(PathBuf);
 
 #[derive(Debug)]
+pub(crate) struct TempSourcePath {
+    root: PathBuf,
+    path: PathBuf,
+}
+
+#[derive(Debug)]
 pub(crate) struct SemCodeArtifactPath {
     root: PathBuf,
     path: PathBuf,
@@ -21,9 +27,31 @@ fn normalize_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+pub(crate) trait SourceInputPath {
+    fn cli_arg(&self) -> String;
+}
+
 impl SourceFixturePath {
     pub(crate) fn cli_arg(&self) -> String {
         normalize_path(&self.0)
+    }
+}
+
+impl TempSourcePath {
+    pub(crate) fn cli_arg(&self) -> String {
+        normalize_path(&self.path)
+    }
+}
+
+impl SourceInputPath for SourceFixturePath {
+    fn cli_arg(&self) -> String {
+        self.cli_arg()
+    }
+}
+
+impl SourceInputPath for TempSourcePath {
+    fn cli_arg(&self) -> String {
+        self.cli_arg()
     }
 }
 
@@ -47,8 +75,34 @@ impl Drop for SemCodeArtifactPath {
     }
 }
 
+impl Drop for TempSourcePath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
 pub(crate) fn source_fixture(path: impl Into<PathBuf>) -> SourceFixturePath {
     SourceFixturePath(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path.into()))
+}
+
+pub(crate) fn temp_source_file(scope: &str, fixture_name: &str, source: &str) -> TempSourcePath {
+    let root = std::env::temp_dir()
+        .join("semantic-tests")
+        .join(scope)
+        .join(format!(
+            "{}_{}_{}_{}",
+            fixture_name,
+            std::process::id(),
+            TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+    std::fs::create_dir_all(&root).expect("mkdir");
+    let path = root.join(fixture_name);
+    std::fs::write(&path, source).expect("write temp source");
+    TempSourcePath { root, path }
 }
 
 pub(crate) fn temp_semcode_artifact(scope: &str, fixture_name: &str) -> SemCodeArtifactPath {
@@ -72,22 +126,22 @@ pub(crate) fn temp_semcode_artifact(scope: &str, fixture_name: &str) -> SemCodeA
     }
 }
 
-pub(crate) fn check_source(source: &SourceFixturePath) {
+pub(crate) fn check_source(source: &impl SourceInputPath) {
     cli_ok(
         vec!["check".to_string(), source.cli_arg()],
-        "smc check for source fixture",
+        "smc check for source input",
     );
 }
 
-pub(crate) fn run_source(source: &SourceFixturePath) {
+pub(crate) fn run_source(source: &impl SourceInputPath) {
     cli_ok(
         vec!["run".to_string(), source.cli_arg()],
-        "smc run for source fixture",
+        "smc run for source input",
     );
 }
 
 pub(crate) fn compile_source_to_artifact(
-    source: &SourceFixturePath,
+    source: &impl SourceInputPath,
     artifact: &SemCodeArtifactPath,
 ) {
     std::fs::create_dir_all(
@@ -104,7 +158,7 @@ pub(crate) fn compile_source_to_artifact(
             "-o".to_string(),
             artifact.cli_arg(),
         ],
-        "smc compile for source fixture",
+        "smc compile for source input",
     );
 }
 


### PR DESCRIPTION
summary

- Migrates the remaining full CLI path acceptance tests to the shared typed source/artifact helper layer.
- Keeps project-root coverage, verifier behavior, VM/runtime behavior, and SemCode behavior unchanged.

changed files

- tests/pcc4_records_acceptance.rs
- tests/pcc5_adt_acceptance.rs
- tests/pcc6_option_acceptance.rs
- tests/pcc6_result_acceptance.rs
- tests/pcc7_map_acceptance.rs
- tests/pcc8_stdlib_acceptance.rs
- tests/support/cli_artifact_support.rs

helper migration summary

- Fixture-backed source inputs now use SourceFixturePath and the shared helper layer.
- The temp-generated pcc4 source path now uses a typed temp-source wrapper instead of raw path handling.
- SemCode artifacts continue to use SemCodeArtifactPath, with parent directories created before compile writes out.smc.

source/artifact role confirmation

- Source inputs and SemCode artifacts are kept as separate typed roles.
- verify_artifact and run_smc_artifact are only used with artifact paths.
- compile_source_to_artifact never receives a raw artifact path and creates the parent directory before writing.

project-root coverage confirmation

- PCC9 project-root coverage remains project-root coverage and was not widened or rewritten here.
- This PR only refactors the remaining full CLI path acceptance tests.

behavior confirmation

- No CLI behavior changed.
- No production code changed.
- No resolver behavior changed.
- No output format or hash algorithm changed.
- No coverage was removed.

explicit non-goals

- No new commands.
- No disasm/verify/run-smc project-root work.
- No verifier/VM/runtime/SemCode changes.
- No docs, CI, snapshot, or .claude/ changes.

CTF touched: none

Reason:
This PR only refactors test helpers for acceptance coverage. It does not change runtime value semantics, VM trap semantics, verifier behavior, capability/audit behavior, trace policy, SemCode format, CLI behavior, project-root resolver behavior, hash algorithms, release gates, or CTF closure.

7hell touched: none

Reason:
This package is test-helper migration for full CLI path acceptance coverage, not 7hell qualification behavior.

local checks run

- cargo fmt --all --check
- cargo test -q --test pcc4_records_acceptance
- cargo test -q --test pcc5_adt_acceptance
- cargo test -q --test pcc5_match_acceptance
- cargo test -q --test pcc6_option_acceptance
- cargo test -q --test pcc6_result_acceptance
- cargo test -q --test pcc7_map_acceptance
- cargo test -q --test pcc7_sequence_acceptance
- cargo test -q --test pcc8_stdlib_acceptance
- cargo test -q --test pcc9_project_model_acceptance
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

confirmation

- .claude/ is not included.
- no generated .smc artifacts are committed.
