### PR TITLE
docs(ui): select next post-ui lane after renderer inspection

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_renderer_inspection.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_renderer_inspection.md
@@ -1,0 +1,95 @@
+# POST-UI Roadmap Next Lane Selection After Renderer Inspection
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Inspection Presentation line.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- inspection and presentation remain inert;
+- layout boundary must not become layout implementation;
+- no backend rendering;
+- no draw/event dispatch;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #959 — skill guardrail update
+- #960 — renderer presentation full-line ledger audit
+- #961 — next lane selection after renderer presentation
+- #962 — renderer inspection presentation source
+- #963 — renderer inspection presentation closeout
+- #964 — renderer inspection presentation ledger audit
+
+## 4. Renderer Inspection State
+Renderer inspection presentation is closed as inert renderer-local read-only metadata over UiRenderModel and existing renderer presentation models.
+
+## 5. Project #2 State
+The Project #2 inspection state matches the audited PR basis (#962, #963, #964) with no duplicates.
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE | Selected | After renderer seed, diagnostics presentation, trace presentation, marker presentation, and inspection presentation are closed and audited, the next structurally safe step is to define the boundary of layout before any layout implementation exists. | Medium | SELECTED |
+| R12-UI-RENDERER-LAYOUT-SEED-LINE-FULL-PACKAGE | Deferred | Too early. A boundary document must exist first. | High | DEFERRED |
+| R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE | Deferred / high-risk | Events are close to action/effect/capability semantics. Event boundary should wait until layout boundary is explicitly closed and audited. | High | DEFERRED |
+| R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE | Deferred / too early | Backend/WGPU/winit/Tauri remains explicitly outside the current renderer substrate. Backend should wait until layout and event boundaries are separately admitted. | Critical | DEFERRED |
+| R12-UI-WORKBENCH-STUDIO-BOUNDARY-LINE-FULL-PACKAGE | Deferred / not yet | Workbench/Studio is a product-level orchestration layer. It must wait until renderer/layout/event/capability boundaries are more mature. | High | DEFERRED |
+| R12-UI-RENDERER-FULL-CONSOLIDATION-AUDIT-PR | Deferred | Useful later, but not the best immediate next step. The renderer line already has ledger audits for presentation and inspection. The next architectural pressure point is layout boundary. | Medium | DEFERRED |
+
+## 7. Selection Criteria
+1. Must preserve DNA alignment.
+2. Must preserve renderer/inspection inertness.
+3. Must not implement layout in the roadmap selection PR.
+4. Must not introduce backend/draw/event prematurely.
+5. Must not introduce runtime/verifier/VM/capability authority.
+6. Must build naturally on closed renderer presentation and inspection metadata.
+7. Must be documentable and auditable before source work.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE
+
+This selection is planning-only.
+This selection does not implement layout.
+This selection only authorizes the next boundary package to be prepared under a separate gate.
+
+## 9. Deferred Lanes
+- R12-UI-RENDERER-LAYOUT-SEED-LINE-FULL-PACKAGE
+- R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-WORKBENCH-STUDIO-BOUNDARY-LINE-FULL-PACKAGE
+- R12-UI-RENDERER-FULL-CONSOLIDATION-AUDIT-PR
+
+## 10. Admission Guard
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| roadmap selection doc | Implemented | ADMITTED | PASS |
+| layout implementation | Absent | FORBIDDEN | PASS |
+| draw/event dispatch | Absent | FORBIDDEN | PASS |
+| backend/WGPU/winit/Tauri | Absent | FORBIDDEN | PASS |
+| runtime/verifier/VM integration | Absent | FORBIDDEN | PASS |
+| capability admission | Absent | FORBIDDEN | PASS |
+| Workbench/Studio integration | Absent | FORBIDDEN | PASS |
+
+## 11. Non-Scope
+No source changes.
+No layout implementation.
+No draw/event implementation.
+No backend/WGPU/winit/Tauri.
+No runtime/verifier/VM integration.
+No capability admission.
+No Workbench/Studio integration.
+No dependency additions.
+
+## 12. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after renderer inspection.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement layout, draw, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Inspection Presentation line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-BOUNDARY-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* closed renderer inspection basis
* Project #2 inspection state
* candidate lane comparison
* selected next lane
* deferred lanes
* admission guard constraints

## Explicit non-scope

* no source changes
* no test changes
* no docs/dna changes
* no agent skill changes
* no Cargo.toml / Cargo.lock changes
* no dependency additions
* no layout implementation
* no draw/event implementation
* no backend/WGPU/winit/Tauri
* no runtime/verifier/VM
* no capability admission
* no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #964
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER RENDERER INSPECTION CLEAN
```
