### PR TITLE
refactor(sm-vm): extract VmProgramView builder

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -564,6 +564,13 @@ fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
                 RuntimeError::BadFormat(msg)
             }
         })?;
+    build_vm_program_view_from_decoded(header, decoded_functions)
+}
+
+fn build_vm_program_view_from_decoded(
+    header: SemcodeHeaderSpec,
+    decoded_functions: Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope>,
+) -> Result<VmProgramView, RuntimeError> {
     let mut out = HashMap::new();
     let mut runtime_symbols = RuntimeSymbolTable::new();
 


### PR DESCRIPTION
Summary:
- Extracts VM runtime-state construction into build_vm_program_view_from_decoded.
- Keeps parse_semcode as the raw defensive parser entrypoint.
- Separates SemCode envelope decoding from VM runtime-state preparation.
- Preserves all existing validation, error mapping, and execution behavior.
- Does not introduce parser bypass.

Contract:
- No public API change.
- No RuntimeError change.
- No raw helper behavior change.
- No disasm_semcode behavior change.
- No compatibility shim change.
- No token constructor for VmProgramView.
- No CLI migration.
- No SemCode byte output change.
- No Cow/lifetime optimization.

Tests:
- cargo test -p sm-vm --quiet
- cargo test -p sm-verify --quiet
- cargo test --test semcode_boundary_characterization --quiet
- cargo test --test g1_execution_integrity --quiet
- cargo test --test public_api_contracts --quiet
- pwsh -File scripts/admission_guard.ps1 -FullPreflight
