### PR TITLE
feat(ui): add renderer inspection presentation

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -217,8 +217,16 @@ pub use raw_event::{
     RawUiEventId, RawUiEventKind, RawUiEventPayload, RawUiEventTarget,
 };
 pub use renderer::{
-    render_projection_to_model, UiRenderError, UiRenderMarker, UiRenderModel, UiRenderModelId,
-    UiRenderNode, UiRenderNodeId, UiRenderNodeKind,
+    present_render_diagnostics, present_render_inspection, present_render_markers,
+    present_render_trace, render_projection_to_model, UiRenderDiagnosticsPresentation,
+    UiRenderDiagnosticsPresentationId, UiRenderError, UiRenderInspectionItem,
+    UiRenderInspectionItemId, UiRenderInspectionItemKind, UiRenderInspectionPresentation,
+    UiRenderInspectionPresentationId, UiRenderInspectionSection, UiRenderInspectionSectionId,
+    UiRenderInspectionSectionKind, UiRenderMarker, UiRenderMarkerEmphasis, UiRenderMarkerItem,
+    UiRenderMarkerItemId, UiRenderMarkerPresentation, UiRenderMarkerPresentationId,
+    UiRenderMarkerVisualRole, UiRenderModel, UiRenderModelId, UiRenderNode, UiRenderNodeId,
+    UiRenderNodeKind, UiRenderTraceLink, UiRenderTraceLinkId, UiRenderTraceLinkKind,
+    UiRenderTracePresentation, UiRenderTracePresentationId,
 };
 pub use runtime_capability_mapping::{
     describe_interaction_runtime_capability_mapping, InteractionRuntimeCapabilityMappingDescriptor,

--- a/crates/prom-ui/src/renderer.rs
+++ b/crates/prom-ui/src/renderer.rs
@@ -630,3 +630,317 @@ pub fn present_render_markers(model: &UiRenderModel) -> UiRenderMarkerPresentati
         items,
     }
 }
