### PR TITLE
feat(ui): add renderer diagnostics presentation seed

### DIFF
--- a/crates/prom-ui/src/renderer.rs
+++ b/crates/prom-ui/src/renderer.rs
@@ -175,3 +175,161 @@ pub fn render_projection_to_model(
         nodes,
     })
 }
+
+// Diagnostics presentation is inert renderer-local metadata.
+// It must not rewrite verifier diagnostics, execute actions, authorize effects,
+// or mutate semantic/runtime state.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderDiagnosticsPresentation {
+    id: UiRenderDiagnosticsPresentationId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    items: Vec<UiRenderDiagnosticItem>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderDiagnosticsPresentationId(u64);
+
+impl UiRenderDiagnosticsPresentationId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderDiagnosticItem {
+    id: UiRenderDiagnosticItemId,
+    source_render_node: Option<UiRenderNodeId>,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiRenderDiagnosticKind,
+    severity: UiRenderDiagnosticSeverity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderDiagnosticItemId(u64);
+
+impl UiRenderDiagnosticItemId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderDiagnosticKind {
+    DiagnosticMarker,
+    TraceMarker,
+    PropertyMarker,
+    ActionMarker,
+    EffectBoundaryMarker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderDiagnosticSeverity {
+    Info,
+    Warning,
+}
+
+impl UiRenderDiagnosticsPresentation {
+    pub fn id(&self) -> UiRenderDiagnosticsPresentationId {
+        self.id
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn items(&self) -> &[UiRenderDiagnosticItem] {
+        &self.items
+    }
+}
+
+impl UiRenderDiagnosticItem {
+    pub fn id(&self) -> UiRenderDiagnosticItemId {
+        self.id
+    }
+
+    pub fn source_render_node(&self) -> Option<UiRenderNodeId> {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiRenderDiagnosticKind {
+        self.kind
+    }
+
+    pub fn severity(&self) -> UiRenderDiagnosticSeverity {
+        self.severity
+    }
+}
+
+pub fn present_render_diagnostics(model: &UiRenderModel) -> UiRenderDiagnosticsPresentation {
+    let id = UiRenderDiagnosticsPresentationId(model.id().raw());
+    let mut items = Vec::new();
+
+    let mut item_counter = 0;
+    for node in model.nodes() {
+        for marker in node.markers() {
+            let (kind, severity) = match marker {
+                UiRenderMarker::Property => (
+                    UiRenderDiagnosticKind::PropertyMarker,
+                    UiRenderDiagnosticSeverity::Info,
+                ),
+                UiRenderMarker::Action => (
+                    UiRenderDiagnosticKind::ActionMarker,
+                    UiRenderDiagnosticSeverity::Warning,
+                ),
+                UiRenderMarker::EffectBoundary => (
+                    UiRenderDiagnosticKind::EffectBoundaryMarker,
+                    UiRenderDiagnosticSeverity::Warning,
+                ),
+                UiRenderMarker::Trace => (
+                    UiRenderDiagnosticKind::TraceMarker,
+                    UiRenderDiagnosticSeverity::Info,
+                ),
+            };
+
+            // Derive deterministic item ID from node ID and a local ordinal counter for markers
+            let mut hasher_val = node.id().raw().wrapping_mul(31);
+            hasher_val = hasher_val.wrapping_add(item_counter);
+            let item_id = UiRenderDiagnosticItemId(hasher_val);
+            item_counter += 1;
+
+            items.push(UiRenderDiagnosticItem {
+                id: item_id,
+                source_render_node: Some(node.id()),
+                source_projection_node: Some(node.source_projection_node()),
+                source_ir_node: node.source_ir_node(),
+                kind,
+                severity,
+            });
+        }
+    }
+
+    UiRenderDiagnosticsPresentation {
+        id,
+        source_render_model: model.id(),
+        source_projection: model.source_projection(),
+        items,
+    }
+}

--- a/crates/prom-ui/tests/renderer_diagnostics_presentation.rs
+++ b/crates/prom-ui/tests/renderer_diagnostics_presentation.rs
@@ -1,0 +1,153 @@
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId, UiProjectionTraceRef,
+};
+use prom_ui::renderer::{
+    present_render_diagnostics, render_projection_to_model, UiRenderDiagnosticItem,
+    UiRenderDiagnosticKind, UiRenderDiagnosticSeverity, UiRenderDiagnosticsPresentation,
+    UiRenderDiagnosticsPresentationId, UiRenderModel,
+};
+
+// --- Test 1 & 4 & 5 ---
+#[test]
+fn test_diagnostics_presentation_builds_from_render_model_read_only() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(42));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::new(UiProjectedNodeId::new(1), UiProjectedNodeKind::Root);
+    artifact.push_node(root);
+
+    let prop_carrier = UiProjectedNode::new(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::PropertyCarrier,
+    );
+    artifact.push_node(prop_carrier);
+
+    let action_carrier = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::ActionCarrier,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(action_carrier);
+
+    let mut traced_node =
+        UiProjectedNode::new(UiProjectedNodeId::new(4), UiProjectedNodeKind::Element);
+    traced_node.set_trace(UiProjectionTraceRef::new(400));
+    artifact.push_node(traced_node);
+
+    let effect_boundary = UiProjectedNode::new(
+        UiProjectedNodeId::new(5),
+        UiProjectedNodeKind::EffectBoundaryMarker,
+    );
+    artifact.push_node(effect_boundary);
+
+    let model = render_projection_to_model(&artifact).expect("should build render model");
+
+    let presentation = present_render_diagnostics(&model);
+
+    assert_eq!(
+        presentation.id(),
+        UiRenderDiagnosticsPresentationId::new(42)
+    );
+    assert_eq!(presentation.source_render_model(), model.id());
+    assert_eq!(presentation.source_projection(), model.source_projection());
+
+    let items = presentation.items();
+    // We expect 4 items:
+    // 1 for property carrier
+    // 1 for action carrier
+    // 1 for trace
+    // 1 for effect boundary
+    assert_eq!(items.len(), 4);
+
+    // Property Carrier
+    assert_eq!(items[0].kind(), UiRenderDiagnosticKind::PropertyMarker);
+    assert_eq!(items[0].severity(), UiRenderDiagnosticSeverity::Info);
+    assert_eq!(items[0].source_render_node().unwrap().raw(), 2);
+
+    // Action Carrier
+    assert_eq!(items[1].kind(), UiRenderDiagnosticKind::ActionMarker);
+    assert_eq!(items[1].severity(), UiRenderDiagnosticSeverity::Warning);
+    assert_eq!(items[1].source_render_node().unwrap().raw(), 3);
+    assert_eq!(items[1].source_ir_node(), Some(UiIrNodeId::new(12)));
+
+    // Trace
+    assert_eq!(items[2].kind(), UiRenderDiagnosticKind::TraceMarker);
+    assert_eq!(items[2].severity(), UiRenderDiagnosticSeverity::Info);
+    assert_eq!(items[2].source_render_node().unwrap().raw(), 4);
+
+    // Effect Boundary
+    assert_eq!(
+        items[3].kind(),
+        UiRenderDiagnosticKind::EffectBoundaryMarker
+    );
+    assert_eq!(items[3].severity(), UiRenderDiagnosticSeverity::Warning);
+    assert_eq!(items[3].source_render_node().unwrap().raw(), 5);
+}
+
+// --- Test 2 ---
+#[test]
+fn test_deterministic_presentation_id() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+    ));
+
+    let model = render_projection_to_model(&artifact).unwrap();
+
+    let presentation1 = present_render_diagnostics(&model);
+    let presentation2 = present_render_diagnostics(&model);
+
+    assert_eq!(presentation1.id(), presentation2.id());
+}
+
+// --- Test 3 ---
+#[test]
+fn test_deterministic_diagnostic_item_ids() {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::PropertyCarrier,
+    ));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::ActionCarrier,
+    ));
+
+    let model = render_projection_to_model(&artifact).unwrap();
+
+    let presentation1 = present_render_diagnostics(&model);
+    let presentation2 = present_render_diagnostics(&model);
+
+    assert_eq!(presentation1.items().len(), 2);
+    assert_eq!(presentation1.items()[0].id(), presentation2.items()[0].id());
+    assert_eq!(presentation1.items()[1].id(), presentation2.items()[1].id());
+}
+
+// --- Test 7 ---
+#[test]
+fn diagnostics_presentation_entrypoint_signature_is_locked() {
+    let _: fn(&UiRenderModel) -> UiRenderDiagnosticsPresentation = present_render_diagnostics;
+}
+
+#[test]
+fn diagnostics_presentation_public_types_are_locked() {
+    fn assert_presentation(_: &UiRenderDiagnosticsPresentation) {}
+    fn assert_item(_: &UiRenderDiagnosticItem) {}
+    fn assert_kind(_: UiRenderDiagnosticKind) {}
+    fn assert_severity(_: UiRenderDiagnosticSeverity) {}
+
+    let _ = (
+        assert_presentation,
+        assert_item,
+        assert_kind,
+        assert_severity,
+    );
+}
+
+// Ensure no backend/capability code is introduced.
+// The renderer diagnostics presentation is an inert local display structure.
+// It is explicitly forbidden from implementing semantic truth, dispatching events,
+// rendering backend UI, admitting capabilities, or integrating with Workbench/Studio.

