### PR TITLE
infra(admission): add full local preflight profile

### DIFF
--- a/scripts/admission_guard.ps1
+++ b/scripts/admission_guard.ps1
@@ -12,6 +12,7 @@
 
 param(
     [switch] $MergePreflight,
+    [switch] $FullPreflight,
 
     [string] $BaseRef = "origin/main"
 )
@@ -131,6 +132,34 @@ $TempRoot = if ($env:TEMP) {
     $env:TMP
 } else {
     [System.IO.Path]::GetTempPath()
+}
+
+if ($FullPreflight) {
+    Invoke-LocalCiStep "cargo fmt --all --check" {
+        cargo fmt --all --check
+    }
+    Invoke-LocalCiStep "cargo test -q --test public_api_contracts" {
+        cargo test -q --test public_api_contracts
+    }
+    Invoke-LocalCiStep "cargo test -q --test pcc9_project_model_acceptance" {
+        cargo test -q --test pcc9_project_model_acceptance
+    }
+    Invoke-LocalCiStep "cargo test --all-targets --quiet" {
+        cargo test --all-targets --quiet
+    }
+    Invoke-LocalCiStep "cargo check --no-default-features --quiet" {
+        cargo check --no-default-features --quiet
+    }
+
+    Invoke-LocalCiMergePreflight -BaseRef $BaseRef
+
+    Invoke-LocalCiStep "git diff --check" {
+        git diff --check
+    }
+
+    Write-Host ""
+    Write-Host "ADMISSION GUARD FULL PREFLIGHT PASS"
+    exit 0
 }
 
 $ManifestPath = Join-Path $TempRoot "semantic_v1_release_bundle_manifest.json"


### PR DESCRIPTION
# Description

Implements the explicit opt-in full preflight mode: `pwsh -File scripts/admission_guard.ps1 -FullPreflight`.

This mode ensures a complete CI-like validation sequence locally, including:
- `cargo fmt --all --check`
- Public API contract verification
- `cargo test --all-targets`
- `cargo check --no-default-features`

## Clarifications

- FullPreflight is a high-signal pre-merge validation profile.
- It does not replace every default admission_guard smoke step.
- Existing default admission_guard behavior is preserved.
- MergePreflight behavior is preserved.
- CTF is not closed.
- 7hell is not promoted to release gate.
- No runtime/verifier/VM/SemCode behavior changed.
- No .claude files touched.

## Changes
- `scripts/admission_guard.ps1`: Added `-FullPreflight` parameter and execution logic.
- Maintains backward compatibility with default and `-MergePreflight` modes.
