### PR TITLE
test: add PCC8 stdlib print arity diagnostic

### DIFF
--- a/tests/fixtures/pcc8_stdlib_diagnostics/negative_print_wrong_arity.sm
+++ b/tests/fixtures/pcc8_stdlib_diagnostics/negative_print_wrong_arity.sm
@@ -1,0 +1,4 @@
+fn main() {
+    print();
+    return;
+}

--- a/tests/pcc8_stdlib_diagnostics.rs
+++ b/tests/pcc8_stdlib_diagnostics.rs
@@ -289,3 +289,12 @@ fn pcc8_to_text_sequence_rejects_and_does_not_verify() {
 fn pcc8_to_text_map_rejects_and_does_not_verify() {
     assert_to_text_map_rejects();
 }
+
+#[test]
+fn pcc8_print_wrong_arity_rejects_and_does_not_verify() {
+    assert_invalid_stdlib_source_does_not_verify(
+        "negative_print_wrong_arity.sm",
+        "E0201",
+        "builtin 'print' takes exactly one positional argument",
+    );
+}


### PR DESCRIPTION
Adds one focused PCC8 stdlib negative diagnostic fixture using existing behavior and stable user-facing markers. Test-only; no runtime, parser, verifier, CLI, docs, CI, or release changes.