### PR TITLE
docs(ui): add internal projection helper closeout

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_projection_builder_internal_projection_helper_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_projection_builder_internal_projection_helper_closeout.md
@@ -1,0 +1,39 @@
+# R12 UI Projection Builder Internal Projection Helper Closeout
+
+**Track:** POST-UI
+**Wave:** R12
+**Status:** MERGED
+**Boundary:** Semantic UI
+**Project:** #2
+
+## Summary
+
+The internal projection helper line is closed as projection construction logic has been successfully consolidated without creating unchecked public paths.
+
+## Consolidation Audit
+
+The consolidation audit confirms:
+
+1. **Private internal helper exists**: `build_projection_from_validated_ir` exists solely as a private `fn` in `projection.rs`.
+2. **Public safety preserved**: The helper is not exposed publicly, preventing bypassing projection-layer validation.
+3. **ValidatedUiIr correctly layered**: `project_validated_ir_to_projection` safely delegates to the private helper using an already-validated `ValidatedUiIr`.
+4. **Raw projection untouched**: `project_ir_to_projection` continues to perform validation explicitly before building.
+5. **No forbidden surface introduced**:
+    - No `project_ir_to_projection_unchecked` exists.
+    - No config identity stored.
+    - No dependency on Workbench/Studio.
+    - No admission authority handles (verifier, runtime, capability, renderer) introduced.
+    - No Cargo changes.
+
+## Final API Surface
+
+```rust
+pub fn project_ir_to_projection(ir: &UiIr) -> Result<UiProjectionArtifact, UiProjectionError>
+pub fn project_validated_ir_to_projection(validated: &ValidatedUiIr<'_>) -> Result<UiProjectionArtifact, UiProjectionError>
+```
+
+Both correctly project `UiIr` into `UiProjectionArtifact` ensuring `UiIrValidationConfig::default()` constraints without duplicating traversal logic.
+
+## Next Steps
+
+This line is fully closed. Project #2 will reflect this completion.


### PR DESCRIPTION
## Summary

Adds the internal projection helper closeout.

This is a docs-only closeout recording the consolidation audit and confirming that projection logic was successfully unified without exposing unchecked public APIs.

## Scope

Records:

- Consolidation audit results
- Final API surface for projection construction
- Confirmation of absent forbidden boundaries

## Explicit non-scope

- no source changes
- no implementation
- no Cargo.toml / Cargo.lock changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Low
Boundary: Semantic UI
Gate: PRReady
Evidence: PR
Depends on: #936
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                      | Observed state      | Classification | Status |
| ------------------------- | ------------------- | -------------- | ------ |
| Closeout documentation    | Written             | ADMITTED       | PASS   |
| Source changes            | Absent              | FORBIDDEN      | PASS   |
