### PR TITLE
refactor(sm-vm): use verified decoded envelopes for token preparation

### DIFF
--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -201,6 +201,20 @@ impl<'a> VerifiedSemCode<'a> {
             })
         }
     }
+
+    /// Workspace-internal accessor for VM preparation.
+    /// Exposes the decoded internal state safely without creating a stable public API.
+    #[cfg(feature = "std")]
+    #[doc(hidden)]
+    pub fn with_decoded_envelopes<R, F>(&self, f: F) -> R
+    where
+        F: for<'scope> FnOnce(
+            &'scope sm_emit::SemcodeHeaderSpec,
+            &'scope [sm_ir::semcode_decode::DecodedFunctionEnvelope<'a>],
+        ) -> R,
+    {
+        f(&self.program.header, &self.decoded)
+    }
 }
 
 /// Canonical admission gate for SemCode bytes.

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -363,7 +363,7 @@ pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config<
     capabilities: &C,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let program = parse_semcode(token.bytes())?;
+    let program = prepare_verified_execution(token)?;
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -419,7 +419,7 @@ pub fn run_verified_entry_semcode_with_ui_capabilities<
     capabilities: &C,
     ui_capabilities: &U,
 ) -> Result<(), RuntimeError> {
-    let program = parse_semcode(token.bytes())?;
+    let program = prepare_verified_execution(token)?;
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -453,7 +453,14 @@ pub fn run_verified_entry_semcode_with_config(
     token: &VerifiedEntrySemCode<'_, '_>,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    run_semcode_with_entry_and_config(token.bytes(), token.entry(), config)
+    let program = prepare_verified_execution(token)?;
+    run_vm_program_view_with_entry_and_config_with_observation_runtime(
+        program,
+        token.entry(),
+        config,
+        HelloObservationRuntime::discard(),
+    )
+    .map(|_| ())
 }
 
 /// Raw / compatibility helper.
@@ -475,9 +482,23 @@ fn run_semcode_with_entry_and_config_with_observation_runtime<'a>(
     bytes: &[u8],
     entry: &str,
     config: ExecutionConfig,
-    mut observation: HelloObservationRuntime<'a>,
+    observation: HelloObservationRuntime<'a>,
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let program = parse_semcode(bytes)?;
+    run_vm_program_view_with_entry_and_config_with_observation_runtime(
+        program,
+        entry,
+        config,
+        observation,
+    )
+}
+
+fn run_vm_program_view_with_entry_and_config_with_observation_runtime<'a>(
+    program: VmProgramView,
+    entry: &str,
+    config: ExecutionConfig,
+    mut observation: HelloObservationRuntime<'a>,
+) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -538,32 +559,50 @@ struct VmProgramView {
     functions: HashMap<String, FunctionBytecode>,
 }
 
