### PR TITLE
feat(ui): add projection validated ir wrapper seed

### DIFF
--- a/crates/prom-ui/src/projection.rs
+++ b/crates/prom-ui/src/projection.rs
@@ -374,6 +374,35 @@ pub fn projection_artifact_id_for_ir(ir: &UiIr) -> UiProjectionArtifactId {
     }
 }
 
+// Projection-layer validation evidence only.
+// This is not Semantic truth, verifier admission, runtime admission,
+// capability admission, renderer readiness, or Workbench/Studio readiness.
+#[derive(Debug, Clone, Copy)]
+pub struct ValidatedUiIr<'ir> {
+    ir: &'ir UiIr,
+}
+
+impl<'ir> ValidatedUiIr<'ir> {
+    pub fn new(ir: &'ir UiIr) -> Result<Self, UiProjectionError> {
+        validate_ir(ir, &UiIrValidationConfig::default()).map_err(UiProjectionError::InvalidIr)?;
+        Ok(Self { ir })
+    }
+
+    pub fn as_ir(&self) -> &'ir UiIr {
+        self.ir
+    }
+}
+
+pub fn validate_ui_ir_for_projection(ir: &UiIr) -> Result<ValidatedUiIr<'_>, UiProjectionError> {
+    ValidatedUiIr::new(ir)
+}
+
+pub fn project_validated_ir_to_projection(
+    validated: &ValidatedUiIr<'_>,
+) -> Result<UiProjectionArtifact, UiProjectionError> {
+    project_ir_to_projection(validated.as_ir())
+}
+
 pub fn project_ir_to_projection(ir: &UiIr) -> Result<UiProjectionArtifact, UiProjectionError> {
     validate_ir(ir, &UiIrValidationConfig::default()).map_err(UiProjectionError::InvalidIr)?;
 
@@ -977,5 +1006,113 @@ mod tests {
             artifact.nodes()[3].kind(),
             UiProjectedNodeKind::EffectBoundaryMarker
         );
+    }
+
+    #[test]
+    fn test_valid_ir_creates_wrapper() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let validated = ValidatedUiIr::new(&ir).expect("creates wrapper");
+        assert!(std::ptr::eq(validated.as_ir(), &ir));
+
+        let validated_conv = validate_ui_ir_for_projection(&ir).expect("creates wrapper");
+        assert!(std::ptr::eq(validated_conv.as_ir(), &ir));
+    }
+
+    #[test]
+    fn test_invalid_ir_cannot_create_wrapper() {
+        let mut ir = UiIr::new();
+        let root = crate::model::UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+        ir.push_node(root);
+        ir.push_node(crate::model::UiIrNode::with_parent(
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Element,
+            UiIrNodeId::new(1),
+        ));
+
+        let err = ValidatedUiIr::new(&ir).expect_err("should reject invalid ir");
+        assert_eq!(err.code(), UiProjectionErrorCode::InvalidIr);
+        assert!(err.validation_diagnostics().is_some());
+    }
+
+    #[test]
+    fn test_validated_projection_matches_raw_projection() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new(&ir).expect("creates wrapper");
+        let via_wrapper = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.id(), via_wrapper.id());
+        assert_eq!(raw.source_ir_root(), via_wrapper.source_ir_root());
+        assert_eq!(raw.len(), via_wrapper.len());
+    }
+
+    #[test]
+    fn test_wrapper_does_not_change_artifact_id_policy() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(42),
+            UiIrNodeKind::Root,
+        ));
+
+        let validated = ValidatedUiIr::new(&ir).expect("creates wrapper");
+        let via_wrapper = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(via_wrapper.id(), UiProjectionArtifactId::new(42));
+    }
+
+    #[test]
+    fn test_wrapper_does_not_change_projected_node_id_policy() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(100),
+            UiIrNodeKind::Root,
+        ));
+
+        let validated = ValidatedUiIr::new(&ir).expect("creates wrapper");
+        let via_wrapper = project_validated_ir_to_projection(&validated).expect("projects");
+
+        let node = &via_wrapper.nodes()[0];
+        assert_eq!(node.id(), UiProjectedNodeId::new(100));
+        assert_eq!(node.source_ir_node_id(), Some(UiIrNodeId::new(100)));
+    }
+
+    #[test]
+    fn test_wrapper_preserves_diagnostics_behavior() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Root,
+        ));
+
+        let err = ValidatedUiIr::new(&ir).expect_err("should reject invalid ir");
+        assert_eq!(err.code(), UiProjectionErrorCode::InvalidIr);
+        assert!(err.validation_diagnostics().is_some());
+    }
+
+    #[test]
+    fn test_wrapper_is_not_admission_authority() {
+        let mut valid_ir = UiIr::new();
+        valid_ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        let validated = ValidatedUiIr::new(&valid_ir).expect("creates wrapper");
+
+        // The wrapper exposes only as_ir. There are no methods for verifier, runtime, capability, renderer, etc.
+        let _ir_ref: &UiIr = validated.as_ir();
     }
 }


