### PR TITLE
feat(ui): add projection validated ir config seed

### DIFF
--- a/crates/prom-ui/src/projection.rs
+++ b/crates/prom-ui/src/projection.rs
@@ -384,7 +384,18 @@ pub struct ValidatedUiIr<'ir> {
 
 impl<'ir> ValidatedUiIr<'ir> {
     pub fn new(ir: &'ir UiIr) -> Result<Self, UiProjectionError> {
-        validate_ir(ir, &UiIrValidationConfig::default()).map_err(UiProjectionError::InvalidIr)?;
+        Self::new_with_config(ir, &UiIrValidationConfig::default())
+    }
+
+    // Config-aware projection validation only.
+    // UiIrValidationConfig is not Semantic truth policy, verifier policy,
+    // runtime admission policy, capability policy, renderer readiness policy,
+    // or Workbench/Studio readiness policy.
+    pub fn new_with_config(
+        ir: &'ir UiIr,
+        config: &UiIrValidationConfig,
+    ) -> Result<Self, UiProjectionError> {
+        validate_ir(ir, config).map_err(UiProjectionError::InvalidIr)?;
         Ok(Self { ir })
     }
 
@@ -395,6 +406,13 @@ impl<'ir> ValidatedUiIr<'ir> {
 
 pub fn validate_ui_ir_for_projection(ir: &UiIr) -> Result<ValidatedUiIr<'_>, UiProjectionError> {
     ValidatedUiIr::new(ir)
+}
+
+pub fn validate_ui_ir_for_projection_with_config<'ir>(
+    ir: &'ir UiIr,
+    config: &UiIrValidationConfig,
+) -> Result<ValidatedUiIr<'ir>, UiProjectionError> {
+    ValidatedUiIr::new_with_config(ir, config)
 }
 
 pub fn project_validated_ir_to_projection(
@@ -1113,6 +1131,120 @@ mod tests {
         let validated = ValidatedUiIr::new(&valid_ir).expect("creates wrapper");
 
         // The wrapper exposes only as_ir. There are no methods for verifier, runtime, capability, renderer, etc.
+        let _ir_ref: &UiIr = validated.as_ir();
+    }
+
+    #[test]
+    fn test_default_constructor_delegates_to_config_path() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let v1 = ValidatedUiIr::new(&ir).expect("ok");
+        let v2 = ValidatedUiIr::new_with_config(&ir, &UiIrValidationConfig::default()).expect("ok");
+
+        assert!(std::ptr::eq(v1.as_ir(), v2.as_ir()));
+    }
+
+    #[test]
+    fn test_config_aware_constructor_rejects_invalid_ir() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Root,
+        ));
+
+        let err =
+            ValidatedUiIr::new_with_config(&ir, &UiIrValidationConfig::default()).unwrap_err();
+        assert_eq!(err.code(), UiProjectionErrorCode::InvalidIr);
+        assert!(err.validation_diagnostics().is_some());
+    }
+
+    #[test]
+    fn test_free_helper_with_config_works() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let v = validate_ui_ir_for_projection_with_config(&ir, &UiIrValidationConfig::default())
+            .expect("ok");
+        assert!(std::ptr::eq(v.as_ir(), &ir));
+    }
+
+    #[test]
+    fn test_free_helper_with_config_rejects_invalid_ir() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Root,
+        ));
+
+        let err = validate_ui_ir_for_projection_with_config(&ir, &UiIrValidationConfig::default())
+            .unwrap_err();
+        assert_eq!(err.code(), UiProjectionErrorCode::InvalidIr);
+    }
+
+    #[test]
+    fn test_config_seed_does_not_change_projection_output() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new_with_config(&ir, &UiIrValidationConfig::default())
+            .expect("creates wrapper");
+        let via_wrapper = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.id(), via_wrapper.id());
+        assert_eq!(raw.source_ir_root(), via_wrapper.source_ir_root());
+        assert_eq!(raw.len(), via_wrapper.len());
+        if !raw.is_empty() {
+            assert_eq!(raw.nodes()[0].id(), via_wrapper.nodes()[0].id());
+        }
+    }
+
+    #[test]
+    fn test_config_seed_does_not_store_config_identity() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        let validated = ValidatedUiIr::new_with_config(&ir, &UiIrValidationConfig::default())
+            .expect("creates wrapper");
+
+        // Exposes only as_ir. Size should just be the reference.
+        assert_eq!(
+            std::mem::size_of_val(&validated),
+            std::mem::size_of::<&UiIr>()
+        );
+    }
+
+    #[test]
+    fn test_config_is_not_authority() {
+        let mut valid_ir = UiIr::new();
+        valid_ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        let validated = ValidatedUiIr::new_with_config(&valid_ir, &UiIrValidationConfig::default())
+            .expect("creates wrapper");
+
+        // The wrapper exposes only as_ir. No handles for verifier, runtime, capability, renderer.
         let _ir_ref: &UiIr = validated.as_ir();
     }
 }


### PR DESCRIPTION
## Summary

Adds the minimal config-aware `ValidatedUiIr` wrapper seed.

This PR adds:

- `ValidatedUiIr::new_with_config`
- `validate_ui_ir_for_projection_with_config`
- focused tests

It preserves:

- `ValidatedUiIr::new`
- `validate_ui_ir_for_projection`
- `project_validated_ir_to_projection`
- raw `project_ir_to_projection(&UiIr)`

## Background

Closed line:

- #929 — Validated IR Wrapper Boundary
- #930 — Validated IR Wrapper Seed
- #931 — Validated IR Wrapper v0 Closeout
- #932 — Validated IR Wrapper Config Boundary

## Scope

Implemented:

- config-aware projection-layer validation constructor
- config-aware validation helper
- tests proving invalid IR is rejected under explicit config
- tests proving default behavior remains stable

Still absent / forbidden:

- config identity storage
- verifier policy
- Semantic truth policy
- runtime admission policy
- capability policy
- renderer readiness policy
- Workbench/Studio readiness policy
- unchecked public projection path

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #932
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                                      | Observed state | Admission Guard classification | Status |
| ----------------------------------------- | -------------- | ------------------------------ | ------ |
| new_with_config                           | Implemented    | ADMITTED                       | PASS   |
| validate_ui_ir_for_projection_with_config | Implemented    | ADMITTED                       | PASS   |
| default constructor                       | Preserved      | ADMITTED                       | PASS   |
| raw projection API                        | Preserved      | ADMITTED                       | PASS   |
| config identity storage                   | Absent         | FUTURE_ONLY_NOT_AUTHORIZED     | PASS   |
| verifier policy                           | Absent         | FORBIDDEN                      | PASS   |
| Semantic truth policy                     | Absent         | FORBIDDEN                      | PASS   |
| runtime admission policy                  | Absent         | FORBIDDEN                      | PASS   |
| capability policy                         | Absent         | FORBIDDEN                      | PASS   |
| renderer readiness policy                 | Absent         | FORBIDDEN                      | PASS   |
| Workbench/Studio readiness policy         | Absent         | FORBIDDEN                      | PASS   |
| dependency additions                      | Absent         | FORBIDDEN                      | PASS   |
