### PR TITLE
test(sm-ir): add I0 lowering qualification tests

### DIFF
--- a/tests/ir_lowering_qualification.rs
+++ b/tests/ir_lowering_qualification.rs
@@ -1,0 +1,109 @@
+use sm_ir::compile_program_to_ir;
+
+fn check_lower_ok(src: &str) {
+    let ir = compile_program_to_ir(src).expect("lowering failed");
+    assert!(!ir.is_empty(), "IR should be non-empty");
+}
+
+#[test]
+fn test_primitive_lowering() {
+    let src = r#"
+        fn get_quad() -> quad { return get_quad(); }
+        fn get_f64() -> f64 { return get_f64(); }
+        fn main() {
+            let q: quad = get_quad();
+            let b: bool = true;
+            let i: i32 = 42;
+            let f: f64 = get_f64();
+            return;
+        }
+    "#;
+    check_lower_ok(src);
+}
+
+#[test]
+fn test_arithmetic_lowering() {
+    let src = r#"
+        fn main() {
+            let x: i32 = 10;
+            let a = x + 1;
+            let b = x - 1;
+            let c = x * 2;
+            let d = x / 2;
+            let e = x % 3;
+            let f = -x;
+        }
+    "#;
+    check_lower_ok(src);
+}
+
+#[test]
+fn test_control_flow_lowering() {
+    let src = r#"
+        fn main() {
+            let x = true;
+            if x {
+                let y = 1;
+            } else {
+                let y = 2;
+            }
+            while x {
+                break;
+            }
+            loop {
+                continue;
+            }
+        }
+    "#;
+    check_lower_ok(src);
+}
+
+#[test]
+fn test_record_lowering() {
+    let src = r#"
+        record R { x: i32, y: bool }
+        fn main() {
+            let r = R { x: 1, y: true };
+            let a = r.x;
+            let b = r.y;
+        }
+    "#;
+    check_lower_ok(src);
+}
+
+#[test]
+fn test_adt_match_lowering() {
+    let src = r#"
+        enum E { A, B(i32) }
+        fn main() {
+            let e1 = E::A;
+            let e2 = E::B(42);
+            let m = match e2 {
+                E::A => { 1 }
+                E::B(x) => { x }
+            };
+        }
+    "#;
+    check_lower_ok(src);
+}
+
+#[test]
+fn test_option_result_lowering() {
+    let src = r#"
+        fn main() {
+            let o: Option(i32) = Option::Some(1);
+            let o2: Option(i32) = Option::None;
+            let r: Result(i32, i32) = Result::Ok(1);
+            let r2: Result(i32, i32) = Result::Err(2);
+            let m1 = match o {
+                Option::Some(x) => { x }
+                Option::None => { 0 }
+            };
+            let m2 = match r {
+                Result::Ok(x) => { x }
+                Result::Err(e) => { e }
+            };
+        }
+    "#;
+    check_lower_ok(src);
+}


### PR DESCRIPTION
# Description

Adds IR / Lowering Qualification I0 tests for the current frontend -> sema -> IR lowering path to qualify existing lowering behavior without changing lowering semantics.

Notes:
- Collections lowering tests were skipped because current public syntax or lowering support for `Sequence`/`Map` isn't fully stable/exposed for this scope without runtime execution bindings.
- No pure lowering-only negative test added; current S0 sema tests already catch invalid frontend/sema forms before lowering is reached.

## Changed Files
- `tests/ir_lowering_qualification.rs` (Added)

## Exact Tests Added
- `test_primitive_lowering`
- `test_arithmetic_lowering`
- `test_control_flow_lowering`
- `test_record_lowering`
- `test_adt_match_lowering`
- `test_option_result_lowering`

## Exact Commands Run
```bash
cargo fmt --all --check
cargo test -q --test ir_lowering_qualification
cargo test -q --test frontend_sema_qualification
cargo test -q --test frontend_parser_qualification
cargo test -q --test frontend_lexer_qualification
cargo test -q --test public_api_contracts
cargo test --all-targets --quiet
pwsh -File scripts/admission_guard.ps1 -FullPreflight
git diff --check
```

## Confirmations
- Lowering semantics were **not changed**.
- Lexer, parser, typecheck, VM, verifier, and SemCode were **not touched**.
- Docs were **not changed**.
- CTF is **not closed**.
- 7hell is **not promoted** to release gate.
- `.claude` was **not touched**.
