### PR TITLE
docs(ui): add renderer full-line ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_full_line_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_full_line_ledger_audit.md
@@ -1,0 +1,183 @@
+# R12 UI Renderer Full-Line Ledger Audit
+
+## 1. Purpose
+
+This document records the full-line ledger audit for the R12 UI Renderer lane through #948.
+
+It verifies that the renderer lane is complete as an inert renderer-local model substrate over UiProjectionArtifact.
+
+## 2. Closed Basis
+
+#941 — R12 UI Projection Builder Final Closeout
+#942 — POST-UI Roadmap Next Lane Selection
+
+## 3. Declared Renderer Line
+
+#943 — R12 UI Renderer Boundary
+#944 — R12 UI Renderer Boundary Closeout
+#945 — R12 UI Renderer Seed
+#946 — R12 UI Renderer Seed Closeout
+#947 — R12 UI Renderer Public API Lock
+#948 — R12 UI Renderer Public API Lock Closeout
+
+## 4. Merge Commit Ledger
+
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #943 | docs(ui): define r12 renderer boundary | MERGED | `86b2034f6d222598f9bf31632a95be1318f54b79` | `docs/roadmap/post_ui/r12_ui_renderer_boundary.md` | Docs | PASS |
+| #944 | docs(ui): close out r12 renderer boundary | MERGED | `136d877d373e6e5920719c6a38ac1569ccb65f68` | `docs/roadmap/post_ui/r12_ui_renderer_boundary_closeout.md` | Docs | PASS |
+| #945 | feat(ui): add inert renderer seed | MERGED | `2560f19bf6d22b9cc6872eb01df47a299078b07c` | `crates/prom-ui/src/lib.rs`<br>`crates/prom-ui/src/renderer.rs`<br>`crates/prom-ui/tests/renderer_seed.rs` | Source | PASS |
+| #946 | docs(ui): close out r12 renderer seed (#945) | MERGED | `a882d46196f94fdc118ec76f09d04a61d0dd3885` | `docs/roadmap/post_ui/r12_ui_renderer_seed_closeout.md` | Docs | PASS |
+| #947 | test(ui): lock renderer public api | MERGED | `4e3d4ca0094c617c7c3fad3606bceeb2c618c252` | `crates/prom-ui/tests/renderer_public_api_lock.rs` | Test | PASS |
+| #948 | docs(ui): close out renderer public api lock | MERGED | `020c3bcd5e7cf7e0b68d4d427792fba8f6aaefd6` | `docs/roadmap/post_ui/r12_ui_renderer_public_api_lock_closeout.md` | Docs | PASS |
+
+## 5. Changed File Surface
+
+Allowed file surface for renderer line observed:
+- `docs/roadmap/post_ui/*.md`
+- `crates/prom-ui/src/renderer.rs`
+- `crates/prom-ui/src/lib.rs`
+- `crates/prom-ui/tests/renderer_seed.rs`
+- `crates/prom-ui/tests/renderer_public_api_lock.rs`
+
+## 6. Final Renderer Source API Ledger
+
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| UiRenderModel | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| UiRenderNode | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| UiRenderModelId | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| UiRenderNodeId | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| UiRenderMarker | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| UiRenderError | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| render_projection_to_model | IMPLEMENTED | Source API | `crates/prom-ui/src/renderer.rs` | PASS |
+| renderer module export | IMPLEMENTED | Source API | `crates/prom-ui/src/lib.rs` | PASS |
+| read-only projection consumption | IMPLEMENTED | Constraint | Source / Tests | PASS |
+| deterministic model identity | IMPLEMENTED | Constraint | Source / Tests | PASS |
+| deterministic node identity | IMPLEMENTED | Constraint | Source / Tests | PASS |
+| backend API | ABSENT | Forbidden | Scan | PASS |
+| layout/draw/event API | ABSENT | Forbidden | Scan | PASS |
+| runtime/verifier/VM API | ABSENT | Forbidden | Scan | PASS |
+| capability API | ABSENT | Forbidden | Scan | PASS |
+| Workbench/Studio API | ABSENT | Forbidden | Scan | PASS |
+
+## 7. Behavior Ledger
+
+Implemented:
+- renderer module;
+- UiRenderModel;
+- UiRenderNode;
+- UiRenderModelId;
+- UiRenderNodeId;
+- UiRenderMarker;
+- UiRenderError;
+- render_projection_to_model;
+- renderer public API lock tests;
+- read-only UiProjectionArtifact consumption;
+- deterministic renderer identity;
+- source projection preservation;
+- source projected node preservation;
+- inert renderer markers.
+
+## 8. Test Coverage Ledger
+
+Tests present in `crates/prom-ui/tests/renderer_seed.rs` and `crates/prom-ui/tests/renderer_public_api_lock.rs` verify:
+- renderer model builds from projection artifact;
+- source projection ID preserved;
+- render node projected node ID preserved;
+- deterministic render model ID;
+- deterministic render node ID;
+- public API signatures locked;
+- accessors locked;
+- absence of backend/event/capability authority recorded.
+
+PASS WITH WARNING — MARKER FIXTURE NOT AVAILABLE THROUGH PUBLIC API
+
+## 9. Documentation Ledger
+
+Renderer documentation confirms that:
+- renderer boundary defined;
+- renderer seed inert;
+- renderer API locked;
+- backend absent;
+- layout/draw/event absent;
+- runtime/verifier/VM absent;
+- capability admission absent;
+- Workbench/Studio absent.
+
+## 10. Project #2 Ledger
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #943 | Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | #942 | 0 |
+| #944 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #943 | 0 |
+| #945 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #944 | 0 |
+| #946 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #945 | 0 |
+| #947 | Done | POST-UI | R12 | Test | High | Renderer | PRReady | PR | #946 | 0 |
+| #948 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #947 | 0 |
+
+## 11. Forbidden Surface Ledger
+
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| backend/WGPU/winit/Tauri | NO | Forbidden | PASS |
+| layout/draw/event | NO | Forbidden | PASS |
+| event dispatch | NO | Forbidden | PASS |
+| action execution | NO | Forbidden | PASS |
+| effect execution | NO | Forbidden | PASS |
+| runtime/verifier/VM | NO | Forbidden | PASS |
+| capability admission | NO | Forbidden | PASS |
+| Workbench/Studio | NO | Forbidden | PASS |
+| Cargo.toml / Cargo.lock | NO | Forbidden | PASS |
+| dependency additions | NO | Forbidden | PASS |
+
+Not implemented:
+- backend rendering;
+- WGPU/winit/Tauri;
+- layout engine;
+- draw engine;
+- event loop;
+- event dispatch;
+- action execution;
+- effect execution;
+- runtime/verifier/VM integration;
+- capability admission;
+- Workbench/Studio integration;
+- dependency additions.
+
+## 12. Manifest / Dependency Ledger
+
+- `Cargo.toml` unmodified.
+- `Cargo.lock` unmodified.
+- No dependency additions.
+
+## 13. Local Validation
+
+- `cargo test -p prom-ui --lib`: PASS
+- `cargo test -p prom-ui`: PASS
+- `cargo fmt --check`: PASS
+- `git diff --check`: PASS
+
+## 14. Admission Guard Summary
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| renderer boundary | CLOSED | IMPLEMENTED / ADMITTED | PASS |
+| renderer seed | IMPLEMENTED | IMPLEMENTED / ADMITTED | PASS |
+| renderer API lock | IMPLEMENTED | IMPLEMENTED / ADMITTED | PASS |
+| backend rendering | ABSENT | ABSENT / FORBIDDEN | PASS |
+| layout/draw/event | ABSENT | ABSENT / FORBIDDEN | PASS |
+| event dispatch | ABSENT | ABSENT / FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | ABSENT / FORBIDDEN | PASS |
+| capability admission | ABSENT | ABSENT / FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | ABSENT / FORBIDDEN | PASS |
+| dependency additions | ABSENT | ABSENT / FORBIDDEN | PASS |
+
+## 15. Final Decision
+
+Final decision:
+PASS — R12 UI Renderer full-line ledger is clean through #948.
+
+The renderer lane is complete as an inert renderer-local model substrate over UiProjectionArtifact with boundary documentation, seed implementation, API lock tests, closeout documentation, and Project #2 tracking.
+
+It does not implement backend rendering, WGPU/winit/Tauri, layout/draw/event, event dispatch, action execution, effect execution, runtime/verifier/VM integration, capability admission, Workbench/Studio integration, or dependency additions.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer full-line ledger audit through #948.

This is a docs-only audit PR.

## Scope

Audits:

- #943 — renderer boundary
- #944 — renderer boundary closeout
- #945 — renderer seed
- #946 — renderer seed closeout
- #947 — renderer public API lock
- #948 — renderer public API lock closeout

Also verifies upstream basis:

- #941 — projection builder final closeout
- #942 — next lane selection

## Explicit non-scope

- no source changes
- no renderer implementation changes
- no lib.rs changes
- no projection.rs changes
- no tests changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend/WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #948
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER FULL-LINE LEDGER AUDIT CLEAN
```
