### PR TITLE
docs: reconcile status documents with recent project-root and stdlib landings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,33 +127,23 @@ The stable public contract lives in `docs/spec/*` and the release/status languag
 
 ### Current active focus
 
-The active implementation focus is **M-Hello**:
+The current active hardening focus is **project-root CLI/status reconciliation and application-completeness evidence alignment**.
 
 ```text
-M-Hello — admit minimal verified Hello World observation surface
-M-Hello — cli: render controlled observation envelope
-```
-
-This track is deliberately narrow. It is not adding general stdout or broad I/O. It is building one verified observation path:
-
-```text
-source
+source (file / project-root)
   -> check
   -> compile
   -> verify
   -> run
-  -> controlled text observation
+  -> controlled observation / output
 ```
 
-Recent M-Hello work has moved the observation path through the required lower layers:
+Recent work has moved the CLI pipeline to support a bounded project-root baseline:
 
-- VM controlled observation event seam;
-- verifier-side controlled observation admission seam;
-- explicit `ControlledObservationSink` capability gate;
-- controlled observation audit policy;
-- CLI rendering envelope for `smc run` and `smc run-smc`.
-
-The current M-Hello track keeps source-run and verified-artifact routes separate and renders only after verifier admission, VM collection, capability allow, and audit decision.
+- Manifest loading and resolution of `semantic.toml` entrypoints.
+- Root-relative execution and analysis routes.
+- Deterministic compiler artifact chains and stale artifact protections.
+- Integrated local CI validation gates.
 
 ### Current guarantees / design posture
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The stable public contract lives in `docs/spec/*` and the release/status languag
 
 ### Current active focus
 
-The current active hardening focus is **project-root CLI/status reconciliation and application-completeness evidence alignment**.
+The current active hardening focus is **project-root CLI hardening and status reconciliation**.
 
 ```text
 source (file / project-root)

--- a/docs/research/scientific_value.md
+++ b/docs/research/scientific_value.md
@@ -173,7 +173,8 @@ The controlled observation envelope and narrow print(text) path have landed:
 
 ```text
 verified SemCode
-  -> VM controlled observation event (print / to_text)
+  -> pure semantic construction (to_text)
+  -> VM controlled observation event (print)
   -> ControlledObservationSink capability gate (CAP_STDOUT)
   -> audit decision
   -> CLI rendering envelope

--- a/docs/research/scientific_value.md
+++ b/docs/research/scientific_value.md
@@ -169,12 +169,12 @@ Research value:
 
 ### 4.6 Audit-oriented controlled observation
 
-The active M-Hello work is a deliberately narrow controlled text observation track.
+The controlled observation envelope and narrow print(text) path have landed:
 
 ```text
 verified SemCode
-  -> VM controlled observation event
-  -> ControlledObservationSink capability gate
+  -> VM controlled observation event (print / to_text)
+  -> ControlledObservationSink capability gate (CAP_STDOUT)
   -> audit decision
   -> CLI rendering envelope
 ```

--- a/docs/roadmap/public_maturity_snapshot.md
+++ b/docs/roadmap/public_maturity_snapshot.md
@@ -13,49 +13,51 @@ Semantic is a deterministic verified execution platform for source-to-SemCode wo
 | Area | Current state |
 |---|---|
 | Workspace structure | Multi-crate Rust workspace with separated frontend, IR, emission, verifier, VM, runtime core, CLI, PROMETHEUS boundary, UI/application, docs, tests, and compatibility perimeter. |
-| Source pipeline | `.sm` source can flow through check / compile-oriented tooling routes. |
+| Source pipeline | `.sm` source and directory project roots can flow through check / compile-oriented tooling routes. |
 | SemCode artifact model | SemCode exists as the executable artifact boundary and is documented as a versioned contract surface. |
 | Verifier-first posture | Public `.smc` execution is treated as verifier-first; verifier admission is a first-class architecture boundary. |
