### PR TITLE
workbench: expose spec index reader contract in catalog

### DIFF
--- a/apps/workbench/src-tauri/src/docs.rs
+++ b/apps/workbench/src-tauri/src/docs.rs
@@ -273,6 +273,13 @@ const DOC_ENTRIES: &[DocEntryDef] = &[
     title: "WBS",
     relative_path: "docs/roadmap/wbs.md",
   },
+  DocEntryDef {
+    key: "workbench_spec_index_reader",
+    section_key: "workbench",
+    section_title: "Workbench",
+    title: "Workbench Spec Index Reader v0",
+    relative_path: "docs/roadmap/workbench_spec_index_reader_v0.md",
+  },
 ];
 
 #[derive(Clone, Debug, Serialize)]


### PR DESCRIPTION
Expose the merged docs-only Workbench Spec Index Reader source contract through the existing read-only Workbench spec/docs catalog.

Scope:
- adds one DocEntryDef for docs/roadmap/workbench_spec_index_reader_v0.md
- keeps Workbench presentation-only
- preserves docs/spec/** and docs/roadmap/** as canonical sources
- does not add parser/typechecker/verifier/VM/runtime semantics
- does not add UI-owned readiness or release authority
- does not change command runner behavior

Validation:
- git diff --check
- cargo fmt --check --manifest-path apps/workbench/src-tauri/Cargo.toml, if available
- PRReady, if available
- Workbench build not run if node_modules / local tsc unavailable
- no FullPreflight
- no release artifacts
- cargo fmt note: workspace-wide cargo fmt check reported unrelated preexisting formatting diffs outside this one-entry patch; the PR diff itself is limited to one DocEntryDef in apps/workbench/src-tauri/src/docs.rs

Non-goals:
- no new Spec Index Reader implementation
- no App.tsx changes
- no docs semantic interpretation
- no release gate execution
- no compiler/verifier/VM/runtime changes
- no package/build config changes