### PR TITLE
docs(ui): define renderer layout boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_boundary.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_boundary.md
@@ -1,0 +1,129 @@
+# R12 UI Renderer Layout Boundary
+
+## 1. Purpose
+This document defines the R12 UI Renderer Layout Boundary after the completed and audited renderer inspection presentation line.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout boundary remains planning/documentation only;
+- no layout implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #959 — skill guardrail update
+- #960 — renderer presentation full-line ledger audit
+- #961 — next lane selection after renderer presentation
+- #962 — renderer inspection presentation source
+- #963 — renderer inspection presentation closeout
+- #964 — renderer inspection presentation ledger audit
+- #965 — next lane selection after renderer inspection
+
+## 4. Layout Position in Pipeline
+UiProjectionArtifact
+  ↓
+UiRenderModel
+  ↓
+Renderer presentation models
+    - diagnostics presentation
+    - trace presentation
+    - marker presentation
+    - inspection presentation
+  ↓
+Future layout model
+  ↓
+Future draw/backend/event layers, not part of this boundary
+
+## 5. Layout Boundary Definition
+Layout Boundary defines where a future layout layer may sit and what authority it must not receive.
+
+It does not implement layout.
+
+Layout is a future renderer-local structural arrangement layer.
+It may later arrange render model / presentation metadata into deterministic layout descriptions.
+It must remain downstream of renderer presentation/inspection metadata.
+It must not draw pixels, dispatch events, call backend APIs, execute actions, authorize effects, call runtime/verifier/VM, admit capabilities, or integrate Workbench/Studio.
+
+## 6. Allowed Future Inputs
+- UiRenderModel
+- UiRenderDiagnosticsPresentation
+- UiRenderTracePresentation
+- UiRenderMarkerPresentation
+- UiRenderInspectionPresentation
+
+No source code input contract is implemented in this PR.
+This is a boundary-level declaration only.
+
+## 7. Allowed Future Outputs
+- deterministic layout model;
+- deterministic layout node references;
+- layout sections/regions/slots;
+- layout metadata for future presentation;
+- source render/projection references preserved where exposed.
+
+No layout structs, layout IDs, layout node types, or layout functions are implemented in this PR.
+
+## 8. Explicit Non-Authority Rules
+- drawing;
+- rasterization;
+- GPU/backend calls;
+- WGPU/winit/Tauri;
+- event dispatch;
+- callbacks/handlers;
+- action execution;
+- effect authorization;
+- runtime/verifier/VM calls;
+- capability admission;
+- Workbench/Studio integration;
+- semantic truth authority;
+- proof/debugger authority.
+
+## 9. Deferred Implementation
+Deferred to a future source package:
+R12-UI-RENDERER-LAYOUT-SEED-LINE-FULL-PACKAGE
+
+That future package must not proceed until this boundary is closed and audited.
+
+## 10. Candidate Future Seed
+R12-UI-RENDERER-LAYOUT-SEED-LINE-FULL-PACKAGE
+
+## 11. Admission Guard
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future layout metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current layout implementation | absent | DEFERRED | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+
+## 12. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Layout boundary | Documented | ADMITTED | PASS |
+| Layout implementation | Not implemented | DEFERRED | PASS |
+| Layout seed | Future package only | DEFERRED | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 13. Final Decision
+Final decision:
+PASS — R12 UI Renderer Layout Boundary defined.
+
+This boundary admits a future layout layer only as deterministic renderer-local structural arrangement metadata.
+
+This PR does not implement layout, draw, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Defines the R12 UI Renderer Layout Boundary.

This is a docs-only boundary PR after the completed and audited renderer inspection presentation line.

## Scope

Documents:

- layout position in the renderer pipeline
- allowed future layout inputs
- allowed future layout outputs
- explicit non-authority rules
- deferred implementation gate
- admission guard constraints

## Explicit non-scope

- no source changes
- no tests changes
- no layout implementation
- no layout structs
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no docs/dna changes
- no agent skill changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Docs
Risk: High
Boundary: Renderer
Gate: Docs-only
Evidence: Roadmap doc
Depends on: #965
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT BOUNDARY DEFINED
```
