### PR TITLE
docs(ui): add renderer presentation full-line ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_presentation_full_line_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_presentation_full_line_ledger_audit.md
@@ -1,0 +1,196 @@
+# R12 UI Renderer Presentation Full-Line Ledger Audit
+
+## 1. Purpose
+This document records the full-line ledger audit for the R12 UI Renderer Presentation lane through diagnostics, trace, marker presentation, and the agent guardrail update PRs.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer presentation is inert display metadata;
+- UI/renderer must remain downstream;
+- no action execution;
+- no effect authorization;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+Closed basis PRs:
+- #941 — R12 UI Projection Builder Final Closeout
+- #942 — POST-UI Roadmap Next Lane Selection
+- #943 — R12 UI Renderer Boundary
+- #944 — R12 UI Renderer Boundary Closeout
+- #945 — R12 UI Renderer Seed
+- #946 — R12 UI Renderer Seed Closeout
+- #947 — R12 UI Renderer Public API Lock
+- #948 — R12 UI Renderer Public API Lock Closeout
+- #949 — R12 UI Renderer Full-Line Ledger Audit
+
+## 4. Declared Presentation Line
+- #950 — Diagnostics Presentation
+- #951 — Diagnostics Presentation Closeout
+- #952 — Diagnostics Cleanup
+- #953 — Trace Presentation
+- #954 — Trace Presentation Closeout
+- #955 — Trace Cleanup
+- #956 — Marker Presentation
+- #957 — Marker Presentation Closeout
+- #959 — Skill Guardrail Update
+
+## 5. Governance Update
+PR #959 updated the semantic agent skills to require docs/dna preflight, inert renderer presentation guardrails, roadmap ledger discipline, no committed pr_body artifacts, and factual Project #2 metadata verification.
+
+## 6. Merge Commit Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #950 | feat(ui): add renderer diagnostics presentation seed | MERGED | fd9a2b32a7c680578c419fd05220ad1e808da133 | 4 | renderer presentation seed | OK |
+| #951 | docs(ui): close out renderer diagnostics presentation line | MERGED | 2cb66349a8bb3ea6fc86da008c42048b7ba8aef2 | 2 | closeout docs | OK |
+| #952 | chore(ui): remove renderer diagnostics presentation pr body artifacts | MERGED | d0d48dad079246592484e4618ef420e2615f701e | 2 | cleanup | OK |
+| #953 | feat(ui): add renderer trace presentation | MERGED | 50bcda4c89d541ea79d33fd9755e901056864bea | 2 | renderer presentation seed | OK |
+| #954 | docs(ui): close out renderer trace presentation | MERGED | edbb6a58ce8329b65ee26afaafac4a657596a024 | 1 | closeout docs | OK |
+| #955 | docs(ui): move renderer trace presentation closeout into roadmap | MERGED | eec81530a68ed6df085a11880911f8ae86256167 | 1 | cleanup docs | OK |
+| #956 | feat(ui): add renderer marker presentation | MERGED | 86fa5ee436876b12679953150476335059d85296 | 2 | renderer presentation seed | OK |
+| #957 | docs(ui): close out renderer marker presentation | MERGED | e4ec8d947467eed55c1b55617c137db9987e10c0 | 1 | closeout docs | OK |
+| #959 | docs(agents): add dna renderer and source authoring guardrails | MERGED | 4e65a54323eb3bc8125357d01837832b381e8a50 | 2 | governance docs | OK |
+
+## 7. Changed File Surface
+- #950: `crates/prom-ui/src/renderer.rs`, `crates/prom-ui/tests/renderer_diagnostics_presentation.rs`, `crates/prom-ui/tests/renderer_seed.rs`, `pr_body_r12_ui_renderer_diagnostics_presentation.md`
+- #951: `docs/roadmap/post_ui/r12_ui_renderer_diagnostics_presentation_closeout.md`, `pr_body_r12_ui_renderer_diagnostics_presentation_closeout.md`
+- #952: `pr_body_r12_ui_renderer_diagnostics_presentation.md`, `pr_body_r12_ui_renderer_diagnostics_presentation_closeout.md`
+- #953: `crates/prom-ui/src/renderer.rs`, `crates/prom-ui/tests/renderer_trace_presentation.rs`
+- #954: `docs/r12-ui-renderer-trace-presentation-closeout.md`
+- #955: `docs/roadmap/post_ui/r12_ui_renderer_trace_presentation_closeout.md`
+- #956: `crates/prom-ui/src/renderer.rs`, `crates/prom-ui/tests/renderer_marker_presentation.rs`
+- #957: `docs/roadmap/post_ui/r12_ui_renderer_marker_presentation_closeout.md`
+- #959: `.agents/skills/semantic/SKILL.md`, `.agents/skills/semantic-source-authoring-guard/SKILL.md`
+
+## 8. Final Renderer Presentation API Ledger
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| UiRenderDiagnosticsPresentation | present | inert renderer-local display metadata | PR #950 / tests | OK |
+| UiRenderDiagnosticItem | present | inert renderer-local display metadata | PR #950 / tests | OK |
+| UiRenderDiagnosticKind | present | inert renderer-local display metadata | PR #950 / tests | OK |
+| UiRenderDiagnosticSeverity | present | inert renderer-local display metadata | PR #950 / tests | OK |
+| present_render_diagnostics | present | read-only renderer presentation | PR #950 / tests | OK |
+| UiRenderTracePresentation | present | inert renderer-local display metadata | PR #953 / tests | OK |
+| UiRenderTraceLink | present | inert renderer-local display metadata | PR #953 / tests | OK |
+| UiRenderTraceLinkKind | present | inert renderer-local display metadata | PR #953 / tests | OK |
+| present_render_trace | present | read-only renderer presentation | PR #953 / tests | OK |
+| UiRenderMarkerPresentation | present | inert renderer-local display metadata | PR #956 / tests | OK |
+| UiRenderMarkerItem | present | inert renderer-local display metadata | PR #956 / tests | OK |
+| UiRenderMarkerVisualRole | present | inert renderer-local display metadata | PR #956 / tests | OK |
+| UiRenderMarkerEmphasis | present | inert renderer-local display metadata | PR #956 / tests | OK |
+| present_render_markers | present | read-only renderer presentation | PR #956 / tests | OK |
+| backend API | absent | forbidden surface | no implementation evidence | OK |
+| layout/draw/event API | absent | forbidden surface | no implementation evidence | OK |
+| event dispatch API | absent | forbidden surface | no implementation evidence | OK |
+| runtime/verifier/VM API | absent | forbidden surface | no implementation evidence | OK |
+| capability API | absent | forbidden surface | no implementation evidence | OK |
+| Workbench/Studio API | absent | forbidden surface | no implementation evidence | OK |
+| proof/debugger API | absent | forbidden surface | no implementation evidence | OK |
+
+## 9. Behavior Ledger
+The renderer presentation layers consume UiRenderModel read-only, keep deterministic presentation identities, preserve source projection references where exposed, and keep marker visual role and emphasis display-only.
+
+## 10. Test Coverage Ledger
+Diagnostics tests:
+- presentation builds from render model
+- deterministic presentation identity
+- deterministic item identity
+- read-only preservation
+- signature/API lock
+
+Trace tests:
+- presentation builds from render model
+- deterministic presentation identity
+- deterministic link identity
+- read-only preservation
+- source link preservation where exposed
+- signature/API lock
+
+Marker tests:
+- presentation builds from render model
+- deterministic presentation identity
+- deterministic marker item identity
+- read-only preservation
+- marker role mapping
+- marker emphasis mapping
+- action marker not executable
+- effect marker not authorization
+- signature/API lock
+
+## 11. Cleanup Ledger
+| Cleanup PR | Reason | Fixed Surface | Final State | Status |
+|---|---|---|---|---|
+| #952 | removed accidental pr_body diagnostics artifacts | `pr_body_r12_ui_renderer_diagnostics_presentation.md`, `pr_body_r12_ui_renderer_diagnostics_presentation_closeout.md` | tracked pr_body artifacts removed | OK |
+| #955 | moved trace closeout into roadmap | `docs/r12-ui-renderer-trace-presentation-closeout.md` to `docs/roadmap/post_ui/r12_ui_renderer_trace_presentation_closeout.md` | roadmap placement restored | OK |
+
+## 12. Documentation Ledger
+- docs/dna inspected: YES
+- docs/roadmap/post_ui inspected: YES
+- docs/dna alignment preserved: YES
+- no docs/dna drift detected
+
+## 13. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #950 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #949 | 0 |
+| #951 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #950 | 0 |
+| #952 | not present in Project #2 at audit time | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 |
+| #953 | not present in Project #2 at audit time | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 |
+| #954 | not present in Project #2 at audit time | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 |
+| #955 | not present in Project #2 at audit time | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 |
+| #956 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #955 | 0 |
+| #957 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #956 | 0 |
+| #959 | not present in Project #2 at audit time | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 |
+
+## 14. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| backend/WGPU/winit/Tauri | absent | forbidden surface not present | OK |
+| layout/draw/event | absent | forbidden surface not present | OK |
+| event dispatch | absent | forbidden surface not present | OK |
+| action execution | absent | forbidden surface not present | OK |
+| effect execution/authorization | absent | forbidden surface not present | OK |
+| runtime/verifier/VM | absent | forbidden surface not present | OK |
+| capability admission | absent | forbidden surface not present | OK |
+| Workbench/Studio | absent | forbidden surface not present | OK |
+| semantic truth authority | absent | forbidden surface not present | OK |
+| proof/debugger authority | absent | forbidden surface not present | OK |
+| Cargo.toml / Cargo.lock | absent | no manifest drift | OK |
+| dependency additions | absent | no dependency drift | OK |
+| tracked pr_body artifacts | absent at audit end | cleanup completed | OK |
+
+## 15. Manifest / Dependency Ledger
+Cargo.toml changed in presentation line: NO
+Cargo.lock changed in presentation line: NO
+dependency additions: NONE
+
+## 16. Local Validation
+Validation on the audit branch is pending until the audit doc is finalized.
+
+## 17. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| diagnostics presentation | IMPLEMENTED | ADMITTED | OK |
+| trace presentation | IMPLEMENTED | ADMITTED | OK |
+| marker presentation | IMPLEMENTED | ADMITTED | OK |
+| DNA guardrails | IMPLEMENTED | ADMITTED | OK |
+| roadmap ledger discipline | IMPLEMENTED | ADMITTED | OK |
+| action execution | ABSENT | FORBIDDEN | OK |
+| effect authorization | ABSENT | FORBIDDEN | OK |
+| event dispatch | ABSENT | FORBIDDEN | OK |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | OK |
+| capability admission | ABSENT | FORBIDDEN | OK |
+| Workbench/Studio | ABSENT | FORBIDDEN | OK |
+| dependency additions | ABSENT | FORBIDDEN | OK |
+
+## 18. Final Decision
+Final decision:
+PASS — R12 UI Renderer Presentation full-line ledger is clean through diagnostics, trace, marker presentation, cleanup corrections, and agent guardrail update #959.
+
+The renderer presentation lane is complete as inert renderer-local display metadata over UiRenderModel.
+
+It does not implement backend rendering, WGPU/winit/Tauri, layout/draw/event, event dispatch, action execution, effect execution or authorization, runtime/verifier/VM integration, capability admission, Workbench/Studio integration, semantic truth authority, proof/debugger authority, or dependency additions.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Presentation full-line ledger audit.

This is a docs-only audit PR covering diagnostics, trace, marker presentation, cleanup corrections, and agent guardrail update #959.

## Scope

Audits:

- #950 — diagnostics presentation
- #951 — diagnostics presentation closeout
- #952 — diagnostics cleanup
- #953 — trace presentation
- #954 — trace presentation closeout
- #955 — trace cleanup
- #956 — marker presentation
- #957 — marker presentation closeout
- #959 — semantic skill guardrail update

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend/WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no action execution
- no effect authorization
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no proof/debugger authority

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #957
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER PRESENTATION FULL-LINE LEDGER AUDIT CLEAN
```