### PR DESCRIPTION
## Summary

Adds the first minimal projection-layer `ValidatedUiIr` wrapper seed.

This wrapper represents prom-ui projection-layer validation evidence only. It does not represent Semantic truth, verifier admission, runtime admission, capability admission, renderer readiness, or Workbench/Studio readiness.

## Background

Closed gates:

- #913 — Projection Builder Contract
- #914 — Contract Audit
- #915 — Seed Approval
- #916 — Inert Projection Builder Seed
- #917 — Seed Closeout
- #918 — ID Policy
- #919 — ID Policy Seed
- #920 — ID Policy Seed Closeout
- #921 — Diagnostics Boundary
- #922 — Traceability Boundary
- #923 — Diagnostics Seed
- #924 — Traceability Seed
- #925 — Property / Action / EffectBoundary Contract
- #926 — Property / Action / EffectBoundary Seed
- #928 — R12 Projection Builder v0 Closeout
- #929 — Validated IR Wrapper Boundary

## Scope

- Adds `ValidatedUiIr`
- Adds safe validation constructor through `validate_ir`
- Adds `validate_ui_ir_for_projection`
- Adds `project_validated_ir_to_projection`
- Preserves existing `project_ir_to_projection(&UiIr)`
- Adds focused unit tests

## Truth discipline

Implemented in this PR:

- projection-layer validated wrapper
- invalid IR rejection before wrapper creation
- wrapper projection convenience function
- tests proving behavior

Still absent / forbidden:

- Semantic truth proof
- verifier admission
- runtime admission
- capability admission
- renderer readiness
- Workbench/Studio readiness
- unchecked public projection path

## Explicit non-scope

- no source files except `projection.rs`
- no `validation.rs` changes
- no API break to `project_ir_to_projection(&UiIr)`
- no verifier/runtime/capability admission
- no renderer/backend
- no layout/draw/event
- no Workbench/Studio
- no new dependencies
- no Cargo.toml / Cargo.lock changes
- no ProjectionBuilder
- no From<UiIr> / TryFrom<UiIr>

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #929
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                               | Observed state | Admission Guard classification | Status |
| ---------------------------------- | -------------- | ------------------------------ | ------ |
| ValidatedUiIr wrapper              | Implemented    | ADMITTED                       | PASS   |
| validate_ui_ir_for_projection      | Implemented    | ADMITTED                       | PASS   |
| project_validated_ir_to_projection | Implemented    | ADMITTED                       | PASS   |
| existing raw projection API        | Preserved      | ADMITTED                       | PASS   |
| Semantic truth authority           | Absent         | FORBIDDEN                      | PASS   |
| verifier admission                 | Absent         | FORBIDDEN                      | PASS   |
| runtime admission                  | Absent         | FORBIDDEN                      | PASS   |
| capability admission               | Absent         | FORBIDDEN                      | PASS   |
| renderer readiness                 | Absent         | FORBIDDEN                      | PASS   |
| Workbench/Studio readiness         | Absent         | FORBIDDEN                      | PASS   |
| dependency additions               | Absent         | FORBIDDEN                      | PASS   |

## Final status

```text
READY_FOR_REVIEW — MINIMAL VALIDATED UI IR WRAPPER SEED
```
