### PR TITLE
docs(ui): record AST validation posture and harden diagnostics

### DIFF
--- a/crates/prom-ui/src/validation.rs
+++ b/crates/prom-ui/src/validation.rs
@@ -101,6 +101,21 @@ impl UiAstValidationDiagnostics {
     pub fn diagnostics(&self) -> &[UiAstValidationDiagnostic] {
         &self.diagnostics
     }
+
+    /// Returns an iterator over the diagnostics.
+    pub fn iter(&self) -> core::slice::Iter<'_, UiAstValidationDiagnostic> {
+        self.diagnostics.iter()
+    }
+
+    /// Returns the first diagnostic, if any.
+    pub fn first(&self) -> Option<&UiAstValidationDiagnostic> {
+        self.diagnostics.first()
+    }
+
+    /// Converts the collection into a vector.
+    pub fn into_vec(self) -> Vec<UiAstValidationDiagnostic> {
+        self.diagnostics
+    }
 }
 
 /// Result of the minimal AST validation seed.
@@ -496,5 +511,135 @@ mod tests {
             .diagnostics()
             .iter()
             .any(|diagnostic| matches!(diagnostic.kind(), UiAstValidationDiagnosticKind::MissingParentTarget { node_id, parent_id } if node_id == UiAstNodeId::new(16) && parent_id == UiAstNodeId::new(17))));
