### PR TITLE
refactor(sm-ir): add shared SemCode decoder

### DIFF
--- a/crates/sm-ir/src/lib.rs
+++ b/crates/sm-ir/src/lib.rs
@@ -24,6 +24,9 @@ mod local_format;
 pub mod hello_ir;
 #[cfg(feature = "std")]
 pub mod hello_semcode;
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub mod semcode_decode;
 
 #[cfg(feature = "std")]
 pub mod semcode_format {

--- a/crates/sm-ir/src/semcode_decode.rs
+++ b/crates/sm-ir/src/semcode_decode.rs
@@ -1,0 +1,348 @@
+use crate::local_format::*;
+
+pub const MAX_FUNCTIONS: usize = 1024;
+pub const MAX_STRING_LEN: usize = 1024;
+pub const MAX_STRINGS_PER_FUNCTION: usize = 256;
+pub const MAX_DEBUG_SYMBOLS_PER_FUNCTION: usize = 8192;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    BadHeader,
+    UnsupportedVersion { found: String, supported: String },
+    TruncatedFunction { offset: usize, msg: &'static str },
+    InvalidFunctionName { offset: usize, msg: &'static str },
+    InvalidStringTable { offset: usize, msg: &'static str },
+    InvalidDebugSection { offset: usize, msg: &'static str },
+    InvalidOwnershipSection { offset: usize, msg: &'static str },
+    ResourceLimit { offset: usize, msg: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedDebugSymbol {
+    pub pc: usize,
+    pub line: u32,
+    pub col: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodedAccessPathComponent {
+    TupleIndex(u16),
+    FieldSymbol(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedAccessPath {
+    pub root_symbol_id: u32,
+    pub components: Vec<DecodedAccessPathComponent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedFunctionEnvelope<'a> {
+    pub name: String,
+    pub name_offset: usize,
+    pub code_offset: usize,
+    pub code_len: usize,
+    pub strings: Vec<String>,
+    pub debug_symbols: Vec<DecodedDebugSymbol>,
+    pub borrowed_paths: Vec<DecodedAccessPath>,
+    pub write_paths: Vec<DecodedAccessPath>,
+    pub has_ownership_section: bool,
+    pub instr_start_offset: usize, // relative to code_slice
+    pub code_slice: &'a [u8],      // the full code block for this function
+}
+
+pub fn decode_semcode_envelope<'a>(
+    bytes: &'a [u8],
+) -> Result<(SemcodeHeaderSpec, Vec<DecodedFunctionEnvelope<'a>>), DecodeError> {
+    if bytes.len() < 8 {
+        return Err(DecodeError::BadHeader);
+    }
+    let mut magic = [0u8; 8];
+    magic.copy_from_slice(&bytes[0..8]);
+    let Some(header) = header_spec_from_magic(&magic) else {
+        let found = String::from_utf8_lossy(&magic).to_string();
+        let supported = supported_headers()
+            .iter()
+            .map(|h| String::from_utf8_lossy(&h.magic).to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(DecodeError::UnsupportedVersion { found, supported });
+    };
+
+    let mut cursor = 8usize;
+    let mut functions = Vec::new();
+
+    while cursor < bytes.len() {
+        if functions.len() >= MAX_FUNCTIONS {
+            return Err(DecodeError::ResourceLimit {
+                offset: cursor,
+                msg: format!("too many functions (>{})", MAX_FUNCTIONS),
+            });
+        }
+
+        let name_offset = cursor;
+        let name_len =
+            read_u16_le(bytes, &mut cursor).map_err(|_| DecodeError::TruncatedFunction {
+                offset: name_offset,
+                msg: "missing function name length",
+            })? as usize;
+
+        if name_len == 0 {
+            return Err(DecodeError::InvalidFunctionName {
+                offset: cursor,
+                msg: "empty function name",
+            });
+        }
+        if name_len > MAX_STRING_LEN {
+            return Err(DecodeError::InvalidFunctionName {
+                offset: cursor,
+                msg: "function name too long",
+            });
+        }
+
+        let name = read_utf8(bytes, &mut cursor, name_len).map_err(|_| {
+            DecodeError::InvalidFunctionName {
+                offset: cursor,
+                msg: "invalid utf8 in function name",
+            }
+        })?;
+
+        let code_len_offset = cursor;
+        let code_len =
+            read_u32_le(bytes, &mut cursor).map_err(|_| DecodeError::TruncatedFunction {
+                offset: code_len_offset,
+                msg: "missing function code length",
+            })? as usize;
+
+        if cursor + code_len > bytes.len() {
+            return Err(DecodeError::TruncatedFunction {
+                offset: cursor,
+                msg: "function code out of bounds",
+            });
+        }
+
+        let code_offset = cursor;
+        let code_slice = &bytes[cursor..cursor + code_len];
+        cursor += code_len;
+
+        let (
+            strings,
+            debug_symbols,
+            borrowed_paths,
+            write_paths,
+            has_ownership_section,
+            instr_start_offset,
+        ) = parse_string_table_debug_and_ownership(code_offset, code_slice)?;
+
+        functions.push(DecodedFunctionEnvelope {
+            name,
+            name_offset,
+            code_offset,
+            code_len,
+            strings,
+            debug_symbols,
+            borrowed_paths,
+            write_paths,
+            has_ownership_section,
+            instr_start_offset,
+            code_slice,
+        });
+    }
+
+    Ok((header, functions))
+}
+
+fn parse_string_table_debug_and_ownership(
+    base_offset: usize,
+    code: &[u8],
+) -> Result<
+    (
+        Vec<String>,
+        Vec<DecodedDebugSymbol>,
+        Vec<DecodedAccessPath>,
+        Vec<DecodedAccessPath>,
+        bool,
+        usize,
+    ),
+    DecodeError,
+> {
+    let mut cursor = 0usize;
+    let string_count_offset = base_offset + cursor;
+    let count = read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidStringTable {
+        offset: string_count_offset,
+        msg: "missing string table header",
+    })? as usize;
+
+    if count > MAX_STRINGS_PER_FUNCTION {
+        return Err(DecodeError::ResourceLimit {
+            offset: base_offset + cursor,
+            msg: format!(
+                "too many strings in function: {} (max {})",
+                count, MAX_STRINGS_PER_FUNCTION
+            ),
+        });
+    }
+
+    let mut strings = Vec::with_capacity(count);
+    for _ in 0..count {
+        let len_offset = base_offset + cursor;
+        let len = read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidStringTable {
+            offset: len_offset,
+            msg: "missing string length",
+        })? as usize;
+
+        if len > MAX_STRING_LEN {
+            return Err(DecodeError::InvalidStringTable {
+                offset: base_offset + cursor,
+                msg: "string too long in function string table",
+            });
+        }
+
+        let str_val =
+            read_utf8(code, &mut cursor, len).map_err(|_| DecodeError::InvalidStringTable {
+                offset: base_offset + cursor,
+                msg: "invalid utf8 in string table",
+            })?;
+        strings.push(str_val);
+    }
+
+    let mut debug_symbols = Vec::new();
+    if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == b"DBG0" {
+        cursor += 4;
+        let dbg_count_offset = base_offset + cursor;
+        let count =
+            read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
+                offset: dbg_count_offset,
+                msg: "missing debug symbol count",
+            })? as usize;
+
+        if count > MAX_DEBUG_SYMBOLS_PER_FUNCTION {
+            return Err(DecodeError::ResourceLimit {
+                offset: base_offset + cursor,
+                msg: format!(
+                    "too many debug symbols: {} (max {})",
+                    count, MAX_DEBUG_SYMBOLS_PER_FUNCTION
+                ),
+            });
+        }
+
+        debug_symbols.reserve(count);
+        for _ in 0..count {
+            let entry_offset = base_offset + cursor;
+            let pc =
+                read_u32_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
+                    offset: entry_offset,
+                    msg: "missing debug pc",
+                })? as usize;
+            let line =
+                read_u32_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
+                    offset: base_offset + cursor,
+                    msg: "missing debug line",
+                })?;
+            let col =
+                read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidDebugSection {
+                    offset: base_offset + cursor,
+                    msg: "missing debug col",
+                })?;
+            debug_symbols.push(DecodedDebugSymbol { pc, line, col });
+        }
+    }
+
+    let mut borrowed_paths = Vec::new();
+    let mut write_paths = Vec::new();
+    let mut has_ownership_section = false;
+    if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == OWNERSHIP_SECTION_TAG {
+        has_ownership_section = true;
+        cursor += OWNERSHIP_SECTION_TAG.len();
+        let own_count_offset = base_offset + cursor;
+        let count =
+            read_u16_le(code, &mut cursor).map_err(|_| DecodeError::InvalidOwnershipSection {
+                offset: own_count_offset,
+                msg: "missing ownership path count",
+            })? as usize;
+
+        borrowed_paths.reserve(count);
+        write_paths.reserve(count);
+        for _ in 0..count {
+            let entry_offset = base_offset + cursor;
+            let kind =
+                read_u8(code, &mut cursor).map_err(|_| DecodeError::InvalidOwnershipSection {
+                    offset: entry_offset,
+                    msg: "missing ownership event kind",
+                })?;
+            let root_symbol_id = read_u32_le(code, &mut cursor).map_err(|_| {
+                DecodeError::InvalidOwnershipSection {
+                    offset: base_offset + cursor,
+                    msg: "missing ownership path root",
+                }
+            })?;
+            let component_count = read_u16_le(code, &mut cursor).map_err(|_| {
+                DecodeError::InvalidOwnershipSection {
+                    offset: base_offset + cursor,
+                    msg: "missing ownership path component count",
+                }
+            })? as usize;
+
+            let mut components = Vec::new();
+            for _ in 0..component_count {
+                let component_kind = read_u8(code, &mut cursor).map_err(|_| {
+                    DecodeError::InvalidOwnershipSection {
+                        offset: base_offset + cursor,
+                        msg: "missing ownership path component kind",
+                    }
+                })?;
+                match component_kind {
+                    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
+                        let index = read_u16_le(code, &mut cursor).map_err(|_| {
+                            DecodeError::InvalidOwnershipSection {
+                                offset: base_offset + cursor,
+                                msg: "missing ownership tuple index",
+                            }
+                        })?;
+                        components.push(DecodedAccessPathComponent::TupleIndex(index));
+                    }
+                    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
+                        let field = read_u32_le(code, &mut cursor).map_err(|_| {
+                            DecodeError::InvalidOwnershipSection {
+                                offset: base_offset + cursor,
+                                msg: "missing ownership field symbol",
+                            }
+                        })?;
+                        components.push(DecodedAccessPathComponent::FieldSymbol(field));
+                    }
+                    _ => {
+                        return Err(DecodeError::InvalidOwnershipSection {
+                            offset: base_offset + cursor,
+                            msg: "unsupported ownership path component kind",
+                        });
+                    }
+                }
+            }
+            match kind {
+                OWNERSHIP_EVENT_KIND_BORROW => borrowed_paths.push(DecodedAccessPath {
+                    root_symbol_id,
+                    components,
+                }),
+                OWNERSHIP_EVENT_KIND_WRITE => write_paths.push(DecodedAccessPath {
+                    root_symbol_id,
+                    components,
+                }),
+                _ => {
+                    return Err(DecodeError::InvalidOwnershipSection {
+                        offset: base_offset + cursor,
+                        msg: "unsupported ownership event kind",
+                    });
+                }
+            }
+        }
+    }
+
+    Ok((
+        strings,
+        debug_symbols,
+        borrowed_paths,
+        write_paths,
+        has_ownership_section,
+        cursor,
+    ))
+}