-| Deterministic VM | VM execution and disassembly are separated from source construction and CLI orchestration. |
+| Deterministic VM | VM execution and disassembly are separated from source construction and CLI orchestration. Includes deterministic seeded PRNG (xorshift64). |
 | Quad logic | `N / F / T / S` are treated as native semantic states rather than ad-hoc comments or external flags. |
+| Imperative Core | Landed same-family `i32` arithmetic (`+`, `-`, `*`, `/`, `%`), mutable locals (`let mut` + reassignment), and loop control exits (`while`, `loop`, `break`, `continue`). |
+| Data Collections | Persistent `Sequence(T)` with utility functions (`len`, `push`, `pop`, `prepend`, `contains`) and persistent `Map(K, V)` persistent lookups. |
 | Runtime ownership slice | Tuple and direct record-field access paths are documented as the current narrow/frozen ownership contract. |
-| PROMETHEUS boundary | Capability, ABI, gate, runtime, state, rule, and audit crates exist as a controlled host-boundary layer. |
-| CLI tooling | `smc` and `svm` expose check, compile, verify, run, run-smc, disassembly, inspection, hashes, snapshots, diagnostics, and related routes. |
-| Testing discipline | Contract, ownership, M-Hello, package-focused, and workspace-level test routes are documented. |
+| PROMETHEUS boundary | Capability, ABI, gate, runtime, state, rule, and audit crates exist as a controlled host-boundary layer. Narrow `print(text)` observation enabled via `CAP_STDOUT`. |
+| CLI tooling | `smc` and `svm` expose check, compile, verify, run, run-smc, disassembly, inspection, hashes (ast), snapshots, diagnostics, and related routes for both single files and project-roots. |
+| Testing discipline | Contract, ownership, M-Hello, package-focused, project-root acceptance tests, and workspace-level test routes are documented. |
 | no_std posture | A core-library `no_std` smoke check exists, scoped explicitly away from CLI/UI/full-workspace claims. |
 | Licensing | Repository licensing is aligned around Apache-2.0 with separate `NOTICE` attribution / project-scope notes. |
 
 ## Active development focus
 
-The active public focus is **M-Hello**: a narrow, verified, controlled text observation path.
+The current active hardening focus is **project-root CLI/status reconciliation and application-completeness evidence alignment**.
 
 ```text
-source
+source (file / project-root)
   -> check
   -> compile
   -> verify
   -> run
-  -> controlled text observation
+  -> output / observation
 ```
 
-This is deliberately not general stdout. The intended route is:
+The CLI pipeline has been updated to resolve entrypoints and execute routes directly from the project root under a bounded project-root baseline:
 
 ```text
-verified SemCode
-  -> VM controlled observation event
-  -> ControlledObservationSink capability gate
-  -> audit decision
-  -> CLI rendering envelope
+smc check <project-root>
+smc run <project-root>
+smc compile <project-root>
+smc dump-ast <project-root>
+smc dump-ir <project-root>
+smc dump-bytecode <project-root>
+smc hash-ast <project-root>
 ```
 
 ## Explicit non-claims
 
 Current public documentation does not claim:
 
-- general stdout;
-- broad `print` / formatting support;
-- implicit scalar-to-text conversion;
-- file / stdin / network I/O;
+- broad standard library or arbitrary host effects;
+- general file / stdin / network I/O;
 - broad host ABI widening;
 - UI-owned execution semantics;
 - full-workspace `no_std`;
@@ -66,8 +68,8 @@ Current public documentation does not claim:
 | Phase | Goal | Boundary |
 |---|---|---|
 | MVP / contract core | Keep the source -> SemCode -> verifier -> VM path stable, testable, and explainable. | No broad I/O or unstable feature promotion. |
