### PR TITLE
docs(ui): close out projection validated ir wrapper v0

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_projection_builder_validated_ir_wrapper_v0_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_projection_builder_validated_ir_wrapper_v0_closeout.md
@@ -1,0 +1,144 @@
+# R12 UI Projection Builder Validated IR Wrapper v0 Closeout
+
+## Purpose
+
+This document closes out the R12 UI Projection Builder Validated IR Wrapper v0 line.
+
+It records the current main reality after PR #930 and the clean ValidatedUiIr consolidation audit.
+
+ValidatedUiIr v0 is closed as projection-layer validation evidence only.
+
+ValidatedUiIr v0 closes projection-layer validation evidence, not admission authority.
+
+## Closed chain
+
+#929 — Validated IR Wrapper Boundary — MERGED
+#930 — Validated IR Wrapper Seed — MERGED
+Validated IR Wrapper Consolidation Audit — PASS
+
+#930 merge commit:
+246faec05c6c3d792f0b3d831cf0eb0064461396
+
+## Current implemented state
+
+Current main:
+246faec05c6c3d792f0b3d831cf0eb0064461396
+
+Implemented:
+- ValidatedUiIr
+- ValidatedUiIr::new
+- validate_ui_ir_for_projection
+- project_validated_ir_to_projection
+- raw project_ir_to_projection(&UiIr) preserved
+- invalid UiIr wrapper creation rejected
+- validation diagnostics preserved
+- artifact ID policy unchanged
+- projected node ID policy unchanged
+- focused tests in projection.rs
+
+## What ValidatedUiIr v0 is
+
+ValidatedUiIr v0 is:
+- projection-layer validation evidence;
+- created only after validate_ir succeeds;
+- local to prom-ui projection;
+- read-only access to the underlying UiIr;
+- compatible with existing project_ir_to_projection(&UiIr);
+- safe convenience for future staged projection flows.
+
+## What ValidatedUiIr v0 is not
+
+ValidatedUiIr v0 is not:
+- Semantic truth;
+- verifier admission;
+- runtime admission;
+- capability admission;
+- effect authorization;
+- renderer readiness;
+- layout readiness;
+- Workbench/Studio readiness;
+- release readiness;
+- unchecked projection path.
+
+ValidatedUiIr may prove projection-layer validation only.
+ValidatedUiIr is not Semantic truth.
+ValidatedUiIr is not verifier admission.
+ValidatedUiIr is not runtime admission.
+ValidatedUiIr is not capability admission.
+UI may display truth. UI does not become truth.
+
+## Evidence Matrix
+
+| Claim | Classification | Evidence | Status |
+|---|---|---|---|
+| ValidatedUiIr exists | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| ValidatedUiIr::new validates through validate_ir | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| validate_ui_ir_for_projection exists | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| project_validated_ir_to_projection exists | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| raw project_ir_to_projection(&UiIr) preserved | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| invalid UiIr wrapper creation rejected | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| validation diagnostics preserved | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| artifact ID policy unchanged | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| projected node ID policy unchanged | IMPLEMENTED | crates/prom-ui/src/projection.rs | PASS |
+| unchecked public path exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| Semantic truth authority exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| verifier admission exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| runtime admission exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| capability admission exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| renderer readiness exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| Workbench/Studio readiness exists | ABSENT / FORBIDDEN | Validated IR Wrapper Consolidation Audit | PASS |
+| dependency additions | ABSENT | Validated IR Wrapper Consolidation Audit | PASS |
+
+## Consolidation audit result
+
+Validated IR Wrapper consolidation audit result:
+PASS — R12 UI PROJECTION BUILDER VALIDATED IR WRAPPER CONSOLIDATION AUDIT CLEAN
+
+Project #2 duplicate items for #930:
+0
+
+Unexpected file surface:
+NO
+
+Dependency additions:
+NO
+
+GitHub CI used as evidence:
+NO
+
+## Admission Guard table
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| ValidatedUiIr v0 closeout | Present | ADMITTED | PASS |
+| ValidatedUiIr | Implemented | ADMITTED | PASS |
+| ValidatedUiIr::new | Implemented | ADMITTED | PASS |
+| validate_ui_ir_for_projection | Implemented | ADMITTED | PASS |
+| project_validated_ir_to_projection | Implemented | ADMITTED | PASS |
+| raw project_ir_to_projection(&UiIr) | Preserved | ADMITTED | PASS |
+| validation diagnostics | Preserved | ADMITTED | PASS |
+| unchecked public path | Absent | FORBIDDEN | PASS |
+| Semantic truth authority | Absent | FORBIDDEN | PASS |
+| verifier admission | Absent | FORBIDDEN | PASS |
+| runtime admission | Absent | FORBIDDEN | PASS |
+| capability admission | Absent | FORBIDDEN | PASS |
+| renderer readiness | Absent | FORBIDDEN | PASS |
+| Workbench/Studio readiness | Absent | FORBIDDEN | PASS |
+| source changes in this PR | Absent | FORBIDDEN | PASS |
+| dependency additions | Absent | FORBIDDEN | PASS |
+
+## Remaining future gates
+
+Possible future gates:
+- R12-UI-PROJECTION-BUILDER-VALIDATED-IR-WRAPPER-CONFIG-BOUNDARY
+- R12-UI-PROJECTION-BUILDER-VALIDATED-IR-WRAPPER-CONFIG-SEED
+- R12-UI-PROJECTION-BUILDER-VALIDATED-PROJECTION-INTERNAL-HELPER-BOUNDARY
+- R12-UI-PROJECTION-BUILDER-VALIDATED-PROJECTION-INTERNAL-HELPER-SEED
+
+These are not implemented in ValidatedUiIr v0.
+They require separate explicit gates.
+
+## Final decision
+
+Final decision:
+CLOSED — ValidatedUiIr v0 is complete as projection-layer validation evidence. It validates through validate_ir, preserves the existing raw projection API, rejects invalid UiIr before wrapper creation, and does not imply Semantic truth, verifier admission, runtime admission, capability admission, renderer readiness, or Workbench/Studio readiness.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Projection Builder Validated IR Wrapper v0 line.

This is a docs-only release-style closeout after PR #930 and the clean ValidatedUiIr consolidation audit.

## Background

Closed line:

- #929 — Validated IR Wrapper Boundary
- #930 — Validated IR Wrapper Seed
- Validated IR Wrapper Consolidation Audit — PASS

## Scope

- Records ValidatedUiIr v0 implemented state
- Records consolidation audit result
- Records what ValidatedUiIr v0 is and is not
- Adds Evidence Matrix
- Preserves truth discipline
- Lists future gates as not implemented

## Explicit non-scope

- no source changes
- no implementation
- no projection.rs changes
- no validation.rs changes
- no verifier/runtime/capability admission
- no renderer/backend/layout/draw/event
- no Workbench/Studio
- no dependencies
- no Cargo.toml / Cargo.lock changes

## Truth discipline

ValidatedUiIr v0 closes projection-layer validation evidence, not admission authority.

No planned capability is presented as implemented.

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Semantic UI
Gate: Release Artifact
Evidence: Roadmap doc / Local audit / PR
Depends on: #930
```

## Validation

Local only:

```text
git diff --check: PASS
cargo test -p prom-ui --lib: PASS
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — ValidatedUiIr v0 is complete as projection-layer validation evidence. It validates through validate_ir, preserves the existing raw projection API, rejects invalid UiIr before wrapper creation, and does not imply Semantic truth, verifier admission, runtime admission, capability admission, renderer readiness, or Workbench/Studio readiness.
```
