### PR TITLE
docs(ui): closeout r12 validated ir wrapper config line

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_projection_builder_validated_ir_wrapper_config_v0_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_projection_builder_validated_ir_wrapper_config_v0_closeout.md
@@ -1,0 +1,41 @@
+# R12 UI Projection Builder Validated IR Wrapper Config v0 Closeout
+
+## Status
+
+**CLOSED**
+
+## Commit boundary
+
+```text
+Commit: 930ba7b
+Line: #929-#933
+Phase: POST-UI
+Wave: R12
+```
+
+## Summary
+
+`ValidatedUiIr` config-aware v0 is closed as a purely inert projection-layer validation wrapper.
+
+It accepts explicit `UiIrValidationConfig`, but stores no config identity, exerts no runtime authority, and provides no admission for broader capabilities.
+
+## Confirmed behavior
+
+| Subsystem                      | Status                                         |
+| ------------------------------ | ---------------------------------------------- |
+| ValidatedUiIr wrapper          | Config-aware validation active, inert          |
+| new_with_config                | Active, returns `Result<ValidatedUiIr, Error>` |
+| Default constructor            | Preserved (delegates to config path)           |
+| Raw projection                 | Preserved                                      |
+| `UiIrValidationConfig` storage | Absent                                         |
+| Validation diagnostics         | Retained projection-only scope                 |
+| verifier policy                | Completely isolated (Forbidden)                |
+| runtime policy                 | Completely isolated (Forbidden)                |
+| capability policy              | Completely isolated (Forbidden)                |
+| renderer readiness             | Completely isolated (Forbidden)                |
+
+## Post-Audit
+
+**CLEAN**.
+
+Consolidation audit confirms `ValidatedUiIr` with configuration retains strict structural boundary and operates exactly as specified in the config boundary contract (#932).


### PR DESCRIPTION
## Summary

Closes the R12 ValidatedUiIr config-aware wrapper line with a formal, docs-only v0 closeout.

This explicitly frames the wrapper as an inert structural projection validation boundary and prevents interpreting the presence of a config object as granting broader system authority.

## Background

Closed line:

- #929 — Validated IR Wrapper Boundary
- #930 — Validated IR Wrapper Seed
- #931 — Validated IR Wrapper v0 Closeout
- #932 — Validated IR Wrapper Config Boundary
- #933 — Validated IR Wrapper Config Seed

## Scope

Implemented:

- R12 Validated IR Wrapper Config v0 Closeout Document

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Docs
Risk: Low
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #933
```