+    }
+
+    #[test]
+    fn diagnostics_iter_matches_slice_order() {
+        let diagnostics = UiAstValidationDiagnostics::new(vec![
+            UiAstValidationDiagnostic::new(None, UiAstValidationDiagnosticKind::MultipleRoots),
+            UiAstValidationDiagnostic::new(
+                None,
+                UiAstValidationDiagnosticKind::SelfParent(UiAstNodeId::new(1)),
+            ),
+        ]);
+
+        let mut iter = diagnostics.iter();
+        assert!(matches!(
+            iter.next().unwrap().kind(),
+            UiAstValidationDiagnosticKind::MultipleRoots
+        ));
+        assert!(matches!(
+            iter.next().unwrap().kind(),
+            UiAstValidationDiagnosticKind::SelfParent(_)
+        ));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn diagnostics_first_returns_first_diagnostic() {
+        let diagnostics = UiAstValidationDiagnostics::new(vec![
+            UiAstValidationDiagnostic::new(None, UiAstValidationDiagnosticKind::MultipleRoots),
+            UiAstValidationDiagnostic::new(
+                None,
+                UiAstValidationDiagnosticKind::SelfParent(UiAstNodeId::new(1)),
+            ),
+        ]);
+
+        assert!(matches!(
+            diagnostics.first().unwrap().kind(),
+            UiAstValidationDiagnosticKind::MultipleRoots
+        ));
+    }
+
+    #[test]
+    fn diagnostics_into_vec_preserves_order() {
+        let diagnostics = UiAstValidationDiagnostics::new(vec![
+            UiAstValidationDiagnostic::new(None, UiAstValidationDiagnosticKind::MultipleRoots),
+            UiAstValidationDiagnostic::new(
+                None,
+                UiAstValidationDiagnosticKind::SelfParent(UiAstNodeId::new(1)),
+            ),
+        ]);
+
+        let vec = diagnostics.into_vec();
+        assert!(matches!(
+            vec[0].kind(),
+            UiAstValidationDiagnosticKind::MultipleRoots
+        ));
+        assert!(matches!(
+            vec[1].kind(),
+            UiAstValidationDiagnosticKind::SelfParent(_)
+        ));
+    }
+
+    #[test]
+    fn validation_accepts_ast_kinds_without_lowering_subset_filter() {
+        let mut root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+        root.push_child(UiAstNodeId::new(2));
+        root.push_child(UiAstNodeId::new(3));
+        root.push_child(UiAstNodeId::new(4));
+
+        let attr = UiAstNode::with_parent(
+            UiAstNodeId::new(2),
+            UiAstNodeKind::Attribute,
+            UiAstNodeId::new(1),
+        );
+        let bind = UiAstNode::with_parent(
+            UiAstNodeId::new(3),
+            UiAstNodeKind::Binding,
+            UiAstNodeId::new(1),
+        );
+        let act = UiAstNode::with_parent(
+            UiAstNodeId::new(4),
+            UiAstNodeKind::Action,
+            UiAstNodeId::new(1),
+        );
+
+        let ast = ast_with_nodes([root, attr, bind, act]);
+
+        let result = validate_ast(&ast, &UiAstValidationConfig::default());
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn validation_result_does_not_produce_ir() {
+        let ast = UiAst::new();
+        let result: UiAstValidationResult = validate_ast(&ast, &UiAstValidationConfig::default());
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn cycle_shape_is_not_rejected_in_first_seed() {
+        let mut a = UiAstNode::with_parent(
+            UiAstNodeId::new(1),
+            UiAstNodeKind::Element,
+            UiAstNodeId::new(2),
+        );
+        a.push_child(UiAstNodeId::new(2));
+
+        let mut b = UiAstNode::with_parent(
+            UiAstNodeId::new(2),
+            UiAstNodeKind::Element,
+            UiAstNodeId::new(1),
+        );
+        b.push_child(UiAstNodeId::new(1));
+
+        let ast = ast_with_nodes([a, b]);
+
+        let result = validate_ast(&ast, &UiAstValidationConfig::default());
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn duplicate_ids_may_accumulate_structural_diagnostics() {
+        let root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+        let dup = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Element);
+
+        let ast = ast_with_nodes([root, dup]);
+
+        let err = validate_ast(&ast, &UiAstValidationConfig::default()).expect_err("duplicate id");
+
+        assert!(err.iter().any(|d| matches!(d.kind(), UiAstValidationDiagnosticKind::DuplicateNodeId(id) if id == UiAstNodeId::new(1))));
+        assert!(!err.is_empty());
     }
 }

--- a/docs/roadmap/post_ui/r12_ui_ast_validation_seed_posture.md
+++ b/docs/roadmap/post_ui/r12_ui_ast_validation_seed_posture.md
@@ -3,13 +3,12 @@
 Status: Draft
 Track: R12 / POST-UI / Semantic UI Model
 Scope type: factual posture note
-Implementation status: no new implementation authorized by this document
+Implementation status: no new pipeline implementation authorized by this document
 
 ## 1. Purpose
 
 * This document records the factual posture after the minimal Semantic UI AST validation seed.
 * It prevents interpreting validation seed as complete UI admission, parser, verifier, runtime, renderer, or application pipeline.
-* It does not authorize new code.
 * It does not authorize parser integration.
 * It does not authorize verifier/VM/runtime integration.
 * It does not authorize renderer/backend integration.
@@ -198,13 +197,13 @@ UI state is projection/cache, not semantic state.
 
 ## 15. Next Recommended Step
 
-Recommended next step after this posture note:
+Recommended next step after this posture note and local hardening:
 
-R12-UI-AST-VALIDATION-SEED-POSTURE-AUDIT
+R12-UI-AST-VALIDATION-POSTURE-AND-HARDENING-REVIEW
 
 Then choose one bounded path:
 
-* R12-UI-AST-VALIDATION-DIAGNOSTICS-HARDENING
+* R12-UI-AST-VALIDATION-DIAGNOSTICS-HARDENING-2
 * or R12-UI-AST-INDEXING-POSTURE
 
 * no parser/runtime/renderer work is authorized by this document.


### PR DESCRIPTION
Records the factual posture after the minimal Semantic UI AST validation seed and hardens local validation diagnostics/tests.

Scope:
* adds AST validation seed posture note
* documents what now exists and what still does not exist
* prevents interpreting AST validation as UI admission or a complete UI pipeline
* preserves validation/lowering separation
* preserves authority/state/Quad-state boundaries
* records indexing/vectorization as future-only and not authorized
* adds validation diagnostics accessors
* adds local tests for diagnostics order/accessors
* adds local tests for validation/lowering separation
* documents no-cycle-detection policy
* documents duplicate-id diagnostic accumulation posture

Validation:
* git diff --check
* cargo test -p prom-ui --lib
* no GitHub CI used
* no GitHub Actions used
* no FullPreflight
* no release artifacts

Non-goals:
* no parser integration
* no verifier/VM/runtime integration
* no renderer/backend
* no WGPU
* no winit
* no layout engine
* no draw commands
* no event loop
* no widget framework
* no new lowering behavior
* no cycle detection implementation
* no indexing implementation
* no HashMap
* no SoA / CSR / dense NodeIndex implementation
* no Turbovec integration
* no Workbench implementation
* no Semantic Studio implementation
* no dependency additions
* no stable/production-ready/public-release-ready claim
* no weakening of #675