### PR TITLE
feat(ui): add inert renderer seed

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -50,6 +50,7 @@ pub mod prepared_effect;
 pub mod prepared_effect_result;
 pub mod projection;
 pub mod raw_event;
+pub mod renderer;
 pub mod runtime_capability_mapping;
 pub mod runtime_capability_mapping_result;
 pub mod trace;
@@ -214,6 +215,10 @@ pub use projection::{
 pub use raw_event::{
     map_raw_event_to_interaction_intent, RawKeyCode, RawPointerButton, RawTextInput, RawUiEvent,
     RawUiEventId, RawUiEventKind, RawUiEventPayload, RawUiEventTarget,
+};
+pub use renderer::{
+    render_projection_to_model, UiRenderError, UiRenderMarker, UiRenderModel, UiRenderModelId,
+    UiRenderNode, UiRenderNodeId, UiRenderNodeKind,
 };
 pub use runtime_capability_mapping::{
     describe_interaction_runtime_capability_mapping, InteractionRuntimeCapabilityMappingDescriptor,

--- a/crates/prom-ui/src/renderer.rs
+++ b/crates/prom-ui/src/renderer.rs
@@ -1,0 +1,177 @@
+//! Inert renderer seed model.
+//!
+//! Renderer seed is an inert downstream projection consumer.
+//!
+//! It converts projection artifacts into renderer-local presentation structures only.
+//! It does not draw pixels.
+//! It does not dispatch events.
+//! It does not execute actions.
+//! It does not authorize capabilities.
+//! It does not mutate Semantic state.
+
+use crate::model::UiIrNodeId;
+use crate::projection::{
+    UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact, UiProjectionArtifactId,
+};
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderModel {
+    id: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    nodes: Vec<UiRenderNode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderModelId(u64);
+
+impl UiRenderModelId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderNode {
+    id: UiRenderNodeId,
+    source_projection_node: UiProjectedNodeId,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiRenderNodeKind,
+    markers: Vec<UiRenderMarker>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderNodeId(u64);
+
+impl UiRenderNodeId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderNodeKind {
+    Element,
+    Text,
+    Fragment,
+    Root,
+}
+
+// Renderer markers are inert presentation hints only.
+// They must not execute actions, authorize effects, or mutate semantic state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderMarker {
+    Property,
+    Action,
+    EffectBoundary,
+    Trace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UiRenderError {
+    EmptyProjection,
+}
+
+impl UiRenderModel {
+    pub fn id(&self) -> UiRenderModelId {
+        self.id
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn nodes(&self) -> &[UiRenderNode] {
+        &self.nodes
+    }
+}
+
+impl UiRenderNode {
+    pub fn id(&self) -> UiRenderNodeId {
+        self.id
+    }
+
+    pub fn source_projection_node(&self) -> UiProjectedNodeId {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiRenderNodeKind {
+        self.kind
+    }
+
+    pub fn markers(&self) -> &[UiRenderMarker] {
+        &self.markers
+    }
+}
+
+pub fn render_projection_to_model(
+    artifact: &UiProjectionArtifact,
+) -> Result<UiRenderModel, UiRenderError> {
+    if artifact.nodes().is_empty() {
+        return Err(UiRenderError::EmptyProjection);
+    }
+
+    let id = UiRenderModelId::new(artifact.id().raw());
+    let mut nodes = Vec::new();
+
+    for proj_node in artifact.nodes() {
+        let mut markers = Vec::new();
+
+        let kind = match proj_node.kind() {
+            UiProjectedNodeKind::Element => UiRenderNodeKind::Element,
+            UiProjectedNodeKind::Text => UiRenderNodeKind::Text,
+            UiProjectedNodeKind::Fragment => UiRenderNodeKind::Fragment,
+            UiProjectedNodeKind::Root => UiRenderNodeKind::Root,
+            UiProjectedNodeKind::PropertyCarrier => {
+                markers.push(UiRenderMarker::Property);
+                UiRenderNodeKind::Fragment
+            }
+            UiProjectedNodeKind::ActionCarrier => {
+                markers.push(UiRenderMarker::Action);
+                UiRenderNodeKind::Fragment
+            }
+            UiProjectedNodeKind::EffectBoundaryMarker => {
+                markers.push(UiRenderMarker::EffectBoundary);
+                UiRenderNodeKind::Fragment
+            }
+        };
+
+        if proj_node.has_trace() {
+            markers.push(UiRenderMarker::Trace);
+        }
+
+        let render_node = UiRenderNode {
+            id: UiRenderNodeId::new(proj_node.id().raw()),
+            source_projection_node: proj_node.id(),
+            source_ir_node: proj_node.source_ir_node_id(),
+            kind,
+            markers,
+        };
+
+        nodes.push(render_node);
+    }
+
+    Ok(UiRenderModel {
+        id,
+        source_projection: artifact.id(),
+        source_ir_root: artifact.source_ir_root(),
+        nodes,
+    })
+}

--- a/crates/prom-ui/tests/renderer_seed.rs
+++ b/crates/prom-ui/tests/renderer_seed.rs
@@ -1,0 +1,139 @@
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId, UiProjectionTraceRef,
+};
+use prom_ui::renderer::{
+    render_projection_to_model, UiRenderError, UiRenderMarker, UiRenderModelId, UiRenderNodeId,
+    UiRenderNodeKind,
+};
+
+#[test]
+fn test_render_model_builds_from_projected_valid_ir() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(42));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::new(UiProjectedNodeId::new(1), UiProjectedNodeKind::Root);
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::new(UiProjectedNodeId::new(2), UiProjectedNodeKind::Element);
+    artifact.push_node(element);
+
+    let model = render_projection_to_model(&artifact).expect("should build render model");
+
+    assert_eq!(model.id(), UiRenderModelId::new(42));
+    assert_eq!(model.source_projection(), UiProjectionArtifactId::new(42));
+    assert_eq!(model.source_ir_root(), Some(UiIrNodeId::new(10)));
+    assert_eq!(model.nodes().len(), 2);
+}
+
+#[test]
+fn test_deterministic_model_ids() {
+    let mut artifact1 = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact1.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+    ));
+
+    let mut artifact2 = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact2.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+    ));
+
+    let model1 = render_projection_to_model(&artifact1).unwrap();
+    let model2 = render_projection_to_model(&artifact2).unwrap();
+
+    assert_eq!(model1.id(), model2.id());
+    assert_eq!(model1.id(), UiRenderModelId::new(100));
+}
+
+#[test]
+fn test_render_node_ids_preserve_projection_node_ids() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(10),
+        UiProjectedNodeKind::Root,
+    ));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(20),
+        UiProjectedNodeKind::Element,
+    ));
+
+    let model = render_projection_to_model(&artifact).unwrap();
+    let nodes = model.nodes();
+
+    assert_eq!(nodes[0].id(), UiRenderNodeId::new(10));
+    assert_eq!(
+        nodes[0].source_projection_node(),
+        UiProjectedNodeId::new(10)
+    );
+
+    assert_eq!(nodes[1].id(), UiRenderNodeId::new(20));
+    assert_eq!(
+        nodes[1].source_projection_node(),
+        UiProjectedNodeId::new(20)
+    );
+}
+
+#[test]
+fn test_source_trace_preservation() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    artifact.set_source_ir_root(UiIrNodeId::new(50));
+
+    let mut node = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(51),
+    );
+    artifact.push_node(node);
+
+    let model = render_projection_to_model(&artifact).unwrap();
+    assert_eq!(model.source_ir_root(), Some(UiIrNodeId::new(50)));
+    assert_eq!(model.nodes()[0].source_ir_node(), Some(UiIrNodeId::new(51)));
+}
+
+#[test]
+fn test_inert_property_action_effect_markers() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::PropertyCarrier,
+    ));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::ActionCarrier,
+    ));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::EffectBoundaryMarker,
+    ));
+
+    let mut traced_node =
+        UiProjectedNode::new(UiProjectedNodeId::new(4), UiProjectedNodeKind::Element);
+    traced_node.set_trace(UiProjectionTraceRef::new(400));
+    artifact.push_node(traced_node);
+
+    let model = render_projection_to_model(&artifact).unwrap();
+    let nodes = model.nodes();
+
+    assert_eq!(nodes[0].kind(), UiRenderNodeKind::Fragment);
+    assert!(nodes[0].markers().contains(&UiRenderMarker::Property));
+
+    assert_eq!(nodes[1].kind(), UiRenderNodeKind::Fragment);
+    assert!(nodes[1].markers().contains(&UiRenderMarker::Action));
+
+    assert_eq!(nodes[2].kind(), UiRenderNodeKind::Fragment);
+    assert!(nodes[2].markers().contains(&UiRenderMarker::EffectBoundary));
+
+    assert_eq!(nodes[3].kind(), UiRenderNodeKind::Element);
+    assert!(nodes[3].markers().contains(&UiRenderMarker::Trace));
+}
+
+#[test]
+fn test_empty_projection_returns_error() {
+    let artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let result = render_projection_to_model(&artifact);
+    assert_eq!(result, Err(UiRenderError::EmptyProjection));
+}


