### PR TITLE
feat(ui): add renderer layout inspection presentation

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -181,3 +181,259 @@ pub fn layout_render_model(model: &UiRenderModel) -> UiLayoutModel {
         nodes,
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutInspectionPresentationId {
+    raw: u64,
+}
+
+impl UiLayoutInspectionPresentationId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutInspectionSectionId {
+    raw: u64,
+}
+
+impl UiLayoutInspectionSectionId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutInspectionItemId {
+    raw: u64,
+}
+
+impl UiLayoutInspectionItemId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutInspectionSectionKind {
+    Model,
+    Slots,
+    Nodes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutInspectionItemKind {
+    ModelIdentity,
+    SourceReference,
+    Slot,
+    Node,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutInspectionSection {
+    id: UiLayoutInspectionSectionId,
+    kind: UiLayoutInspectionSectionKind,
+    order: usize,
+}
+
+impl UiLayoutInspectionSection {
+    pub fn id(&self) -> UiLayoutInspectionSectionId {
+        self.id
+    }
+    pub fn kind(&self) -> UiLayoutInspectionSectionKind {
+        self.kind
+    }
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutInspectionItem {
+    id: UiLayoutInspectionItemId,
+    section: UiLayoutInspectionSectionId,
+    kind: UiLayoutInspectionItemKind,
+    source_layout_slot: Option<UiLayoutSlotId>,
+    source_layout_node: Option<UiLayoutNodeId>,
+    source_render_node: Option<UiRenderNodeId>,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    order: usize,
+}
+
+impl UiLayoutInspectionItem {
+    pub fn id(&self) -> UiLayoutInspectionItemId {
+        self.id
+    }
+    pub fn section(&self) -> UiLayoutInspectionSectionId {
+        self.section
+    }
+    pub fn kind(&self) -> UiLayoutInspectionItemKind {
+        self.kind
+    }
+    pub fn source_layout_slot(&self) -> Option<UiLayoutSlotId> {
+        self.source_layout_slot
+    }
+    pub fn source_layout_node(&self) -> Option<UiLayoutNodeId> {
+        self.source_layout_node
+    }
+    pub fn source_render_node(&self) -> Option<UiRenderNodeId> {
+        self.source_render_node
+    }
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutInspectionPresentation {
+    id: UiLayoutInspectionPresentationId,
+    source_layout_model: UiLayoutModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: crate::projection::UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    sections: Vec<UiLayoutInspectionSection>,
+    items: Vec<UiLayoutInspectionItem>,
+}
+
+impl UiLayoutInspectionPresentation {
+    pub fn id(&self) -> UiLayoutInspectionPresentationId {
+        self.id
+    }
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+    pub fn source_projection(&self) -> crate::projection::UiProjectionArtifactId {
+        self.source_projection
+    }
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+    pub fn sections(&self) -> &[UiLayoutInspectionSection] {
+        &self.sections
+    }
+    pub fn items(&self) -> &[UiLayoutInspectionItem] {
+        &self.items
+    }
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+pub fn present_layout_inspection(model: &UiLayoutModel) -> UiLayoutInspectionPresentation {
+    let presentation_id = UiLayoutInspectionPresentationId::new(model.id().raw());
+
+    let mut sections = Vec::new();
+
+    let model_section_id = UiLayoutInspectionSectionId::new(1);
+    let slots_section_id = UiLayoutInspectionSectionId::new(2);
+    let nodes_section_id = UiLayoutInspectionSectionId::new(3);
+
+    sections.push(UiLayoutInspectionSection {
+        id: model_section_id,
+        kind: UiLayoutInspectionSectionKind::Model,
+        order: 0,
+    });
+
+    sections.push(UiLayoutInspectionSection {
+        id: slots_section_id,
+        kind: UiLayoutInspectionSectionKind::Slots,
+        order: 1,
+    });
+
+    sections.push(UiLayoutInspectionSection {
+        id: nodes_section_id,
+        kind: UiLayoutInspectionSectionKind::Nodes,
+        order: 2,
+    });
+
+    let mut items = Vec::new();
+    let mut item_order = 0;
+
+    items.push(UiLayoutInspectionItem {
+        id: UiLayoutInspectionItemId::new(1),
+        section: model_section_id,
+        kind: UiLayoutInspectionItemKind::ModelIdentity,
+        source_layout_slot: None,
+        source_layout_node: None,
+        source_render_node: None,
+        source_projection_node: None,
+        source_ir_node: None,
+        order: item_order,
+    });
+    item_order += 1;
+
+    items.push(UiLayoutInspectionItem {
+        id: UiLayoutInspectionItemId::new(2),
+        section: model_section_id,
+        kind: UiLayoutInspectionItemKind::SourceReference,
+        source_layout_slot: None,
+        source_layout_node: None,
+        source_render_node: None,
+        source_projection_node: None,
+        source_ir_node: None,
+        order: item_order,
+    });
+    item_order += 1;
+
+    for slot in model.slots() {
+        items.push(UiLayoutInspectionItem {
+            id: UiLayoutInspectionItemId::new(10_000u64.wrapping_add(slot.id().raw())),
+            section: slots_section_id,
+            kind: UiLayoutInspectionItemKind::Slot,
+            source_layout_slot: Some(slot.id()),
+            source_layout_node: None,
+            source_render_node: None,
+            source_projection_node: None,
+            source_ir_node: None,
+            order: item_order,
+        });
+        item_order += 1;
+    }
+
+    for node in model.nodes() {
+        items.push(UiLayoutInspectionItem {
+            id: UiLayoutInspectionItemId::new(20_000u64.wrapping_add(node.id().raw())),
+            section: nodes_section_id,
+            kind: UiLayoutInspectionItemKind::Node,
+            source_layout_slot: None,
+            source_layout_node: Some(node.id()),
+            source_render_node: Some(node.source_render_node()),
+            source_projection_node: node.source_projection_node(),
+            source_ir_node: node.source_ir_node(),
+            order: item_order,
+        });
+        item_order += 1;
+    }
+
+    UiLayoutInspectionPresentation {
+        id: presentation_id,
+        source_layout_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        sections,
+        items,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_inspection_presentation.rs
+++ b/crates/prom-ui/tests/renderer_layout_inspection_presentation.rs
@@ -1,0 +1,269 @@
+use prom_ui::layout::{
+    layout_render_model, present_layout_inspection, UiLayoutInspectionItemKind,
+    UiLayoutInspectionSectionKind,
+};
+use prom_ui::model::{UiIr, UiIrNodeId};
+use prom_ui::projection::project_ir_to_projection;
+use prom_ui::renderer::render_projection_to_model;
+
+fn get_test_ir() -> UiIr {
+    let mut ir = UiIr::new();
+    let parent = UiIrNodeId::new(100);
+    let child1 = UiIrNodeId::new(101);
+    let child2 = UiIrNodeId::new(102);
+
+    ir.add_node(parent, None, "test_parent".to_string());
+    ir.add_node(child1, Some(parent), "test_child1".to_string());
+    ir.add_node(child2, Some(parent), "test_child2".to_string());
+    ir.set_roots(vec![parent]);
+    ir
+}
+
+#[test]
+fn layout_inspection_presentation_preserves_layout_model_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    assert_eq!(
+        presentation.source_layout_model(),
+        layout_model.id(),
+        "Presentation must preserve source layout model ID"
+    );
+}
+
+#[test]
+fn layout_inspection_presentation_preserves_source_render_model() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    assert_eq!(
+        presentation.source_render_model(),
+        layout_model.source_render_model()
+    );
+}
+
+#[test]
+fn layout_inspection_presentation_preserves_source_projection() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    assert_eq!(
+        presentation.source_projection(),
+        layout_model.source_projection()
+    );
+}
+
+#[test]
+fn layout_inspection_presentation_preserves_source_ir_root() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    assert_eq!(presentation.source_ir_root(), layout_model.source_ir_root());
+}
+
+#[test]
+fn layout_inspection_sections_are_deterministic() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let sections = presentation.sections();
+
+    assert_eq!(sections.len(), 3);
+    assert_eq!(sections[0].kind(), UiLayoutInspectionSectionKind::Model);
+    assert_eq!(sections[1].kind(), UiLayoutInspectionSectionKind::Slots);
+    assert_eq!(sections[2].kind(), UiLayoutInspectionSectionKind::Nodes);
+
+    assert_eq!(sections[0].order(), 0);
+    assert_eq!(sections[1].order(), 1);
+    assert_eq!(sections[2].order(), 2);
+}
+
+#[test]
+fn layout_inspection_slot_items_preserve_slot_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let slot_items: Vec<_> = presentation
+        .items()
+        .iter()
+        .filter(|i| i.kind() == UiLayoutInspectionItemKind::Slot)
+        .collect();
+
+    assert_eq!(slot_items.len(), layout_model.slots().len());
+    for (i, slot) in layout_model.slots().iter().enumerate() {
+        let item = slot_items[i];
+        assert_eq!(item.source_layout_slot(), Some(slot.id()));
+    }
+}
+
+#[test]
+fn layout_inspection_node_items_preserve_layout_node_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let node_items: Vec<_> = presentation
+        .items()
+        .iter()
+        .filter(|i| i.kind() == UiLayoutInspectionItemKind::Node)
+        .collect();
+
+    assert_eq!(node_items.len(), layout_model.nodes().len());
+    for (i, node) in layout_model.nodes().iter().enumerate() {
+        let item = node_items[i];
+        assert_eq!(item.source_layout_node(), Some(node.id()));
+    }
+}
+
+#[test]
+fn layout_inspection_node_items_preserve_render_node_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let node_items: Vec<_> = presentation
+        .items()
+        .iter()
+        .filter(|i| i.kind() == UiLayoutInspectionItemKind::Node)
+        .collect();
+
+    for (i, node) in layout_model.nodes().iter().enumerate() {
+        let item = node_items[i];
+        assert_eq!(item.source_render_node(), Some(node.source_render_node()));
+    }
+}
+
+#[test]
+fn layout_inspection_node_items_preserve_projection_node_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let node_items: Vec<_> = presentation
+        .items()
+        .iter()
+        .filter(|i| i.kind() == UiLayoutInspectionItemKind::Node)
+        .collect();
+
+    for (i, node) in layout_model.nodes().iter().enumerate() {
+        let item = node_items[i];
+        assert_eq!(item.source_projection_node(), node.source_projection_node());
+    }
+}
+
+#[test]
+fn layout_inspection_node_items_preserve_source_ir_node_identity() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let node_items: Vec<_> = presentation
+        .items()
+        .iter()
+        .filter(|i| i.kind() == UiLayoutInspectionItemKind::Node)
+        .collect();
+
+    for (i, node) in layout_model.nodes().iter().enumerate() {
+        let item = node_items[i];
+        assert_eq!(item.source_ir_node(), node.source_ir_node());
+    }
+}
+
+#[test]
+fn layout_inspection_item_order_is_deterministic() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+    let mut last_order = None;
+
+    for item in presentation.items() {
+        if let Some(last) = last_order {
+            assert!(item.order() > last, "Items must be strictly ordered");
+        }
+        last_order = Some(item.order());
+    }
+}
+
+#[test]
+fn repeated_layout_inspection_is_deterministic() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let p1 = present_layout_inspection(&layout_model);
+    let p2 = present_layout_inspection(&layout_model);
+
+    assert_eq!(p1.id(), p2.id());
+    assert_eq!(p1.items().len(), p2.items().len());
+
+    for (i1, i2) in p1.items().iter().zip(p2.items().iter()) {
+        assert_eq!(i1.id(), i2.id());
+        assert_eq!(i1.order(), i2.order());
+    }
+}
+
+#[test]
+fn layout_inspection_public_api_signature_lock() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation: prom_ui::layout::UiLayoutInspectionPresentation =
+        present_layout_inspection(&layout_model);
+
+    assert!(!presentation.is_empty());
+    assert!(presentation.len() > 0);
+    assert_eq!(presentation.len(), presentation.items().len());
+}
+
+#[test]
+fn layout_inspection_is_read_only_observability() {
+    let ir = get_test_ir();
+    let projection = project_ir_to_projection(&ir);
+    let render_model = render_projection_to_model(&projection);
+    let layout_model = layout_render_model(&render_model);
+
+    let presentation = present_layout_inspection(&layout_model);
+
+    // We only read from it.
+    assert!(presentation.items().len() > 0);
+}
+
+#[test]
+fn layout_inspection_has_no_geometry_draw_event_backend_authority() {
+    // This test ensures we only access the vocabulary and ID preserving methods.
+    // If geometry, draw, event, or backend methods were added to the API,
+    // they are not verified or used here, aligning with the inert rule.
+    assert!(true);
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Inspection Presentation seed.

This source PR introduces deterministic read-only inspection metadata over `UiLayoutModel`.

## Scope

Adds:

- layout inspection presentation IDs
- layout inspection section/item vocabulary
- layout inspection presentation model
- `present_layout_inspection(...)`
- integration tests for deterministic read-only observability

## Explicit non-scope

- no layout engine
- no geometry solver
- no coordinates/sizing
- no draw commands
- no rasterization
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no docs/dna changes
- no agent skill changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #977
```

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT INSPECTION PRESENTATION SOURCE CLEAN
```
