### PR TITLE
docs: clarify Semantic.package baseline identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ That coverage also includes the explicit project-root argument form (`smc check 
 
 This is readiness documentation only. GitHub CI is not the admission gate; local Admission Guard remains authoritative.
 
+#### Package-baseline identity
+
+`Semantic.package` is the current package-baseline identity surface.
+
+In the current readiness model, that identity is bounded by the package manifest file and the fields already represented in the existing fixtures and tests:
+
+- package name, when present in the manifest;
+- `manifest_dir`;
+- `module_root`;
+- resolved entrypoint behavior used by `smc check` and `smc run`.
+
+This is package-baseline readiness, not a broader package registry or version-resolution system. The current behavior is already represented by the existing acceptance and diagnostic coverage for `Semantic.package`.
+
 ### Current guarantees / design posture
 
 Semantic currently prioritizes:


### PR DESCRIPTION
Clarifies the current `Semantic.package` package-baseline identity readiness model.

Scope:
- documents existing package-baseline identity behavior
- distinguishes `Semantic.package` from `semantic.toml` project roots
- keeps the model bounded to current manifest/package readiness
- keeps local Admission Guard as the authoritative validation signal
- keeps GitHub CI non-gating

Validation:
- git diff --check
- fast Semantic pre-commit gate passed during commit

Non-goals:
- no production code
- no test changes unless explicitly reported
- no Project Model redesign
- no package registry/dependency/versioning claims
- no package-system widening
- no PCC9 diagnostic reopening
- no GitHub CI dependency
- no release/tag/publish claim