### PR DESCRIPTION
## Summary

Adds the first inert R12 UI renderer seed.

This introduces a renderer-local model over `UiProjectionArtifact`.

It does not implement backend rendering, WGPU/winit/Tauri, layout, draw, event dispatch, runtime/verifier/VM integration, capability admission, or Workbench/Studio integration.

## Closed basis

- #941 — R12 UI Projection Builder Final Closeout
- #942 — POST-UI Roadmap Next Lane Selection
- #943 — R12 UI Renderer Boundary
- #944 — R12 UI Renderer Boundary Closeout

## Scope

Implemented:

- `renderer` module
- inert `UiRenderModel`
- inert `UiRenderNode`
- deterministic render model/node identity
- read-only consumption of `UiProjectionArtifact`
- projection ID preservation
- source/root trace preservation where available
- inert presentation markers
- focused tests

Preserved:

- projection substrate remains unchanged
- renderer is downstream only
- no semantic authority
- no action execution
- no effect authorization
- no runtime/verifier/capability integration

## Explicit non-scope

- no projection.rs changes
- no validation.rs changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no WGPU/winit/Tauri
- no backend
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #944
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                             | Observed state | Classification | Status |
| -------------------------------- | -------------- | -------------- | ------ |
| inert renderer seed              | Implemented    | ADMITTED       | PASS   |
| UiProjectionArtifact consumption | Read-only      | ADMITTED       | PASS   |
| renderer-local model             | Inert          | ADMITTED       | PASS   |
| backend/WGPU/winit/Tauri         | Absent         | FORBIDDEN      | PASS   |
| layout/draw/event                | Absent         | FORBIDDEN      | PASS   |
| action execution                 | Absent         | FORBIDDEN      | PASS   |
| capability admission             | Absent         | FORBIDDEN      | PASS   |
| runtime/verifier/VM              | Absent         | FORBIDDEN      | PASS   |
| Workbench/Studio                 | Absent         | FORBIDDEN      | PASS   |
