### PR TITLE
docs(ui): add projection builder full-line ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_projection_builder_full_line_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_projection_builder_full_line_ledger_audit.md
@@ -1,0 +1,170 @@
+# R12 UI Projection Builder Full-Line Ledger Audit
+
+## 1. Purpose
+
+This document serves as the final full-line ledger audit for the R12 UI Projection Builder v0 line (through PR #934). It proves that the line is fully closed, its implemented surface is exactly as intended (an inert projection validation substrate), and all forbidden broader authorities remain completely absent.
+
+## 2. Scope
+
+- Audits all PRs and issues #913–#934.
+- Audits the merge commit ledger.
+- Audits the changed file surface.
+- Audits the final projection.rs source API and behavior.
+- Audits test coverage categories.
+- Audits Project #2 metadata correctness and duplicate status.
+- Confirms absence of forbidden system integrations (verifier, runtime, capability, renderer, Workbench/Studio).
+
+## 3. Declared PR / Issue Ledger
+
+| PR/Issue | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| 913 | docs(ui): add projection builder contract | MERGED | a34c636 | 1 | Contract | PASS |
+| 914 | R12-UI-PROJECTION-BUILDER-CONTRACT-AUDIT | CLOSED | N/A | N/A | Audit | PASS |
+| 915 | docs(ui): add projection builder seed approval | MERGED | e31f25c | 1 | Contract | PASS |
+| 916 | feat(ui): add inert projection builder seed | MERGED | b696cff | 1 | Code | PASS |
+| 917 | docs(ui): close out projection builder seed | MERGED | f051371 | 1 | Closeout | PASS |
+| 918 | docs(ui): add projection builder id policy | MERGED | 3c6f964 | 1 | Contract | PASS |
+| 919 | feat(ui): add deterministic projection artifact id policy | MERGED | 995d7e9 | 1 | Code | PASS |
+| 920 | docs(ui): close out projection builder id policy seed | MERGED | 0805e1f | 1 | Closeout | PASS |
+| 921 | docs(ui): add projection builder diagnostics boundary | MERGED | b3d2d99 | 1 | Boundary | PASS |
+| 922 | docs(ui): add projection builder traceability boundary | MERGED | c138dc2 | 1 | Boundary | PASS |
+| 923 | feat(ui): add projection diagnostics seed | MERGED | ed71e90 | 1 | Code | PASS |
+| 924 | feat(ui): add projection traceability seed | MERGED | 8c2af63 | 1 | Code | PASS |
+| 925 | docs(ui): add projection property action effect contract | MERGED | dd3de1e | 1 | Contract | PASS |
+| 926 | feat(ui): add projection property action effect seed | MERGED | 5c35657 | 1 | Code | PASS |
+| 928 | docs(ui): close out projection builder v0 | MERGED | 82b910c | 1 | Closeout | PASS |
+| 929 | docs(ui): add projection builder validated ir wrapper boundary | MERGED | 100d854 | 1 | Boundary | PASS |
+| 930 | feat(ui): add projection validated ir wrapper seed | MERGED | 246faec | 1 | Code | PASS |
+| 931 | docs(ui): close out projection validated ir wrapper v0 | MERGED | c10b444 | 1 | Closeout | PASS |
+| 932 | docs(ui): add projection validated ir wrapper config boundary | MERGED | 2774fc5 | 1 | Boundary | PASS |
+| 933 | feat(ui): add projection validated ir config seed | MERGED | 930ba7b | 1 | Code | PASS |
+| 934 | docs(ui): closeout r12 validated ir wrapper config line | MERGED | c69d211 | 1 | Closeout | PASS |
+
+## 4. Merge Commit Ledger
+
+All merge commits confirmed in main. History represents a linear progression of R12 objectives.
+
+## 5. Changed File Surface
+
+Total permitted surface:
+- `crates/prom-ui/src/projection.rs`
+- `docs/roadmap/post_ui/*.md`
+
+Unexpected or forbidden files changed: **NONE**
+
+## 6. Final Source API Ledger
+
+| API / Behavior | Current state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| project_ir_to_projection | Present | Structural core | projection.rs | PASS |
+| ValidatedUiIr | Present | Inert validation wrapper | projection.rs | PASS |
+| ValidatedUiIr::new | Present | Default constructor | projection.rs | PASS |
+| ValidatedUiIr::new_with_config | Present | Config constructor | projection.rs | PASS |
+| validate_ui_ir_for_projection | Present | Default free function | projection.rs | PASS |
+| validate_ui_ir_for_projection_with_config | Present | Config free function | projection.rs | PASS |
+| project_validated_ir_to_projection | Present | Validated projection path | projection.rs | PASS |
+| projection_artifact_id_for_ir | Present | Deterministic ID policy | projection.rs | PASS |
+| UiProjectionErrorCode | Present | Error classification | projection.rs | PASS |
+| validation diagnostics accessor | Present | Validation integration | projection.rs | PASS |
+| source/root trace accessors | Present | Traceability integration | projection.rs | PASS |
+| PropertyCarrier classification | Present | Inert property holder | projection.rs | PASS |
+| ActionCarrier classification | Present | Inert action holder | projection.rs | PASS |
+| EffectBoundaryMarker classification | Present | Inert boundary marker | projection.rs | PASS |
+| unchecked public projection path | Absent | Forbidden | Code search | PASS |
+| config identity storage | Absent | Forbidden | Code search | PASS |
+| verifier/runtime/capability authority | Absent | Forbidden | Code search | PASS |
+| renderer/Workbench readiness | Absent | Forbidden | Code search | PASS |
+
+## 7. Behavior Ledger
+
+Verified in projection.rs:
+- Raw UiIr projection still works and validates internally.
+- `ValidatedUiIr::new` leverages `UiIrValidationConfig::default`.
+- `ValidatedUiIr::new_with_config` respects explicitly provided configuration.
+- Invalid UiIr instances cannot be wrapped into `ValidatedUiIr`.
+- Validation failures correctly populate structural diagnostics.
+- `project_validated_ir_to_projection` allows bypassing duplicate projection validation safely.
+- No public unchecked projection path is exposed.
+- Artifact and node identities remain strict and deterministic.
+- Node vocabulary respects Property, Action, and Effect Boundaries solely as structural placeholders.
+
+## 8. Test Coverage Ledger
+
+Test categories implemented:
+- Projection success paths.
+- Invalid IR diagnostics.
+- Artifact ID policy determinism.
+- Trace and source identity preservation.
+- Inert behavior of Property/Action/EffectBoundary.
+- ValidatedUiIr standard and config-aware valid/invalid behaviors.
+- Validation wrapper authority isolation verification.
+
+## 9. Documentation Ledger
+
+All required R12 UI Projection Builder docs present in `docs/roadmap/post_ui`.
+No doc/code drift detected. Claims accurately match the inert nature of the substrate.
+
+## 10. Project #2 Ledger
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #913 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | N/A | No |
+| #914 | Done | POST-UI | R12 | Audit | Low | Semantic UI | Audit | Issue | N/A | No |
+| #915 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #913 | No |
+| #916 | Done | POST-UI | R12 | Code | Medium | Semantic UI | PRReady | PR | #915 | No |
+| #917 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #916 | No |
+| #918 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #917 | No |
+| #919 | Done | POST-UI | R12 | Code | Low | Semantic UI | PRReady | PR | #918 | No |
+| #920 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #919 | No |
+| #921 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #920 | No |
+| #922 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #921 | No |
+| #923 | Done | POST-UI | R12 | Code | Low | Semantic UI | PRReady | PR | #922 | No |
+| #924 | Done | POST-UI | R12 | Code | Low | Semantic UI | PRReady | PR | #923 | No |
+| #925 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #924 | No |
+| #926 | Done | POST-UI | R12 | Code | Low | Semantic UI | PRReady | PR | #925 | No |
+| #928 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #926 | No |
+| #929 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #928 | No |
+| #930 | Done | POST-UI | R12 | Code | Low | Semantic UI | PRReady | PR | #929 | No |
+| #931 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #930 | No |
+| #932 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #931 | No |
+| #933 | Done | POST-UI | R12 | Code | High | Semantic UI | PRReady | PR | #932 | No |
+| #934 | Done | POST-UI | R12 | Docs | Low | Semantic UI | PRReady | PR | #933 | No |
+
+## 11. Forbidden Surface Ledger
+
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| Cargo.toml / Cargo.lock | No | Forbidden | PASS |
+| lib.rs/model.rs/validation.rs/lowering.rs | No | Forbidden | PASS |
+| renderer/backend | No | Forbidden | PASS |
+| layout/draw/event | No | Forbidden | PASS |
+| event dispatch | No | Forbidden | PASS |
+| parser/verifier/VM/runtime | No | Forbidden | PASS |
+| capability admission | No | Forbidden | PASS |
+| Workbench/Studio | No | Forbidden | PASS |
+| unchecked projection | No | Forbidden | PASS |
+| config identity storage | No | Forbidden | PASS |
+| dependency additions | No | Forbidden | PASS |
+
+## 12. Manifest / Dependency Ledger
+
+Verified via `git diff` that `Cargo.toml` and `Cargo.lock` remain unchanged.
+
+## 13. Local Validation
+
+- `cargo fmt --check`: PASS
+- `cargo test -p prom-ui --lib`: PASS
+- `git diff --check`: PASS
+
+## 14. Admission Guard Summary
+
+The R12 Projection Builder line safely advanced the project structurally while strictly honoring the defined Semantic boundaries and maintaining full isolation from broader runtime and renderer execution contexts.
+
+## 15. Final Decision
+
+Final decision:
+PASS — R12 UI Projection Builder full-line ledger is clean through #934.
+
+The line is complete as validated deterministic inert projection substrate with ValidatedUiIr and config-aware projection validation helpers.
+
+It is not renderer, runtime, verifier admission, capability admission, Workbench/Studio integration, event dispatch, or full UI system.


### PR DESCRIPTION
## Summary

Adds the R12 UI Projection Builder full-line ledger audit through #934.

This is a docs-only audit PR.

## Scope

Audits:

- PRs/issues #913–#934 in the declared R12 UI Projection Builder line
- merge commits
- changed-file surface
- final projection.rs API
- test coverage
- docs/code alignment
- Project #2 metadata and duplicates
- forbidden surfaces
- local validation

## Explicit non-scope

- no source changes
- no implementation
- no projection.rs changes
- no validation.rs changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no renderer/backend
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Semantic UI
Gate: FullPreflight
Evidence: Roadmap doc / Local audit / PR
Depends on: #934
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI PROJECTION BUILDER FULL-LINE LEDGER AUDIT CLEAN
```
