### PR TITLE
docs(ui): close out r12 projection builder v0 substrate

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_projection_builder_v0_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_projection_builder_v0_closeout.md
@@ -1,0 +1,76 @@
+# R12 UI Projection Builder v0 Closeout
+
+## Executive Summary
+
+The **R12 UI Projection Builder v0 substrate is closed and complete**. 
+
+It provides an **inert, deterministic projection layer** that serves as a structurally sound foundation for the Semantic UI. It enforces strict architectural boundaries to prevent capability collapse and ensures total traceability from interaction artifacts back to source IR.
+
+**Status**: CLOSED
+**Verification**: CONSOLIDATION AUDIT PASSED
+
+## What is included in v0
+
+The following capabilities are implemented and verified in the current substrate:
+
+*   **Projection Function**: `project_ir_to_projection` is implemented.
+*   **Validation Bridge**: `validate_ir` is integrated into the projection flow.
+*   **Deterministic Artifact Policy**: Artifact IDs (`UiProjectionArtifactId`) are generated deterministically.
+*   **Structural Node ID Policy**: Projected node IDs (`UiProjectedNodeId`) strictly preserve the structural uniqueness defined in the source IR.
+*   **Diagnostics Seed**: `UiProjectionErrorCode` and inert projection diagnostic accessors are implemented.
+*   **Traceability Seed**: Source and root trace accessors (`source_ir_node_id`, `source_ir_root`) and inert trace handles are implemented.
+*   **Carrier Classification**: Inert classification helpers for `PropertyCarrier`, `ActionCarrier`, and `EffectBoundaryMarker` are implemented.
+
+## What is NOT included in v0 (Forbidden)
+
+The projection layer maintains strict truth discipline. The following systems are deliberately **ABSENT** and **FORBIDDEN** in the projection substrate:
+
+*   **Renderer / Backend**: No layout, draw, winit, wgpu, or presentation logic.
+*   **Event Handling**: No event loops, DOM, or UI event dispatchers.
+*   **Capability Admission**: No runtime capability bridging or authorization paths.
+*   **Runtime Execution**: No host effect execution or VM side-effects.
+*   **Workbench / Studio Integration**: No editor bindings or external orchestrator coupling.
+*   **Unverified Assumptions**: No wishful docs claims or "mock" backend state.
+
+## Pull Requests Closing the Line
+
+The v0 substrate is constituted by the following merged R12 pull requests:
+
+*   #913 — Projection Builder Contract
+*   #915 — Seed Approval
+*   #916 — Inert Projection Builder Seed
+*   #917 — Seed Closeout
+*   #918 — ID Policy
+*   #919 — ID Policy Seed
+*   #920 — ID Policy Seed Closeout
+*   #921 — Diagnostics Boundary
+*   #922 — Traceability Boundary
+*   #923 — Diagnostics Seed
+*   #924 — Traceability Seed
+*   #925 — Property / Action / EffectBoundary Contract
+*   #926 — Property / Action / EffectBoundary Seed
+
+## Verification Tests
+
+The inert structure is protected by explicit unit tests demonstrating boundary enforcement, notably:
+
+*   `test_no_renderer_layout_draw_event_artifacts`
+*   `test_property_action_effect_remain_inert`
+*   `test_traceability_projected_node_exposes_source_ir_node_id`
+*   `test_traceability_trace_handle_is_inert`
+*   `test_node_kind_classifies_inert_carriers`
+*   `test_invalid_ir_rejected`
+*   `test_diagnostics_structural_error_isolation`
+*   `test_parent_child_structure_preserved`
+
+## Future Gates
+
+With the v0 substrate closed, future lines of work (beyond this substrate) may include:
+
+*   **R12-UI-PROJECTION-BUILDER-VALIDATED-IR-WRAPPER-BOUNDARY**: Hardening the boundaries around the validated IR structure and exploring validated IR capabilities.
+*   **Semantic Capabilities**: Formalizing the capability boundary atop the inert action carriers.
+*   **Renderer Adapter Contracts**: Building the actual layout/draw implementations against the structurally sound projection representation.
+
+## Final Status
+
+**R12 projection builder substrate is officially closed and structurally sound.**


### PR DESCRIPTION
## Goal
Close out the v0 iteration of the R12 UI Projection Builder substrate.

## Scope
- docs-only closeout
- no source edits
- no implementation changes
- no boundary expansion

## Truth Discipline
- The R12 projection layer is completely verified as deterministic, inert, and structurally sound.
- All renderer, layout, event, capability, and runtime execution systems are expressly verified as absent and forbidden in the v0 substrate.
- The boundary between validation and projection remains enforced.

## Verification
- Pre-flight consolidation audit confirms complete alignment of docs and code.
- All R12 PRs #913–#926 have been merged and integrated.
- 339 tests passing, covering structural isolation and absence of behavioral drift.
