### PR TITLE
docs(ui): select next post-ui lane after layout seed

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_seed.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_seed.md
@@ -1,0 +1,97 @@
+# POST-UI Roadmap Next Lane Selection After Layout Seed
+
+## 1. Purpose
+
+This document selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Seed line.
+
+## 2. DNA Alignment
+
+docs/dna inspected: YES
+DNA files inspected: SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout seed remains inert structural metadata;
+- public API lock must not introduce new layout behavior;
+- no geometry solver;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Corrected Layout Seed Basis
+
+The layout seed line required recovery because #969 was merged before the final corrected source PR #970.
+
+Accepted corrected lineage:
+
+#968 — layout boundary ledger audit
+#970 — actual layout seed source implementation
+#969 — premature original layout seed closeout
+#971 — corrective recovery closeout
+#972 — layout seed ledger audit after recovery correction
+
+## 4. Project #2 State
+
+| PR | Title | State |
+|---|---|---|
+| #968 | docs(ui): add renderer layout boundary ledger audit | Done |
+| #970 | feat(ui): add inert renderer layout seed | Done |
+| #969 | docs(ui): close out renderer layout seed | Done |
+| #971 | docs(ui): corrective renderer layout seed closeout | Done |
+| #972 | docs(ui): add renderer layout seed ledger audit | Done |
+
+## 5. Candidate Lanes
+
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| Layout Public API Lock | Selected | Must lock the public surface before expansion | Low | SELECTED |
+| Layout Seed Expansion | Deferred | Requires public API lock first | Low | DEFERRED |
+| Layout Geometry Boundary | Deferred / high-risk | Requires stable locked layout API first | High | DEFERRED |
+| Layout Inspection Presentation | Deferred | Premature before base layout lock | Low | DEFERRED |
+| Event Boundary | Deferred / high-risk | Requires layout closure first | High | DEFERRED |
+| Backend Boundary | Deferred / too early | Out of scope for current renderer substrate | Low | DEFERRED |
+| Workbench / Studio Boundary | Deferred / not yet | Requires product-level maturity | Low | DEFERRED |
+
+## 6. Selection Criteria
+
+1. Must preserve DNA alignment.
+2. Must preserve layout seed inertness.
+3. Must not implement new layout behavior in this roadmap PR.
+4. Must not introduce geometry, draw, event, backend, runtime, capability, or Workbench/Studio authority.
+5. Must stabilize the public layout API before expansion.
+6. Must explicitly account for the #969/#970 recovery lineage.
+7. Must be documentable and auditable before source/test work.
+
+## 7. Selected Next Lane
+
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-PUBLIC-API-LOCK-LINE-FULL-PACKAGE
+
+## 8. Deferred Lanes
+
+- Layout Seed Expansion
+- Layout Geometry Boundary
+- Layout Inspection Presentation
+- Event Boundary
+- Backend Boundary
+- Workbench / Studio Boundary
+
+## 9. Admission Guard
+
+This selection is planning-only.
+This selection does not implement public API lock tests.
+This selection does not modify layout.rs.
+This selection only authorizes the next API-lock package to be prepared under a separate gate.
+
+## 10. Non-Scope
+
+This document does not implement layout behavior, geometry solving, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, or Workbench/Studio integration.
+
+## 11. Final Decision
+
+Final decision:
+PASS — POST-UI next lane selected after layout seed.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-PUBLIC-API-LOCK-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement public API lock tests, layout behavior, geometry solving, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Seed line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-PUBLIC-API-LOCK-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* corrected layout seed recovery basis
* Project #2 layout seed state
* candidate lane comparison
* selected next lane
* deferred lanes
* admission guard constraints

## Explicit non-scope

* no source changes
* no test changes
* no docs/dna changes
* no agent skill changes
* no Cargo.toml / Cargo.lock changes
* no dependency additions
* no public API lock implementation
* no layout.rs changes
* no layout behavior changes
* no geometry solver
* no draw/event implementation
* no backend/WGPU/winit/Tauri
* no runtime/verifier/VM
* no capability admission
* no Workbench/Studio

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #972
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT SEED CLEAN
```
