### PR TITLE
test(cli): audit remaining raw SemCode artifact CLI paths

### DIFF
--- a/tests/smc_run_smc_cli.rs
+++ b/tests/smc_run_smc_cli.rs
@@ -1,55 +1,17 @@
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[path = "support/cli_artifact_support.rs"]
+mod cli_artifact_support;
 
-fn repo_path(rel: &str) -> String {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(rel)
-        .to_string_lossy()
-        .replace('\\', "/")
-}
-
-fn cli_ok(args: Vec<String>, context: &str) {
-    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
-}
-
-fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
-        prefix,
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).expect("mkdir");
-    dir
-}
+use cli_artifact_support::{
+    compile_source_to_artifact, run_smc_artifact, source_fixture, temp_semcode_artifact,
+    verify_artifact,
+};
 
 #[test]
 fn smc_run_smc_executes_emitted_semcode_artifact() {
-    let input = repo_path("examples/canonical/cli_batch_core/src/main.sm");
-    let dir = mk_temp_dir("smc_run_smc_cli");
-    let out = dir.join("cli_batch_core.smc");
-    let out_arg = out.to_string_lossy().replace('\\', "/");
+    let source = source_fixture("examples/canonical/cli_batch_core/src/main.sm");
+    let artifact = temp_semcode_artifact("smc-run-smc-cli", "cli_batch_core");
 
-    cli_ok(
-        vec![
-            "compile".to_string(),
-            input.clone(),
-            "-o".to_string(),
-            out_arg.clone(),
-        ],
-        &format!("smc compile for {input}"),
-    );
-    cli_ok(
-        vec!["verify".to_string(), out_arg.clone()],
-        &format!("smc verify for {out_arg}"),
-    );
-    cli_ok(
-        vec!["run-smc".to_string(), out_arg.clone()],
-        &format!("smc run-smc for {out_arg}"),
-    );
-
-    let _ = std::fs::remove_dir_all(&dir);
+    compile_source_to_artifact(&source, &artifact);
+    verify_artifact(&artifact);
+    run_smc_artifact(&artifact);
 }


### PR DESCRIPTION
Summary
- Audited remaining raw SemCode artifact CLI paths and migrated the one positive artifact-path smoke to the shared typed helper layer.

Changed files
- tests/smc_run_smc_cli.rs

Classification
- positive_artifact_path_should_use_helper: migrated
- malformed_artifact_fixture: already intentional in tests/artifact_command_diagnostics.rs
- artifact_only_boundary_assertion: already intentional in tests/pcc9_project_model_acceptance.rs
- false_positive: none

Follow-up
- none required from this audit pass

Local checks run
- cargo fmt --all --check
- cargo test -q --test smc_run_smc_cli
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

GitHub CI
- pending on the new draft PR at creation time

Notes
- .claude/ is not included