### PR TITLE
docs: clarify practical core boundary example

### DIFF
--- a/docs/examples_index.md
+++ b/docs/examples_index.md
@@ -78,8 +78,9 @@ cargo run --bin smc -- check examples/canonical/positive_selected_import/src/mai
 ### `boundary_alias_import`
 
 - path: `examples/canonical/boundary_alias_import/`
-- purpose: honest boundary example showing that executable-path alias import is still rejected
+- purpose: intentional boundary example showing that executable-path alias import is still rejected
 - current reading: `out of scope`
+- note: this is not a supported workflow; it documents a current executable-module / alias-import limit in the current baseline
 - first command:
 
 ```powershell
@@ -89,6 +90,8 @@ cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.s
 Expected result:
 
 - this example should fail with the current executable import boundary diagnostic
+- it should not be treated as a failing canonical success example
+- future support requires an explicit language/source-admission change
 
 ## Validation
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -79,6 +79,8 @@ If you want to run from source instead of the verified artifact route, `smc run 
 5. run the verified artifact
 6. disassemble if needed
 
+The admitted Practical Core path uses explicit source/project-root entry resolution through the current bounded admission model.
+
 The current baseline also exposes `smc 7hell program.sm [--json]` as a diagnostic/readiness path. Use it for report-quality checks and qualification review, not as the normal first-run route.
 
 ## Canonical Example Loop
@@ -138,4 +140,4 @@ The canonical examples pack includes one honest boundary example:
 
 - `examples/canonical/boundary_alias_import/`
 
-It exists to show a real current limit, not a supported workflow.
+It exists to show a real current limit, not a supported workflow, and future support for that alias-import form would require an explicit language/source-admission change.

--- a/examples/canonical/boundary_alias_import/README.md
+++ b/examples/canonical/boundary_alias_import/README.md
@@ -1,10 +1,13 @@
 # boundary_alias_import
 
-- purpose: honest boundary example for the still-blocked top-level alias import
-  form on the executable path
+- purpose: intentional boundary example for the still-blocked top-level alias
+  import form on the executable path
 - demonstrates:
   - `Import "helper.sm" as Helper`
   - current executable-path narrowing
+- note:
+  - this is not a supported workflow in the current baseline
+  - future support requires an explicit language/source-admission change
 - commands:
   - `cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.sm`
 - expected output:


### PR DESCRIPTION
Clarifies the existing executable-module / alias-import boundary example without changing runtime behavior, tests, CLI behavior, or release state.