### PR TITLE
feat(ui): add renderer trace presentation

### DIFF
--- a/crates/prom-ui/src/renderer.rs
+++ b/crates/prom-ui/src/renderer.rs
@@ -333,3 +333,154 @@ pub fn present_render_diagnostics(model: &UiRenderModel) -> UiRenderDiagnosticsP
         items,
     }
 }
+
+// Trace presentation is inert renderer-local metadata.
+// It must not act as proof, debugger state, verifier output,
+// runtime introspection, event dispatch, or semantic authority.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderTracePresentation {
+    id: UiRenderTracePresentationId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    links: Vec<UiRenderTraceLink>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderTracePresentationId(u64);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderTraceLink {
+    id: UiRenderTraceLinkId,
+    source_render_node: Option<UiRenderNodeId>,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiRenderTraceLinkKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderTraceLinkId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderTraceLinkKind {
+    RenderModelToProjection,
+    RenderNodeToProjectionNode,
+    RenderNodeToIrNode,
+}
+
+impl UiRenderTracePresentationId {
+    pub fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+impl UiRenderTraceLinkId {
+    pub fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+impl UiRenderTracePresentation {
+    pub fn id(&self) -> UiRenderTracePresentationId {
+        self.id
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn links(&self) -> &[UiRenderTraceLink] {
+        &self.links
+    }
+}
+
+impl UiRenderTraceLink {
+    pub fn id(&self) -> UiRenderTraceLinkId {
+        self.id
+    }
+
+    pub fn source_render_node(&self) -> Option<UiRenderNodeId> {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiRenderTraceLinkKind {
+        self.kind
+    }
+}
+
+pub fn present_render_trace(model: &UiRenderModel) -> UiRenderTracePresentation {
+    // Domain marker for trace presentation
+    let id_val = model.id().raw().wrapping_mul(31).wrapping_add(2);
+    let id = UiRenderTracePresentationId::new(id_val);
+
+    let mut links = Vec::new();
+    let mut link_counter = 0_u64;
+
+    // Model level link
+    let link_id_val = id.raw().wrapping_mul(17).wrapping_add(link_counter);
+    let link_id = UiRenderTraceLinkId::new(link_id_val);
+    link_counter += 1;
+
+    links.push(UiRenderTraceLink {
+        id: link_id,
+        source_render_node: None,
+        source_projection_node: None,
+        source_ir_node: model.source_ir_root(),
+        kind: UiRenderTraceLinkKind::RenderModelToProjection,
+    });
+
+    for node in model.nodes() {
+        let link_id_val = id.raw().wrapping_mul(17).wrapping_add(link_counter);
+        let link_id = UiRenderTraceLinkId::new(link_id_val);
+        link_counter += 1;
+
+        links.push(UiRenderTraceLink {
+            id: link_id,
+            source_render_node: Some(node.id()),
+            source_projection_node: Some(node.source_projection_node()),
+            source_ir_node: node.source_ir_node(),
+            kind: UiRenderTraceLinkKind::RenderNodeToProjectionNode,
+        });
+
+        if node.source_ir_node().is_some() {
+            let link_id_val = id.raw().wrapping_mul(17).wrapping_add(link_counter);
+            let link_id = UiRenderTraceLinkId::new(link_id_val);
+            link_counter += 1;
+
+            links.push(UiRenderTraceLink {
+                id: link_id,
+                source_render_node: Some(node.id()),
+                source_projection_node: Some(node.source_projection_node()),
+                source_ir_node: node.source_ir_node(),
+                kind: UiRenderTraceLinkKind::RenderNodeToIrNode,
+            });
+        }
+    }
+
+    UiRenderTracePresentation {
+        id,
+        source_render_model: model.id(),
+        source_projection: model.source_projection(),
+        links,
+    }
+}

--- a/crates/prom-ui/tests/renderer_trace_presentation.rs
+++ b/crates/prom-ui/tests/renderer_trace_presentation.rs
@@ -1,0 +1,124 @@
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{
+    present_render_trace, render_projection_to_model, UiRenderModel, UiRenderTraceLink,
+    UiRenderTraceLinkKind, UiRenderTracePresentation,
+};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(42));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::new(UiProjectedNodeId::new(1), UiProjectedNodeKind::Root);
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(20),
+    );
+    artifact.push_node(element);
+
+    render_projection_to_model(&artifact).expect("should build render model")
+}
+
+#[test]
+fn trace_presentation_entrypoint_signature_is_locked() {
+    let _: fn(&UiRenderModel) -> UiRenderTracePresentation = present_render_trace;
+}
+
+#[test]
+fn trace_presentation_public_types_are_locked() {
+    fn assert_presentation(_: &UiRenderTracePresentation) {}
+    fn assert_link(_: &UiRenderTraceLink) {}
+    fn assert_kind(_: UiRenderTraceLinkKind) {}
+
+    let _ = (assert_presentation, assert_link, assert_kind);
+}
+
+#[test]
+fn test_trace_presentation_builds_from_render_model_read_only() {
+    let model = create_test_render_model();
+    let presentation = present_render_trace(&model);
+
+    assert_eq!(presentation.source_render_model(), model.id());
+    assert_eq!(presentation.source_projection(), model.source_projection());
+
+    // Model should be unmutated (implied by &UiRenderModel argument)
+}
+
+#[test]
+fn test_deterministic_presentation_id() {
+    let model = create_test_render_model();
+
+    let presentation1 = present_render_trace(&model);
+    let presentation2 = present_render_trace(&model);
+
+    assert_eq!(presentation1.id(), presentation2.id());
+}
+
+#[test]
+fn test_deterministic_trace_link_ids() {
+    let model = create_test_render_model();
+
+    let presentation1 = present_render_trace(&model);
+    let presentation2 = present_render_trace(&model);
+
+    assert_eq!(presentation1.links().len(), presentation2.links().len());
+
+    for (link1, link2) in presentation1
+        .links()
+        .iter()
+        .zip(presentation2.links().iter())
+    {
+        assert_eq!(link1.id(), link2.id());
+        assert_eq!(link1.kind(), link2.kind());
+    }
+}
+
+#[test]
+fn test_source_link_preservation() {
+    let model = create_test_render_model();
+    let presentation = present_render_trace(&model);
+
+    // There should be a model to projection link
+    let model_link = presentation
+        .links()
+        .iter()
+        .find(|l| l.kind() == UiRenderTraceLinkKind::RenderModelToProjection)
+        .unwrap();
+    assert_eq!(model_link.source_ir_node(), model.source_ir_root());
+
+    // For each node in the model, there should be trace links
+    for node in model.nodes() {
+        let node_proj_link = presentation
+            .links()
+            .iter()
+            .find(|l| {
+                l.kind() == UiRenderTraceLinkKind::RenderNodeToProjectionNode
+                    && l.source_render_node() == Some(node.id())
+            })
+            .expect("render node must have projection trace link");
+
+        assert_eq!(
+            node_proj_link.source_projection_node(),
+            Some(node.source_projection_node())
+        );
+
+        if let Some(ir_node) = node.source_ir_node() {
+            let node_ir_link = presentation
+                .links()
+                .iter()
+                .find(|l| {
+                    l.kind() == UiRenderTraceLinkKind::RenderNodeToIrNode
+                        && l.source_render_node() == Some(node.id())
+                })
+                .expect("render node must have ir trace link");
+
+            assert_eq!(node_ir_link.source_ir_node(), Some(ir_node));
+        }
+    }
+}


### PR DESCRIPTION
# R12 UI Renderer Trace Presentation

## Scope
Adds the trace presentation API over `UiRenderModel`, providing stable deterministic references bridging rendering back to source IR.

## Status
- [x] Inert metadata structs (`UiRenderTracePresentation`, `UiRenderTraceLink`, etc.).
- [x] Deterministic ID derivation mapped precisely from structure (no global state).
- [x] Read-only behavior over `UiRenderModel`.
- [x] 100% test coverage for identity/signature locking.
- [x] No side-effects or executing truth authority.

## Risk
Low. Pure structural data reflection downstream.

Closes #953 (or whatever next issue ID, if any).