--- a/crates/sm-verify/Cargo.toml
+++ b/crates/sm-verify/Cargo.toml
@@ -13,6 +13,7 @@ std = ["sm-emit/std", "sm-runtime-core/std"]
 [dependencies]
 sm-emit = { path = "../sm-emit", default-features = false, features = ["std"] }
 sm-runtime-core = { path = "../sm-runtime-core", default-features = false, features = ["std"] }
+sm-ir = { path = "../sm-ir", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-sm-ir = { path = "../sm-ir", default-features = false, features = ["std"] }
+

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -5,14 +5,11 @@ extern crate std;
 
 #[cfg(feature = "std")]
 use sm_emit::{
-    header_spec_from_magic, read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8,
-    Opcode, SemcodeFormatError, SemcodeHeaderSpec, CAP_CLOCK_READ, CAP_CLOSURE_VALUES,
-    CAP_DEBUG_SYMBOLS, CAP_EVENT_POST, CAP_F64_MATH, CAP_FX_MATH, CAP_FX_VALUES, CAP_GATE_SURFACE,
-    CAP_MAP_VALUES, CAP_OWNERSHIP_FIELD_PATHS, CAP_OWNERSHIP_PATHS, CAP_PRNG,
-    CAP_SEQUENCE_ITERATION, CAP_SEQUENCE_VALUES, CAP_STATE_QUERY, CAP_STATE_UPDATE, CAP_STDOUT,
-    CAP_TEXT_VALUES, OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
-    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
-    OWNERSHIP_SECTION_TAG,
+    read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, Opcode, SemcodeFormatError,
+    SemcodeHeaderSpec, CAP_CLOCK_READ, CAP_CLOSURE_VALUES, CAP_DEBUG_SYMBOLS, CAP_EVENT_POST,
+    CAP_F64_MATH, CAP_FX_MATH, CAP_FX_VALUES, CAP_GATE_SURFACE, CAP_MAP_VALUES,
+    CAP_OWNERSHIP_FIELD_PATHS, CAP_OWNERSHIP_PATHS, CAP_PRNG, CAP_SEQUENCE_ITERATION,
+    CAP_SEQUENCE_VALUES, CAP_STATE_QUERY, CAP_STATE_UPDATE, CAP_STDOUT, CAP_TEXT_VALUES,
 };
 use sm_runtime_core::RuntimeQuotas;
 use std::collections::HashSet;
@@ -102,70 +99,70 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
     let mut diagnostics = Vec::new();
     let quotas = RuntimeQuotas::verified_local();
 
-    if bytes.len() < 8 {
-        diagnostics.push(diag(
-            VerificationCode::BadHeader,
-            None,
-            None,
-            "SemCode file is shorter than the 8-byte header",
-        ));
-        return Err(RejectReport { diagnostics });
-    }
-
-    let mut magic = [0u8; 8];
-    magic.copy_from_slice(&bytes[..8]);
-    let Some(header) = header_spec_from_magic(&magic) else {
-        diagnostics.push(diag(
-            VerificationCode::UnsupportedVersion,
-            None,
-            Some(0),
-            format!(
-                "unsupported SemCode header '{}'",
-                String::from_utf8_lossy(&magic)
-            ),
-        ));
-        return Err(RejectReport { diagnostics });
+    let (header, decoded_functions) = match sm_ir::semcode_decode::decode_semcode_envelope(bytes) {
+        Ok(v) => v,
+        Err(err) => {
+            let diag = match err {
+                sm_ir::semcode_decode::DecodeError::BadHeader => diag(
+                    VerificationCode::BadHeader,
+                    None,
+                    None,
+                    "SemCode file is shorter than the 8-byte header",
+                ),
+                sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, .. } => diag(
+                    VerificationCode::UnsupportedVersion,
+                    None,
+                    Some(0),
+                    format!("unsupported SemCode header '{}'", found),
+                ),
+                sm_ir::semcode_decode::DecodeError::TruncatedFunction { offset, msg } => {
+                    diag(VerificationCode::TruncatedFunction, None, Some(offset), msg)
+                }
+                sm_ir::semcode_decode::DecodeError::InvalidFunctionName { offset, msg } => diag(
+                    VerificationCode::InvalidFunctionName,
+                    None,
+                    Some(offset),
+                    msg,
+                ),
+                sm_ir::semcode_decode::DecodeError::InvalidStringTable { offset, msg } => diag(
+                    VerificationCode::InvalidStringTable,
+                    None,
+                    Some(offset),
+                    msg,
+                ),
+                sm_ir::semcode_decode::DecodeError::InvalidDebugSection { offset, msg } => diag(
+                    VerificationCode::InvalidDebugSection,
+                    None,
+                    Some(offset),
+                    msg,
+                ),
+                sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { offset, msg } => {
+                    diag(
+                        VerificationCode::InvalidOwnershipSection,
+                        None,
+                        Some(offset),
+                        msg,
+                    )
+                }
+                sm_ir::semcode_decode::DecodeError::ResourceLimit { offset, msg } => diag(
+                    VerificationCode::ResourceLimitExceeded,
+                    None,
+                    Some(offset),
+                    msg,
+                ),
+            };
+            diagnostics.push(diag);
+            return Err(RejectReport { diagnostics });
+        }
     };
 
-    let mut cursor = 8usize;
     let mut functions = Vec::new();
     let mut pending_functions = Vec::new();
     let mut seen_names = HashSet::new();
-    while cursor < bytes.len() {
-        let function_start = cursor;
-        let name_len = match read_u16_le(bytes, &mut cursor) {
-            Ok(v) => v as usize,
-            Err(_) => {
-                diagnostics.push(diag(
-                    VerificationCode::TruncatedFunction,
-                    None,
-                    Some(function_start),
-                    "truncated function header while reading name length",
-                ));
-                break;
-            }
-        };
-        if name_len == 0 {
-            diagnostics.push(diag(
-                VerificationCode::InvalidFunctionName,
-                None,
-                Some(function_start),
-                "function name must not be empty",
-            ));
-            break;
-        }
-        let name = match read_utf8(bytes, &mut cursor, name_len) {
-            Ok(v) => v,
-            Err(_) => {
-                diagnostics.push(diag(
-                    VerificationCode::InvalidFunctionName,
-                    None,
-                    Some(function_start),
-                    "function name is truncated or invalid utf-8",
-                ));
-                break;
-            }
-        };
+
+    for env in decoded_functions {
+        let function_start = env.name_offset;
+        let name = env.name.clone();
 
         if !seen_names.insert(name.clone()) {
             diagnostics.push(diag(
@@ -177,31 +174,7 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
             break;
         }
 
-        let code_len = match read_u32_le(bytes, &mut cursor) {
-            Ok(v) => v as usize,
-            Err(_) => {
-                diagnostics.push(diag(
-                    VerificationCode::TruncatedFunction,
-                    Some(name.clone()),
-                    Some(function_start),
-                    "truncated function header while reading code length",
-                ));
-                break;
-            }
-        };
-        if cursor + code_len > bytes.len() {
-            diagnostics.push(diag(
-                VerificationCode::TruncatedFunction,
-                Some(name.clone()),
-                Some(cursor),
-                "function code extends past end of file",
-            ));
-            break;
-        }
-        let code = &bytes[cursor..cursor + code_len];
-        cursor += code_len;
-
-        match verify_function_code(&name, code, &header, &quotas) {
+        match verify_function_code(&env, &header, &quotas) {
             Ok(function) => {
                 functions.push(function.verified.clone());
                 pending_functions.push(function);
@@ -282,20 +255,12 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
 
 #[cfg(feature = "std")]
 fn verify_function_code(
-    name: &str,
-    code: &[u8],
+    env: &sm_ir::semcode_decode::DecodedFunctionEnvelope,
     header: &SemcodeHeaderSpec,
     quotas: &RuntimeQuotas,
 ) -> Result<PendingVerifiedFunction, RejectReport> {
-    let mut cursor = 0usize;
-    let string_count = read_u16_le(code, &mut cursor).map_err(|_| {
-        reject_one(
-            name,
-            VerificationCode::InvalidStringTable,
-            0,
-            "missing string table header",
-        )
-    })? as usize;
+    let name = env.name.as_str();
+    let string_count = env.strings.len();
     if string_count > quotas.max_symbol_table {
         return Err(reject_one(
             name,
@@ -308,87 +273,35 @@ fn verify_function_code(
         ));
     }
 
-    let mut strings = Vec::with_capacity(string_count);
-    for _ in 0..string_count {
-        let len = read_u16_le(code, &mut cursor).map_err(|_| {
-            reject_one(
-                name,
-                VerificationCode::InvalidStringTable,
-                cursor,
-                "truncated string length",
-            )
-        })? as usize;
-        let string = read_utf8(code, &mut cursor, len).map_err(|_| {
-            reject_one(
-                name,
-                VerificationCode::InvalidStringTable,
-                cursor,
-                "invalid function string entry",
-            )
-        })?;
-        strings.push(string);
+    let debug_symbol_count = env.debug_symbols.len();
+    if debug_symbol_count > quotas.max_trace_entries {
+        return Err(reject_one(
+            name,
+            VerificationCode::ResourceLimitExceeded,
+            0,
+            format!(
+                "debug section uses {} entries, exceeding the verified-local trace budget of {}",
+                debug_symbol_count, quotas.max_trace_entries
+            ),
+        ));
     }
 
-    let mut debug_symbol_count = 0usize;
-    let mut debug_pcs = Vec::new();
-    if cursor + 4 <= code.len() && &code[cursor..cursor + 4] == b"DBG0" {
-        cursor += 4;
-        debug_symbol_count = read_u16_le(code, &mut cursor).map_err(|_| {
-            reject_one(
-                name,
-                VerificationCode::InvalidDebugSection,
-                cursor,
-                "truncated debug section header",
-            )
-        })? as usize;
-        if debug_symbol_count > quotas.max_trace_entries {
-            return Err(reject_one(
-                name,
-                VerificationCode::ResourceLimitExceeded,
-                cursor,
-                format!(
-                    "debug section uses {} entries, exceeding the verified-local trace budget of {}",
-                    debug_symbol_count, quotas.max_trace_entries
-                ),
-            ));
-        }
-        for _ in 0..debug_symbol_count {
-            let pc = read_u32_le(code, &mut cursor).map_err(|_| {
-                reject_one(
-                    name,
-                    VerificationCode::InvalidDebugSection,
-                    cursor,
-                    "truncated debug pc",
-                )
-            })?;
-            read_u32_le(code, &mut cursor).map_err(|_| {
-                reject_one(
-                    name,
-                    VerificationCode::InvalidDebugSection,
-                    cursor,
-                    "truncated debug line",
-                )
-            })?;
-            read_u16_le(code, &mut cursor).map_err(|_| {
-                reject_one(
-                    name,
-                    VerificationCode::InvalidDebugSection,
-                    cursor,
-                    "truncated debug column",
-                )
-            })?;
-            debug_pcs.push(pc as usize);
-        }
-    }
+    let has_ownership_section = env.has_ownership_section;
+    let has_record_field_ownership =
+        env.borrowed_paths
+            .iter()
+            .chain(env.write_paths.iter())
+            .any(|p| {
+                p.components.iter().any(|c| {
+                    matches!(
+                        c,
+                        sm_ir::semcode_decode::DecodedAccessPathComponent::FieldSymbol(_)
+                    )
+                })
+            });
 
-    let has_ownership_section =
-        cursor + 4 <= code.len() && &code[cursor..cursor + 4] == OWNERSHIP_SECTION_TAG;
-    let ownership_usage = if has_ownership_section {
-        verify_ownership_section(name, code, &mut cursor, quotas)?
-    } else {
-        OwnershipSectionUsage::default()
-    };
-
+    let code = env.code_slice;
+    let mut cursor = env.instr_start_offset;
     let instr_start = cursor;
     let instr_len = code.len().saturating_sub(instr_start);
     let mut instr_starts = Vec::new();
@@ -432,12 +345,12 @@ fn verify_function_code(
         };
     }
 
-    for pc in debug_pcs {
-        if pc >= instr_len {
+    for sym in &env.debug_symbols {
+        if sym.pc >= instr_len {
             return Err(reject_one(
                 name,
                 VerificationCode::InvalidDebugSection,
-                pc,
+                sym.pc,
                 "debug symbol pc points past the instruction stream",
             ));
         }
@@ -449,7 +362,7 @@ fn verify_function_code(
     if has_ownership_section {
         used_caps |= CAP_OWNERSHIP_PATHS;
     }
-    if ownership_usage.has_record_field_ownership {
+    if has_record_field_ownership {
         used_caps |= CAP_OWNERSHIP_FIELD_PATHS;
     }
 
@@ -497,7 +410,7 @@ fn verify_function_code(
             ));
         }
         if usage == "call target" {
-            call_targets.push((offset, strings[sid].clone()));
+            call_targets.push((offset, env.strings[sid].clone()));
         }
     }
 
@@ -1081,145 +994,6 @@ fn builtin_call_required_capabilities(name: &str) -> Option<u32> {
         "print" => Some(CAP_STDOUT),
         _ => None,
     }
-}
-
-#[cfg(feature = "std")]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct OwnershipSectionUsage {
-    has_record_field_ownership: bool,
-}
-
-#[cfg(feature = "std")]
-fn verify_ownership_section(
-    function: &str,
-    code: &[u8],
-    cursor: &mut usize,
-    quotas: &RuntimeQuotas,
-) -> Result<OwnershipSectionUsage, RejectReport> {
-    let section_start = *cursor;
-    *cursor += OWNERSHIP_SECTION_TAG.len();
-    let mut usage = OwnershipSectionUsage::default();
-
-    let event_count = read_u16_le(code, cursor).map_err(|_| {
-        reject_one(
-            function,
-            VerificationCode::InvalidOwnershipSection,
-            section_start,
-            "truncated OWN0 section header",
-        )
-    })? as usize;
-
-    if event_count > quotas.max_symbol_table {
-        return Err(reject_one(
-            function,
-            VerificationCode::ResourceLimitExceeded,
-            section_start,
-            format!(
-                "OWN0 section uses {} events, exceeding the verified-local symbol budget of {}",
-                event_count, quotas.max_symbol_table
-            ),
-        ));
-    }
-
-    for event_idx in 0..event_count {
-        let event_offset = *cursor;
-        let kind = read_u8(code, cursor).map_err(|_| {
-            reject_one(
-                function,
-                VerificationCode::InvalidOwnershipSection,
-                event_offset,
-                "truncated ownership event kind",
-            )
-        })?;
-        if !matches!(
-            kind,
-            OWNERSHIP_EVENT_KIND_BORROW | OWNERSHIP_EVENT_KIND_WRITE
-        ) {
-            return Err(reject_one(
-                function,
-                VerificationCode::InvalidOwnershipSection,
-                *cursor - 1,
-                format!("unsupported ownership event kind 0x{kind:02x}"),
-            ));
-        }
-
-        read_u32_le(code, cursor).map_err(|_| {
-            reject_one(
-                function,
-                VerificationCode::InvalidOwnershipSection,
-                *cursor,
-                "truncated ownership path root",
-            )
-        })?;
-        let component_count = read_u16_le(code, cursor).map_err(|_| {
-            reject_one(
-                function,
-                VerificationCode::InvalidOwnershipSection,
-                *cursor,
-                "truncated ownership path component count",
-            )
-        })? as usize;
-
-        if component_count > quotas.max_symbol_table {
-            return Err(reject_one(
-                function,
-                VerificationCode::ResourceLimitExceeded,
-                event_offset,
-                format!(
-                    "ownership path {} uses {} components, exceeding the verified-local symbol budget of {}",
-                    event_idx, component_count, quotas.max_symbol_table
-                ),
-            ));
-        }
-
-        let mut event_has_field_component = false;
-        for _ in 0..component_count {
-            let component_offset = *cursor;
-            let component_kind = read_u8(code, cursor).map_err(|_| {
-                reject_one(
-                    function,
-                    VerificationCode::InvalidOwnershipSection,
-                    component_offset,
-                    "truncated ownership path component kind",
-                )
-            })?;
-            match component_kind {
-                OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
-                    read_u16_le(code, cursor).map_err(|_| {
-                        reject_one(
-                            function,
-                            VerificationCode::InvalidOwnershipSection,
-                            *cursor,
-                            "truncated tuple-index ownership path component",
-                        )
-                    })?;
-                }
-                OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
-                    event_has_field_component = true;
-                    read_u32_le(code, cursor).map_err(|_| {
-                        reject_one(
-                            function,
-                            VerificationCode::InvalidOwnershipSection,
-                            *cursor,
-                            "truncated field-symbol ownership path component",
-                        )
-                    })?;
-                }
-                _ => {
-                    return Err(reject_one(
-                        function,
-                        VerificationCode::InvalidOwnershipSection,
-                        *cursor - 1,
-                        format!("unsupported ownership path component kind 0x{component_kind:02x}"),
-                    ));
-                }
-            }
-        }
-
-        usage.has_record_field_ownership |= event_has_field_component;
-    }
-
-    Ok(usage)
 }
 
 #[cfg(feature = "std")]

--- a/crates/sm-vm/Cargo.toml
+++ b/crates/sm-vm/Cargo.toml
@@ -17,3 +17,4 @@ sm-verify = { path = "../sm-verify", default-features = false, features = ["std"
 prom-abi = { path = "../prom-abi", default-features = false, features = ["std"] }
 prom-cap = { path = "../prom-cap", default-features = false, features = ["std"] }
 prom-ui = { path = "../prom-ui", default-features = false, features = ["std"] }
+sm-ir = { path = "../sm-ir", default-features = false, features = ["std"] }

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -3,11 +3,8 @@
 #[cfg(feature = "std")]
 mod semcode_format {
     pub use sm_emit::{
-        header_spec_from_magic, read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8,
-        read_utf8, supported_headers, Opcode, SemcodeFormatError, SemcodeHeaderSpec,
-        OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
-        OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
-        OWNERSHIP_SECTION_TAG,
+        read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8, Opcode,
+        SemcodeFormatError, SemcodeHeaderSpec,
     };
 }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1,8 +1,6 @@
 use crate::semcode_format::{
-    header_spec_from_magic, read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8,
-    supported_headers, Opcode, SemcodeFormatError, SemcodeHeaderSpec, OWNERSHIP_EVENT_KIND_BORROW,
-    OWNERSHIP_EVENT_KIND_WRITE, OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL,
-    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX, OWNERSHIP_SECTION_TAG,
+    read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8, Opcode,
+    SemcodeFormatError, SemcodeHeaderSpec,
 };
 use crate::QuadVal;
 use prom_abi::{AbiError, AbiValue, HostCallId, PrometheusHostAbi};
@@ -18,11 +16,6 @@ use sm_runtime_core::{
 use sm_verify::verify_semcode;
 use sm_verify::RejectReport;
 use std::collections::{HashMap, HashSet};
-
-const MAX_FUNCTIONS: usize = 4096;
-const MAX_STRINGS_PER_FUNCTION: usize = 4096;
-const MAX_STRING_LEN: usize = 8192;
-const MAX_DEBUG_SYMBOLS_PER_FUNCTION: usize = 8192;
 
 /// Scalar key type for Map values.
 ///
@@ -442,75 +435,81 @@ fn parse_semcode(
     ),
     RuntimeError,
 > {
-    if bytes.len() < 8 {
-        return Err(RuntimeError::BadHeader);
-    }
-    let mut magic = [0u8; 8];
-    magic.copy_from_slice(&bytes[0..8]);
-    let Some(header) = header_spec_from_magic(&magic) else {
-        if &magic[0..7] == b"SEMCODE" {
-            return Err(RuntimeError::UnsupportedBytecodeVersion {
-                found: String::from_utf8_lossy(&magic).to_string(),
-                supported: supported_headers()
-                    .iter()
-                    .map(|h| String::from_utf8_lossy(&h.magic).to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            });
-        }
-        return Err(RuntimeError::BadHeader);
-    };
-    let mut i = 8usize;
+    let (header, decoded_functions) = sm_ir::semcode_decode::decode_semcode_envelope(bytes)
+        .map_err(|e| match e {
+            sm_ir::semcode_decode::DecodeError::BadHeader => RuntimeError::BadHeader,
+            sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, supported } => {
+                RuntimeError::UnsupportedBytecodeVersion { found, supported }
+            }
+            sm_ir::semcode_decode::DecodeError::TruncatedFunction { msg, .. } => {
+                RuntimeError::BadFormat(msg.to_string())
+            }
+            sm_ir::semcode_decode::DecodeError::InvalidFunctionName { msg, .. } => {
+                RuntimeError::BadFormat(msg.to_string())
+            }
+            sm_ir::semcode_decode::DecodeError::InvalidStringTable { msg, .. } => {
+                RuntimeError::BadFormat(msg.to_string())
+            }
+            sm_ir::semcode_decode::DecodeError::InvalidDebugSection { msg, .. } => {
+                RuntimeError::BadFormat(msg.to_string())
+            }
+            sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { msg, .. } => {
+                RuntimeError::BadFormat(msg.to_string())
+            }
+            sm_ir::semcode_decode::DecodeError::ResourceLimit { msg, .. } => {
+                RuntimeError::BadFormat(msg)
+            }
+        })?;
     let mut out = HashMap::new();
     let mut runtime_symbols = RuntimeSymbolTable::new();
-    while i < bytes.len() {
-        if out.len() >= MAX_FUNCTIONS {
-            return Err(RuntimeError::BadFormat(format!(
-                "too many functions (>{})",
-                MAX_FUNCTIONS
-            )));
-        }
-        let name_len = read_u16_le(bytes, &mut i).map_err(map_format_err)? as usize;
-        if name_len == 0 {
-            return Err(RuntimeError::BadFormat("empty function name".to_string()));
-        }
-        if name_len > MAX_STRING_LEN {
-            return Err(RuntimeError::BadFormat(format!(
-                "function name too long: {}",
-                name_len
-            )));
-        }
-        let name = read_utf8(bytes, &mut i, name_len).map_err(map_format_err)?;
-        let code_len = read_u32_le(bytes, &mut i).map_err(map_format_err)? as usize;
-        if i + code_len > bytes.len() {
-            return Err(RuntimeError::BadFormat(
-                "function code out of bounds".to_string(),
-            ));
-        }
-        let code = bytes[i..i + code_len].to_vec();
-        i += code_len;
 
-        let (strings, debug_symbols, borrowed_paths, write_paths, instr_start) =
-            parse_string_table_debug_and_ownership(&code)?;
+    for env in decoded_functions {
+        let name = env.name.clone();
+        let strings = env.strings.clone();
+
+        let debug_symbols = env
+            .debug_symbols
+            .into_iter()
+            .map(|s| DebugSymbol {
+                pc: s.pc,
+                line: s.line,
+                col: s.col,
+            })
+            .collect();
+
         let symbol_ids = strings
             .iter()
             .map(|name| runtime_symbols.intern(name))
             .collect::<Vec<_>>();
-        let remap_paths = |paths: Vec<AccessPath>| {
+
+        let remap_paths = |paths: Vec<sm_ir::semcode_decode::DecodedAccessPath>| {
             paths
                 .into_iter()
                 .map(|path| {
-                    let local_root = path.root.raw() as usize;
-                    let root = symbol_ids.get(local_root).copied().unwrap_or(path.root);
-                    Ok(AccessPath {
-                        root,
-                        components: path.components,
-                    })
+                    let local_root = path.root_symbol_id as usize;
+                    let root = symbol_ids
+                        .get(local_root)
+                        .copied()
+                        .unwrap_or(SymbolId(path.root_symbol_id));
+                    let mut p = AccessPath::new(root);
+                    for c in path.components {
+                        match c {
+                            sm_ir::semcode_decode::DecodedAccessPathComponent::TupleIndex(i) => {
+                                p = p.tuple_index(i);
+                            }
+                            sm_ir::semcode_decode::DecodedAccessPathComponent::FieldSymbol(s) => {
+                                p = p.field(SymbolId(s));
+                            }
+                        }
+                    }
+                    Ok(p)
                 })
                 .collect::<Result<Vec<_>, RuntimeError>>()
         };
-        let borrowed_paths = remap_paths(borrowed_paths)?;
-        let write_paths = remap_paths(write_paths)?;
+
+        let borrowed_paths = remap_paths(env.borrowed_paths)?;
+        let write_paths = remap_paths(env.write_paths)?;
+
         let f = FunctionBytecode {
             name: name.clone(),
             strings,
@@ -518,8 +517,8 @@ fn parse_semcode(
             debug_symbols,
             borrowed_paths,
             write_paths,
-            code,
-            instr_start,
+            code: env.code_slice.to_vec(),
+            instr_start: env.instr_start_offset,
         };
         validate_function_bytecode(&f)?;
         if out.insert(name.clone(), f).is_some() {
@@ -530,99 +529,6 @@ fn parse_semcode(
         }
     }
     Ok((header, runtime_symbols, out))
-}
-
-fn parse_string_table_debug_and_ownership(
-    code: &[u8],
-) -> Result<
-    (
-        Vec<String>,
-        Vec<DebugSymbol>,
-        Vec<AccessPath>,
-        Vec<AccessPath>,
-        usize,
-    ),
-    RuntimeError,
-> {
-    let mut i = 0usize;
-    let count = read_u16_le(code, &mut i).map_err(map_format_err)? as usize;
-    if count > MAX_STRINGS_PER_FUNCTION {
-        return Err(RuntimeError::BadFormat(format!(
-            "too many strings in function: {} (max {})",
-            count, MAX_STRINGS_PER_FUNCTION
-        )));
-    }
-    let mut strings = Vec::with_capacity(count);
-    for _ in 0..count {
-        let len = read_u16_le(code, &mut i).map_err(map_format_err)? as usize;
-        if len > MAX_STRING_LEN {
-            return Err(RuntimeError::BadFormat(format!(
-                "string too long in function string table: {}",
-                len
-            )));
-        }
-        strings.push(read_utf8(code, &mut i, len).map_err(map_format_err)?);
-    }
-    let mut debug_symbols = Vec::new();
-    if i + 4 <= code.len() && &code[i..i + 4] == b"DBG0" {
-        i += 4;
-        let count = read_u16_le(code, &mut i).map_err(map_format_err)? as usize;
-        if count > MAX_DEBUG_SYMBOLS_PER_FUNCTION {
-            return Err(RuntimeError::BadFormat(format!(
-                "too many debug symbols in function: {} (max {})",
-                count, MAX_DEBUG_SYMBOLS_PER_FUNCTION
-            )));
-        }
-        debug_symbols.reserve(count);
-        for _ in 0..count {
-            let pc = read_u32_le(code, &mut i).map_err(map_format_err)? as usize;
-            let line = read_u32_le(code, &mut i).map_err(map_format_err)?;
-            let col = read_u16_le(code, &mut i).map_err(map_format_err)?;
-            debug_symbols.push(DebugSymbol { pc, line, col });
-        }
-    }
-    let mut borrowed_paths = Vec::new();
-    let mut write_paths = Vec::new();
-    if i + 4 <= code.len() && &code[i..i + 4] == OWNERSHIP_SECTION_TAG {
-        i += OWNERSHIP_SECTION_TAG.len();
-        let count = read_u16_le(code, &mut i).map_err(map_format_err)? as usize;
-        borrowed_paths.reserve(count);
-        write_paths.reserve(count);
-        for _ in 0..count {
-            let kind = read_u8(code, &mut i).map_err(map_format_err)?;
-            let root = SymbolId(read_u32_le(code, &mut i).map_err(map_format_err)?);
-            let component_count = read_u16_le(code, &mut i).map_err(map_format_err)? as usize;
-            let mut path = AccessPath::new(root);
-            for _ in 0..component_count {
-                let component_kind = read_u8(code, &mut i).map_err(map_format_err)?;
-                match component_kind {
-                    OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX => {
-                        let index = read_u16_le(code, &mut i).map_err(map_format_err)?;
-                        path = path.tuple_index(index);
-                    }
-                    OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL => {
-                        let field = SymbolId(read_u32_le(code, &mut i).map_err(map_format_err)?);
-                        path = path.field(field);
-                    }
-                    _ => {
-                        return Err(RuntimeError::BadFormat(format!(
-                            "unsupported ownership path component kind 0x{component_kind:02x}"
-                        )));
-                    }
-                }
-            }
-            match kind {
-                OWNERSHIP_EVENT_KIND_BORROW => borrowed_paths.push(path),
-                OWNERSHIP_EVENT_KIND_WRITE => write_paths.push(path),
-                _ => {
-                    return Err(RuntimeError::BadFormat(format!(
-                        "unsupported ownership event kind 0x{kind:02x}"
-                    )))
-                }
-            }
-        }
-    }
-    Ok((strings, debug_symbols, borrowed_paths, write_paths, i))
 }
 
 fn map_format_err(err: SemcodeFormatError) -> RuntimeError {
@@ -2955,7 +2861,12 @@ fn disasm_one(f: &FunctionBytecode, pc: usize) -> Result<(String, usize), Runtim
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sm_emit::compile_program_to_semcode;
+    use super::*;
+    use sm_emit::{
+        compile_program_to_semcode, OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
+        OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,
+        OWNERSHIP_SECTION_TAG,
+    };
     use sm_runtime_core::{
         ExecutionConfig, ExecutionContext, PathComponent, QuotaExceeded, QuotaKind, RuntimeTrap,
     };
@@ -4279,8 +4190,11 @@ mod tests {
         let code_start = cursor;
         let code_end = code_start + code_len;
         let code = &bytes[code_start..code_end];
-        let (strings, _, _, _, instr_start) =
-            parse_string_table_debug_and_ownership(code).expect("parse");
+        let (_, mut decoded_functions) =
+            sm_ir::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let env = decoded_functions.remove(0);
+        let strings = env.strings;
+        let instr_start = env.instr_start_offset;
         let ctx_root = strings
             .iter()
             .position(|s| s == "ctx")
@@ -4385,8 +4299,11 @@ mod tests {
         let code_start = cursor;
         let code_end = code_start + code_len;
         let code = &bytes[code_start..code_end];
-        let (strings, _, _, _, instr_start) =
-            parse_string_table_debug_and_ownership(code).expect("parse");
+        let (_, mut decoded_functions) =
+            sm_ir::semcode_decode::decode_semcode_envelope(&bytes).expect("decode");
+        let env = decoded_functions.remove(0);
+        let strings = env.strings;
+        let instr_start = env.instr_start_offset;
         let total_root = strings
             .iter()
             .position(|s| s == "total")

--- a/tests/golden_snapshots/public_api/sm_ir_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_ir_lib.txt
@@ -6,6 +6,9 @@ pub mod hello_ir;
 #[cfg(feature = "std")]
 pub mod hello_semcode;
 #[cfg(feature = "std")]
+#[doc(hidden)]
+pub mod semcode_decode;
+#[cfg(feature = "std")]
 pub mod semcode_format {
 pub use crate::local_format::{
 #[cfg(feature = "std")]


### PR DESCRIPTION
# Implement shared policy-neutral SemCode Decoder (PR-PACK-2)

Introduce a shared, policy-neutral SemCode envelope and section decoder at the current canonical SemCode boundary under `sm-ir`.

The decoder centralizes header, function envelope, string table, DBG0, and OWN0 parsing for `sm-verify` and `sm-vm` while preserving existing admission and runtime policies.

## Constraints & Verifications
- **No root/user-facing public API change:** Adds a `#[doc(hidden)]` workspace-internal `sm-ir` decoder module. The public API footprint is updated only in the internal golden snapshot.
- **Duplicate function-name rejection remains verifier-owned:** `sm-verify` continues to explicitly reject duplicate function names via its own Set tracking.
- **Missing main remains verifier-valid:** Empty entrypoints remain supported unless explicitly rejected by execution.
- **Raw VM helper behavior remains unchanged:** VM test vectors retain prior unsupported vs. bad header characterizations.
- **No `VerifiedSemCode` token is introduced:** This phase is strictly structural refactoring.
- **`legacy_lowering.rs` remains untouched.**

## Impact
- Centralizes decoding logic.
- Differentiates properly between an empty `OWN0` section and a missing `OWN0` section for strict ownership checks.
- Eliminates redundant manual `bytes` cursor parsing loops from the VM.
