### PR TITLE
feat(ui): add internal projection helper

### DIFF
--- a/crates/prom-ui/src/projection.rs
+++ b/crates/prom-ui/src/projection.rs
@@ -418,12 +418,19 @@ pub fn validate_ui_ir_for_projection_with_config<'ir>(
 pub fn project_validated_ir_to_projection(
     validated: &ValidatedUiIr<'_>,
 ) -> Result<UiProjectionArtifact, UiProjectionError> {
-    project_ir_to_projection(validated.as_ir())
+    build_projection_from_validated_ir(validated.as_ir())
 }
 
 pub fn project_ir_to_projection(ir: &UiIr) -> Result<UiProjectionArtifact, UiProjectionError> {
     validate_ir(ir, &UiIrValidationConfig::default()).map_err(UiProjectionError::InvalidIr)?;
+    build_projection_from_validated_ir(ir)
+}
 
+// Internal projection construction for UiIr that already passed projection-layer validation.
+// This is not a public unchecked API and must not be exported.
+fn build_projection_from_validated_ir(
+    ir: &UiIr,
+) -> Result<UiProjectionArtifact, UiProjectionError> {
     let mut artifact = UiProjectionArtifact::new(projection_artifact_id_for_ir(ir));
 
     let root_node = ir.nodes().iter().find(|n| n.kind() == UiIrNodeKind::Root);
@@ -1246,5 +1253,106 @@ mod tests {
 
         // The wrapper exposes only as_ir. No handles for verifier, runtime, capability, renderer.
         let _ir_ref: &UiIr = validated.as_ir();
+    }
+
+    #[test]
+    fn test_helper_raw_projection_still_validates_invalid_ir() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Root,
+        ));
+
+        let err = project_ir_to_projection(&ir).unwrap_err();
+        assert_eq!(err.code(), UiProjectionErrorCode::InvalidIr);
+        assert!(err.validation_diagnostics().is_some());
+    }
+
+    #[test]
+    fn test_helper_validated_projection_matches_raw_projection() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new(&ir).expect("validates");
+        let via_validated = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.id(), via_validated.id());
+        assert_eq!(raw.source_ir_root(), via_validated.source_ir_root());
+        assert_eq!(raw.len(), via_validated.len());
+        assert_eq!(raw.nodes()[0].id(), via_validated.nodes()[0].id());
+    }
+
+    #[test]
+    fn test_helper_config_validated_projection_matches_raw_projection() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new_with_config(&ir, &UiIrValidationConfig::default())
+            .expect("validates");
+        let via_validated = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.id(), via_validated.id());
+        assert_eq!(raw.source_ir_root(), via_validated.source_ir_root());
+        assert_eq!(raw.len(), via_validated.len());
+    }
+
+    #[test]
+    fn test_helper_split_does_not_change_artifact_id_policy() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(42),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new(&ir).expect("validates");
+        let via_validated = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.id().raw(), 42);
+        assert_eq!(via_validated.id().raw(), 42);
+        assert_eq!(raw.id(), via_validated.id());
+    }
+
+    #[test]
+    fn test_helper_split_does_not_change_projected_node_id_policy() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(42),
+            UiIrNodeKind::Root,
+        ));
+
+        let raw = project_ir_to_projection(&ir).expect("projects");
+        let validated = ValidatedUiIr::new(&ir).expect("validates");
+        let via_validated = project_validated_ir_to_projection(&validated).expect("projects");
+
+        assert_eq!(raw.nodes()[0].id().raw(), 42);
+        assert_eq!(via_validated.nodes()[0].id().raw(), 42);
+    }
+
+    #[test]
+    fn test_helper_boundary_test_non_authority() {
+        let mut ir = UiIr::new();
+        ir.push_node(crate::model::UiIrNode::new(
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+        ));
+
+        let validated = ValidatedUiIr::new(&ir).expect("validates");
+        let via_validated = project_validated_ir_to_projection(&validated).expect("projects");
+
+        let _id = via_validated.id();
+        // Exposes no renderer handle, runtime admission, or capability admission.
     }
 }


### PR DESCRIPTION
## Summary

Adds a private internal projection construction helper for already-validated UI IR.

This avoids routing `ValidatedUiIr` projection back through the raw validation entry point while preserving public safety boundaries.

## Scope

Implemented:

- private internal projection helper
- raw projection still validates before helper call
- validated projection uses helper through `ValidatedUiIr`
- focused tests for raw/validated/config-validated projection equivalence
- no public unchecked projection path

Preserved:

- `project_ir_to_projection(&UiIr)`
- `ValidatedUiIr`
- `ValidatedUiIr::new`
- `ValidatedUiIr::new_with_config`
- `validate_ui_ir_for_projection`
- `validate_ui_ir_for_projection_with_config`
- artifact ID policy
- projected node ID policy
- diagnostics / traceability behavior
- Property / Action / EffectBoundary inert classification

## Explicit non-scope

- no public unchecked API
- no source files except `projection.rs`
- no validation.rs/model.rs/lowering.rs/lib.rs changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no renderer/backend
- no layout/draw/event
- no verifier/runtime/VM integration
- no capability admission
- no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #935
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                          | Observed state      | Classification | Status |
| ----------------------------- | ------------------- | -------------- | ------ |
| private internal helper       | Implemented         | ADMITTED       | PASS   |
| raw projection validation     | Preserved           | ADMITTED       | PASS   |
| ValidatedUiIr projection path | Uses private helper | ADMITTED       | PASS   |
| public unchecked path         | Absent              | FORBIDDEN      | PASS   |
| artifact ID policy            | Preserved           | ADMITTED       | PASS   |
| node ID policy                | Preserved           | ADMITTED       | PASS   |
| verifier/runtime/capability   | Absent              | FORBIDDEN      | PASS   |
| renderer/Workbench            | Absent              | FORBIDDEN      | PASS   |
