### PR TITLE
docs(agents): add dna renderer and source authoring guardrails

### DIFF
--- a/.agents/skills/semantic-source-authoring-guard/SKILL.md
+++ b/.agents/skills/semantic-source-authoring-guard/SKILL.md
@@ -33,6 +33,25 @@ Hard rules:
 
 The two skills are complementary and non-overlapping.
 
+## Boundary With Repository Architecture Work
+
+This skill is only for Semantic `.sm` source authoring, fixtures, examples, and diagnostic probes.
+
+Use the main `semantic` skill instead for:
+- Rust source changes;
+- repository architecture;
+- UI / renderer work;
+- roadmap / closeout / ledger PRs;
+- Project #2 metadata;
+- capability / runtime / verifier / VM ownership;
+- Workbench / Studio boundaries;
+- agent skill governance.
+
+If a task combines `.sm` fixtures with architecture, renderer, roadmap, verifier, runtime, capability, or Project #2 workflow:
+1. Use the main `semantic` skill for repository and architectural boundaries.
+2. Use this source authoring guard only for the `.sm` fixture/source portion.
+3. Do not let `.sm` fixture convenience widen compiler, parser, verifier, runtime, or UI behavior.
+
 ## Required Source Authorities
 
 Read these canonical docs first:
@@ -56,6 +75,21 @@ Treat these live paths as stronger evidence than intuition and stronger than fut
 - `examples/**/*.sm`
 
 If docs and fixtures disagree, prefer the fixture/test evidence for current authoring and stop if the conflict cannot be resolved safely.
+
+## DNA-Aware Source Authoring
+
+For `.sm` authoring that touches public examples, doctrine, roadmap-facing examples, UI examples, capability examples, verifier examples, runtime examples, or language identity examples, inspect `docs/dna` before authoring.
+
+DNA-sensitive `.sm` work must report:
+- docs/dna inspected: YES/NO
+- DNA files inspected:
+- DNA alignment:
+- DNA conflicts detected:
+- DNA-driven constraints applied:
+
+If docs/dna conflicts with the proposed `.sm` example or fixture framing, stop and report the contradiction.
+
+If docs/dna is not relevant to a tiny local negative fixture, say so explicitly.
 
 ## Mandatory Authoring Workflow
 
@@ -219,7 +253,9 @@ Stop and report if:
 - `smc check` fails because the syntax is unsupported;
 - the requested fixture requires language widening;
 - the task would require compiler/runtime/parser/verifier changes but was scoped as test-only;
-- you are about to invent syntax to satisfy the task.
+- you are about to invent syntax to satisfy the task;
+- the `.sm` source would conflict with docs/dna project identity;
+- the task is actually repository architecture / renderer / roadmap work and should use the main `semantic` skill first.
 
 ## Acceptance Criteria
 

--- a/.agents/skills/semantic/SKILL.md
+++ b/.agents/skills/semantic/SKILL.md
@@ -704,3 +704,4 @@ Changes:
 Tests:
 Risks:
 Next:
+ 


### PR DESCRIPTION
## Summary

Updates the existing Semantic agent skills with explicit DNA preflight, renderer presentation guardrails, roadmap ledger discipline, and source-authoring skill boundary clarification.

## Scope

Updates:

- `.agents/skills/semantic/SKILL.md`
- `.agents/skills/semantic-source-authoring-guard/SKILL.md`

Adds to `semantic`:

- `DNA_RULES`
- `R12_RENDERER_PRESENTATION_RULES`
- `ROADMAP_LEDGER_DISCIPLINE`

Adds to `semantic-source-authoring-guard`:

- boundary with repository architecture work
- DNA-aware source authoring
- stop conditions for skill misuse / DNA conflict

## Why

Recent R12 POST-UI renderer work showed that agents can pass code tests while still drifting in ledger discipline, Project #2 metadata, closeout paths, or DNA alignment.

This update makes those constraints explicit in the agent skills.

## Explicit non-scope

- no Rust source changes
- no `.sm` fixture changes
- no Cargo.toml / Cargo.lock changes
- no roadmap status change
- no docs/dna change
- no new skill

## Validation

```text
git diff --check: PASS
changed files only:
- .agents/skills/semantic/SKILL.md
- .agents/skills/semantic-source-authoring-guard/SKILL.md
tracked pr_body files: NO
```
