### PR TITLE
test(project-model): guard semantic.toml manifest preservation

### DIFF
--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1226,7 +1226,7 @@ manifest_dir .
     }
 
     #[test]
-    fn parse_semantic_toml_manifest_accepts_minimal_project_surface() {
+    fn parse_semantic_toml_manifest_preserves_default_entry_and_manifest_shape() {
         let manifest = parse_semantic_toml_manifest(
             Path::new("semantic.toml"),
             r#"
@@ -1242,6 +1242,47 @@ entry = "src/main.sm"
         assert_eq!(manifest.entry, "src/main.sm");
         assert_eq!(manifest.manifest.package.root.manifest_dir, ".");
         assert_eq!(manifest.manifest.package.root.module_root, "src");
+        assert!(manifest.manifest.dependencies.is_empty());
+    }
+
+    #[test]
+    fn parse_semantic_toml_manifest_preserves_explicit_nested_entry_shape() {
+        let manifest = parse_semantic_toml_manifest(
+            Path::new("semantic.toml"),
+            r#"
+[package]
+name = "app"
+
+[project]
+entry = "examples/main.sm"
+"#,
+        )
+        .expect("parse semantic.toml with explicit nested entry");
+        assert_eq!(manifest.manifest.package.name, "app");
+        assert_eq!(manifest.entry, "examples/main.sm");
+        assert_eq!(manifest.manifest.package.root.manifest_dir, ".");
+        assert_eq!(manifest.manifest.package.root.module_root, "examples");
+        assert!(manifest.manifest.dependencies.is_empty());
+    }
+
+    #[test]
+    fn parse_semantic_toml_manifest_preserves_root_level_entry_shape() {
+        let manifest = parse_semantic_toml_manifest(
+            Path::new("semantic.toml"),
+            r#"
+[package]
+name = "app"
+
+[project]
+entry = "main.sm"
+"#,
+        )
+        .expect("parse semantic.toml with root-level entry");
+        assert_eq!(manifest.manifest.package.name, "app");
+        assert_eq!(manifest.entry, "main.sm");
+        assert_eq!(manifest.manifest.package.root.manifest_dir, ".");
+        assert_eq!(manifest.manifest.package.root.module_root, ".");
+        assert!(manifest.manifest.dependencies.is_empty());
     }
 
     #[test]
@@ -1256,7 +1297,44 @@ name = "app"
         .expect("parse semantic.toml with default entry");
         assert_eq!(manifest.entry, "src/main.sm");
         assert_eq!(manifest.manifest.package.root.module_root, "src");
+        assert_eq!(manifest.manifest.package.name, "app");
+        assert_eq!(manifest.manifest.package.root.manifest_dir, ".");
+        assert!(manifest.manifest.dependencies.is_empty());
 
+        let err = parse_semantic_toml_manifest(
+            Path::new("semantic.toml"),
+            r#"
+[package]
+name = "app"
+
+[project]
+entry = "../escape.sm"
+"#,
+        )
+        .expect_err("must reject entry escape");
+        assert_eq!(
+            err.code,
+            SemanticTomlManifestErrorCode::ProjectEntryMustNotEscapeRoot
+        );
+        assert!(err.message.contains("must not escape the project root"));
+    }
+
+    #[test]
+    fn parse_semantic_toml_manifest_rejects_empty_package_name() {
+        let err = parse_semantic_toml_manifest(
+            Path::new("semantic.toml"),
+            r#"
+[package]
+name = ""
+"#,
+        )
+        .expect_err("must reject empty package name");
+        assert_eq!(err.code, SemanticTomlManifestErrorCode::EmptyPackageName);
+        assert!(err.message.contains("empty [package].name"));
+    }
+
+    #[test]
+    fn parse_semantic_toml_manifest_rejects_path_escape_entry() {
         let err = parse_semantic_toml_manifest(
             Path::new("semantic.toml"),
             r#"
@@ -1356,7 +1434,7 @@ entry = ""
 name = "app"
 
 [project]
-entry = "/abs/main.sm"
+entry = "C:/abs/main.sm"
 "#,
                 SemanticTomlManifestErrorCode::ProjectEntryMustBeRelative,
                 "must be relative",


### PR DESCRIPTION
Summary
- Added narrow unit tests guarding semantic.toml manifest shape preservation after structured diagnostics were introduced.

Changed files
- crates/smc-cli/src/package_manifest.rs

Preservation guards added
- default entry preserves entry, package name, manifest_dir, module_root, and empty dependencies
- explicit nested entry preserves entry, package name, manifest_dir, module_root, and empty dependencies
- root-level entry preserves entry, package name, manifest_dir, module_root, and empty dependencies
- empty package name still rejects with SemanticTomlManifestErrorCode::EmptyPackageName
- path escape still rejects with SemanticTomlManifestErrorCode::ProjectEntryMustNotEscapeRoot

Behavior preservation
- No CLI behavior changed.
- No project-root resolver behavior changed.
- No user-visible error text was changed.
- semantic.toml remains intentionally minimal and bounded.

Explicit non-goals
- no docs changes
- no CLI changes
- no resolver widening
- no new dependencies
- no verifier/VM/runtime/SemCode changes
- no CI changes
- no snapshot updates

CTF touched: none
7hell touched: none

Local checks run
- cargo fmt --all --check
- cargo test -q -p smc-cli package_manifest::tests::parse_semantic_toml
- cargo test -q --test pcc9_project_model_acceptance
- cargo test -q --test public_api_contracts
- cargo test --all-targets --quiet
- pwsh -File scripts/local_ci.ps1
- git diff --check

Notes
- .claude/ is not included.