+fn decode_and_map_errors(
+    bytes: &[u8],
+) -> Result<
+    (
+        SemcodeHeaderSpec,
+        Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope<'_>>,
+    ),
+    RuntimeError,
+> {
+    sm_ir::semcode_decode::decode_semcode_envelope(bytes).map_err(|e| match e {
+        sm_ir::semcode_decode::DecodeError::BadHeader => RuntimeError::BadHeader,
+        sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, supported } => {
+            RuntimeError::UnsupportedBytecodeVersion { found, supported }
+        }
+        sm_ir::semcode_decode::DecodeError::TruncatedFunction { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidFunctionName { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidStringTable { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidDebugSection { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::ResourceLimit { msg, .. } => {
+            RuntimeError::BadFormat(msg)
+        }
+    })
+}
+
 fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
-    let (header, decoded_functions) = sm_ir::semcode_decode::decode_semcode_envelope(bytes)
-        .map_err(|e| match e {
-            sm_ir::semcode_decode::DecodeError::BadHeader => RuntimeError::BadHeader,
-            sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, supported } => {
-                RuntimeError::UnsupportedBytecodeVersion { found, supported }
-            }
-            sm_ir::semcode_decode::DecodeError::TruncatedFunction { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidFunctionName { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidStringTable { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidDebugSection { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::ResourceLimit { msg, .. } => {
-                RuntimeError::BadFormat(msg)
-            }
-        })?;
+    let (header, decoded_functions) = decode_and_map_errors(bytes)?;
+    build_vm_program_view_from_decoded(header, decoded_functions)
+}
+
+fn prepare_verified_execution(
+    token: &VerifiedEntrySemCode<'_, '_>,
+) -> Result<VmProgramView, RuntimeError> {
+    let (header, decoded_functions) = decode_and_map_errors(token.bytes())?;
     build_vm_program_view_from_decoded(header, decoded_functions)
 }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -564,6 +564,13 @@ fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
                 RuntimeError::BadFormat(msg)
             }
         })?;
+    build_vm_program_view_from_decoded(header, decoded_functions)
+}
+
+fn build_vm_program_view_from_decoded(
+    header: SemcodeHeaderSpec,
+    decoded_functions: Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope>,
+) -> Result<VmProgramView, RuntimeError> {
     let mut out = HashMap::new();
     let mut runtime_symbols = RuntimeSymbolTable::new();
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -596,19 +596,22 @@ fn decode_and_map_errors(
 
 fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
     let (header, decoded_functions) = decode_and_map_errors(bytes)?;
-    build_vm_program_view_from_decoded(header, decoded_functions)
+    build_vm_program_view_from_decoded(header, &decoded_functions)
 }
 
 fn prepare_verified_execution(
     token: &VerifiedEntrySemCode<'_, '_>,
 ) -> Result<VmProgramView, RuntimeError> {
-    let (header, decoded_functions) = decode_and_map_errors(token.bytes())?;
-    build_vm_program_view_from_decoded(header, decoded_functions)
+    token
+        .artifact()
+        .with_decoded_envelopes(|header, decoded_functions| {
+            build_vm_program_view_from_decoded(header.clone(), decoded_functions)
+        })
 }
 
 fn build_vm_program_view_from_decoded(
     header: SemcodeHeaderSpec,
-    decoded_functions: Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope>,
+    decoded_functions: &[sm_ir::semcode_decode::DecodedFunctionEnvelope<'_>],
 ) -> Result<VmProgramView, RuntimeError> {
     let mut out = HashMap::new();
     let mut runtime_symbols = RuntimeSymbolTable::new();
@@ -619,7 +622,7 @@ fn build_vm_program_view_from_decoded(
 
         let debug_symbols = env
             .debug_symbols
-            .into_iter()
+            .iter()
             .map(|s| DebugSymbol {
                 pc: s.pc,
                 line: s.line,
@@ -632,9 +635,9 @@ fn build_vm_program_view_from_decoded(
             .map(|name| runtime_symbols.intern(name))
             .collect::<Vec<_>>();
 
-        let remap_paths = |paths: Vec<sm_ir::semcode_decode::DecodedAccessPath>| {
+        let remap_paths = |paths: &[sm_ir::semcode_decode::DecodedAccessPath]| {
             paths
-                .into_iter()
+                .iter()
                 .map(|path| {
                     let local_root = path.root_symbol_id as usize;
                     let root = symbol_ids
@@ -642,13 +645,13 @@ fn build_vm_program_view_from_decoded(
                         .copied()
                         .unwrap_or(SymbolId(path.root_symbol_id));
                     let mut p = AccessPath::new(root);
-                    for c in path.components {
+                    for c in &path.components {
                         match c {
                             sm_ir::semcode_decode::DecodedAccessPathComponent::TupleIndex(i) => {
-                                p = p.tuple_index(i);
+                                p = p.tuple_index(*i);
                             }
                             sm_ir::semcode_decode::DecodedAccessPathComponent::FieldSymbol(s) => {
-                                p = p.field(SymbolId(s));
+                                p = p.field(SymbolId(*s));
                             }
                         }
                     }
@@ -657,8 +660,8 @@ fn build_vm_program_view_from_decoded(
                 .collect::<Result<Vec<_>, RuntimeError>>()
         };
 
-        let borrowed_paths = remap_paths(env.borrowed_paths)?;
-        let write_paths = remap_paths(env.write_paths)?;
+        let borrowed_paths = remap_paths(&env.borrowed_paths)?;
+        let write_paths = remap_paths(&env.write_paths)?;
 
         let f = FunctionBytecode {
             name: name.clone(),

--- a/tests/golden_snapshots/public_api/sm_verify_lib.txt
+++ b/tests/golden_snapshots/public_api/sm_verify_lib.txt
@@ -48,6 +48,9 @@ pub fn function_names(&self) -> impl Iterator<Item = &str> {
 pub fn has_entry(&self, entry: &str) -> bool {
 pub fn require_entry<'token>( &'token self, entry: &str, ) -> Result<VerifiedEntrySemCode<'token, 'a>, EntryResolutionError> {
 #[cfg(feature = "std")]
+#[doc(hidden)]
+pub fn with_decoded_envelopes<R, F>(&self, f: F) -> R where F: for<'scope> FnOnce( &'scope sm_emit::SemcodeHeaderSpec, &'scope [sm_ir::semcode_decode::DecodedFunctionEnvelope<'a>], ) -> R, {
+#[cfg(feature = "std")]
 pub fn verify_semcode_token(bytes: &[u8]) -> Result<VerifiedSemCode<'_>, RejectReport> {
 #[cfg(feature = "std")]
 pub fn verify_semcode(bytes: &[u8]) -> Result<VerifiedProgram, RejectReport> {


### PR DESCRIPTION
Status:
implementation complete
commit created:
refactor(sm-vm): use verified decoded envelopes for token preparation
FullPreflight PASS
ready for PR after final file-list check

## PR-3N: Use verified decoded envelopes in VM preparation

This PR implements the verified token execution by leveraging the visitor API introduced in `VerifiedSemCode` to avoid redundant decoding of SemCode bytes.

### Changes
*   Exposed a visitor pattern `with_decoded_envelopes` in `sm-verify/src/lib.rs` under `#[doc(hidden)]` public API to allow execution consumers to borrow `DecodedFunctionEnvelope`s while respecting `VerifiedSemCode` invariants.
*   Updated `sm-vm/src/semcode_vm.rs` to accept `&[DecodedFunctionEnvelope]` during the internal `VmProgramView` construction instead of taking an owned `Vec`.
*   Modified `prepare_verified_execution` to call `with_decoded_envelopes` on the `VerifiedEntrySemCode` token, mapping the cached envelopes directly to `build_vm_program_view_from_decoded` without running `decode_and_map_errors(token.bytes())`.

### Integrity Maintained
*   The raw entrypoint `parse_semcode(bytes)` remains intact, continuing to parse from raw bytes.
*   No logic has been moved out of the VM preparation sequence; we've simply swapped a double-decode for a cache read.
*   The API boundary strictly prevents mutating the internal cached data, utilizing borrowed types appropriately.
*   The snapshot contract tests reflect the intentional API addition for `with_decoded_envelopes`.
