### PR TITLE
docs(ui): select next post-ui lane after renderer presentation

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_renderer_presentation.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_renderer_presentation.md
@@ -1,0 +1,99 @@
+# POST-UI Roadmap Next Lane Selection After Renderer Presentation
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completed R12 UI Renderer Presentation subline and its Project #2 backfill correction.
+
+It does not implement the selected lane.
+It only records the next authorized roadmap direction.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- presentation remains inert;
+- no runtime/verifier/VM/capability authority;
+- no event dispatch;
+- no backend rendering;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #959 — skill guardrail update
+- #960 — renderer presentation full-line ledger audit
+- Project #2 backfill correction for #952/#953/#954/#955/#959/#960
+
+## 4. Renderer Presentation State
+Diagnostics, trace, and marker presentation are closed as inert renderer-local display metadata.
+
+## 5. Project #2 Backfill State
+Project #2 rows for the renderer presentation line are present and corrected:
+- #952 — Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #951
+- #953 — Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #952
+- #954 — Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #953
+- #955 — Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #954
+- #959 — Done | POST-UI | R12 | Docs | Medium | Semantic UI | PRReady | PR | #957
+- #960 — Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #957
+
+Duplicate count for the audited rows is zero.
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| R12-UI-RENDERER-INSPECTION-PRESENTATION-LINE-FULL-PACKAGE | Selected | Builds on diagnostics, trace, and marker presentation as a read-only inspection metadata layer over existing renderer presentation models. | Medium | SELECTED |
+| R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE | Deferred | Layout is closer to visual structure and future draw/event systems, so it should wait until inspection presentation is closed. | High | DEFERRED |
+| R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE | Deferred | Event boundary is high-risk and should not precede separate action/effect/capability boundary discipline. | High | DEFERRED |
+| R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE | Deferred | Backend/WGPU/winit/Tauri is explicitly outside current renderer presentation substrate and is too early for the next lane. | Critical | DEFERRED |
+| R12-UI-WORKBENCH-STUDIO-BOUNDARY-LINE-FULL-PACKAGE | Deferred | Workbench/Studio integration is product-level orchestration and should wait for more mature renderer presentation, inspection, layout, event, and capability boundaries. | High | DEFERRED |
+
+## 7. Selection Criteria
+1. Must preserve DNA alignment.
+2. Must preserve renderer presentation inertness.
+3. Must not introduce backend/layout/draw/event prematurely.
+4. Must not introduce runtime/verifier/VM/capability authority.
+5. Must have clear dependency on completed diagnostics/trace/marker presentation.
+6. Must be testable with deterministic read-only models.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-INSPECTION-PRESENTATION-LINE-FULL-PACKAGE
+
+This selection does not implement inspection presentation.
+It only authorizes the next planning/source package to be prepared under separate gate.
+
+## 9. Deferred Lanes
+- R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-WORKBENCH-STUDIO-BOUNDARY-LINE-FULL-PACKAGE
+
+## 10. Admission Guard
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| roadmap selection doc | Implemented | ADMITTED | PASS |
+| renderer presentation | Closed | CLOSED | PASS |
+| inspection presentation | Selected for future planning | AUTHORIZED_FOR_FUTURE | PASS |
+| layout/draw/event implementation | Absent | FORBIDDEN | PASS |
+| backend/WGPU/winit/Tauri | Absent | FORBIDDEN | PASS |
+| runtime/verifier/VM integration | Absent | FORBIDDEN | PASS |
+| capability admission | Absent | FORBIDDEN | PASS |
+| Workbench/Studio integration | Absent | FORBIDDEN | PASS |
+
+## 11. Non-Scope
+No inspection presentation implementation.
+No layout/draw/event implementation.
+No backend/WGPU/winit/Tauri.
+No runtime/verifier/VM integration.
+No capability admission.
+No Workbench/Studio integration.
+No source changes.
+No dependency additions.
+
+## 12. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after renderer presentation.
+
+The next selected lane is R12-UI-RENDERER-INSPECTION-PRESENTATION-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement inspection presentation, layout, draw, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed R12 UI Renderer Presentation subline.

Selected next lane:

```text
R12-UI-RENDERER-INSPECTION-PRESENTATION-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* closed renderer presentation basis
* Project #2 backfill state
* candidate lane comparison
* selected next lane
* deferred lanes
* admission guard constraints

## Explicit non-scope

* no source changes
* no tests changes
* no docs/dna changes
* no agent skill changes
* no Cargo.toml / Cargo.lock changes
* no dependency additions
* no inspection presentation implementation
* no layout/draw/event
* no backend/WGPU/winit/Tauri
* no runtime/verifier/VM
* no capability admission
* no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #960
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER RENDERER PRESENTATION CLEAN
```