### PR TITLE
docs(ui): add renderer layout public api lock ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_public_api_lock_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_public_api_lock_ledger_audit.md
@@ -1,0 +1,205 @@
+# R12 UI Renderer Layout Public API Lock Ledger Audit
+
+## 1. Purpose
+
+This document records the ledger audit for the R12 UI Renderer Layout Public API Lock line after test PR #974 and closeout PR #975.
+
+## 2. Project Backfill Context
+
+The layout public API lock line required Project #2 backfill correction after #974 and #975 were merged.
+
+The code/test and closeout PRs were already merged, but the Project #2 rows were not initially updated automatically.
+
+The accepted corrected Project #2 state is:
+
+#974 — Done | POST-UI | R12 | Test | High | Renderer | PRReady | PR | #973
+#975 — Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #974
+
+This audit accepts the line only with the Project #2 backfill context explicitly recorded.
+
+## 3. DNA Alignment
+
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout public API lock remains test-only;
+- no layout behavior expansion;
+- no geometry solver;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 4. Closed Basis
+
+#968 — renderer layout boundary ledger audit
+#970 — actual renderer layout seed source
+#969 — premature original renderer layout seed closeout
+#971 — corrective renderer layout seed recovery closeout
+#972 — renderer layout seed ledger audit
+#973 — roadmap selection after layout seed
+#974 — renderer layout public API lock tests
+#975 — renderer layout public API lock closeout
+
+## 5. PR Ledger
+
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #968 | docs(ui): add renderer layout boundary ledger audit | MERGED | bf899ea7e2858e3cb56147c64580f6f8689cd8e8 | 1 | Boundary | PASS |
+| #970 | feat(ui): add inert renderer layout seed | MERGED | 89532ce32e2c5ab5e43ba20be6a61f6f53704c19 | 3 | Source | PASS |
+| #969 | docs(ui): close out renderer layout seed | MERGED | 2b1ff96c81dab35384b9d2eab404fb63020bf3ba | 1 | Closeout | PREMATURE |
+| #971 | docs(ui): corrective renderer layout seed closeout | MERGED | 3b64f926ba42a0929c8f3a705cd18dae90c5700a | 1 | Closeout | PASS |
+| #972 | docs(ui): add renderer layout seed ledger audit | MERGED | ccc2e6833b7ba88ef7e12f60a95c960dfde232c9 | 1 | Audit | PASS |
+| #973 | docs(ui): select next post-ui lane after layout seed | MERGED | fef9a2e6f4afc9233f2c5950882eebc03e33cbf7 | 1 | Roadmap | PASS |
+| #974 | test(ui): lock renderer layout public api | MERGED | e57bcefbdf04e304f58ba4a2346efddbbbfba4ec | 1 | Tests | PASS |
+| #975 | docs(ui): close out renderer layout public api lock | MERGED | bde2c53a23277685642cd02d338bc8651c6b12a0 | 1 | Closeout | PASS |
+
+## 6. Changed File Surface
+
+| PR | Changed files | Production source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---|---|---|---|---|
+| #974 | crates/prom-ui/tests/renderer_layout_public_api_lock.rs | NO | YES | NO | NO | PASS |
+| #975 | docs/roadmap/post_ui/r12_ui_renderer_layout_public_api_lock_closeout.md | NO | NO | YES | NO | PASS |
+
+## 7. Locked Public API Surface
+
+| API / Surface | Lock evidence | Classification | Status |
+|---|---|---|---|
+| UiLayoutModelId | test coverage | public struct | PASS |
+| UiLayoutNodeId | test coverage | public struct | PASS |
+| UiLayoutSlotId | test coverage | public struct | PASS |
+| UiLayoutSlotKind | test coverage | public enum | PASS |
+| UiLayoutSlot | test coverage | public struct | PASS |
+| UiLayoutNode | test coverage | public struct | PASS |
+| UiLayoutModel | test coverage | public struct | PASS |
+| layout_render_model | test coverage | public fn | PASS |
+| pub mod layout | test coverage | module export | PASS |
+| layout engine | scan | forbidden | PASS |
+| geometry solver | scan | forbidden | PASS |
+| draw API | scan | forbidden | PASS |
+| event API | scan | forbidden | PASS |
+| backend API | scan | forbidden | PASS |
+| runtime/verifier/VM API | scan | forbidden | PASS |
+| capability admission API | scan | forbidden | PASS |
+| Workbench/Studio API | scan | forbidden | PASS |
+| proof/debugger API | scan | forbidden | PASS |
+
+## 8. Behavior Lock Ledger
+
+| Behavior | Lock evidence | Status |
+|---|---|---|
+| layout_render_model signature | test coverage | PASS |
+| deterministic repeated layout | test coverage | PASS |
+| deterministic model ID | test coverage | PASS |
+| deterministic slot IDs | test coverage | PASS |
+| deterministic node IDs | test coverage | PASS |
+| source render model preservation | test coverage | PASS |
+| source projection preservation | test coverage | PASS |
+| source IR root preservation where exposed | test coverage | PASS |
+| source render node preservation | test coverage | PASS |
+| source projection node preservation where exposed | test coverage | PASS |
+| source IR node preservation where exposed | test coverage | PASS |
+| slot order preservation | test coverage | PASS |
+| node order preservation | test coverage | PASS |
+| no geometry contract | test coverage | PASS |
+| no draw/event/backend contract | test coverage | PASS |
+
+## 9. Test Coverage Ledger
+
+| Test category | Present | Evidence | Status |
+|---|---|---|---|
+| layout module public export | YES | layout_module_is_public | PASS |
+| ID constructors/raw accessors | YES | layout_id_new_and_raw_are_public | PASS |
+| ID trait bounds | YES | layout_id_new_and_raw_are_public | PASS |
+| slot kind vocabulary | YES | layout_slot_kind_variants_are_public | PASS |
+| slot accessors | YES | layout_slot_accessors_are_public | PASS |
+| node accessors | YES | layout_node_accessors_are_public | PASS |
+| model accessors | YES | layout_model_accessors_are_public | PASS |
+| layout_render_model signature | YES | layout_render_model_signature_is_locked | PASS |
+| model identity preservation | YES | layout_render_model_preserves_model_identity | PASS |
+| source projection preservation | YES | layout_render_model_preserves_source_projection | PASS |
+| source IR root preservation | YES | layout_render_model_preserves_source_ir_root | PASS |
+| node reference preservation | YES | layout_render_model_preserves_node_references | PASS |
+| node order preservation | YES | layout_render_model_preserves_node_order | PASS |
+| repeated deterministic layout | YES | repeated_layout_render_model_is_deterministic | PASS |
+| no geometry contract | YES | layout_api_exposes_no_geometry_contract | PASS |
+| no draw/event/backend contract | YES | layout_api_exposes_no_draw_event_backend_contract | PASS |
+
+## 10. Project #2 Ledger
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #973 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #972 | NO |
+| #974 | Done | POST-UI | R12 | Test | High | Renderer | PRReady | PR | #973 | NO |
+| #975 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #974 | NO |
+
+## 11. Forbidden Surface Ledger
+
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| production source changes | NO | FORBIDDEN | PASS |
+| layout behavior expansion | NO | FORBIDDEN | PASS |
+| layout engine | NO | FORBIDDEN | PASS |
+| geometry solver | NO | FORBIDDEN | PASS |
+| draw commands | NO | FORBIDDEN | PASS |
+| backend/WGPU/winit/Tauri | NO | FORBIDDEN | PASS |
+| event dispatch | NO | FORBIDDEN | PASS |
+| action execution | NO | FORBIDDEN | PASS |
+| effect authorization | NO | FORBIDDEN | PASS |
+| runtime/verifier/VM | NO | FORBIDDEN | PASS |
+| capability admission | NO | FORBIDDEN | PASS |
+| Workbench/Studio | NO | FORBIDDEN | PASS |
+| semantic truth authority | NO | FORBIDDEN | PASS |
+| proof/debugger authority | NO | FORBIDDEN | PASS |
+| Cargo.toml / Cargo.lock | NO | FORBIDDEN | PASS |
+| dependency additions | NO | FORBIDDEN | PASS |
+| tracked pr_body artifacts | NO | FORBIDDEN | PASS |
+
+## 12. Manifest / Dependency Ledger
+
+Cargo.toml and Cargo.lock are unchanged. No dependency additions detected.
+
+## 13. Local Validation
+
+```text
+cargo fmt --check: PASS
+cargo test -p prom-ui --lib: PASS
+cargo test -p prom-ui: PASS
+git diff --check: PASS
+tracked pr_body files: NONE
+```
+
+## 14. Admission Guard Summary
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| layout public API lock | IMPLEMENTED | ADMITTED | PASS |
+| Project #2 backfill correction | DOCUMENTED | ADMITTED | PASS |
+| production source changes | ABSENT | FORBIDDEN | PASS |
+| layout behavior expansion | ABSENT | FORBIDDEN | PASS |
+| layout engine | ABSENT | DEFERRED | PASS |
+| geometry solver | ABSENT | DEFERRED | PASS |
+| draw commands | ABSENT | FORBIDDEN | PASS |
+| event dispatch | ABSENT | FORBIDDEN | PASS |
+| backend rendering | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 15. Final Decision
+
+Final decision:
+PASS — R12 UI Renderer Layout Public API Lock ledger audit is clean after Project #2 backfill correction.
+
+The accepted public API lock implementation is PR #974.
+
+The closeout PR is #975.
+
+The Project #2 metadata correction for #974 and #975 is explicitly documented and accepted.
+
+The existing inert layout public API is locked by tests and remains deterministic renderer-local structural metadata.
+
+This line does not implement layout behavior expansion, a layout engine, geometry solver, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, Workbench/Studio integration, or dependency additions.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Public API Lock ledger audit.

This is a docs-only audit PR covering:

- #973 — roadmap selection after layout seed
- #974 — layout public API lock tests
- #975 — layout public API lock closeout
- Project #2 backfill correction for #974/#975

## Scope

Audits:

- closed PR basis
- changed file surface
- public API lock coverage
- behavior lock coverage
- Project #2 metadata
- Project #2 backfill context
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no layout behavior expansion
- no layout engine
- no geometry solver
- no draw commands
- no backend/WGPU/winit/Tauri
- no event dispatch
- no action/effect execution
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no proof/debugger authority

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #975
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT PUBLIC API LOCK LEDGER AUDIT CLEAN AFTER PROJECT BACKFILL CORRECTION
```
