### PR TITLE
docs(ui): close out renderer layout boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_boundary_closeout.md
@@ -1,0 +1,85 @@
+# R12 UI Renderer Layout Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Boundary line.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout boundary remains planning/documentation only;
+- no layout implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+- #966 — docs(ui): define renderer layout boundary
+
+## 4. Implemented State
+Implemented:
+- layout boundary document;
+- layout pipeline position;
+- allowed future input categories;
+- allowed future output categories;
+- explicit non-authority rules;
+- deferred layout seed gate.
+
+## 5. Deferred State
+Deferred:
+- layout source implementation;
+- layout structs;
+- layout IDs;
+- layout functions;
+- layout tests;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+Layout boundary introduces no draw, event, backend, runtime, verifier, capability, or Workbench/Studio authority.
+
+## 7. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Layout boundary | Documented | ADMITTED | PASS |
+| Layout implementation | Not implemented | DEFERRED | PASS |
+| Layout seed | Future package only | DEFERRED | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future layout metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current layout implementation | absent | DEFERRED | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+The Project #2 state matches the audited PR basis (#966) with no duplicates.
+
+## 10. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-BOUNDARY-LEDGER-AUDIT-PR
+
+## 11. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Boundary is complete as a docs-only boundary artifact.
+
+It defines the future layout layer only as deterministic renderer-local structural arrangement metadata and does not implement layout, draw, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Boundary line.

This is a docs-only closeout after the layout boundary PR.

## Scope

Records:

- layout boundary document
- layout position in renderer pipeline
- allowed future input categories
- allowed future output categories
- explicit non-authority rules
- deferred layout seed gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no layout implementation
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #966
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — R12 UI Renderer Layout Boundary is complete as a docs-only boundary artifact.
```
