### PR TITLE
feat(ui): add projection property action effect seed

### DIFF
--- a/crates/prom-ui/src/projection.rs
+++ b/crates/prom-ui/src/projection.rs
@@ -91,6 +91,27 @@ pub enum UiProjectedNodeKind {
     EffectBoundaryMarker,
 }
 
+impl UiProjectedNodeKind {
+    pub const fn is_property_carrier(self) -> bool {
+        matches!(self, Self::PropertyCarrier)
+    }
+
+    pub const fn is_action_carrier(self) -> bool {
+        matches!(self, Self::ActionCarrier)
+    }
+
+    pub const fn is_effect_boundary_marker(self) -> bool {
+        matches!(self, Self::EffectBoundaryMarker)
+    }
+
+    pub const fn is_inert_carrier(self) -> bool {
+        matches!(
+            self,
+            Self::PropertyCarrier | Self::ActionCarrier | Self::EffectBoundaryMarker
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UiProjectedNode {
     id: UiProjectedNodeId,
@@ -143,6 +164,22 @@ impl UiProjectedNode {
 
     pub fn kind(&self) -> UiProjectedNodeKind {
         self.kind
+    }
+
+    pub fn is_property_carrier(&self) -> bool {
+        self.kind().is_property_carrier()
+    }
+
+    pub fn is_action_carrier(&self) -> bool {
+        self.kind().is_action_carrier()
+    }
+
+    pub fn is_effect_boundary_marker(&self) -> bool {
+        self.kind().is_effect_boundary_marker()
+    }
+
+    pub fn is_inert_carrier(&self) -> bool {
+        self.kind().is_inert_carrier()
     }
 
     pub const fn source_ir_node_id(&self) -> Option<UiIrNodeId> {
@@ -383,6 +420,134 @@ pub fn project_ir_to_projection(ir: &UiIr) -> Result<UiProjectionArtifact, UiPro
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_node_kind_classifies_inert_carriers() {
+        assert!(UiProjectedNodeKind::PropertyCarrier.is_property_carrier());
+        assert!(UiProjectedNodeKind::ActionCarrier.is_action_carrier());
+        assert!(UiProjectedNodeKind::EffectBoundaryMarker.is_effect_boundary_marker());
+
+        assert!(UiProjectedNodeKind::PropertyCarrier.is_inert_carrier());
+        assert!(UiProjectedNodeKind::ActionCarrier.is_inert_carrier());
+        assert!(UiProjectedNodeKind::EffectBoundaryMarker.is_inert_carrier());
+
+        assert!(!UiProjectedNodeKind::Element.is_property_carrier());
+        assert!(!UiProjectedNodeKind::Root.is_action_carrier());
+        assert!(!UiProjectedNodeKind::Text.is_effect_boundary_marker());
+        assert!(!UiProjectedNodeKind::Fragment.is_inert_carrier());
+    }
+
+    #[test]
+    fn test_property_projects_to_inert_carrier() {
+        let mut ir = UiIr::new();
+        let root_id = UiIrNodeId::new(1);
+        let prop_id = UiIrNodeId::new(2);
+        let mut root = crate::model::UiIrNode::new(root_id, UiIrNodeKind::Root);
+        root.push_child(prop_id);
+        ir.push_node(root);
+        ir.push_node(crate::model::UiIrNode::with_parent(
+            prop_id,
+            UiIrNodeKind::Property,
+            root_id,
+        ));
+
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.nodes().len(), 2);
+
+        let prop_node = artifact
+            .nodes()
+            .iter()
+            .find(|n| n.source_ir_node_id() == Some(prop_id))
+            .unwrap();
+        assert!(prop_node.is_property_carrier());
+        assert!(prop_node.is_inert_carrier());
+    }
+
+    #[test]
+    fn test_action_projects_to_inert_carrier() {
+        let mut ir = UiIr::new();
+        let root_id = UiIrNodeId::new(1);
+        let action_id = UiIrNodeId::new(2);
+        let mut root = crate::model::UiIrNode::new(root_id, UiIrNodeKind::Root);
+        root.push_child(action_id);
+        ir.push_node(root);
+        ir.push_node(crate::model::UiIrNode::with_parent(
+            action_id,
+            UiIrNodeKind::Action,
+            root_id,
+        ));
+
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.nodes().len(), 2);
+
+        let action_node = artifact
+            .nodes()
+            .iter()
+            .find(|n| n.source_ir_node_id() == Some(action_id))
+            .unwrap();
+        assert!(action_node.is_action_carrier());
+        assert!(action_node.is_inert_carrier());
+    }
+
+    #[test]
+    fn test_effect_boundary_projects_to_inert_marker() {
+        let mut ir = UiIr::new();
+        let root_id = UiIrNodeId::new(1);
+        let boundary_id = UiIrNodeId::new(2);
+        ir.push_node(crate::model::UiIrNode::new(root_id, UiIrNodeKind::Root));
+        ir.push_node(crate::model::UiIrNode::new(
+            boundary_id,
+            UiIrNodeKind::EffectBoundary,
+        ));
+
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.nodes().len(), 2);
+
+        let boundary_node = artifact
+            .nodes()
+            .iter()
+            .find(|n| n.source_ir_node_id() == Some(boundary_id))
+            .unwrap();
+        assert!(boundary_node.is_effect_boundary_marker());
+        assert!(boundary_node.is_inert_carrier());
+    }
+
+    #[test]
+    fn test_classification_does_not_affect_identity_or_traceability() {
+        let mut ir = UiIr::new();
+        let root_id = UiIrNodeId::new(1);
+        let prop_id = UiIrNodeId::new(2);
+        let mut root = crate::model::UiIrNode::new(root_id, UiIrNodeKind::Root);
+        root.push_child(prop_id);
+        ir.push_node(root);
+        ir.push_node(crate::model::UiIrNode::with_parent(
+            prop_id,
+            UiIrNodeKind::Property,
+            root_id,
+        ));
+
+        let artifact = project_ir_to_projection(&ir).expect("projects");
+        assert_eq!(artifact.id(), UiProjectionArtifactId::new(1));
+
+        let prop_node = artifact
+            .nodes()
+            .iter()
+            .find(|n| n.source_ir_node_id() == Some(prop_id))
+            .unwrap();
+        assert_eq!(prop_node.id(), UiProjectedNodeId::new(2));
+    }
+
+    #[test]
+    fn test_classification_does_not_affect_diagnostics() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Property,
+        ));
+
+        let err = project_ir_to_projection(&ir).unwrap_err();
+        assert_eq!(err.code(), UiProjectionErrorCode::MissingRoot);
+    }
 
     #[test]
     fn test_traceability_projected_node_exposes_source_ir_node_id() {


### PR DESCRIPTION
## Summary

Adds the first minimal projection-layer Property / Action / EffectBoundary seed.

This PR adds small classification helpers and tests proving that projected Property / Action / EffectBoundary nodes remain inert carriers/markers.

## Background

Closed gates:

- #913 — Projection Builder Contract
- #914 — Contract Audit
- #915 — Seed Approval
- #916 — Inert Projection Builder Seed
- #917 — Seed Closeout
- #918 — ID Policy
- #919 — ID Policy Seed
- #920 — ID Policy Seed Closeout
- #921 — Diagnostics Boundary
- #922 — Traceability Boundary
- #923 — Diagnostics Seed
- #924 — Traceability Seed
- #925 — Property / Action / EffectBoundary Contract

## Scope

- Adds PropertyCarrier classification helpers
- Adds ActionCarrier classification helpers
- Adds EffectBoundaryMarker classification helpers
- Adds focused unit tests
- Preserves projection behavior
- Preserves deterministic artifact ID policy
- Preserves diagnostics and traceability seed behavior

## Truth discipline

Implemented in this PR:

- minimal projection-layer carrier classification helpers
- tests proving carriers remain inert

Still absent:

- renderer property binding
- event dispatch
- action execution
- capability admission
- runtime effect execution
- verifier/VM integration
- Workbench/Studio integration

## Explicit non-scope

- no renderer/backend
- no WGPU/winit/Tauri
- no layout/draw/event
- no event handler system
- no parser/verifier/VM/runtime
- no capability admission
- no Workbench/Studio
- no user-facing UI framework behavior
- no new dependencies
- no Cargo.toml / Cargo.lock changes
- no ProjectionBuilder
- no From<UiIr> / TryFrom<UiIr>

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #925
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                                | Observed state | Admission Guard classification | Status |
| ----------------------------------- | -------------- | ------------------------------ | ------ |
| property/action/effect seed         | Implemented    | ADMITTED                       | PASS   |
| PropertyCarrier classification      | Implemented    | ADMITTED_WITH_BOUNDARY         | PASS   |
| ActionCarrier classification        | Implemented    | ADMITTED_WITH_BOUNDARY         | PASS   |
| EffectBoundaryMarker classification | Implemented    | ADMITTED_WITH_BOUNDARY         | PASS   |
| renderer property binding           | Absent         | FORBIDDEN                      | PASS   |
| event handler dispatch              | Absent         | FORBIDDEN                      | PASS   |
| capability admission                | Absent         | FORBIDDEN                      | PASS   |
| runtime effect execution            | Absent         | FORBIDDEN                      | PASS   |
| parser/verifier/VM integration      | Absent         | FORBIDDEN                      | PASS   |
| Workbench/Studio integration        | Absent         | FORBIDDEN                      | PASS   |
| dependency additions                | Absent         | FORBIDDEN                      | PASS   |

## Final status

```text
READY_FOR_REVIEW — MINIMAL PROPERTY / ACTION / EFFECTBOUNDARY PROJECTION SEED
```
