### PR TITLE
docs: document opcode admission matrix

### DIFF
--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -257,7 +257,7 @@ Current SemCode admission validates:
 
 - header magic and supported version
 - section and function-layout integrity
-- opcode validity
+- opcode validity against the public opcode admission matrix in `verifier.md`
 - operand shape validity
 - jump-target validity
 - call-target validity

--- a/docs/spec/verifier.md
+++ b/docs/spec/verifier.md
@@ -38,6 +38,23 @@ Current SemCode verification checks include:
 - call-target validity
 - capability consistency with actual opcode usage
 
+## Opcode Admission Matrix
+
+The verifier treats opcode admission as part of SemCode admission.
+
+This matrix documents the current public admission boundary. It uses operation
+families rather than binary opcode numbers so that internal encodings can change
+without turning this document into a stable bytecode ISA promise.
+
+| Operation family | Admission status | Capability / boundary | Notes |
+| --- | --- | --- | --- |
+| Ordinary source-derived families: control flow, data movement, literal loading, arithmetic, comparison, calls, and returns | Admitted when produced by supported SemCode and consistent with the emitted contract | No extra capability beyond the artifact contract | Baseline verifier-admitted surface; this document intentionally does not stabilize binary opcode numbers. |
+| `SEQUENCE_LEN` | Admitted only when the emitted contract carries `CAP_SEQUENCE_ITERATION` and the header family supports the sequence-iteration contract | Capability-gated | Built-in sequence lowering opcode for the admitted `Sequence(T)` iteration slice. |
+| Effect-oriented host-boundary families such as `GateRead`, `GateWrite`, and `PulseEmit` | Admitted only when the emitted contract matches the required capability envelope | Capability-gated / host-boundary | These opcodes do not define capability policy semantics by themselves. |
+| Ownership transport payloads admitted through `OWN0` | Admitted structurally only when the ownership transport slice is present and well formed | Header and capability consistency required | This covers the currently documented tuple-only and direct record-field ownership transport slices. |
+| Unknown, unsupported, or malformed opcode encodings | Rejected | N/A | Rejection must happen before a successful VM execution path. |
+| Opcode streams that fail operand, jump-target, call-target, register-budget, string-reference, or section-integrity checks | Rejected | N/A | These are verifier admission failures, not successful runtime executions. |
+
 Current ownership-specific structural checks for ownership transport include:
 
 - `OWN0` section presence and layout validity when ownership transport is used


### PR DESCRIPTION
Documents the current opcode admission matrix for the FR-5 Verified Execution Closure track.

Scope:
- adds a compact public opcode/operation-family admission matrix
- clarifies admitted, rejected/unsupported, and capability-gated operation families
- keeps the verifier-first execution contract intact
- does not change SemCode format or VM behavior

Validation:
- git diff --check
- pwsh scripts/admission_guard.ps1 -PRReady
- pwsh scripts/admission_guard.ps1 -Readiness, if run

Non-goals:
- no production code
- no tests unless explicitly reported
- no new opcodes
- no opcode renaming
- no SemCode format change
- no VM/runtime redesign
- no capability widening
- no stable binary ISA claim
- no release claim
- no GitHub CI dependency
