### PR TITLE
feat(sm-verify): add VerifiedEntrySemCode layer

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -103,6 +103,52 @@ pub struct VerifiedSemCode<'a> {
 }
 
 #[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryResolutionError {
+    MissingEntry { entry: String },
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Display for EntryResolutionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EntryResolutionError::MissingEntry { entry } => {
+                write!(f, "entry function '{}' not found in SemCode", entry)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EntryResolutionError {}
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct VerifiedEntrySemCode<'token, 'bytes> {
+    artifact: &'token VerifiedSemCode<'bytes>,
+    entry: String,
+}
+
+#[cfg(feature = "std")]
+impl<'token, 'bytes> VerifiedEntrySemCode<'token, 'bytes> {
+    pub fn artifact(&self) -> &'token VerifiedSemCode<'bytes> {
+        self.artifact
+    }
+
+    pub fn entry(&self) -> &str {
+        &self.entry
+    }
+
+    pub fn bytes(&self) -> &'bytes [u8] {
+        self.artifact.bytes()
+    }
+
+    pub fn program(&self) -> &VerifiedProgram {
+        self.artifact.program()
+    }
+}
+
+#[cfg(feature = "std")]
 impl<'a> VerifiedSemCode<'a> {
     pub fn bytes(&self) -> &'a [u8] {
         self.bytes
@@ -118,6 +164,22 @@ impl<'a> VerifiedSemCode<'a> {
 
     pub fn has_entry(&self, entry: &str) -> bool {
         self.decoded.iter().any(|env| env.name == entry)
+    }
+
+    pub fn require_entry<'token>(
+        &'token self,
+        entry: &str,
+    ) -> Result<VerifiedEntrySemCode<'token, 'a>, EntryResolutionError> {
+        if self.has_entry(entry) {
+            Ok(VerifiedEntrySemCode {
+                artifact: self,
+                entry: entry.to_string(),
+            })
+        } else {
+            Err(EntryResolutionError::MissingEntry {
+                entry: entry.to_string(),
+            })
+        }
     }
 }
 
@@ -2033,5 +2095,78 @@ mod tests {
             report.diagnostics[0].code,
             VerificationCode::DuplicateFunction
         );
+    }
+
+    #[test]
+    fn require_entry_main_ok_for_executable_semcode() {
+        let src = "fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        let entry_token = token.require_entry("main").expect("require_entry");
+        assert_eq!(entry_token.entry(), "main");
+    }
+
+    #[test]
+    fn require_entry_main_fails_for_helper_only_semcode() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "helper".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        let err = token.require_entry("main").expect_err("should fail");
+        assert_eq!(
+            err,
+            EntryResolutionError::MissingEntry {
+                entry: "main".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn require_entry_helper_ok_for_helper_only_semcode() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "helper".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        let entry_token = token.require_entry("helper").expect("require_entry");
+        assert_eq!(entry_token.entry(), "helper");
+    }
+
+    #[test]
+    fn missing_entry_error_is_not_reject_report() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "helper".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        let err = token.require_entry("main").expect_err("should fail");
+        let error_msg = err.to_string();
+        assert!(error_msg.contains("entry function 'main' not found"));
+    }
+
+    #[test]
+    fn verified_entry_token_reuses_original_artifact() {
+        let src = "fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        let entry_token = token.require_entry("main").expect("require_entry");
+        assert_eq!(entry_token.bytes(), token.bytes());
+        assert_eq!(entry_token.program(), token.program());
     }
 }

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -95,7 +95,34 @@ impl core::fmt::Display for RejectReport {
 impl std::error::Error for RejectReport {}
 
 #[cfg(feature = "std")]
-pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
+#[derive(Debug)]
+pub struct VerifiedSemCode<'a> {
+    bytes: &'a [u8],
+    program: VerifiedProgram,
+    decoded: Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope<'a>>,
+}
+
+#[cfg(feature = "std")]
+impl<'a> VerifiedSemCode<'a> {
+    pub fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+
+    pub fn program(&self) -> &VerifiedProgram {
+        &self.program
+    }
+
+    pub fn function_names(&self) -> impl Iterator<Item = &str> {
+        self.decoded.iter().map(|env| env.name.as_str())
+    }
+
+    pub fn has_entry(&self, entry: &str) -> bool {
+        self.decoded.iter().any(|env| env.name == entry)
+    }
+}
+
+#[cfg(feature = "std")]
+pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
     let mut diagnostics = Vec::new();
     let quotas = RuntimeQuotas::verified_local();
 
@@ -160,7 +187,7 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
     let mut pending_functions = Vec::new();
     let mut seen_names = HashSet::new();
 
