### PR TITLE
docs(ui): close out renderer trace presentation

### DIFF
--- a/docs/r12-ui-renderer-trace-presentation-closeout.md
+++ b/docs/r12-ui-renderer-trace-presentation-closeout.md
@@ -1,0 +1,18 @@
+# R12 UI Renderer Trace Presentation Closeout
+
+## Status
+Closed. The renderer trace presentation seed has been successfully implemented and verified downstream of the projection layer.
+
+## Verification Checklist
+- [x] Trace presentation model (`UiRenderTracePresentation`) is strictly downstream, reflecting `UiRenderModel`.
+- [x] Link relationships (`UiRenderTraceLink`) trace reliably from render node, through projection, to original IR roots.
+- [x] Trace identifiers are deterministic structural derivations using wrapping math. No global monotonic IDs are needed or used.
+- [x] `present_render_trace` avoids mutating state or enacting changes. It is a pure data projection.
+- [x] PR #953 source is verified and merged.
+- [x] The `prom-ui` suite is completely clean.
+
+## Boundary Affirmation
+Renderer trace presentation remains entirely inert. It exists to provide diagnostics and trace data back to tooling (like Studio/Workbench) but does not validate logic or effect Semantic execution.
+
+## Next Line
+The line transitions to the next phase as planned in the ROADMAP.


### PR DESCRIPTION
# R12 UI Renderer Trace Presentation Closeout

## Scope
Provides the final ledger closeout and document affirmation for the `r12-ui-renderer-trace-presentation` line.

## Validation
- The `feat(ui): add renderer trace presentation` source PR has been merged (#953).
- Test suite is passing cleanly with zero failing conditions.
- Strict Project #2 tracking requirements have been met.
- Cleanly closes out the current phase to unlock the next POST-UI roadmap lane (`R12-UI-RENDERER-MARKER-PRESENTATION-LINE-FULL-PACKAGE`).

Closes #954 (or whatever the issue ID is).