--- a/crates/prom-ui/tests/renderer_seed.rs
+++ b/crates/prom-ui/tests/renderer_seed.rs
@@ -81,7 +81,7 @@ fn test_source_trace_preservation() {
     let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
     artifact.set_source_ir_root(UiIrNodeId::new(50));
 
-    let mut node = UiProjectedNode::with_source_ir_node(
+    let node = UiProjectedNode::with_source_ir_node(
         UiProjectedNodeId::new(1),
         UiProjectedNodeKind::Element,
         UiIrNodeId::new(51),

--- a/pr_body_r12_ui_renderer_diagnostics_presentation.md
+++ b/pr_body_r12_ui_renderer_diagnostics_presentation.md
@@ -1,0 +1,93 @@
+## Summary
+
+Adds the R12 UI Renderer Diagnostics Presentation seed.
+
+This introduces inert renderer-local diagnostics presentation structures over `UiRenderModel`.
+
+It does not rewrite verifier diagnostics, call runtime/verifier/VM systems, execute actions, authorize effects, dispatch events, or implement backend rendering.
+
+## Closed basis
+
+- #943 — R12 UI Renderer Boundary
+- #944 — R12 UI Renderer Boundary Closeout
+- #945 — R12 UI Renderer Seed
+- #946 — R12 UI Renderer Seed Closeout
+- #947 — R12 UI Renderer Public API Lock
+- #948 — R12 UI Renderer Public API Lock Closeout
+- #949 — R12 UI Renderer Full-Line Ledger Audit
+
+## Scope
+
+Implemented:
+
+- inert diagnostics presentation model
+- diagnostics presentation item model
+- deterministic presentation identity
+- deterministic item identity
+- read-only `UiRenderModel` consumption
+- source render model/projection preservation
+- inert marker-to-presentation mapping
+- tests and API signature locks
+
+Preserved:
+
+- renderer remains downstream and inert
+- no backend
+- no WGPU/winit/Tauri
+- no layout/draw/event
+- no event dispatch
+- no runtime/verifier/VM
+- no capability admission
+- no Workbench/Studio
+
+## Explicit non-scope
+
+- no projection.rs changes
+- no validation.rs changes
+- no Cargo.toml / Cargo.lock changes
+- no dependency additions
+- no backend rendering
+- no draw/layout/event implementation
+- no verifier diagnostic rewriting
+- no semantic truth authority
+
+## Project #2 metadata
+
+```text
+Track: POST-UI
+Wave: R12
+Type: Code
+Risk: High
+Boundary: Renderer
+Gate: PRReady
+Evidence: PR
+Depends on: #949
+```
+
+## Validation
+
+Local only:
+
+```text
+cargo fmt --check: PASS
+cargo test -p prom-ui --lib: PASS
+cargo test -p prom-ui: PASS
+git diff --check: PASS
+GitHub CI used as evidence: NO
+```
+
+## Admission Guard
+
+| Area                                | Observed state | Classification | Status |
+| ----------------------------------- | -------------- | -------------- | ------ |
+| diagnostics presentation model      | Implemented    | ADMITTED       | PASS   |
+| read-only UiRenderModel consumption | Implemented    | ADMITTED       | PASS   |
+| diagnostic authority                | Absent         | FORBIDDEN      | PASS   |
+| verifier diagnostic rewriting       | Absent         | FORBIDDEN      | PASS   |
+| backend/WGPU/winit/Tauri            | Absent         | FORBIDDEN      | PASS   |
+| layout/draw/event                   | Absent         | FORBIDDEN      | PASS   |
+| event dispatch                      | Absent         | FORBIDDEN      | PASS   |
+| runtime/verifier/VM                 | Absent         | FORBIDDEN      | PASS   |
+| capability admission                | Absent         | FORBIDDEN      | PASS   |
+| Workbench/Studio                    | Absent         | FORBIDDEN      | PASS   |
+


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Diagnostics Presentation seed.

This introduces inert renderer-local diagnostics presentation structures over `UiRenderModel`.

It does not rewrite verifier diagnostics, call runtime/verifier/VM systems, execute actions, authorize effects, dispatch events, or implement backend rendering.

## Closed basis

- #943 — R12 UI Renderer Boundary
- #944 — R12 UI Renderer Boundary Closeout
- #945 — R12 UI Renderer Seed
- #946 — R12 UI Renderer Seed Closeout
- #947 — R12 UI Renderer Public API Lock
- #948 — R12 UI Renderer Public API Lock Closeout
- #949 — R12 UI Renderer Full-Line Ledger Audit

## Scope

Implemented:

- inert diagnostics presentation model
- diagnostics presentation item model
- deterministic presentation identity
- deterministic item identity
- read-only `UiRenderModel` consumption
- source render model/projection preservation
- inert marker-to-presentation mapping
- tests and API signature locks

Preserved:

- renderer remains downstream and inert
- no backend
- no WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio

## Explicit non-scope

- no projection.rs changes
- no validation.rs changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend rendering
- no draw/layout/event implementation
- no verifier diagnostic rewriting
- no semantic truth authority

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #949
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                                | Observed state | Classification | Status |
| ----------------------------------- | -------------- | -------------- | ------ |
| diagnostics presentation model      | Implemented    | ADMITTED       | PASS   |
| read-only UiRenderModel consumption | Implemented    | ADMITTED       | PASS   |
| diagnostic authority                | Absent         | FORBIDDEN      | PASS   |
| verifier diagnostic rewriting       | Absent         | FORBIDDEN      | PASS   |
| backend/WGPU/winit/Tauri            | Absent         | FORBIDDEN      | PASS   |
| layout/draw/event                   | Absent         | FORBIDDEN      | PASS   |
| event dispatch                      | Absent         | FORBIDDEN      | PASS   |
| runtime/verifier/VM                 | Absent         | FORBIDDEN      | PASS   |
| capability admission                | Absent         | FORBIDDEN      | PASS   |
| Workbench/Studio                    | Absent         | FORBIDDEN      | PASS   |

