### PR TITLE
docs: align i32 arithmetic readiness wording

### DIFF
--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -822,11 +822,14 @@ Current honest limit:
 - current `main` now also admits plain same-family `i32` relational operators
   through the existing verified compare opcodes
 - current `main` now also admits plain same-family `i32` unary `-` and binary
-  `+`, `-`, `*` through explicit lowering, verified opcodes, and VM execution
+  `+`, `-`, `*`, `/`, `%` through explicit lowering, verified opcodes, and VM
+  execution
+- division and modulo by zero currently surface as deterministic runtime
+  failures in the benchmark-negative fixtures
 - broader numeric relational surfaces for `u32`, `f64`, `fx`, and measured
   values remain outside the current application-completeness wave
-- broader integer arithmetic for `u32`, mixed numeric families, and `i32`
-  division remains outside the current first arithmetic wave
+- broader integer arithmetic for `u32` and mixed numeric families remains
+  outside the current first arithmetic wave
 - iteration, `len`, `is_empty`, maps, sets, and collection protocol machinery
   remain outside the current `M8.3` first-wave contract
 - current `main` now also admits one first-wave closure family through the

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -177,9 +177,10 @@ Current rules:
 - equality comparisons are valid inside the same family
 - plain same-family `i32` relational comparisons `>`, `<`, `>=`, `<=` are now
   admitted on current `main`
-- plain same-family `i32` unary `-` and binary `+`, `-`, `*` are now admitted
-  on current `main`
-- same-family `i32 / i32` remains outside the current first arithmetic wave
+- plain same-family `i32` unary `-` and binary `+`, `-`, `*`, `/`, `%` are now
+  admitted on current `main`
+- division and modulo by zero remain runtime failure edges exercised by the
+  current benchmark-negative fixtures
 - `u32` remains equality-only in the current first application-completeness wave
 - implicit cross-family numeric coercion is not part of the current contract
 


### PR DESCRIPTION
Aligns the public docs/spec wording for the bounded same-family `i32` arithmetic readiness slice.

Scope:
- documents the existing `i32` practical arithmetic contour consistently
- aligns `types.md` and `source_semantics.md` with existing fixtures/tests
- keeps `/` and `%` inside the bounded `i32` slice where current tests already exercise them
- preserves exclusions for mixed numeric families and broader numeric surfaces

Validation:
- git diff --check
- pwsh scripts/admission_guard.ps1 -PRReady, if run
- pwsh scripts/admission_guard.ps1 -Readiness, if run

Non-goals:
- no production code
- no test changes unless explicitly reported
- no parser/typechecker/runtime changes
- no new arithmetic behavior
- no mixed-family arithmetic
- no numeric redesign
- no published-stable promotion
- no GitHub CI dependency
- no release claim