### PR TITLE
docs: align text usability readiness wording

### DIFF
--- a/docs/roadmap/v1_readiness.md
+++ b/docs/roadmap/v1_readiness.md
@@ -86,6 +86,7 @@ The benchmark-qualified contour includes:
 
 - same-family `i32` relational operators and arithmetic (`+`, `-`, `*`, `/`, `%`)
 - mutable locals (`let mut` + reassignments) and loop control exits (`while`, `loop`, `break`, `continue`)
+- bounded text usability (`text` literals, same-family equality, `text + text`, explicit `to_text` for admitted scalar families)
 - built-in `Sequence(T)` persistent utilities (`len`, `push`, `pop`, `prepend`, `contains`)
 - persistent functional `Map(K, V)` lookup tables
 - deterministic seeded PRNG (xorshift64)

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -814,7 +814,9 @@ Current honest limit:
 - the published stable `v1.1.1` line still does not expose executable `text`
 - current `main` now admits `text` through the source type/equality layer and
   through the canonical runtime carrier for those admitted programs
-- text concatenation remains a later `M8.1` wave
+- current `main` now also admits bounded `text + text` concatenation and
+  explicit `to_text` for the admitted scalar families represented by the
+  existing fixtures
 - host-facing text ABI widening is still out of scope
 - current `main` now also admits one ordered sequence family with bracketed
   literals, same-family equality, and `expr[index]` through the canonical

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -81,8 +81,9 @@ Current honest baseline:
   in the same source path
 - current `main` admits same-family equality on `text`
 - current `main` now admits a canonical runtime text carrier for admitted
-  literal/equality programs
-- current `main` still does not admit text concatenation
+  literal/equality/concatenation/to_text programs
+- current `main` now admits `text + text` concatenation and explicit `to_text`
+  for the admitted scalar families represented by existing fixtures
 - current `main` does not widen the PROMETHEUS host ABI with text values
 
 Current text-surface limits:


### PR DESCRIPTION
Aligns the public docs/spec wording for the bounded text usability readiness slice.

Scope:
- documents the existing bounded `text` practical contour consistently
- aligns `source_semantics.md`, `types.md`, and `v1_readiness.md` with existing fixtures/tests
- keeps `text + text` and explicit `to_text` inside the bounded admitted slice where current fixtures already exercise them
- preserves exclusions for broad string-library behavior, implicit coercions, and broad IO

Validation:
- git diff --check
- pre-commit docs gate: PASS
- pwsh scripts/admission_guard.ps1 -PRReady: attempted, but blocked by a local cargo test / broken-pipe failure in the workspace test harness

Non-goals:
- no production code
- no test changes unless explicitly reported
- no parser/typechecker/runtime changes
- no new text behavior
- no broad string library
- no implicit scalar-to-text coercion
- no stdout / IO widening
- no published-stable promotion
- no GitHub CI dependency
- no release claim