### PR TITLE
test: promote rule_state_decision application benchmark anchor

### DIFF
--- a/examples/canonical/rule_state_decision/README.md
+++ b/examples/canonical/rule_state_decision/README.md
@@ -1,5 +1,7 @@
 # rule_state_decision
 
+- benchmark-class application anchor: deterministic policy/admission decision
+  logic on the admitted surface
 - purpose: record-oriented rule/state decision logic with explicit
   `Result(T, E)` handling
 - demonstrates:
@@ -7,6 +9,7 @@
   - `quad`
   - contextual `Result::Ok` / `Result::Err`
   - explicit `match` settlement
+  - deterministic decision path with `assert(verdict == T)`
 - commands:
   - `cargo run --bin smc -- check examples/canonical/rule_state_decision/src/main.sm`
   - `cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm`
@@ -16,3 +19,7 @@
   - `check` succeeds
   - `run` exits successfully
   - `verify` accepts the compiled `.smc`
+- non-goals:
+  - no host effects
+  - no UI
+  - no package or release packaging work

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -79,6 +79,11 @@ fn canonical_positive_examples_check_run_compile_and_verify() {
 }
 
 #[test]
+fn canonical_rule_state_decision_is_the_first_application_completeness_anchor() {
+    check_run_compile_verify("examples/canonical/rule_state_decision/src/main.sm");
+}
+
+#[test]
 fn canonical_boundary_example_reports_current_alias_limit() {
     let input = repo_path("examples/canonical/boundary_alias_import/src/main.sm");
     let err = cli_err(


### PR DESCRIPTION
Promotes the existing canonical rule_state_decision example as the first Application Completeness benchmark-class anchor.

Scope:
- strengthens the existing canonical example/readme/test path
- documents deterministic policy/admission decision behavior
- keeps the example on admitted Semantic surface
- uses local validation only

Validation:
- cargo test --test canonical_examples --quiet
- smc check/run/compile/verify commands, if run
- pwsh scripts/admission_guard.ps1 -PRReady
- pwsh scripts/admission_guard.ps1 -Readiness
- pwsh scripts/admission_guard.ps1 -FullPreflight, if run

Non-goals:
- no new language/runtime behavior
- no parser/lowering/verifier/VM changes
- no stdlib expansion
- no UI/package/release packaging work
- no GitHub CI dependency
- no release/tag/publish claim