-| Controlled observation | Finish M-Hello as a narrow verified observation path with capability and audit boundaries. | Controlled observation does not become general stdout by accident. |
-| Production hardening | Harden specs, tests, diagnostics, release artifacts, runtime contracts, and public status labels. | No public claim widens without spec + tests + verifier/VM/CLI coverage. |
+| Application Completeness | Benchmark-class execution (Q-learning headless Snake) with PRNG, Maps, same-family arithmetic, loops, and narrow stdout observation. | Controlled observation does not become general stdout by accident. |
+| Project root model | Bounded project-root CLI baseline (`semantic.toml` entrypoint resolution) and local validation workflows. Excludes full package ecosystem, registry, multi-package resolution, and package manager semantics. | Keep project manifest boundaries strict and failure diagnostics deterministic. |
 
 ## Custody and visibility note
 
@@ -84,14 +86,15 @@ A first-time reader should not treat the repository as a finished general-purpos
 The practical reading order is:
 
 1. `README.md`
-2. `docs/roadmap/public_status_model.md`
-3. `docs/spec/index.md`
-4. `docs/spec/semcode.md`
-5. `docs/spec/verifier.md`
-6. `docs/spec/vm.md`
-7. `docs/spec/runtime_ownership.md`
-8. `docs/language/semantic_hello_*`
-9. `docs/roadmap/private_custody_mode.md`, when repository custody / visibility policy is relevant
+2. `docs/status/feature_maturity_matrix.md`
+3. `docs/roadmap/public_status_model.md`
+4. `docs/spec/index.md`
+5. `docs/spec/semcode.md`
+6. `docs/spec/verifier.md`
+7. `docs/spec/vm.md`
+8. `docs/spec/runtime_ownership.md`
+9. `docs/language/semantic_hello_*`
+10. `docs/roadmap/private_custody_mode.md`, when repository custody / visibility policy is relevant
 
 ## Public communication rule
 

--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -74,6 +74,24 @@ It is not enough for:
 
 - `public release`
 
+## Application Completeness Benchmark Contour
+
+The completed Application-Completeness evidence supports a practical-programming contour documented in:
+
+- `reports/application_completeness_benchmark_verdict.md`
+
+This contour is **landed and benchmark-qualified on main, not yet promoted to published stable or Gate-1 qualified contour**.
+
+The benchmark-qualified contour includes:
+
+- same-family `i32` relational operators and arithmetic (`+`, `-`, `*`, `/`, `%`)
+- mutable locals (`let mut` + reassignments) and loop control exits (`while`, `loop`, `break`, `continue`)
+- built-in `Sequence(T)` persistent utilities (`len`, `push`, `pop`, `prepend`, `contains`)
+- persistent functional `Map(K, V)` lookup tables
+- deterministic seeded PRNG (xorshift64)
+- narrow stdout observation (`print(text)`) under capability and audit boundaries
+- bounded project-root CLI baseline (`semantic.toml` entrypoint resolution)
+
 ## Landed On `main`, Not Yet Promised
 
 Current `main` contains widened surfaces beyond both:

--- a/docs/status/feature_maturity_matrix.md
+++ b/docs/status/feature_maturity_matrix.md
@@ -50,48 +50,39 @@ landed on main != published stable
 | Feature | Maturity level | Confidence | Evidence type | Status | Notes |
 |---|---:|---|---|---|---|
 | Native quad logic | D6 | High | Docs claim, VM/spec evidence | Stable release surface | `N / F / T / S` is a native semantic value domain. |
