### PR TITLE
docs(ui): close out r12 renderer boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_boundary_closeout.md
@@ -1,0 +1,83 @@
+# R12 UI Renderer Boundary Closeout
+
+## 1. Purpose
+
+The R12 UI Renderer Boundary line is closed as a docs-only boundary.
+
+Renderer implementation remains absent.
+The next authorized gate is R12-UI-RENDERER-SEED-LINE-FULL-PACKAGE.
+
+## 2. Closed Boundary PR
+
+Boundary defined in PR #943.
+
+## 3. Boundary State
+
+Boundary defined:
+- renderer downstream of UiProjectionArtifact;
+- read-only projection consumption;
+- renderer-local presentation data only;
+- diagnostics/trace presentation allowed;
+- property/action/effect markers remain inert;
+- Quad-state flattening forbidden;
+- renderer authority forbidden.
+
+## 4. What Was Defined
+
+The boundary clarifies that the future renderer may consume projection artifacts, project nodes, and classification markers, but must not execute them, must not rewrite verification authority, and must preserve the determinism of the projection substrate.
+
+## 5. What Remains Absent
+
+Absent:
+- renderer code;
+- renderer module;
+- WGPU/winit/Tauri;
+- backend;
+- layout/draw/event;
+- event dispatch;
+- runtime/verifier/VM integration;
+- capability admission;
+- Workbench/Studio integration;
+- dependency additions.
+
+## 6. Evidence Matrix
+
+| Claim | Classification | Evidence | Status |
+|---|---|---|---|
+| renderer boundary document exists | DOCUMENTED | #943 | PASS |
+| renderer implementation exists | ABSENT / FORBIDDEN | Code audit | PASS |
+| UiProjectionArtifact consumption authorized for future | AUTHORIZED_FOR_FUTURE | #943 | PASS |
+| renderer non-authority rules defined | DOCUMENTED | #943 | PASS |
+| future renderer seed gate defined | AUTHORIZED_FOR_FUTURE | #943 | PASS |
+| source changes in boundary line | ABSENT | Code audit | PASS |
+| dependency additions | ABSENT | Code audit | PASS |
+
+## 7. Admission Guard Table
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| renderer boundary | CLOSED | ADMITTED | PASS |
+| renderer implementation | ABSENT / FORBIDDEN | FORBIDDEN | PASS |
+| layout/draw/event | ABSENT / FORBIDDEN | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT / FORBIDDEN | FORBIDDEN | PASS |
+| capability admission | ABSENT / FORBIDDEN | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT / FORBIDDEN | FORBIDDEN | PASS |
+| next seed gate | Planned | AUTHORIZED_FOR_FUTURE | PASS |
+
+## 8. Project #2 State
+
+Renderer Boundary PR #943 tracking complete.
+Closeout PR tracking complete.
+
+## 9. Next Gate
+
+R12-UI-RENDERER-SEED-LINE-FULL-PACKAGE
+
+## 10. Final Decision
+
+Final decision:
+CLOSED — R12 UI Renderer Boundary is complete as a docs-only boundary.
+
+A future renderer may be introduced only as a downstream read-only consumer of UiProjectionArtifact.
+
+Renderer implementation, backend integration, layout/draw/event, event dispatch, runtime/verifier/VM integration, capability admission, and Workbench/Studio integration remain absent until separate explicit gates.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Boundary line.

This is a docs-only closeout after the renderer boundary PR and clean post-merge audit.

## Scope

Records:

- renderer boundary state
- read-only downstream consumption of `UiProjectionArtifact`
- renderer non-authority rules
- absent renderer implementation
- absent backend/layout/draw/event/runtime/capability/Workbench integration
- next authorized seed gate

## Explicit non-scope

- no source changes
- no renderer implementation
- no backend implementation
- no WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc / Local audit / PR
Depends on: 943
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — R12 UI Renderer Boundary is complete as a docs-only boundary.
```
