### PR TITLE
docs: document FR-9 release qualification path

### DIFF
--- a/docs/roadmap/stable_release_policy.md
+++ b/docs/roadmap/stable_release_policy.md
@@ -58,6 +58,35 @@ validation remains green, including:
 - release asset smoke verification
 - release-facing docs matching actual repository behavior
 
+## FR-9 Release Qualification Path
+
+This path defines the order for release qualification. It does not produce a
+release, publish a stable version, or mark the project production-ready.
+
+| Step | Gate / check | Owner | Required before | Produces release artifact? | Notes |
+|---:|---|---|---|---|---|
+| 1 | Status freeze / scope check | release-facing docs | any release-candidate gate | No | Confirm the release target is explicit, no widened feature surface is smuggled in, current-main behavior is not silently promoted, and the public status vocabulary remains honest. |
+| 2 | `PRReady` local gate | `scripts/admission_guard.ps1` | readiness validation | No | Useful for PR admission, but not sufficient for release qualification. This is a local gate, not a GitHub CI dependency. |
+| 3 | `Readiness` local gate | `scripts/admission_guard.ps1` | full release-gate validation | No | Stronger readiness validation, but still not publication and not release-ready by itself. |
+| 4 | `FullPreflight` local gate candidate | `scripts/admission_guard.ps1` | release bundle or tag decision when explicitly scoped | No | Heavy local gate candidate. Do not run casually; use only under an explicit release-gate scope, not for ordinary docs PR validation. |
+| 5 | Release bundle verification | `scripts/verify_release_bundle.ps1` | asset smoke or release-candidate decision | No | Separate from ordinary PR readiness. Requires an explicit release-bundle candidate; documentation-only PRs do not create that bundle. |
+| 6 | Release asset smoke verification | `scripts/verify_release_assets.ps1` | publication decision | No | Separate from ordinary PR readiness. Requires explicit candidate artifacts; documentation-only PRs do not create artifacts. |
+| 7 | Release-facing docs / status review | public status and release-policy docs | final release decision | No | Public status must match actual behavior. Release notes, if used, must preserve the status disclaimer: published stable remains distinct from qualified limited release, and landed-on-main or current-main-only behavior must not be described as stable. |
+| 8 | Final human release decision | project owner / release owner | tag or publication | Yes, only if explicitly approved | Passing gates does not automatically publish. Stable publication requires an explicit later human decision. |
+
+FR-9 release qualification must not imply:
+
+- public stable release before an explicit publication decision;
+- production-ready status;
+- stable runtime ABI;
+- stable binary ISA;
+- package registry support;
+- dependency solving;
+- `smc new` support;
+- broad host IO;
+- GitHub CI authority;
+- release artifact creation by a documentation-only PR.
+
 ## Promotion Rule
 
 Behavior should be described as `published stable` only when:


### PR DESCRIPTION
Documents the FR-9 release qualification path as an ordered docs-only gate sequence.

Scope:
- defines gate order for PRReady, Readiness, FullPreflight, release bundle verification, asset smoke, release-facing docs review, and final human release decision
- keeps local Admission Guard authoritative
- keeps GitHub CI non-authoritative
- keeps release qualification planning separate from published stable status

Validation:
- git diff --check
- pwsh scripts/admission_guard.ps1 -PRReady

Non-goals:
- no production code
- no tests
- no release artifacts
- no FullPreflight
- no release-ready claim
- no public stable claim
- no production-ready claim
- no stable runtime ABI claim
- no stable binary ISA claim
- no package ecosystem expansion
- no smc new support
- no GitHub CI dependency
