### PR TITLE
test: make mk_temp_dir thread-safe against concurrent collisions

### DIFF
--- a/tests/artifact_command_diagnostics.rs
+++ b/tests/artifact_command_diagnostics.rs
@@ -56,19 +56,21 @@ impl MalformedArtifactCase {
     }
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = std::env::temp_dir()
-        .join("semantic-tests")
-        .join("artifact-command-diagnostics")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }

--- a/tests/cache_reuse_smoke.rs
+++ b/tests/cache_reuse_smoke.rs
@@ -2,15 +2,20 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -16,15 +16,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -20,15 +20,20 @@ fn cli_err(command: &str, rel: &str) -> String {
         .expect_err(&format!("smc {command} unexpectedly passed for {path}"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/hello_cli_observation_envelope.rs
+++ b/tests/hello_cli_observation_envelope.rs
@@ -2,15 +2,20 @@ use std::path::PathBuf;
 use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc1_control_flow_diagnostics.rs
+++ b/tests/pcc1_control_flow_diagnostics.rs
@@ -5,15 +5,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc1_control_flow_gate.rs
+++ b/tests/pcc1_control_flow_gate.rs
@@ -16,15 +16,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc1_control_flow_lowering_stability.rs
+++ b/tests/pcc1_control_flow_lowering_stability.rs
@@ -9,15 +9,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc2_numeric_core_gate.rs
+++ b/tests/pcc2_numeric_core_gate.rs
@@ -20,15 +20,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc2_numeric_diagnostics.rs
+++ b/tests/pcc2_numeric_diagnostics.rs
@@ -20,15 +20,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc2_numeric_lowering_stability.rs
+++ b/tests/pcc2_numeric_lowering_stability.rs
@@ -20,15 +20,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc3_text_core_gate.rs
+++ b/tests/pcc3_text_core_gate.rs
@@ -24,15 +24,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc3_text_diagnostics.rs
+++ b/tests/pcc3_text_diagnostics.rs
@@ -24,15 +24,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc3_text_lowering_stability.rs
+++ b/tests/pcc3_text_lowering_stability.rs
@@ -24,15 +24,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc4_records_diagnostics.rs
+++ b/tests/pcc4_records_diagnostics.rs
@@ -16,15 +16,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc5_adt_diagnostics.rs
+++ b/tests/pcc5_adt_diagnostics.rs
@@ -16,18 +16,21 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }

--- a/tests/pcc6_option_result_diagnostics.rs
+++ b/tests/pcc6_option_result_diagnostics.rs
@@ -18,15 +18,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/pcc7_collections_diagnostics.rs
+++ b/tests/pcc7_collections_diagnostics.rs
@@ -22,18 +22,21 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }

--- a/tests/pcc8_stdlib_diagnostics.rs
+++ b/tests/pcc8_stdlib_diagnostics.rs
@@ -20,18 +20,21 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("target")
-        .join(format!(
-            "{}_{}_{}",
-            prefix,
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir
 }

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -465,18 +465,23 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(context)
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let base = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
-    std::fs::create_dir_all(&base).expect("mkdir");
-    base
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
 }
 
 fn normalize_path(path: &std::path::Path) -> String {

--- a/tests/pcc9_project_model_diagnostics.rs
+++ b/tests/pcc9_project_model_diagnostics.rs
@@ -22,18 +22,23 @@ fn fixture_text(rel: &str) -> String {
         .unwrap_or_else(|err| panic!("read fixture {rel}: {err}"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
-    let base = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
-    std::fs::create_dir_all(&base).expect("mkdir");
-    base
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
 }
 
 fn assert_manifest_parse_error(rel: &str, code: PackageManifestParseCode, needle: &str) {

--- a/tests/snake_benchmark_gap_matrix.rs
+++ b/tests/snake_benchmark_gap_matrix.rs
@@ -16,15 +16,20 @@ fn cli_err(args: Vec<String>, context: &str) -> String {
     smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/snake_core_benchmark.rs
+++ b/tests/snake_core_benchmark.rs
@@ -12,15 +12,20 @@ fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir

--- a/tests/snake_learning_benchmark.rs
+++ b/tests/snake_learning_benchmark.rs
@@ -12,15 +12,20 @@ fn cli_ok(args: Vec<String>, context: &str) {
     smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
 }
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 fn mk_temp_dir(prefix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         prefix,
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
-            .as_nanos()
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
     ));
     std::fs::create_dir_all(&dir).expect("mkdir");
     dir


### PR DESCRIPTION
Summary:
* Makes test `mk_temp_dir` helpers resilient against concurrent name collisions.
* Adds an `AtomicUsize` suffix to temporary directory names used by affected tests.
* Keeps production code unchanged.
* Removes no test coverage and changes no runtime semantics.

Problem:
During `FullPreflight` / `cargo test --all-targets`, some tests using timestamp-based temporary directory names could collide under concurrent execution. This caused flaky file-read or directory-access failures unrelated to the tested behavior.

Contract:
* Test-only change.
* No production code change.
* No public API change.
* No Semantic/SemCode behavior change.
* Intended only to stabilize concurrent test execution.

Verification:
* `pwsh -File scripts/admission_guard.ps1 -FullPreflight`
* Result: `ADMISSION GUARD FULL PREFLIGHT PASS`

Notes:
This stabilization PR should be merged before continuing with admitted-token or other SemCode boundary work, so future architecture PRs are not polluted by unrelated test infrastructure flakes.
