### PR TITLE
test: add PCC6 Option/Result diagnostic fixture

### DIFF
--- a/tests/fixtures/pcc6_option_result_diagnostics/negative_option_some_wrong_arity.sm
+++ b/tests/fixtures/pcc6_option_result_diagnostics/negative_option_some_wrong_arity.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let x: Option(i32) = Option::Some();
+    return;
+}

--- a/tests/pcc6_option_result_diagnostics.rs
+++ b/tests/pcc6_option_result_diagnostics.rs
@@ -185,3 +185,12 @@ fn pcc6_option_none_payload_rejects_and_does_not_verify() {
         "Option::None does not accept payload items",
     );
 }
+
+#[test]
+fn pcc6_option_some_wrong_arity_rejects_and_does_not_verify() {
+    assert_invalid_option_result_source_does_not_verify(
+        "negative_option_some_wrong_arity.sm",
+        "E0000",
+        "enum constructor payload cannot be empty parentheses; omit '()' for unit variant",
+    );
+}


### PR DESCRIPTION
Adds one focused PCC6 Option/Result negative diagnostic fixture using existing fixture/test patterns.\n\nThis PR also validates the new Semantic Source Authoring Guard workflow:\n- fixture-first .sm authoring\n- no invented Semantic syntax\n- one diagnostic boundary only\n\nScope:\n- one PCC6 test case\n- one PCC6 fixture\n- no runtime widening\n- no parser/lowering/verifier/VM changes\n- no stdlib expansion\n- no docs-only chain\n- no refactor\n\nValidation:\n- cargo test --test pcc6_option_result_diagnostics --quiet\n- pwsh scripts\\admission_guard.ps1 -PRReady\n- pwsh scripts\\admission_guard.ps1 -Readiness\n- pwsh scripts\\admission_guard.ps1 -FullPreflight