### PR TITLE
docs(cli): align dump project-root usage with current CLI

### DIFF
--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -45,9 +45,9 @@ Current accepted usage forms are:
 - `smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]`
 - `smc watch <input.sm> [--metrics] [--color auto|always|never]`
 - `smc fmt [--check] <path>`
-- `smc dump-ast <input.sm>`
-- `smc dump-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
-- `smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]`
+- `smc dump-ast <input.sm|project-root>`
+- `smc dump-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
+- `smc dump-bytecode <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]`
 - `smc hash-ast <input.sm|project-root>`
 - `smc hash-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
 - `smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
@@ -132,6 +132,7 @@ Current rule:
 - `smc check` also accepts a bounded admitted project-root entrypoint through `Semantic.package` + `src/main.sm`
 - project-root `smc check` also resolves a minimal `semantic.toml` manifest when present
 - project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route
+- project-root `smc dump-ast`, `smc dump-ir`, and `smc dump-bytecode` use the same bounded project entry resolution, then emit the existing dump output for the resolved source
 - project-root `smc hash-ast` uses the same bounded project entry resolution and emits the existing AST hash for the resolved source file
 - project-root `smc hash-ir` uses the same bounded project entry resolution and emits the existing IR hash for the resolved source file
 - project-root `smc hash-smc` uses the same bounded project entry resolution and emits the existing SemCode hash for the resolved source or artifact path


### PR DESCRIPTION
Summary
- Aligned docs/spec/cli.md with the currently implemented dump-* project-root behavior.

Changed files
- docs/spec/cli.md

Exact spec drift fixed
- Updated dump-ast, dump-ir, and dump-bytecode usage to accept <input.sm|project-root>.
- Added one compact Source Admission Rule bullet stating that project-root dump-* commands use the same bounded project entry resolution and emit the existing dump output for the resolved source.

Confirmation
- No behavior changed.
- No code or tests changed.
- No output format changed.

Local checks run
- git diff --check
- cargo fmt --all --check
- cargo test -q --test public_api_contracts

CTF touched: none
7hell touched: none

Notes
- .claude/ is not included.