-| i32 relational operators | D7 | High | Roadmap note, test evidence | Qualified limited release | Covers relational/equality-style operators, not general arithmetic. |
-| Text equality | D7 | High | Roadmap note, test evidence | Qualified limited release | Same-family text equality only; does not imply formatting or concatenation. |
-| Sequence indexing and iteration | D7 | High | Roadmap note, test evidence | Qualified limited release | Qualified for the benchmark-positive baseline. |
-| First-class immutable closures | D7 | High | Roadmap note, test evidence | Qualified limited release | Immutable closure path only; mutable capture semantics are separate. |
+| i32 relational operators | D7 | High | Test evidence | Qualified limited release | Covers relational/equality-style operators (`==`, `!=`, `<`, `<=`, `>`, `=>`). |
+| same-family i32 arithmetic | D7 | High | Test evidence | Qualified application-completeness contour | Covers `+`, `-`, `*`, `/`, `%` and unary `-`. Not published stable. |
+| Mutable locals & reassignment | D7 | High | Test evidence | Qualified application-completeness contour | Supports `let mut` declarations and plain reassignments. Not published stable. |
+| Loops and control exits | D7 | High | Test evidence | Qualified application-completeness contour | Supports `while` loops, statement `loop`, and exits `break`/`continue`. Not published stable. |
+| Text concatenation and to_text | D7 | High | Test evidence | Qualified application-completeness contour | Supports `text + text` and explicit `to_text(scalar)`. Not published stable. |
+| Sequence indexing and iteration | D7 | High | Test evidence | Qualified limited release | Qualified for sequence iteration and indexing. |
+| First-class immutable closures | D7 | High | Test evidence | Qualified limited release | Immutable closure path only; mutable capture semantics are separate. |
+| Map surface | D7 | High | Test evidence | Qualified application-completeness contour | Supports `Map(K, V)` functional get, set, contains. Not published stable. |
+| Deterministic seeded PRNG | D7 | High | Test evidence | Qualified application-completeness contour | Deterministic seeded PRNG (xorshift64) via `random_seed` / `random_next_i32`. Not published stable. |
+| Controlled observation (stdout) | D7 | High | Test evidence | Qualified application-completeness contour | Narrow `print(text)` via `CAP_STDOUT` capability. Not published stable. |
+| Bounded project-root CLI baseline | D7 | High | Test evidence | Qualified application-completeness contour | Supports resolving and running routes from project root. Excludes registry, multi-package resolution, package manager semantics. Not published stable. |
 | Runtime ownership OWN0 | D6 | High | Docs claim, VM/spec evidence | Stable release surface, frozen | Tuple and direct record-field access paths only. |
-| Function contracts: `requires` / `ensures` | D5 | Medium | Docs claim, verifier spec | Implemented but unqualified | Should be split into syntax, typechecking, lowering, verifier integration, and runtime behavior in future status updates. |
-| PROMETHEUS ABI / host boundary | D6 | Medium | Docs claim, CLI evidence | Implemented but unqualified | Should be split into ABI, capability policy, audit, VM host bridge, and real effects. |
-| Units-of-measure surface | D2 | High | Docs claim, crate/status evidence | Experimental | Type/semantic surface only unless later evidence proves deeper pipeline support. |
-| Integer arithmetic | D0/D1 | Medium | Roadmap blocker | Roadmap blocker | Parser evidence should be confirmed before claiming D1. Distinct from i32 relational operators. |
-| Mutable locals / reassignment | D0/D1 | Medium | Roadmap blocker | Roadmap blocker | Parser evidence should be confirmed before claiming D1. Interaction with active borrow paths must be specified. |
-| Loops and control exits | D0/D1 | Medium | Roadmap blocker | Roadmap blocker | Parser evidence should be confirmed before claiming D1. Requires bounded execution / quota discipline. |
-| Map surface | D0 | High | Roadmap note | Roadmap | Not current stable behavior. |
-| Deterministic seeded PRNG | D0 | High | Roadmap note | Roadmap | Must remain deterministic and replay-compatible when introduced. |
-| Text concatenation / formatting | D0 | High | Roadmap note | Roadmap | Not implied by text equality. |
-| General stdout | D0 | High | Roadmap / non-goal note | Roadmap | Narrow controlled observation work must not be read as general stdout. |
+| Function contracts: `requires` / `ensures` | D5 | Medium | Docs claim, verifier spec | Implemented but unqualified | Requires syntax, typecheck, lowering, verifier and runtime qualification. |
+| PROMETHEUS ABI / host boundary | D6 | Medium | Docs claim, CLI evidence | Implemented but unqualified | Needs qualification of ABI, capability policy, audit, and host bridge. |
+| Units-of-measure surface | D2 | High | Docs claim, crate/status evidence | Experimental | Type/semantic surface only. |
 | ADT payload paths for ownership | N/A | High | Runtime ownership docs | Out of scope | Explicitly excluded from the current OWN0 slice. |
 
 ## Important distinctions
 
