### PR TITLE
test: add PCC7 sequence index diagnostic fixture

### DIFF
--- a/tests/fixtures/pcc7_collections_diagnostics/negative_sequence_index_type_mismatch.sm
+++ b/tests/fixtures/pcc7_collections_diagnostics/negative_sequence_index_type_mismatch.sm
@@ -1,0 +1,5 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    let first: i32 = values[true];
+    return;
+}

--- a/tests/pcc7_collections_diagnostics.rs
+++ b/tests/pcc7_collections_diagnostics.rs
@@ -237,3 +237,12 @@ fn pcc7_sequence_pop_empty_traps_deterministically() {
 fn pcc7_sequence_index_requires_i32_index_rejects() {
     assert_sequence_index_type_error("true", "sequence indexing currently requires i32 index");
 }
+
+#[test]
+fn pcc7_sequence_index_type_mismatch_fixture_rejects_and_does_not_verify() {
+    assert_invalid_collection_source_does_not_verify(
+        "negative_sequence_index_type_mismatch.sm",
+        "E0201",
+        "sequence indexing currently requires i32 index",
+    );
+}


### PR DESCRIPTION
Adds one focused PCC7 collections negative diagnostic fixture for sequence index type mismatch.\n\nSelected gap:\n- Sequence(T) indexed with non-i32 index\n- fixture-backed backfill for an existing stable diagnostic path\n\nScope:\n- one PCC7 test case\n- one PCC7 fixture\n- no production code\n- no parser/lowering/verifier/VM changes\n- no runtime widening\n- no stdlib expansion\n- no docs-only chain\n- no refactor\n\nValidation:\n- cargo test --test pcc7_collections_diagnostics --quiet\n- pwsh scripts/admission_guard.ps1 -PRReady\n- pwsh scripts/admission_guard.ps1 -Readiness\n- pwsh scripts/admission_guard.ps1 -FullPreflight