-    for env in decoded_functions {
+    for env in &decoded_functions {
         let function_start = env.name_offset;
         let name = env.name.clone();
 
@@ -174,7 +201,7 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
             break;
         }
 
-        match verify_function_code(&env, &header, &quotas) {
+        match verify_function_code(env, &header, &quotas) {
             Ok(function) => {
                 functions.push(function.verified.clone());
                 pending_functions.push(function);
@@ -247,10 +274,19 @@ pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
     }
 
     if diagnostics.is_empty() {
-        Ok(VerifiedProgram { header, functions })
+        Ok(VerifiedSemCode {
+            bytes,
+            program: VerifiedProgram { header, functions },
+            decoded: decoded_functions,
+        })
     } else {
         Err(RejectReport { diagnostics })
     }
+}
+
+#[cfg(feature = "std")]
+pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {
+    verify_semcode_token(bytes).map(|token| token.program.clone())
 }
 
 #[cfg(feature = "std")]
@@ -1945,5 +1981,57 @@ mod tests {
 
     fn find_opcode(bytes: &[u8], opcode: u8) -> Option<usize> {
         bytes.iter().position(|byte| *byte == opcode)
+    }
+
+    #[test]
+    fn verify_semcode_token_accepts_no_main_helper_semcode() {
+        let bytes = emit_ir_to_semcode(
+            &[IrFunction {
+                name: "helper".to_string(),
+                instrs: vec![IrInstr::Ret { src: None }],
+                ownership_events: Vec::new(),
+            }],
+            false,
+        )
+        .expect("emit");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        assert!(token.has_entry("helper"));
+        assert!(!token.has_entry("main"));
+        assert_eq!(token.function_names().collect::<Vec<_>>(), vec!["helper"]);
+    }
+
+    #[test]
+    fn verify_semcode_token_metadata_matches_verify_semcode() {
+        let src = "fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let metadata = verify_semcode(&bytes).expect("verify_semcode");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        assert_eq!(token.program(), &metadata);
+    }
+
+    #[test]
+    fn verify_semcode_token_rejects_malformed_header() {
+        let report = verify_semcode_token(b"SEMC").expect_err("must reject");
+        assert_eq!(report.diagnostics[0].code, VerificationCode::BadHeader);
+    }
+
+    #[test]
+    fn verified_semcode_token_keeps_original_bytes() {
+        let src = "fn main() { return; }";
+        let bytes = compile_program_to_semcode(src).expect("compile");
+        let token = verify_semcode_token(&bytes).expect("token admission");
+        assert_eq!(token.bytes(), bytes.as_slice());
+    }
+
+    #[test]
+    fn verify_semcode_token_rejects_duplicate_function_names() {
+        let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
+        let function_block = bytes[8..].to_vec();
+        bytes.extend_from_slice(&function_block);
+        let report = verify_semcode_token(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::DuplicateFunction
+        );
     }
 }

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -19,6 +19,9 @@ Current verifier surface is centered on:
 - `VerifiedProgram`
 - `VerifiedFunction`
 - `RejectReport`
+- `VerifiedSemCode`
+- `VerifiedEntrySemCode`
+- `EntryResolutionError`
 
 ## Verification Scope
 
@@ -48,12 +51,13 @@ Current ownership-specific structural checks for ownership transport include:
 
 Standard execution uses the chain:
 
-`emit SemCode -> verify_semcode -> execute`
+`emit SemCode -> verify_semcode -> (optional) require_entry -> execute`
 
 Important rule:
 
 - VM execution does not replace SemCode admission
 - a valid producer path does not waive verifier admission
+- entry resolution failure (`EntryResolutionError`) is distinct from verifier rejection (`RejectReport`); missing an entrypoint does not make the artifact itself invalid.
 
 ## Separation Rule
 

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -30,4 +30,13 @@ pub struct VerifiedProgram {
 pub header: SemcodeHeaderSpec,
 pub functions: Vec<VerifiedFunction>,
 #[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct VerifiedSemCode<'a> {
+pub fn bytes(&self) -> &'a [u8] {
+pub fn program(&self) -> &VerifiedProgram {
+pub fn function_names(&self) -> impl Iterator<Item = &str> {
+pub fn has_entry(&self, entry: &str) -> bool {
+#[cfg(feature = "std")]
+pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
+#[cfg(feature = "std")]
 pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -32,10 +32,21 @@ pub functions: Vec<VerifiedFunction>,
 #[cfg(feature = "std")]
 #[derive(Debug)]
 pub struct VerifiedSemCode<'a> {
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntryResolutionError {
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct VerifiedEntrySemCode<'token, 'bytes> {
+pub fn artifact(&self) -> &'token VerifiedSemCode<'bytes> {
+pub fn entry(&self) -> &str {
+pub fn bytes(&self) -> &'bytes [u8] {
+pub fn program(&self) -> &VerifiedProgram {
 pub fn bytes(&self) -> &'a [u8] {
 pub fn program(&self) -> &VerifiedProgram {
 pub fn function_names(&self) -> impl Iterator<Item = &str> {
 pub fn has_entry(&self, entry: &str) -> bool {
+pub fn require_entry<'token>( &'token self, entry: &str, ) -> Result<VerifiedEntrySemCode<'token, 'a>, EntryResolutionError> {
 #[cfg(feature = "std")]
 pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
 #[cfg(feature = "std")]


### PR DESCRIPTION
Status: READY FOR MERGE
PR-PACK-3C

Title: feat(sm-verify): add VerifiedEntrySemCode layer

### What This Does
Builds upon the `VerifiedSemCode` admission token introduced in PR-3B by adding an entry resolution layer. It introduces:
- `EntryResolutionError`: A specific error type when a requested entrypoint does not exist in the verified module.
- `VerifiedEntrySemCode<'token, 'bytes>`: A zero-cost view token that binds a `VerifiedSemCode` artifact to a specific verified entrypoint string.
- `require_entry`: A method on `VerifiedSemCode` that returns a `VerifiedEntrySemCode` if the entry exists, or `EntryResolutionError` if it doesn't.

### Why It's Needed
This maintains the strict boundary that we've architected:
1. `VerifiedSemCode` proves the artifact is valid (which allows library/helper code without a `main` function).
2. `VerifiedEntrySemCode` proves that a specific entrypoint exists and is ready to execute.

This allows us to handle entrypoint resolution safely in `sm-verify` rather than having the VM reject execution, moving entrypoint resolution into the verified-token boundary before VM migration.

### Verification
- Added tests verifying behavior of `require_entry` on both executable SemCode and helper-only SemCode.
- Updated the `public_api_contracts` snapshot for `sm-verify`.
- `FullPreflight` script is passing cleanly.
