### PR TITLE
feat(ui): add deterministic projection artifact id policy

### DIFF
--- a/crates/prom-ui/src/projection.rs
+++ b/crates/prom-ui/src/projection.rs
@@ -262,10 +262,21 @@ pub enum UiProjectionError {
     InconsistentHandle,
 }
 
+// Deterministic projection-layer artifact identity.
+// This is not renderer identity, runtime identity, Semantic truth,
+// verifier admission, or capability admission.
+pub fn projection_artifact_id_for_ir(ir: &UiIr) -> UiProjectionArtifactId {
+    if let Some(root) = ir.nodes().iter().find(|n| n.kind() == UiIrNodeKind::Root) {
+        UiProjectionArtifactId::new(root.id().raw())
+    } else {
+        UiProjectionArtifactId::new(0)
+    }
+}
+
 pub fn project_ir_to_projection(ir: &UiIr) -> Result<UiProjectionArtifact, UiProjectionError> {
     validate_ir(ir, &UiIrValidationConfig::default()).map_err(UiProjectionError::InvalidIr)?;
 
-    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let mut artifact = UiProjectionArtifact::new(projection_artifact_id_for_ir(ir));
 
     let root_node = ir.nodes().iter().find(|n| n.kind() == UiIrNodeKind::Root);
     if let Some(root) = root_node {
@@ -462,6 +473,44 @@ mod tests {
         let artifact = project_ir_to_projection(&ir).expect("projects");
         assert_eq!(artifact.len(), 1);
         assert_eq!(artifact.source_ir_root(), Some(UiIrNodeId::new(1)));
+    }
+
+    #[test]
+    fn artifact_id_follows_root_id() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(42),
+            UiIrNodeKind::Root,
+        ));
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.id(), UiProjectionArtifactId::new(42));
+    }
+
+    #[test]
+    fn empty_valid_ir_uses_empty_policy() {
+        let ir = UiIr::new();
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.id(), UiProjectionArtifactId::new(0));
+    }
+
+    #[test]
+    fn projected_node_ids_remain_structural() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(42),
+            UiIrNodeKind::Root,
+        ));
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.nodes()[0].id(), UiProjectedNodeId::new(42));
+    }
+
+    #[test]
+    fn no_renderer_runtime_identity_introduced() {
+        // artifact id is projection-layer only
+        // no renderer/runtime handles exist in artifact
+        let ir = UiIr::new();
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.id(), UiProjectionArtifactId::new(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the first deterministic projection artifact ID policy for the R12 UI Projection Builder seed.

The previous seed used `UiProjectionArtifactId::new(1)` as a seed-only artifact identity.
This PR replaces/formalizes that behavior with a deterministic projection-layer ID policy.

## Background

Closed gates:

- #913 — Projection Builder Contract
- #914 — Contract Audit
- #915 — Seed Approval
- #916 — Inert Projection Builder Seed
- #917 — Seed Closeout
- #918 — ID Policy

## Scope

- Adds deterministic artifact ID helper/policy
- Derives artifact ID from the validated UI IR structure
- Preserves `UiProjectedNodeId` structural derivation from `UiIrNodeId`
- Preserves parent/child projection behavior
- Preserves inert projection artifact behavior
- Adds focused unit tests

## Explicit non-scope

- no renderer/backend
- no WGPU/winit/Tauri
- no layout engine
- no draw commands
- no event loop
- no parser/verifier/VM/runtime integration
- no Workbench/Studio
- no Semantic state mutation
- no capability admission
- no `ProjectionBuilder` type
- no `From<UiIr>` / `TryFrom<UiIr>`
- no dependency additions
- no Cargo.toml / Cargo.lock changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: Medium
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                                   | Observed state                     | Admission Guard classification | Status |
| -------------------------------------- | ---------------------------------- | ------------------------------ | ------ |
| artifact ID policy seed                | Implemented                        | ADMITTED                       | PASS   |
| projection_artifact_id_for_ir          | Implemented                        | ADMITTED                       | PASS   |
| UiProjectionArtifactId constant seed   | Replaced/formalized                | ADMITTED                       | PASS   |
| UiProjectedNodeId policy               | Unchanged structural deterministic | ADMITTED                       | PASS   |
| validate_ir integration                | Unchanged internal call            | ADMITTED                       | PASS   |
| parent/child mapping                   | Preserved                          | ADMITTED                       | PASS   |
| source traceability                    | Preserved                          | ADMITTED                       | PASS   |
| ProjectionBuilder type                 | Absent                             | FUTURE_ONLY_NOT_AUTHORIZED     | PASS   |
| From/TryFrom UiIr                      | Absent                             | FUTURE_ONLY_NOT_AUTHORIZED     | PASS   |
| renderer/backend integration           | Absent                             | FORBIDDEN                      | PASS   |
| layout/draw/event implementation       | Absent                             | FORBIDDEN                      | PASS   |
| parser/verifier/VM/runtime integration | Absent                             | FORBIDDEN                      | PASS   |
| Workbench/Studio integration           | Absent                             | FORBIDDEN                      | PASS   |
| dependency additions                   | Absent                             | FORBIDDEN                      | PASS   |

## Final status

```text
READY_FOR_REVIEW — DETERMINISTIC PROJECTION ARTIFACT ID POLICY SEED
```
