### PR TITLE
docs: clarify project-root check/run readiness path

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,25 @@ Recent work has moved the CLI pipeline to support a bounded project-root baselin
 - Deterministic compiler artifact chains and stale artifact protections.
 - Integrated local CI validation gates.
 
+#### Project-root readiness path
+
+The existing Project Model v0 readiness path is:
+
+```text
+cd <semantic-project-root>
+smc check .
+smc run .
+```
+
+The acceptance coverage already exercises both supported project-root shapes:
+
+- `semantic.toml` project roots;
+- `Semantic.package` package-baseline roots.
+
+That coverage also includes the explicit project-root argument form (`smc check <project-root>` / `smc run <project-root>`), alongside the `.` form from inside the root.
+
+This is readiness documentation only. GitHub CI is not the admission gate; local Admission Guard remains authoritative.
+
 ### Current guarantees / design posture
 
 Semantic currently prioritizes:


### PR DESCRIPTION
Clarifies the user-facing Project Model v0 readiness path for project-root `smc check` / `smc run`.

Scope:
- documents the existing project-root check/run workflow
- ties the path to existing project-root acceptance/diagnostic coverage
- keeps local Admission Guard as the authoritative validation signal
- keeps GitHub CI non-gating

Validation:
- git diff --check
- fast Semantic pre-commit gate passed during commit

Non-goals:
- no production code
- no test changes
- no Project Model redesign
- no package-system widening
- no PCC9 diagnostic reopening
- no GitHub CI dependency
- no release/tag/publish claim