### PR TITLE
docs(ui): close out renderer layout inspection presentation

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_closeout.md
@@ -1,0 +1,28 @@
+# R12 UI Renderer Layout Inspection Presentation Closeout
+
+## Mission
+
+This closeout document formally seals the R12 UI Renderer Layout Inspection Presentation seed line.
+
+## Scope
+
+We confirm the implementation:
+
+- introduced layout inspection presentation model
+- introduced \present_layout_inspection\ mapping
+- maintained strict structural read-only observability over \UiLayoutModel\`n- passed determinism tests for section and item derivation
+- preserved layout node, slot, and projection metadata mapping
+
+## Exclusions Confirmed
+
+- no backend/WGPU integration
+- no layout execution, solving, or sizing
+- no draw, pixel, or raster integration
+- no event dispatch or runtime logic
+- no capability admission changes
+- no Workbench/Studio integration
+- no DNA or dependency mutations
+
+## Validation
+
+All source tests, code formatting, and pre-commit checks pass.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Inspection Presentation seed.

## Scope

- Adds \12_ui_renderer_layout_inspection_presentation_closeout.md\ to \docs/roadmap/post_ui/\`n
## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Docs
Risk: Low
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #978
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT INSPECTION PRESENTATION CLOSEOUT CLEAN
```
