### PR TITLE
docs: classify VM token execution policy

### DIFF
--- a/crates/prom-runtime/src/lib.rs
+++ b/crates/prom-runtime/src/lib.rs
@@ -352,10 +352,18 @@ impl<'a, H: PrometheusHostAbi, C: CapabilityChecker> ExecutionSession<'a, H, C> 
         apply_rule_audit_note_effects(trail, rule)
     }
 
+    /// Public compatibility API accepting bytes.
+    ///
+    /// Internally routes through verified token admission and VM token execution.
+    /// Retained for public compatibility and is not evidence that `sm-vm` canonical execution is byte-first.
     pub fn run_verified_semcode(&mut self, bytes: &[u8]) -> Result<(), RuntimeError> {
         self.run_verified_semcode_entry(bytes, "main")
     }
 
+    /// Public compatibility API accepting bytes.
+    ///
+    /// Internally routes through verified token admission and VM token execution.
+    /// Retained for public compatibility and is not evidence that `sm-vm` canonical execution is byte-first.
     pub fn run_verified_semcode_entry(
         &mut self,
         bytes: &[u8],
@@ -510,10 +518,18 @@ impl<'a, B: GateBinding, C: CapabilityChecker> GateExecutionSession<'a, B, C> {
         apply_rule_audit_note_effects(trail, rule)
     }
 
+    /// Public compatibility API accepting bytes.
+    ///
+    /// Internally routes through verified token admission and VM token execution.
+    /// Retained for public compatibility and is not evidence that `sm-vm` canonical execution is byte-first.
     pub fn run_verified_semcode(&mut self, bytes: &[u8]) -> Result<(), RuntimeError> {
         self.run_verified_semcode_entry(bytes, "main")
     }
 
+    /// Public compatibility API accepting bytes.
+    ///
+    /// Internally routes through verified token admission and VM token execution.
+    /// Retained for public compatibility and is not evidence that `sm-vm` canonical execution is byte-first.
     pub fn run_verified_semcode_entry(
         &mut self,
         bytes: &[u8],

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -213,10 +213,11 @@ impl core::fmt::Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
-/// Raw / compatibility helper.
+/// Raw execution path.
 ///
-/// Executes raw SemCode bytes without a verifier admission gate.
-/// Not part of the canonical execution path.
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes.
+/// Intentionally retained for tests, diagnostics, and malformed-byte behavior.
+/// Must not be confused with verified execution.
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     run_semcode_with_config(
         bytes,
@@ -224,10 +225,11 @@ pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     )
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
 ///
-/// Internally routes through `verify_semcode_token` and `require_entry`,
-/// preserving the legacy public API signature.
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry("main").map_err(|err| match err {
@@ -239,7 +241,11 @@ pub fn run_verified_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
     )
 }
 
-/// Raw / compatibility helper.
+/// Raw execution path.
+///
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes.
+/// Intentionally retained for tests, diagnostics, and malformed-byte behavior.
+/// Must not be confused with verified execution.
 pub fn run_semcode_collecting_hello_observations(
     bytes: &[u8],
 ) -> Result<Vec<HelloObservationEvent>, RuntimeError> {
@@ -254,7 +260,11 @@ pub fn run_semcode_collecting_hello_observations(
     Ok(collected)
 }
 
-/// Raw / compatibility helper.
+/// Raw execution path.
+///
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes.
+/// Intentionally retained for tests, diagnostics, and malformed-byte behavior.
+/// Must not be confused with verified execution.
 pub fn run_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeError> {
     run_semcode_with_entry_and_config(
         bytes,
@@ -263,12 +273,20 @@ pub fn run_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeEr
     )
 }
 
-/// Raw / compatibility helper.
+/// Raw execution path.
+///
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes.
+/// Intentionally retained for tests, diagnostics, and malformed-byte behavior.
+/// Must not be confused with verified execution.
 pub fn run_semcode_with_config(bytes: &[u8], config: ExecutionConfig) -> Result<(), RuntimeError> {
     run_semcode_with_entry_and_config(bytes, "main", config)
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode_with_config(
     bytes: &[u8],
     config: ExecutionConfig,
@@ -280,7 +298,11 @@ pub fn run_verified_semcode_with_config(
     run_verified_entry_semcode_with_config(&entry_token, config)
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), RuntimeError> {
     let token = verify_semcode_token(bytes).map_err(RuntimeError::VerifierRejected)?;
     let entry_token = token.require_entry(entry).map_err(|err| match err {
@@ -292,7 +314,11 @@ pub fn run_verified_semcode_with_entry(bytes: &[u8], entry: &str) -> Result<(), 
     )
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode_with_entry_and_config(
     bytes: &[u8],
     entry: &str,
@@ -305,7 +331,11 @@ pub fn run_verified_semcode_with_entry_and_config(
     run_verified_entry_semcode_with_config(&entry_token, config)
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode_with_host_and_capabilities<
     H: PrometheusHostAbi,
     C: CapabilityChecker,
@@ -326,7 +356,11 @@ pub fn run_verified_semcode_with_host_and_capabilities<
     )
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 pub fn run_verified_semcode_with_host_and_capabilities_and_config<
     H: PrometheusHostAbi,
     C: CapabilityChecker,
@@ -349,11 +383,11 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config<
     )
 }
 
-/// Canonical verified execution.
+/// Canonical verified token execution path.
 ///
-/// This is the canonical entry point for verified execution with host bindings.
+/// This is the canonical and preferred path for internal verified execution.
 /// It requires a `VerifiedEntrySemCode` token, ensuring that admission
-/// and entry resolution have already occurred.
+/// and entry resolution have already occurred, and does not accept raw bytes.
 pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config<
     H: PrometheusHostAbi,
     C: CapabilityChecker,
@@ -378,7 +412,11 @@ pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config<
     exec_loop(&mut vm, &mut bridge, &mut observation)
 }
 
-/// Compatibility verified shim.
+/// Compatibility verified-bytes shim.
+///
+/// Preserves older byte-based call sites. Internally performs admission through
+/// `verify_semcode_token`, resolves the entry via `require_entry`, and delegates
+/// to canonical token execution. It should not be preferred for new internal callers.
 ///
 /// Run verified SemCode with both a standard capability checker and a UI
 /// capability checker.
@@ -408,7 +446,11 @@ pub fn run_verified_semcode_with_ui_capabilities<
     )
 }
 
-/// Canonical verified execution.
+/// Canonical verified token execution path.
+///
+/// This is the canonical and preferred path for internal verified execution.
+/// It requires a `VerifiedEntrySemCode` token, ensuring that admission
+/// and entry resolution have already occurred, and does not accept raw bytes.
 pub fn run_verified_entry_semcode_with_ui_capabilities<
     H: PrometheusHostAbi,
     C: CapabilityChecker,
@@ -438,7 +480,11 @@ pub fn run_verified_entry_semcode_with_ui_capabilities<
     exec_loop(&mut vm, &mut bridge, &mut observation)
 }
 
-/// Canonical verified execution.
+/// Canonical verified token execution path.
+///
+/// This is the canonical and preferred path for internal verified execution.
+/// It requires a `VerifiedEntrySemCode` token, ensuring that admission
+/// and entry resolution have already occurred, and does not accept raw bytes.
 pub fn run_verified_entry_semcode(
     token: &VerifiedEntrySemCode<'_, '_>,
 ) -> Result<(), RuntimeError> {
@@ -448,7 +494,11 @@ pub fn run_verified_entry_semcode(
     )
 }
 
-/// Canonical verified execution.
+/// Canonical verified token execution path.
+///
+/// This is the canonical and preferred path for internal verified execution.
+/// It requires a `VerifiedEntrySemCode` token, ensuring that admission
+/// and entry resolution have already occurred, and does not accept raw bytes.
 pub fn run_verified_entry_semcode_with_config(
     token: &VerifiedEntrySemCode<'_, '_>,
     config: ExecutionConfig,
@@ -463,7 +513,11 @@ pub fn run_verified_entry_semcode_with_config(
     .map(|_| ())
 }
 
-/// Raw / compatibility helper.
+/// Raw execution path.
+///
+/// Bypasses `sm-verify` admission and executes raw SemCode bytes.
+/// Intentionally retained for tests, diagnostics, and malformed-byte behavior.
+/// Must not be confused with verified execution.
 pub fn run_semcode_with_entry_and_config(
     bytes: &[u8],
     entry: &str,
@@ -516,10 +570,10 @@ fn run_vm_program_view_with_entry_and_config_with_observation_runtime<'a>(
     }
 }
 
-/// Raw diagnostic path.
+/// Diagnostic raw-byte path.
 ///
-/// Parses SemCode for diagnostic output without verifier enforcement.
-/// Not part of the execution path.
+/// Intentionally parses raw SemCode for diagnostic output without verifier enforcement.
+/// Not a verified execution API.
 pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {
     let program = parse_semcode(bytes)?;
     let spec = program.header;


### PR DESCRIPTION
Summary:

* Documents the VM verified execution policy after the token-boundary work.
* Marks `run_verified_entry_semcode*` as the canonical verified token execution path.
* Marks `run_verified_semcode*` as compatibility verified-bytes shims.
* Marks `run_semcode*` as raw execution APIs that bypass verifier admission.
* Marks `disasm_semcode` as a diagnostic raw-byte path.
* Documents `prom-runtime` byte-based APIs as public compatibility wrappers over token admission and VM token execution.

Contract:

* No runtime behavior change.
* No public API signature change.
* No RuntimeError or RejectReport change.
* No SemCode byte output change.
* No CLI behavior change.
* No test migration.
* No compatibility shim removal.
* No raw helper removal.

Verification:

* `cargo fmt --all --check`
* `cargo test -p sm-vm --quiet`
* `cargo test -p prom-runtime --quiet`
* `cargo test --test public_api_contracts --quiet`
* `pwsh scripts/admission_guard.ps1 -PRReady`
* `pwsh scripts/admission_guard.ps1 -FullPreflight`

Notes:
This PR does not declare the VM fully token-first yet. It documents the current policy: canonical verified execution is token-based, while byte-based verified APIs remain compatibility shims.
