### PR TITLE
docs(ui): expand Semantic UI DNA invariants

### DIFF
--- a/docs/dna/SEMANTIC_UI_DNA.md
+++ b/docs/dna/SEMANTIC_UI_DNA.md
@@ -120,6 +120,167 @@ Renderer adapts to Semantic.
 Semantic does not adapt itself to a foreign UI lifecycle.
 ```
 
+## Self-hosted App Shell DNA
+
+Semantic UI is not merely a UI model; it must become the foundation from which Semantic-authored application shells can be defined.
+
+Workbench and Semantic Studio must not become standalone product-level applications until Semantic can define and drive application UI shells through Semantic-owned UI model, UI AST / IR, admission rules, and renderer adapter contract.
+
+Workbench and Semantic Studio are future Semantic UI applications, not external centers of gravity.
+
+This strengthens the existing `#675` pause and does not close or weaken it.
+
+## Bootstrap Tooling DNA
+
+Temporary tooling may exist during bootstrap.
+
+Temporary Workbench surfaces may remain only as bounded presentation, orchestration, diagnostics, reports, and documentation tooling.
+
+Such tooling is scaffolding, not product UI.
+
+Temporary tooling must not become Semantic UI owner, semantic authority, release authority, Studio substitute, or Local Admission Guard replacement.
+
+React and Tauri may exist as current tooling shell dependencies, but they must not become the strategic Semantic UI architecture.
+
+## Authority Non-Transfer DNA
+
+UI may display truth. UI does not become truth.
+
+No UI surface may acquire authority over:
+
+- semantic meaning;
+- verifier admission;
+- VM/runtime behavior;
+- compiler/parser/typechecker behavior;
+- release readiness;
+- Local Admission Guard;
+- canonical documentation truth;
+- Semantic UI model ownership;
+- GitHub CI authority.
+
+UI presents evidence and projections.
+
+UI does not become the source of semantic, release, or admission truth.
+
+## Quad-State UI DNA
+
+Semantic UI must preserve uncertainty and conflict as first-class visible states.
+
+- `N` - unknown
+- `F` - false
+- `T` - true
+- `S` - conflict
+
+unknown is not absent.
+
+conflict is not merely failure.
+
+denied is not false.
+
+not admitted is not equivalent to invalid source.
+
+UI must not flatten Quad-state meaning into ordinary boolean UI status.
+
+## Evidence / Trace DNA
+
+Every meaningful UI claim should be traceable to source, admission, diagnostic, runtime, repository, or governance evidence.
+
+Distinguish:
+
+- raw output
+- repository document
+- verifier result
+- admission verdict
+- diagnostic source
+- runtime observation
+- cached UI projection
+- UI interpretation
+
+UI should make evidence provenance visible where practical.
+
+UI claims without evidence must not be presented as authoritative truth.
+
+## UI State Separation DNA
+
+Distinguish:
+
+- Semantic state
+- runtime state
+- admission state
+- repository truth
+- UI state
+- presentation cache
+- view-model projection
+
+UI state is projection/cache, not semantic state.
+
+UI state may help interaction and presentation.
+
+UI state must not redefine Semantic state or repository truth.
+
+## Fault / Denial / Recovery DNA
+
+Fault, denial, conflict, and recovery are first-class UI states.
+
+- denial
+- quarantine
+- rollback
+- conflict
+- partial admission
+- capability rejection
+- runtime fault
+- diagnostic uncertainty
+
+These states must not be hidden behind generic success/failure UI.
+
+Semantic UI should preserve the reason, boundary, and evidence for each denial or fault when available.
+
+## Operator Surface DNA
+
+Semantic UI is an operator surface, not an authority replacement.
+
+UI assists the operator.
+
+UI does not replace admission, verification, governance, or Local Admission Guard.
+
+The operator should be able to see what happened, why it happened, what evidence exists, what was blocked, what is allowed, and what is forbidden.
+
+## Semantic UI Maturity Ladder
+
+1. UI model names and inert types.
+2. UI Tree.
+3. UI AST.
+4. UI IR.
+5. capability/effect admission model.
+6. diagnostics/fault model.
+7. renderer adapter contract.
+8. Semantic-authored shell definition.
+9. bounded app shell prototype.
+10. Workbench / Studio only later as Semantic UI applications.
+
+Workbench / Studio product work before Semantic-authored shell capability is forbidden unless explicitly superseded by governance.
+
+Future model seed work belongs only to foundation stages, not product application stages.
+
+## R12 Expanded Formula
+
+```text
+Semantic UI =
+  Semantic-owned UI model
++ UI Tree
++ UI AST
++ UI IR
++ state/update/event discipline
++ capability/effect admission
++ quad-state visibility
++ evidence/trace discipline
++ fault/denial/recovery visibility
++ diagnostics/fault model
++ renderer adapter contract
++ self-hosted app shell capability
++ strict authority non-transfer
+```
+
 ## Close
 
 Semantic UI acknowledges the open-source ecosystem honestly while preserving its own architecture.


### PR DESCRIPTION
Expands Semantic UI DNA with additive R12 invariants.

Scope:

- preserves existing Semantic UI DNA doctrine
- adds self-hosted app shell DNA
- adds bootstrap tooling DNA
- adds authority non-transfer DNA
- adds quad-state UI DNA
- adds evidence/trace DNA
- adds UI state separation DNA
- adds fault/denial/recovery DNA
- adds operator surface DNA
- adds Semantic UI maturity ladder
- adds R12 expanded formula

Validation:

- git diff --check
- docs-only diff
- existing DNA strings preserved
- new DNA strings verified
- no code changes
- no manifest changes
- no FullPreflight
- no release artifacts

Non-goals:

- no UI implementation
- no Workbench implementation
- no Semantic Studio implementation
- no model seed code in this PR
- no renderer/backend dependency admission
- no browser/WebView ownership
- no widget framework scope
- no physical rename of apps/workbench
- no physical rename of docs/workbench
- no final API commitment
- no public release/stable/production-ready claim
- no compiler/verifier/VM/runtime changes
- no dependency additions
- no closure or weakening of #675