### PR TITLE
docs: improve CLI quickstart readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,9 +326,9 @@ The repository intentionally retains a narrow compatibility perimeter. It is not
 
 New architecture must land in the appropriate owner crate, not in compatibility paths.
 
-## Quickstart
+## CLI Quickstart
 
-This quickstart is a **zero-effect verifier smoke path**. It proves the core pipeline:
+This quickstart is the recommended first pass for a new user. It is a **zero-effect verifier smoke path** that proves the core pipeline:
 
 ```text
 source -> check -> compile -> verify -> run -> disasm
@@ -413,6 +413,10 @@ The smoke path should:
 - produce disassembly containing the compiled `main` function.
 
 For controlled text observation / Hello World work, follow the active M-Hello documents under `docs/language/semantic_hello_*`.
+
+For the full CLI contract and command semantics, see `docs/spec/cli.md`.
+
+The current `smc 7hell <file.sm> [--json]` path exists as a diagnostic/readiness route. It is useful for qualification and report review, but it is not the normal beginner onboarding flow.
 
 For a fuller onboarding path, see:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,8 @@ This guide gives an external engineer the shortest honest path from clone to:
 - building the public CLI entrypoints
 - checking and running a minimal program
 - compiling and verifying a `.smc` artifact
-- running one canonical example from the current readiness contour
+- running the verified artifact and inspecting it when needed
+- optionally reviewing the current diagnostic/readiness path
 
 This is an onboarding guide, not a release-promotion document. Current `main`
 includes landed work beyond the published stable line, so release reading still
@@ -45,12 +46,6 @@ Check the source:
 cargo run --bin smc -- check program.sm
 ```
 
-Run the source directly:
-
-```powershell
-cargo run --bin smc -- run program.sm
-```
-
 Compile to SemCode:
 
 ```powershell
@@ -74,6 +69,17 @@ Disassemble the compiled artifact:
 ```powershell
 cargo run --bin svm -- disasm program.smc
 ```
+
+If you want to run from source instead of the verified artifact route, `smc run program.sm` remains the source-execution workflow command. The practical onboarding order is still:
+
+1. write or use a small `.sm` example
+2. check source
+3. compile to SemCode
+4. verify the compiled artifact
+5. run the verified artifact
+6. disassemble if needed
+
+The current baseline also exposes `smc 7hell program.sm [--json]` as a diagnostic/readiness path. Use it for report-quality checks and qualification review, not as the normal first-run route.
 
 ## Canonical Example Loop
 

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -37,6 +37,7 @@ The admitted `smc` command surface is currently:
 - `run`
 - `run-smc`
 - `disasm`
+- `7hell`
 
 Current accepted usage forms are:
 
@@ -59,6 +60,7 @@ Current accepted usage forms are:
 - `smc run <input.sm|project-root>`
 - `smc run-smc <input.smc>`
 - `smc disasm <input.smc>`
+- `smc 7hell <input.sm> [--json]`
 
 This draft does not claim that every command is permanently frozen, but it defines the current public CLI surface that tooling may rely on.
 
@@ -92,6 +94,19 @@ The following inspection commands are public workflow surface, but their plain-t
 - `smc hash-ir`
 - `smc hash-smc`
 - `smc disasm`
+
+## Diagnostic / Readiness Path
+
+`smc 7hell` is the current single-file diagnostic/readiness route. It is a
+compatibility and qualification path, not the normal beginner onboarding flow.
+
+Current command surface:
+
+- `smc 7hell <input.sm> [--json]`
+
+Current output rule:
+
+- `smc 7hell` emits either human-readable text or JSON via `--json`
 
 ## Output Modes
 


### PR DESCRIPTION
Improves user-facing CLI onboarding for the existing smc/svm flow after the v0.1.0-baseline release. Docs-only; no runtime behavior changes.