### PR TITLE
feat(sm-verify): reject duplicate SemCode function names

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -29,6 +29,7 @@ pub enum VerificationCode {
     UnsupportedVersion,
     TruncatedFunction,
     InvalidFunctionName,
+    DuplicateFunction,
     InvalidStringTable,
     InvalidDebugSection,
     InvalidOwnershipSection,
@@ -129,6 +130,7 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
     let mut cursor = 8usize;
     let mut functions = Vec::new();
     let mut pending_functions = Vec::new();
+    let mut seen_names = HashSet::new();
     while cursor < bytes.len() {
         let function_start = cursor;
         let name_len = match read_u16_le(bytes, &mut cursor) {
@@ -164,6 +166,17 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
                 break;
             }
         };
+
+        if !seen_names.insert(name.clone()) {
+            diagnostics.push(diag(
+                VerificationCode::DuplicateFunction,
+                Some(name.clone()),
+                Some(function_start),
+                format!("duplicate function '{}'", name),
+            ));
+            break;
+        }
+
         let code_len = match read_u32_le(bytes, &mut cursor) {
             Ok(v) => v as usize,
             Err(_) => {

--- a/tests/semcode_boundary_characterization.rs
+++ b/tests/semcode_boundary_characterization.rs
@@ -1,0 +1,81 @@
+use sm_emit::compile_program_to_semcode;
+use sm_verify::{verify_semcode, VerificationCode};
+use sm_vm::{run_verified_semcode, run_verified_semcode_with_entry};
+
+#[test]
+fn raw_helper_current_behavior_short_and_unsupported_headers_are_rejected_consistently() {
+    let bytes = vec![0u8; 4];
+    let err = verify_semcode(&bytes).expect_err("expected rejection for short header");
+    assert!(err
+        .diagnostics
+        .iter()
+        .any(|d| d.code == VerificationCode::BadHeader));
+
+    let mut bad_magic = b"BADC0DE0".to_vec();
+    bad_magic.extend(vec![0u8; 100]);
+    let err = verify_semcode(&bad_magic).expect_err("expected rejection for unsupported header");
+    assert!(err
+        .diagnostics
+        .iter()
+        .any(|d| d.code == VerificationCode::UnsupportedVersion));
+}
+
+#[test]
+fn duplicate_function_names_are_rejected_by_verifier() {
+    let mut bytes =
+        compile_program_to_semcode("fn main() { return; } fn maib() { return; }").expect("compile");
+
+    // Find "maib" and replace it with "main" to create a duplicate function
+    let target = b"maib";
+    let replacement = b"main";
+    let mut found = false;
+    for i in 0..bytes.len() - target.len() {
+        if &bytes[i..i + target.len()] == target {
+            bytes[i..i + target.len()].copy_from_slice(replacement);
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "could not find maib to replace");
+
+    let err = verify_semcode(&bytes).expect_err("expected verifier to reject duplicate function");
+    assert!(
+        err.diagnostics
+            .iter()
+            .any(|d| d.code == VerificationCode::DuplicateFunction),
+        "expected DuplicateFunction code, got {:?}",
+        err.diagnostics
+    );
+}
+
+#[test]
+fn missing_main_entrypoint_current_behavior_is_verifier_ok_and_explicit_entry_ok() {
+    let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
+
+    // Rename 'main' to 'help' to remove main entrypoint
+    let target = b"main";
+    let replacement = b"help";
+    let mut found = false;
+    for i in 0..bytes.len() - target.len() {
+        if &bytes[i..i + target.len()] == target {
+            bytes[i..i + target.len()].copy_from_slice(replacement);
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "could not find main to replace");
+
+    // Verifier is OK with it
+    verify_semcode(&bytes).expect("verifier should accept missing main");
+
+    // Default VM run fails at lookup
+    let err = run_verified_semcode(&bytes).expect_err("should fail to find main");
+    assert!(
+        err.to_string().contains("unknown function 'main'"),
+        "actual error: {}",
+        err
+    );
+
+    // Explicit entry lookup succeeds
+    run_verified_semcode_with_entry(&bytes, "help").expect("should run explicitly");
+}


### PR DESCRIPTION
Title:
feat(sm-verify): reject duplicate SemCode function names

Summary:
- Adds verifier-level rejection for duplicate function names using `VerificationCode::DuplicateFunction`.
- Keeps VM duplicate-name rejection as a defensive backstop.
- Keeps missing `main` verifier-valid, preserving library/helper SemCode artifacts.
- Adds SemCode boundary characterization tests for duplicate-name rejection and explicit-entry execution.

Contract:
- `verify_semcode` now rejects duplicate function names.
- `verify_semcode` still does not require `main`.
- Default VM execution still requires `main`.
- Explicit VM entry execution remains valid for helper-only SemCode.
- No public API change.
- No shared decoder introduced.
- No `VerifiedSemCode` token introduced.

Tests:
- `cargo test -p sm-verify`
- `cargo test --test semcode_boundary_characterization`
- `cargo test --test bytecode_compat`
- `cargo test --test g1_execution_integrity`
- `pwsh -File scripts/admission_guard.ps1 -FullPreflight`

This PR includes the focused SemCode boundary characterization file needed to prove the policy reconciliation.
This PR resolves the first admission-policy split before any shared decoder work.
