### PR TITLE
chore: clean up post-refactor compiler warnings

### DIFF
--- a/crates/prom-ui-demo/src/main.rs
+++ b/crates/prom-ui-demo/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
         })
         .expect("event loop must succeed");
 
-    session.close();
+    let _ = session.close();
 
     println!();
     println!("Session state after close: {:?}", session.state());
@@ -201,7 +201,7 @@ mod tests {
             })
             .expect("run must succeed");
 
-        session.close();
+        let _ = session.close();
         assert_eq!(session.state(), SessionState::Closed);
         assert_eq!(frame_count, 3);
     }

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -10713,6 +10713,7 @@ pub(crate) fn validate_binding_plan_conflicts(plan: &BindingPlan) -> Result<(), 
 }
 
 /// Determine whether the scrutinee is consumed (moved) by the plan.
+#[allow(dead_code)]
 pub(crate) fn scrutinee_use_from_plan(plan: &BindingPlan) -> ScrutineeUse {
     if plan.items.iter().any(|it| it.capture == CaptureMode::Move) {
         ScrutineeUse::Consumed

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
+#[allow(unused_imports)]
 mod semcode_format {
     pub use sm_emit::{
         read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8, Opcode,

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -363,7 +363,7 @@ pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config<
     capabilities: &C,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    let program = parse_semcode(token.bytes())?;
+    let program = prepare_verified_execution(token)?;
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -419,7 +419,7 @@ pub fn run_verified_entry_semcode_with_ui_capabilities<
     capabilities: &C,
     ui_capabilities: &U,
 ) -> Result<(), RuntimeError> {
-    let program = parse_semcode(token.bytes())?;
+    let program = prepare_verified_execution(token)?;
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -453,7 +453,14 @@ pub fn run_verified_entry_semcode_with_config(
     token: &VerifiedEntrySemCode<'_, '_>,
     config: ExecutionConfig,
 ) -> Result<(), RuntimeError> {
-    run_semcode_with_entry_and_config(token.bytes(), token.entry(), config)
+    let program = prepare_verified_execution(token)?;
+    run_vm_program_view_with_entry_and_config_with_observation_runtime(
+        program,
+        token.entry(),
+        config,
+        HelloObservationRuntime::discard(),
+    )
+    .map(|_| ())
 }
 
 /// Raw / compatibility helper.
@@ -475,9 +482,23 @@ fn run_semcode_with_entry_and_config_with_observation_runtime<'a>(
     bytes: &[u8],
     entry: &str,
     config: ExecutionConfig,
-    mut observation: HelloObservationRuntime<'a>,
+    observation: HelloObservationRuntime<'a>,
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let program = parse_semcode(bytes)?;
+    run_vm_program_view_with_entry_and_config_with_observation_runtime(
+        program,
+        entry,
+        config,
+        observation,
+    )
+}
+
+fn run_vm_program_view_with_entry_and_config_with_observation_runtime<'a>(
+    program: VmProgramView,
+    entry: &str,
+    config: ExecutionConfig,
+    mut observation: HelloObservationRuntime<'a>,
+) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
     let mut vm = VM {
         functions: program.functions,
         callstack: Vec::new(),
@@ -538,32 +559,50 @@ struct VmProgramView {
     functions: HashMap<String, FunctionBytecode>,
 }
 
+fn decode_and_map_errors(
+    bytes: &[u8],
+) -> Result<
+    (
+        SemcodeHeaderSpec,
+        Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope<'_>>,
+    ),
+    RuntimeError,
+> {
+    sm_ir::semcode_decode::decode_semcode_envelope(bytes).map_err(|e| match e {
+        sm_ir::semcode_decode::DecodeError::BadHeader => RuntimeError::BadHeader,
+        sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, supported } => {
+            RuntimeError::UnsupportedBytecodeVersion { found, supported }
+        }
+        sm_ir::semcode_decode::DecodeError::TruncatedFunction { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidFunctionName { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidStringTable { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidDebugSection { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { msg, .. } => {
+            RuntimeError::BadFormat(msg.to_string())
+        }
+        sm_ir::semcode_decode::DecodeError::ResourceLimit { msg, .. } => {
+            RuntimeError::BadFormat(msg)
+        }
+    })
+}
+
 fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
-    let (header, decoded_functions) = sm_ir::semcode_decode::decode_semcode_envelope(bytes)
-        .map_err(|e| match e {
-            sm_ir::semcode_decode::DecodeError::BadHeader => RuntimeError::BadHeader,
-            sm_ir::semcode_decode::DecodeError::UnsupportedVersion { found, supported } => {
-                RuntimeError::UnsupportedBytecodeVersion { found, supported }
-            }
-            sm_ir::semcode_decode::DecodeError::TruncatedFunction { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidFunctionName { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidStringTable { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidDebugSection { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::InvalidOwnershipSection { msg, .. } => {
-                RuntimeError::BadFormat(msg.to_string())
-            }
-            sm_ir::semcode_decode::DecodeError::ResourceLimit { msg, .. } => {
-                RuntimeError::BadFormat(msg)
-            }
-        })?;
+    let (header, decoded_functions) = decode_and_map_errors(bytes)?;
+    build_vm_program_view_from_decoded(header, decoded_functions)
+}
+
+fn prepare_verified_execution(
+    token: &VerifiedEntrySemCode<'_, '_>,
+) -> Result<VmProgramView, RuntimeError> {
+    let (header, decoded_functions) = decode_and_map_errors(token.bytes())?;
     build_vm_program_view_from_decoded(header, decoded_functions)
 }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -564,6 +564,13 @@ fn parse_semcode(bytes: &[u8]) -> Result<VmProgramView, RuntimeError> {
                 RuntimeError::BadFormat(msg)
             }
         })?;
+    build_vm_program_view_from_decoded(header, decoded_functions)
+}
+
+fn build_vm_program_view_from_decoded(
+    header: SemcodeHeaderSpec,
+    decoded_functions: Vec<sm_ir::semcode_decode::DecodedFunctionEnvelope>,
+) -> Result<VmProgramView, RuntimeError> {
     let mut out = HashMap::new();
     let mut runtime_symbols = RuntimeSymbolTable::new();
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -1,6 +1,6 @@
 use crate::semcode_format::{
-    read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, read_utf8, Opcode,
-    SemcodeFormatError, SemcodeHeaderSpec,
+    read_f64_le, read_i32_le, read_u16_le, read_u32_le, read_u8, Opcode, SemcodeFormatError,
+    SemcodeHeaderSpec,
 };
 use crate::QuadVal;
 use prom_abi::{AbiError, AbiValue, HostCallId, PrometheusHostAbi};
@@ -1022,6 +1022,7 @@ trait VmHostBridge {
     ///
     /// Default implementations return not-admitted. Overridden in
     /// `PrometheusVmHost` when a `UiCapabilityChecker` is provided.
+    #[allow(dead_code)] // intentionally retained as UI host bridge surface
     fn ui_window_create(&mut self) -> Result<(), RuntimeError> {
         Err(RuntimeError::BadFormat(
             "UI operations are not admitted in the current execution context; \
@@ -1029,6 +1030,7 @@ trait VmHostBridge {
                 .to_string(),
         ))
     }
+    #[allow(dead_code)] // intentionally retained as UI host bridge surface
     fn ui_window_run(&mut self) -> Result<(), RuntimeError> {
         Err(RuntimeError::BadFormat(
             "UI operations are not admitted in the current execution context; \
@@ -1036,6 +1038,7 @@ trait VmHostBridge {
                 .to_string(),
         ))
     }
+    #[allow(dead_code)] // intentionally retained as UI host bridge surface
     fn ui_event_poll(&mut self) -> Result<(), RuntimeError> {
         Err(RuntimeError::BadFormat(
             "UI operations are not admitted in the current execution context; \
@@ -1043,6 +1046,7 @@ trait VmHostBridge {
                 .to_string(),
         ))
     }
+    #[allow(dead_code)] // intentionally retained as UI host bridge surface
     fn ui_frame_submit(&mut self) -> Result<(), RuntimeError> {
         Err(RuntimeError::BadFormat(
             "UI operations are not admitted in the current execution context; \
@@ -1166,6 +1170,7 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker> VmHostBridge for Prometheus
 struct PrometheusUiVmHost<'a, H: PrometheusHostAbi, C: CapabilityChecker, U: UiCapabilityChecker> {
     host: &'a mut H,
     capabilities: &'a C,
+    #[allow(dead_code)] // intentionally retained as UI host bridge surface
     ui_capabilities: &'a U,
 }
 
@@ -3018,6 +3023,7 @@ fn disasm_one(f: &FunctionBytecode, pc: usize) -> Result<(String, usize), Runtim
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::semcode_format::read_utf8;
     use sm_emit::{
         compile_program_to_semcode, OWNERSHIP_EVENT_KIND_BORROW, OWNERSHIP_EVENT_KIND_WRITE,
         OWNERSHIP_PATH_COMPONENT_FIELD_SYMBOL, OWNERSHIP_PATH_COMPONENT_TUPLE_INDEX,

--- a/tests/pcc2_numeric_diagnostics.rs
+++ b/tests/pcc2_numeric_diagnostics.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/tests/pcc3_text_diagnostics.rs
+++ b/tests/pcc3_text_diagnostics.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/tests/support/cli_artifact_support.rs
+++ b/tests/support/cli_artifact_support.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use sm_front::types::{
     AstArena, ExecutableImport, Expr, ExprId, Function, Stmt, StmtId, SymbolId, TokenKind, Type,
 };


### PR DESCRIPTION
Summary:

* Cleans up post-refactor Rust compiler warnings after the verified-execution/token-boundary work.
* Removes or isolates unused imports where safe.
* Preserves intentional UI host bridge methods with narrow `#[allow(dead_code)]` annotations.
* Fixes unused `Result` handling in `prom-ui-demo`.
* Keeps diagnostic/test helper code available while silencing test-only dead-code warnings.

Contract:

* No runtime behavior change.
* No public API change.
* No SemCode byte output change.
* No CLI output change.
* No verifier/token/VM boundary change.
* No PCC/CTF fixture behavior change.
* No public API snapshot update expected.

Verification:

* `cargo check --workspace --all-targets`
* `cargo fmt --all`
* `cargo test --workspace --quiet`
* `cargo test --test public_api_contracts --quiet`
* `pwsh -File scripts/admission_guard.ps1 -FullPreflight`

Notes:
Intentional bridge surfaces are retained rather than deleted. This keeps future UI/capability ABI work possible while restoring a clean warning baseline.
