### PR TITLE
docs(ui): close out renderer layout seed

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_seed_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_seed_closeout.md
@@ -1,0 +1,74 @@
+# R12 UI Renderer Layout Seed Closeout
+
+## 1. Purpose
+
+The purpose of this line was to introduce the first inert deterministic renderer-local structural layout seed downstream of the `UiRenderModel`. This establishes a type-safe metadata layer without introducing unauthorized executable behavior (like drawing or a layout engine).
+
+## 2. DNA Alignment
+
+The implementation strictly respects the DNA defined in `SEMANTIC_UI_DNA.md`. The UI layout remains a structural projection. It does not become an execution or admission authority. No runtime capability was breached.
+
+## 3. Source PR
+
+The implementation is contained in the merged source PR.
+
+## 4. Implemented State
+
+Implemented:
+- inert layout module;
+- layout model identity;
+- layout node identity;
+- layout slot vocabulary;
+- read-only transform from UiRenderModel;
+- deterministic layout node ordering;
+- source render/projection/IR references preserved where exposed;
+- tests for deterministic structural behavior.
+
+## 5. Deferred State
+
+Deferred:
+- layout engine;
+- geometry solver;
+- coordinates/sizing;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+
+The code introduces no drawing primitives, no backend event callbacks, and no logic to bypass semantic boundaries. Layout remains structurally passive.
+
+## 7. Evidence Matrix
+
+| Area | Evidence |
+|------|----------|
+| Tests | Deterministic behavior is guarded |
+| Source | Types use simple integer identities |
+| Build | `cargo check` and `cargo test` pass |
+
+## 8. Admission Guard Table
+
+| Surface | Protected |
+|---------|-----------|
+| Runtime Capability | Yes |
+| UI Frame Emit | Yes |
+| UI Event Poll | Yes |
+| Proof Validation | Yes |
+
+## 9. Project #2 State
+
+Metadata for this closeout has been synchronized to the roadmap board.
+
+## 10. Recommended Next Gate
+
+R12-UI-RENDERER-LAYOUT-SEED-LEDGER-AUDIT-PR
+
+## 11. Final Decision
+
+Final decision:
+CLOSED — R12 UI Renderer Layout Seed is complete as an inert deterministic renderer-local structural metadata seed.
+
+It does not implement a layout engine, geometry solver, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Seed line.

## Scope

Records:

- inert layout seed implementation
- deterministic layout metadata behavior
- source reference preservation
- tests and validation
- deferred non-authority surfaces

## Explicit non-scope

- no source changes in this closeout PR
- no layout engine
- no geometry solver
- no draw/event/backend
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #969
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
CLOSED — R12 UI Renderer Layout Seed is complete as an inert deterministic renderer-local structural metadata seed.
```
