### PR TITLE
test: promote data_audit_record_iterable benchmark anchor

### DIFF
--- a/examples/canonical/data_audit_record_iterable/README.md
+++ b/examples/canonical/data_audit_record_iterable/README.md
@@ -1,11 +1,14 @@
 # data_audit_record_iterable
 
+- benchmark-class application anchor: deterministic data-processing / record
+  workflow on the admitted surface
 - purpose: data-heavy audit pass over direct-record `Iterable` dispatch
 - demonstrates:
   - direct-record `Iterable` impls
   - `for value in samples`
   - immutable record update with `with { ... }`
   - boolean accumulation over record data
+  - assert-based proof
 - commands:
   - `cargo run --bin smc -- check examples/canonical/data_audit_record_iterable/src/main.sm`
   - `cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm`
@@ -15,3 +18,7 @@
   - `check` succeeds
   - `run` exits successfully
   - `verify` accepts the compiled `.smc`
+- non-goals:
+  - no host effects
+  - no UI
+  - no package or release packaging work

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -84,6 +84,11 @@ fn canonical_rule_state_decision_is_the_first_application_completeness_anchor() 
 }
 
 #[test]
+fn canonical_data_audit_record_iterable_is_the_second_application_completeness_anchor() {
+    check_run_compile_verify("examples/canonical/data_audit_record_iterable/src/main.sm");
+}
+
+#[test]
 fn canonical_boundary_example_reports_current_alias_limit() {
     let input = repo_path("examples/canonical/boundary_alias_import/src/main.sm");
     let err = cli_err(


### PR DESCRIPTION
Promotes the existing canonical data_audit_record_iterable example as the second Application Completeness benchmark-class anchor.

Scope:
- strengthens the canonical README
- adds a dedicated canonical test for the anchor
- documents deterministic data-processing / record workflow behavior
- keeps the example on admitted Semantic surface
- uses local validation only

Validation:
- cargo test --test canonical_examples --quiet
- cargo test --test g1_real_program_trial --quiet
- cargo test --test g1_benchmark_baseline --quiet
- smc check/run/compile/verify commands, if run
- pwsh scripts/admission_guard.ps1 -PRReady
- pwsh scripts/admission_guard.ps1 -Readiness
- pwsh scripts/admission_guard.ps1 -FullPreflight, if run

Non-goals:
- no Semantic source logic changes unless explicitly reported
- no new language/runtime behavior
- no parser/lowering/verifier/VM changes
- no stdlib expansion
- no package/UI/release packaging work
- no GitHub CI dependency
- no release/tag/publish claim