+
+// Inspection presentation is inert renderer-local metadata.
+// It composes diagnostics, trace, and marker presentation data for future UI inspection.
+// It must not act as debugger state, proof, runtime introspection, event dispatch,
+// action execution, effect authorization, or capability admission.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderInspectionPresentation {
+    id: UiRenderInspectionPresentationId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    sections: Vec<UiRenderInspectionSection>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderInspectionPresentationId(u64);
+
+impl UiRenderInspectionPresentationId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderInspectionSection {
+    id: UiRenderInspectionSectionId,
+    kind: UiRenderInspectionSectionKind,
+    items: Vec<UiRenderInspectionItem>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderInspectionSectionId(u64);
+
+impl UiRenderInspectionSectionId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiRenderInspectionItem {
+    id: UiRenderInspectionItemId,
+    kind: UiRenderInspectionItemKind,
+    source_render_node: Option<UiRenderNodeId>,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiRenderInspectionItemId(u64);
+
+impl UiRenderInspectionItemId {
+    pub const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderInspectionSectionKind {
+    Overview,
+    Diagnostics,
+    Trace,
+    Markers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiRenderInspectionItemKind {
+    OverviewSummary,
+    DiagnosticItem,
+    TraceLink,
+    MarkerItem,
+}
+
+impl UiRenderInspectionPresentation {
+    pub fn id(&self) -> UiRenderInspectionPresentationId {
+        self.id
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn sections(&self) -> &[UiRenderInspectionSection] {
+        &self.sections
+    }
+}
+
+impl UiRenderInspectionSection {
+    pub fn id(&self) -> UiRenderInspectionSectionId {
+        self.id
+    }
+
+    pub fn kind(&self) -> UiRenderInspectionSectionKind {
+        self.kind
+    }
+
+    pub fn items(&self) -> &[UiRenderInspectionItem] {
+        &self.items
+    }
+}
+
+impl UiRenderInspectionItem {
+    pub fn id(&self) -> UiRenderInspectionItemId {
+        self.id
+    }
+
+    pub fn kind(&self) -> UiRenderInspectionItemKind {
+        self.kind
+    }
+
+    pub fn source_render_node(&self) -> Option<UiRenderNodeId> {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+}
+
+const fn inspection_section_kind_ordinal(kind: UiRenderInspectionSectionKind) -> u64 {
+    match kind {
+        UiRenderInspectionSectionKind::Overview => 0,
+        UiRenderInspectionSectionKind::Diagnostics => 1,
+        UiRenderInspectionSectionKind::Trace => 2,
+        UiRenderInspectionSectionKind::Markers => 3,
+    }
+}
+
+const fn inspection_item_kind_ordinal(kind: UiRenderInspectionItemKind) -> u64 {
+    match kind {
+        UiRenderInspectionItemKind::OverviewSummary => 0,
+        UiRenderInspectionItemKind::DiagnosticItem => 1,
+        UiRenderInspectionItemKind::TraceLink => 2,
+        UiRenderInspectionItemKind::MarkerItem => 3,
+    }
+}
+
+fn inspection_section_id(
+    presentation_id: UiRenderInspectionPresentationId,
+    kind: UiRenderInspectionSectionKind,
+) -> UiRenderInspectionSectionId {
+    UiRenderInspectionSectionId::new(
+        presentation_id
+            .raw()
+            .wrapping_mul(37)
+            .wrapping_add(inspection_section_kind_ordinal(kind)),
+    )
+}
+
+fn inspection_item_id(
+    section_id: UiRenderInspectionSectionId,
+    kind: UiRenderInspectionItemKind,
+    ordinal: u64,
+) -> UiRenderInspectionItemId {
+    UiRenderInspectionItemId::new(
+        section_id
+            .raw()
+            .wrapping_mul(17)
+            .wrapping_add(inspection_item_kind_ordinal(kind))
+            .wrapping_add(ordinal),
+    )
+}
+
+fn build_overview_section(
+    presentation_id: UiRenderInspectionPresentationId,
+    model: &UiRenderModel,
+) -> UiRenderInspectionSection {
+    let kind = UiRenderInspectionSectionKind::Overview;
+    let section_id = inspection_section_id(presentation_id, kind);
+    let mut items = Vec::new();
+
+    items.push(UiRenderInspectionItem {
+        id: inspection_item_id(section_id, UiRenderInspectionItemKind::OverviewSummary, 0),
+        kind: UiRenderInspectionItemKind::OverviewSummary,
+        source_render_node: None,
+        source_projection_node: None,
+        source_ir_node: model.source_ir_root(),
+    });
+
+    UiRenderInspectionSection {
+        id: section_id,
+        kind,
+        items,
+    }
+}
+
+fn build_diagnostics_section(
+    presentation_id: UiRenderInspectionPresentationId,
+    diagnostics: &UiRenderDiagnosticsPresentation,
+) -> UiRenderInspectionSection {
+    let kind = UiRenderInspectionSectionKind::Diagnostics;
+    let section_id = inspection_section_id(presentation_id, kind);
+    let mut items = Vec::new();
+
+    for (ordinal, item) in diagnostics.items().iter().enumerate() {
+        items.push(UiRenderInspectionItem {
+            id: inspection_item_id(
+                section_id,
+                UiRenderInspectionItemKind::DiagnosticItem,
+                ordinal as u64,
+            ),
+            kind: UiRenderInspectionItemKind::DiagnosticItem,
+            source_render_node: item.source_render_node(),
+            source_projection_node: item.source_projection_node(),
+            source_ir_node: item.source_ir_node(),
+        });
+    }
+
+    UiRenderInspectionSection {
+        id: section_id,
+        kind,
+        items,
+    }
+}
+
+fn build_trace_section(
+    presentation_id: UiRenderInspectionPresentationId,
+    trace: &UiRenderTracePresentation,
+) -> UiRenderInspectionSection {
+    let kind = UiRenderInspectionSectionKind::Trace;
+    let section_id = inspection_section_id(presentation_id, kind);
+    let mut items = Vec::new();
+
+    for (ordinal, link) in trace.links().iter().enumerate() {
+        items.push(UiRenderInspectionItem {
+            id: inspection_item_id(
+                section_id,
+                UiRenderInspectionItemKind::TraceLink,
+                ordinal as u64,
+            ),
+            kind: UiRenderInspectionItemKind::TraceLink,
+            source_render_node: link.source_render_node(),
+            source_projection_node: link.source_projection_node(),
+            source_ir_node: link.source_ir_node(),
+        });
+    }
+
+    UiRenderInspectionSection {
+        id: section_id,
+        kind,
+        items,
+    }
+}
+
+fn build_markers_section(
+    presentation_id: UiRenderInspectionPresentationId,
+    markers: &UiRenderMarkerPresentation,
+) -> UiRenderInspectionSection {
+    let kind = UiRenderInspectionSectionKind::Markers;
+    let section_id = inspection_section_id(presentation_id, kind);
+    let mut items = Vec::new();
+
+    for (ordinal, item) in markers.items().iter().enumerate() {
+        items.push(UiRenderInspectionItem {
+            id: inspection_item_id(
+                section_id,
+                UiRenderInspectionItemKind::MarkerItem,
+                ordinal as u64,
+            ),
+            kind: UiRenderInspectionItemKind::MarkerItem,
+            source_render_node: Some(item.source_render_node()),
+            source_projection_node: None,
+            source_ir_node: None,
+        });
+    }
+
+    UiRenderInspectionSection {
+        id: section_id,
+        kind,
+        items,
+    }
+}
+
+pub fn present_render_inspection(
+    model: &UiRenderModel,
+    diagnostics: &UiRenderDiagnosticsPresentation,
+    trace: &UiRenderTracePresentation,
+    markers: &UiRenderMarkerPresentation,
+) -> UiRenderInspectionPresentation {
+    let id = UiRenderInspectionPresentationId::new(model.id().raw());
+    let sections = vec![
+        build_overview_section(id, model),
+        build_diagnostics_section(id, diagnostics),
+        build_trace_section(id, trace),
+        build_markers_section(id, markers),
+    ];
+
+    UiRenderInspectionPresentation {
+        id,
+        source_render_model: model.id(),
+        source_projection: model.source_projection(),
+        sections,
+    }
+}

--- a/crates/prom-ui/tests/renderer_inspection_presentation.rs
+++ b/crates/prom-ui/tests/renderer_inspection_presentation.rs
@@ -1,0 +1,324 @@
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId, UiProjectionTraceRef,
+};
+use prom_ui::renderer::{
+    present_render_diagnostics, present_render_inspection, present_render_markers,
+    present_render_trace, render_projection_to_model, UiRenderDiagnosticsPresentation,
+    UiRenderInspectionItem, UiRenderInspectionItemId, UiRenderInspectionItemKind,
+    UiRenderInspectionPresentation, UiRenderInspectionPresentationId, UiRenderInspectionSection,
+    UiRenderInspectionSectionId, UiRenderInspectionSectionKind, UiRenderMarkerPresentation,
+    UiRenderModel, UiRenderModelId, UiRenderNodeId, UiRenderTracePresentation,
+};
+
+fn create_test_renderer_presentation_bundle() -> (
+    UiRenderModel,
+    UiRenderDiagnosticsPresentation,
+    UiRenderTracePresentation,
+    UiRenderMarkerPresentation,
+) {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(42));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+    ));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::PropertyCarrier,
+    ));
+    artifact.push_node(UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::ActionCarrier,
+        UiIrNodeId::new(12),
+    ));
+    let mut traced_node =
+        UiProjectedNode::new(UiProjectedNodeId::new(4), UiProjectedNodeKind::Element);
+    traced_node.set_trace(UiProjectionTraceRef::new(400));
+    artifact.push_node(traced_node);
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(5),
+        UiProjectedNodeKind::EffectBoundaryMarker,
+    ));
+
+    let model = render_projection_to_model(&artifact).expect("should build render model");
+    let diagnostics = present_render_diagnostics(&model);
+    let trace = present_render_trace(&model);
+    let markers = present_render_markers(&model);
+
+    (model, diagnostics, trace, markers)
+}
+
+#[test]
+fn inspection_presentation_builds_from_existing_presentation_models() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+    let model_before = model.clone();
+    let diagnostics_before = diagnostics.clone();
+    let trace_before = trace.clone();
+    let markers_before = markers.clone();
+
+    let presentation = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    assert_eq!(presentation.source_render_model(), model.id());
+    assert_eq!(presentation.source_projection(), model.source_projection());
+    assert_eq!(model, model_before);
+    assert_eq!(diagnostics, diagnostics_before);
+    assert_eq!(trace, trace_before);
+    assert_eq!(markers, markers_before);
+
+    let sections = presentation.sections();
+    assert_eq!(sections.len(), 4);
+    assert_eq!(sections[0].kind(), UiRenderInspectionSectionKind::Overview);
+    assert_eq!(
+        sections[1].kind(),
+        UiRenderInspectionSectionKind::Diagnostics
+    );
+    assert_eq!(sections[2].kind(), UiRenderInspectionSectionKind::Trace);
+    assert_eq!(sections[3].kind(), UiRenderInspectionSectionKind::Markers);
+
+    assert_eq!(sections[0].items().len(), 1);
+    assert_eq!(
+        sections[0].items()[0].kind(),
+        UiRenderInspectionItemKind::OverviewSummary
+    );
+    assert_eq!(
+        sections[0].items()[0].source_ir_node(),
+        Some(UiIrNodeId::new(10))
+    );
+
+    assert_eq!(sections[1].items().len(), 4);
+    assert!(sections[1]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::DiagnosticItem));
+    assert_eq!(
+        sections[1].items()[0].source_render_node().unwrap().raw(),
+        2
+    );
+    assert_eq!(
+        sections[1].items()[1].source_render_node().unwrap().raw(),
+        3
+    );
+    assert_eq!(
+        sections[1].items()[1].source_ir_node(),
+        Some(UiIrNodeId::new(12))
+    );
+    assert_eq!(
+        sections[1].items()[2].source_render_node().unwrap().raw(),
+        4
+    );
+    assert_eq!(
+        sections[1].items()[3].source_render_node().unwrap().raw(),
+        5
+    );
+
+    assert!(!sections[2].items().is_empty());
+    assert!(sections[2]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::TraceLink));
+
+    assert_eq!(sections[3].items().len(), 4);
+    assert!(sections[3]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::MarkerItem));
+}
+
+#[test]
+fn inspection_presentation_deterministic_presentation_id() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+
+    let presentation1 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+    let presentation2 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    assert_eq!(presentation1.id(), presentation2.id());
+}
+
+#[test]
+fn inspection_presentation_deterministic_section_ids_and_order() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+
+    let presentation1 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+    let presentation2 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    let sections1 = presentation1.sections();
+    let sections2 = presentation2.sections();
+
+    assert_eq!(sections1.len(), sections2.len());
+    assert_eq!(
+        sections1
+            .iter()
+            .map(UiRenderInspectionSection::kind)
+            .collect::<Vec<_>>(),
+        vec![
+            UiRenderInspectionSectionKind::Overview,
+            UiRenderInspectionSectionKind::Diagnostics,
+            UiRenderInspectionSectionKind::Trace,
+            UiRenderInspectionSectionKind::Markers,
+        ]
+    );
+    assert_eq!(
+        sections1
+            .iter()
+            .map(UiRenderInspectionSection::id)
+            .collect::<Vec<_>>(),
+        sections2
+            .iter()
+            .map(UiRenderInspectionSection::id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn inspection_presentation_deterministic_item_ids() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+
+    let presentation1 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+    let presentation2 = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    for (section1, section2) in presentation1
+        .sections()
+        .iter()
+        .zip(presentation2.sections().iter())
+    {
+        assert_eq!(section1.id(), section2.id());
+        assert_eq!(section1.kind(), section2.kind());
+        assert_eq!(
+            section1
+                .items()
+                .iter()
+                .map(UiRenderInspectionItem::id)
+                .collect::<Vec<_>>(),
+            section2
+                .items()
+                .iter()
+                .map(UiRenderInspectionItem::id)
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn inspection_presentation_is_read_only_over_inputs() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+    let model_before = model.clone();
+    let diagnostics_before = diagnostics.clone();
+    let trace_before = trace.clone();
+    let markers_before = markers.clone();
+
+    let _presentation = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    assert_eq!(model, model_before);
+    assert_eq!(diagnostics, diagnostics_before);
+    assert_eq!(trace, trace_before);
+    assert_eq!(markers, markers_before);
+}
+
+#[test]
+fn inspection_presentation_section_kind_coverage_is_locked() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+    let presentation = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    let kinds = presentation
+        .sections()
+        .iter()
+        .map(UiRenderInspectionSection::kind)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        kinds,
+        vec![
+            UiRenderInspectionSectionKind::Overview,
+            UiRenderInspectionSectionKind::Diagnostics,
+            UiRenderInspectionSectionKind::Trace,
+            UiRenderInspectionSectionKind::Markers,
+        ]
+    );
+}
+
+#[test]
+fn inspection_presentation_item_kind_coverage_is_locked() {
+    let (model, diagnostics, trace, markers) = create_test_renderer_presentation_bundle();
+    let presentation = present_render_inspection(&model, &diagnostics, &trace, &markers);
+
+    assert_eq!(
+        presentation.sections()[0].items()[0].kind(),
+        UiRenderInspectionItemKind::OverviewSummary
+    );
+    assert!(presentation.sections()[1]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::DiagnosticItem));
+    assert!(presentation.sections()[2]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::TraceLink));
+    assert!(presentation.sections()[3]
+        .items()
+        .iter()
+        .all(|item| item.kind() == UiRenderInspectionItemKind::MarkerItem));
+}
+
+#[test]
+fn inspection_presentation_entrypoint_signature_is_locked() {
+    let _: fn(
+        &UiRenderModel,
+        &UiRenderDiagnosticsPresentation,
+        &UiRenderTracePresentation,
+        &UiRenderMarkerPresentation,
+    ) -> UiRenderInspectionPresentation = present_render_inspection;
+}
+
+#[test]
+fn inspection_presentation_public_types_are_locked() {
+    fn assert_presentation(_: &UiRenderInspectionPresentation) {}
+    fn assert_section(_: &UiRenderInspectionSection) {}
+    fn assert_item(_: &UiRenderInspectionItem) {}
+    fn assert_section_kind(_: UiRenderInspectionSectionKind) {}
+    fn assert_item_kind(_: UiRenderInspectionItemKind) {}
+
+    let _ = (
+        assert_presentation,
+        assert_section,
+        assert_item,
+        assert_section_kind,
+        assert_item_kind,
+    );
+}
+
+#[test]
+fn inspection_presentation_accessor_surface_is_locked() {
+    let _: fn(&UiRenderInspectionPresentation) -> UiRenderInspectionPresentationId =
+        UiRenderInspectionPresentation::id;
+    let _: fn(&UiRenderInspectionPresentation) -> UiRenderModelId =
+        UiRenderInspectionPresentation::source_render_model;
+    let _: fn(&UiRenderInspectionPresentation) -> UiProjectionArtifactId =
+        UiRenderInspectionPresentation::source_projection;
+    let _: fn(&UiRenderInspectionPresentation) -> &[UiRenderInspectionSection] =
+        UiRenderInspectionPresentation::sections;
+}
+
+#[test]
+fn inspection_section_accessor_surface_is_locked() {
+    let _: fn(&UiRenderInspectionSection) -> UiRenderInspectionSectionId =
+        UiRenderInspectionSection::id;
+    let _: fn(&UiRenderInspectionSection) -> UiRenderInspectionSectionKind =
+        UiRenderInspectionSection::kind;
+    let _: fn(&UiRenderInspectionSection) -> &[UiRenderInspectionItem] =
+        UiRenderInspectionSection::items;
+}
+
+#[test]
+fn inspection_item_accessor_surface_is_locked() {
+    let _: fn(&UiRenderInspectionItem) -> UiRenderInspectionItemId = UiRenderInspectionItem::id;
+    let _: fn(&UiRenderInspectionItem) -> UiRenderInspectionItemKind = UiRenderInspectionItem::kind;
+    let _: fn(&UiRenderInspectionItem) -> Option<UiRenderNodeId> =
+        UiRenderInspectionItem::source_render_node;
+    let _: fn(&UiRenderInspectionItem) -> Option<UiProjectedNodeId> =
+        UiRenderInspectionItem::source_projection_node;
+    let _: fn(&UiRenderInspectionItem) -> Option<UiIrNodeId> =
+        UiRenderInspectionItem::source_ir_node;
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Inspection Presentation seed.

This introduces an inert renderer-local inspection presentation layer over existing renderer presentation models:

- diagnostics presentation
- trace presentation
- marker presentation

It does not create debugger authority, proof authority, runtime introspection, event dispatch, capability admission, or backend rendering.

## Closed basis

- #959 — semantic skill guardrails
- #960 — renderer presentation full-line ledger audit
- #961 — next lane selection after renderer presentation

## Scope

Implemented:

- inert inspection presentation model
- inspection section model
- inspection item model
- deterministic inspection presentation identity
- deterministic section/item identity
- read-only `UiRenderModel` consumption
- read-only diagnostics/trace/marker presentation consumption
- deterministic section ordering
- tests and API signature locks

Preserved:

- renderer remains downstream and inert
- no proof engine
- no debugger execution
- no backend
- no WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio

## Explicit non-scope

- no projection.rs changes
- no validation.rs changes
- no Cargo.toml / Cargo.lock changes
- no docs/dna changes
- no agent skill changes
- no dependency additions
- no backend rendering
- no layout/draw/event implementation
- no verifier diagnostic rewriting
- no semantic truth authority
- no debugger integration
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #961
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Admission Guard

| Area                               | Observed state | Classification | Status |
| ---------------------------------- | -------------- | -------------- | ------ |
| inspection presentation model      | Implemented    | ADMITTED       | PASS   |
| read-only presentation consumption | Implemented    | ADMITTED       | PASS   |
| proof authority                    | Absent         | FORBIDDEN      | PASS   |
| debugger authority                 | Absent         | FORBIDDEN      | PASS   |
| backend/WGPU/winit/Tauri           | Absent         | FORBIDDEN      | PASS   |
| layout/draw/event                  | Absent         | FORBIDDEN      | PASS   |
| event dispatch                     | Absent         | FORBIDDEN      | PASS   |
| runtime/verifier/VM                | Absent         | FORBIDDEN      | PASS   |
| capability admission               | Absent         | FORBIDDEN      | PASS   |
| Workbench/Studio                   | Absent         | FORBIDDEN      | PASS   |

