### PR TITLE
docs(ui): add renderer inspection presentation ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_inspection_presentation_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_inspection_presentation_ledger_audit.md
@@ -1,0 +1,155 @@
+# R12 UI Renderer Inspection Presentation Ledger Audit
+
+## 1. Purpose
+This document records the ledger audit for the R12 UI Renderer Inspection Presentation line after source PR #962 and closeout PR #963.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- inspection presentation remains inert;
+- no debugger/proof/runtime authority;
+- no runtime/verifier/VM/capability authority;
+- no event dispatch;
+- no action execution;
+- no effect authorization;
+- no backend rendering;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #959 — skill guardrail update
+- #960 — renderer presentation full-line ledger audit
+- #961 — next lane selection after renderer presentation
+- #962 — inspection presentation source
+- #963 — inspection presentation closeout
+
+## 4. PR Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #959 | docs(agents): add dna renderer and source authoring guardrails | MERGED | 4e65a54 | 2 | Governance | OK |
+| #960 | docs(ui): add renderer presentation full-line ledger audit | MERGED | 88d143b | 1 | Audit | OK |
+| #961 | docs(ui): select next post-ui lane after renderer presentation | MERGED | 29588e6 | 1 | Roadmap | OK |
+| #962 | feat(ui): add renderer inspection presentation | MERGED | ca74686 | 3 | Code | OK |
+| #963 | docs(ui): close out renderer inspection presentation | MERGED | cc6ad18 | 1 | Closeout | OK |
+
+## 5. Changed File Surface
+- crates/prom-ui/src/lib.rs
+- crates/prom-ui/src/renderer.rs
+- crates/prom-ui/tests/renderer_inspection_presentation.rs
+- docs/roadmap/post_ui/r12_ui_renderer_inspection_presentation_closeout.md
+
+## 6. Inspection Presentation API Ledger
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| UiRenderInspectionPresentation | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionSection | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionItem | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionPresentationId | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionSectionId | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionItemId | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionSectionKind | Implemented | ADMITTED | source | OK |
+| UiRenderInspectionItemKind | Implemented | ADMITTED | source | OK |
+| present_render_inspection | Implemented | ADMITTED | source | OK |
+| debugger API | Absent | FORBIDDEN | scan | OK |
+| proof API | Absent | FORBIDDEN | scan | OK |
+| runtime introspection API | Absent | FORBIDDEN | scan | OK |
+| verifier authority API | Absent | FORBIDDEN | scan | OK |
+| event dispatch API | Absent | FORBIDDEN | scan | OK |
+| action execution API | Absent | FORBIDDEN | scan | OK |
+| effect authorization API | Absent | FORBIDDEN | scan | OK |
+| capability admission API | Absent | FORBIDDEN | scan | OK |
+| backend rendering API | Absent | FORBIDDEN | scan | OK |
+| layout/draw/event API | Absent | FORBIDDEN | scan | OK |
+| Workbench/Studio API | Absent | FORBIDDEN | scan | OK |
+
+## 7. Behavior Ledger
+| Behavior | Final state | Evidence | Status |
+|---|---|---|---|
+| read-only UiRenderModel consumption | Implemented | source | OK |
+| read-only diagnostics presentation consumption | Implemented | source | OK |
+| read-only trace presentation consumption | Implemented | source | OK |
+| read-only marker presentation consumption | Implemented | source | OK |
+| deterministic presentation ID | Implemented | tests | OK |
+| deterministic section IDs | Implemented | tests | OK |
+| deterministic item IDs | Implemented | tests | OK |
+| source render model preservation | Implemented | tests | OK |
+| source projection preservation | Implemented | tests | OK |
+| source render node preservation where exposed | LIMITED | tests | OK |
+| source projection node preservation where exposed | LIMITED | tests | OK |
+| source IR node preservation where exposed | LIMITED | tests | OK |
+| no input mutation | Implemented | tests | OK |
+| no authority escalation | Implemented | tests | OK |
+
+## 8. Test Coverage Ledger
+Coverage complete:
+- inspection presentation builds from existing presentation models
+- deterministic presentation ID
+- deterministic section IDs/order
+- deterministic item IDs
+- read-only input preservation
+- section kind coverage
+- item kind coverage where public fixtures expose items
+- inspection is not debugger/proof/runtime
+- public entrypoint signature lock
+- public type/accessor lock
+
+## 9. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #961 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #960 | 0 |
+| #962 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #961 | 0 |
+| #963 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #962 | 0 |
+
+## 10. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| backend/WGPU/winit/Tauri | NO | FORBIDDEN | OK |
+| layout/draw/event | NO | FORBIDDEN | OK |
+| event dispatch | NO | FORBIDDEN | OK |
+| action execution | NO | FORBIDDEN | OK |
+| effect execution/authorization | NO | FORBIDDEN | OK |
+| runtime/verifier/VM | NO | FORBIDDEN | OK |
+| capability admission | NO | FORBIDDEN | OK |
+| Workbench/Studio | NO | FORBIDDEN | OK |
+| semantic truth authority | NO | FORBIDDEN | OK |
+| proof/debugger authority | NO | FORBIDDEN | OK |
+| Cargo.toml / Cargo.lock | NO | FORBIDDEN | OK |
+| dependency additions | NO | FORBIDDEN | OK |
+| tracked pr_body artifacts | NO | FORBIDDEN | OK |
+
+## 11. Manifest / Dependency Ledger
+Cargo.toml changed: NO
+Cargo.lock changed: NO
+dependency additions: NONE
+
+## 12. Local Validation
+Validation pending on the audit PR branch.
+
+## 13. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| inspection presentation | IMPLEMENTED | ADMITTED | OK |
+| read-only presentation consumption | IMPLEMENTED | ADMITTED | OK |
+| deterministic identities | IMPLEMENTED | ADMITTED | OK |
+| source reference preservation | LIMITED | ADMITTED | OK |
+| debugger authority | ABSENT | FORBIDDEN | OK |
+| proof authority | ABSENT | FORBIDDEN | OK |
+| runtime introspection | ABSENT | FORBIDDEN | OK |
+| event dispatch | ABSENT | FORBIDDEN | OK |
+| action execution | ABSENT | FORBIDDEN | OK |
+| effect authorization | ABSENT | FORBIDDEN | OK |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | OK |
+| capability admission | ABSENT | FORBIDDEN | OK |
+| Workbench/Studio | ABSENT | FORBIDDEN | OK |
+| dependency additions | ABSENT | FORBIDDEN | OK |
+
+## 14. Final Decision
+Final decision:
+PASS — R12 UI Renderer Inspection Presentation ledger audit is clean after source PR #962 and closeout PR #963.
+
+The inspection presentation line is complete as inert renderer-local read-only metadata over UiRenderModel and existing renderer presentation models.
+
+It does not implement debugger authority, proof authority, runtime introspection, verifier result authority, event dispatch, action execution, effect execution or authorization, runtime/verifier/VM integration, capability admission, backend rendering, layout/draw/event, Workbench/Studio integration, or dependency additions.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Inspection Presentation ledger audit.

This is a docs-only audit PR covering:

- #961 — roadmap selection
- #962 — inspection presentation source implementation
- #963 — inspection presentation closeout
- #959 — semantic skill guardrail update
- #960 — renderer presentation full-line ledger audit

## Scope

Audits:

- source file surface
- public inspection presentation API
- behavior/inertness
- test coverage
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend/WGPU/winit/Tauri
- no layout/draw/event
- no event dispatch
- no action execution
- no effect authorization
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no proof/debugger authority

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #963
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER INSPECTION PRESENTATION LEDGER AUDIT CLEAN
```
