### PR TITLE
test: add PCC5 ADT pattern-family diagnostic fixture

### DIFF
--- a/tests/fixtures/pcc5_adt_diagnostics/negative_match_pattern_type_mismatch.sm
+++ b/tests/fixtures/pcc5_adt_diagnostics/negative_match_pattern_type_mismatch.sm
@@ -1,0 +1,22 @@
+enum Direction {
+    North,
+    South,
+}
+
+enum Signal {
+    Red,
+    Green,
+}
+
+fn main() {
+    let d: Direction = Direction::North;
+
+    let x: i32 = match d {
+        Signal::Red => { 1 }
+        Direction::North => { 2 }
+        Direction::South => { 3 }
+    };
+
+    let _ = x;
+    return;
+}

--- a/tests/pcc5_adt_diagnostics.rs
+++ b/tests/pcc5_adt_diagnostics.rs
@@ -157,3 +157,12 @@ fn pcc5_match_unknown_variant_and_result_diagnostics_are_stable() {
         assert_invalid_adt_source_does_not_verify(rel, code, needle);
     }
 }
+
+#[test]
+fn pcc5_match_pattern_family_mismatch_rejects_and_does_not_verify() {
+    assert_invalid_adt_source_does_not_verify(
+        "negative_match_pattern_type_mismatch.sm",
+        "E0201",
+        "match arm pattern type 'Signal' does not match scrutinee enum 'Direction'",
+    );
+}


### PR DESCRIPTION
Adds one focused PCC5 ADT negative diagnostic fixture for match arm pattern-family mismatch.

Selected gap:
- ADT match arm pattern family mismatch
- example: Signal pattern used while matching Direction scrutinee

Scope:
- one PCC5 test case
- one PCC5 fixture
- no runtime widening
- no parser/lowering/verifier/VM changes
- no stdlib expansion
- no docs-only chain
- no refactor

Validation:
- cargo test --test pcc5_adt_diagnostics --quiet
- pwsh scripts/admission_guard.ps1 -PRReady
- pwsh scripts/admission_guard.ps1 -Readiness
- pwsh scripts/admission_guard.ps1 -FullPreflight