### PR TITLE
docs(ui): close out renderer inspection presentation

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_inspection_presentation_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_inspection_presentation_closeout.md
@@ -1,0 +1,121 @@
+# R12 UI Renderer Inspection Presentation Closeout
+
+Status: Draft
+Track: POST-UI / R12 / Renderer
+Scope type: closeout document
+Implementation status: not authorized by this document
+
+## 1. Purpose
+
+This document records the closeout of the R12 UI Renderer Inspection Presentation line after the source PR and consolidation audit.
+
+It does not authorize implementation.
+It does not claim the inspection presentation is a debugger, proof engine, runtime introspection layer, event system, or capability authority.
+It does not authorize Workbench or Semantic Studio integration.
+
+## 2. DNA Alignment
+
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- presentation remains inert;
+- no runtime/verifier/VM/capability authority;
+- no event dispatch;
+- no backend rendering;
+- no Workbench/Studio integration.
+
+## 3. Closed Source PR
+
+- #962 — feat(ui): add renderer inspection presentation
+
+## 4. Implemented State
+
+Implemented:
+- inert inspection presentation model;
+- inspection section model;
+- inspection item model;
+- deterministic inspection presentation identity;
+- deterministic section identity;
+- deterministic item identity;
+- read-only UiRenderModel consumption;
+- read-only diagnostics/trace/marker presentation consumption;
+- deterministic inspection section ordering;
+- tests and API signature locks.
+
+## 5. What Inspection Presentation Is
+
+Inspection Presentation is read-only renderer-local metadata over existing renderer presentation models.
+
+It is a deterministic inspection surface for future UI panels.
+
+## 6. What Inspection Presentation Is Not
+
+Inspection Presentation is not:
+- a debugger;
+- runtime introspection;
+- a proof engine;
+- event dispatch;
+- action execution;
+- effect execution;
+- capability admission;
+- backend rendering;
+- layout/draw/event;
+- Workbench/Studio integration.
+
+## 7. Evidence Matrix
+
+| Evidence | Status | Notes |
+| --- | --- | --- |
+| Source PR #962 | Closed | merged into main |
+| Local validation | Passed | cargo fmt/test/diff checks passed |
+| Project #2 metadata | Corrected | source item set to Done |
+| Skill guardrails | Present | semantic skill rules verified |
+| DNA alignment | Clean | no conflicts detected |
+
+## 8. Consolidation Audit Result
+
+R12 UI Renderer Inspection Presentation is implemented as an inert renderer-local inspection presentation layer over UiRenderModel and existing renderer presentation models.
+
+The layer does not prove semantic truth, rewrite verifier results, execute debugger actions, dispatch events, call runtime/verifier/VM systems, admit capabilities, implement backend rendering, or integrate Workbench/Studio.
+
+## 9. Admission Guard Table
+
+| Area | Observed state | Classification | Status |
+| --- | --- | --- | --- |
+| inspection presentation model | Implemented | ADMITTED | PASS |
+| read-only presentation consumption | Implemented | ADMITTED | PASS |
+| proof authority | Absent | FORBIDDEN | PASS |
+| debugger authority | Absent | FORBIDDEN | PASS |
+| backend/WGPU/winit/Tauri | Absent | FORBIDDEN | PASS |
+| layout/draw/event | Absent | FORBIDDEN | PASS |
+| event dispatch | Absent | FORBIDDEN | PASS |
+| runtime/verifier/VM | Absent | FORBIDDEN | PASS |
+| capability admission | Absent | FORBIDDEN | PASS |
+| Workbench/Studio | Absent | FORBIDDEN | PASS |
+
+## 10. Project #2 State
+
+Status: Done
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #962
+
+## 11. Remaining Future Gates
+
+- R12 UI Renderer Inspection Presentation ledger audit PR
+- POST-UI roadmap next lane selection or follow-on renderer presentation planning
+
+## 12. Final Decision
+
+Final decision:
+CLOSED — R12 UI Renderer Inspection Presentation is complete as an inert renderer-local inspection presentation layer over UiRenderModel and existing renderer presentation models.
+
+It does not prove semantic truth, rewrite verifier results, execute debugger actions, dispatch events, call runtime/verifier/VM systems, admit capabilities, implement backend rendering, or integrate Workbench/Studio.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Inspection Presentation line.

This is a docs-only closeout after the inspection presentation source PR and clean consolidation audit.

## Scope

Records:

- inert inspection presentation model
- read-only `UiRenderModel` consumption
- read-only diagnostics/trace/marker presentation consumption
- deterministic inspection identity
- deterministic section/item identity
- tests and validation
- absent proof/debugger/runtime/capability/Workbench integration

## Explicit non-scope

- no source changes
- no renderer implementation changes
- no projection.rs changes
- no validation.rs changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend rendering
- no layout/draw/event
- no event dispatch
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no proof engine
- no debugger execution

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #962
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — R12 UI Renderer Inspection Presentation is complete as an inert renderer-local inspection presentation layer over UiRenderModel and existing renderer presentation models.
```

