### PR TITLE
test: promote cli_batch_core benchmark anchor

### DIFF
--- a/examples/canonical/cli_batch_core/README.md
+++ b/examples/canonical/cli_batch_core/README.md
@@ -1,10 +1,13 @@
 # cli_batch_core
 
+- benchmark-class application anchor: deterministic utility / batch-core
+  computation on the admitted surface
 - purpose: small CLI-style computation core over `Sequence(i32)` and `text`
 - demonstrates:
   - `Sequence(i32)` literals and iteration
-  - `text` production and equality
-  - single-file executable authoring
+  - deterministic text classification
+  - assert-based proof
+  - no host effects
 - commands:
   - `cargo run --bin smc -- check examples/canonical/cli_batch_core/src/main.sm`
   - `cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm`
@@ -14,3 +17,7 @@
   - `check` succeeds
   - `run` exits successfully
   - `verify` accepts the compiled `.smc`
+- non-goals:
+  - no real CLI IO readiness
+  - no command-line argument support
+  - no package or release packaging work

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -89,6 +89,11 @@ fn canonical_data_audit_record_iterable_is_the_second_application_completeness_a
 }
 
 #[test]
+fn canonical_cli_batch_core_is_the_third_application_completeness_anchor() {
+    check_run_compile_verify("examples/canonical/cli_batch_core/src/main.sm");
+}
+
+#[test]
 fn canonical_boundary_example_reports_current_alias_limit() {
     let input = repo_path("examples/canonical/boundary_alias_import/src/main.sm");
     let err = cli_err(


### PR DESCRIPTION
Promotes the existing canonical cli_batch_core example as the third Application Completeness benchmark-class anchor.\n\nScope:\n- strengthens the canonical README\n- adds a dedicated canonical test for the anchor\n- documents deterministic utility / batch-core computation\n- keeps the example on admitted Semantic surface\n- uses local validation only\n\nValidation:\n- cargo test --test canonical_examples --quiet\n- cargo test --test g1_real_program_trial --quiet\n- cargo test --test g1_benchmark_baseline --quiet\n- smc check/run/compile/verify commands, if run\n- pwsh scripts/admission_guard.ps1 -PRReady\n- pwsh scripts/admission_guard.ps1 -Readiness\n- pwsh scripts/admission_guard.ps1 -FullPreflight, if run\n\nNon-goals:\n- no Semantic source logic changes unless explicitly reported\n- no new language/runtime behavior\n- no parser/lowering/verifier/VM changes\n- no stdlib expansion\n- no package/UI/release packaging work\n- no GitHub CI dependency\n- no release/tag/publish claim