### PR TITLE
test: add PCC6 Option/Result diagnostic fixture

### DIFF
--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_none_payload.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_none_payload.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let x: Option(i32) = Option::None(1);
+    return;
+}

--- a/tests/pcc6_option_result_diagnostics.rs
+++ b/tests/pcc6_option_result_diagnostics.rs
@@ -176,3 +176,12 @@ fn pcc6_result_match_arm_result_type_mismatch_rejects_and_does_not_verify() {
         "match expression branch type mismatch",
     );
 }
+
+#[test]
+fn pcc6_option_none_payload_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_none_payload.sm",
+        "E0201",
+        "Option::None does not accept payload items",
+    );
+}


### PR DESCRIPTION
Adds one focused PCC6 Option/Result negative diagnostic fixture using existing behavior and stable user-facing markers. Test-only; no runtime widening, no stdlib expansion, no parser/lowering/verifier/VM changes, no docs-only chain, and no refactor.