-### i32 relational operators are not general integer arithmetic
+### same-family i32 arithmetic is qualified
 
-The current status distinguishes between:
+The current status includes qualified support for:
 
 ```text
-i32 relational operators:
-  ==, !=, <, <=, >, >=
-
-integer arithmetic:
-  +, -, *, /, %, overflow behavior, checked arithmetic contract
+same-family i32 arithmetic:
+  +, -, *, /, %, unary -
 ```
 
-A relational operator being qualified does not imply that the full arithmetic
-surface is qualified.
+This is distinct from multi-family numeric compatibility or implicit float conversions.
 
-### Text equality is not text formatting
+### Text concatenation is not general formatting
 
-Text equality being qualified does not imply support for:
-
-- text concatenation;
-- formatted printing;
-- implicit scalar-to-text conversion;
-- general stdout.
+Text concatenation and explicit `to_text` are qualified, but general template formatting and implicit conversion of complex structures are roadmap/non-goals.
 
 ### Controlled observation is not general stdout
 
@@ -105,7 +96,7 @@ verified SemCode
   -> CLI rendering envelope
 ```
 
-It must not be read as broad I/O support.
+Narrow `print(text)` is qualified under the `CAP_STDOUT` capability, but general file I/O, command-line arguments (argv), or unconstrained stdout remain out of scope.
 
 ### OWN0 is intentionally narrow
 

--- a/docs/status/feature_maturity_matrix.md
+++ b/docs/status/feature_maturity_matrix.md
@@ -50,7 +50,7 @@ landed on main != published stable
 | Feature | Maturity level | Confidence | Evidence type | Status | Notes |
 |---|---:|---|---|---|---|
 | Native quad logic | D6 | High | Docs claim, VM/spec evidence | Stable release surface | `N / F / T / S` is a native semantic value domain. |
-| i32 relational operators | D7 | High | Test evidence | Qualified limited release | Covers relational/equality-style operators (`==`, `!=`, `<`, `<=`, `>`, `=>`). |
+| i32 relational operators | D7 | High | Test evidence | Qualified limited release | Covers relational/equality-style operators (`==`, `!=`, `<`, `<=`, `>`, `>=`). |
 | same-family i32 arithmetic | D7 | High | Test evidence | Qualified application-completeness contour | Covers `+`, `-`, `*`, `/`, `%` and unary `-`. Not published stable. |
 | Mutable locals & reassignment | D7 | High | Test evidence | Qualified application-completeness contour | Supports `let mut` declarations and plain reassignments. Not published stable. |
 | Loops and control exits | D7 | High | Test evidence | Qualified application-completeness contour | Supports `while` loops, statement `loop`, and exits `break`/`continue`. Not published stable. |


### PR DESCRIPTION
This PR aligns the documentation with the actual technical state of `main` after recent feature landings.
It ensures we do not prematurely claim "Stable" status for recently landed features (like standard library math/text or project-root CLI routes) that are still in benchmark/qualification phases.

**Changes:**
- `docs/status/feature_maturity_matrix.md`:
  - Fixed maturity matrix typo (`=>` to `>=`).
  - Adjusted recent capability statuses to bounded phrasing (e.g., "Benchmark-qualified on main", "Qualified application-completeness contour") rather than "Stable".
- `docs/research/scientific_value.md`: Separated `to_text` (pure construction) from `print(text)` (controlled observation gated by `CAP_STDOUT`).
- `README.md`: Tightened current focus.

**Constraints respected:**
- Minimal docs-only changes.
- Actively bounds and protects against premature release claims.
