### PR TITLE
docs(ui): corrective renderer layout inspection presentation closeout

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_closeout.md
@@ -1,28 +1,68 @@
-# R12 UI Renderer Layout Inspection Presentation Closeout
+# R12 UI Renderer Layout Inspection Presentation Corrective Closeout
 
 ## Mission
 
-This closeout document formally seals the R12 UI Renderer Layout Inspection Presentation seed line.
+This corrective closeout formally seals the R12 UI Renderer Layout Inspection Presentation seed line, acknowledging the recovery PRs required to stabilize tests.
 
-## Scope
+## DNA Alignment
 
-We confirm the implementation:
+The `UiLayoutInspectionPresentation` explicitly maps `UiLayoutModel` without mutating or interpreting logic. It exists strictly as a read-only metadata observability layer, preserving deterministic identity mapping between the layout node, layout slot, projection node, render node, and original IR node.
 
-- introduced layout inspection presentation model
-- introduced \present_layout_inspection\ mapping
-- maintained strict structural read-only observability over \UiLayoutModel\`n- passed determinism tests for section and item derivation
-- preserved layout node, slot, and projection metadata mapping
+## Source PR
 
-## Exclusions Confirmed
+- #978 — initial source implementation (feat(ui): add renderer layout inspection presentation)
+- #979 — recovery test fix 1 (test(ui): fix compilation in layout inspection presentation tests)
+- #980 — recovery test fix 2 / final green state (test(ui): fix compilation in layout inspection presentation tests correctly)
+- #981 — original closeout (docs(ui): close out renderer layout inspection presentation)
 
-- no backend/WGPU integration
-- no layout execution, solving, or sizing
-- no draw, pixel, or raster integration
-- no event dispatch or runtime logic
-- no capability admission changes
-- no Workbench/Studio integration
-- no DNA or dependency mutations
+## Implemented State
 
-## Validation
+- layout inspection presentation model and identifiers
+- deterministic `present_layout_inspection` function
+- section and item vocabulary
+- extensive layout inspection unit tests
 
-All source tests, code formatting, and pre-commit checks pass.
+## Deferred State
+
+- No dynamic tracking or updates (it is an inert snapshot)
+- No user-facing text formatting (raw inspection IDs only)
+
+## Non-Authority Confirmation
+
+It does not implement backend rendering, WGPU/winit/Tauri, layout execution, geometry solving, coordinates, sizing, draw commands, rasterization, event dispatch, execution engines, runtime logic, verifier/VM integration, capability admission, semantic truth authority, proof/debugger authority, Workbench/Studio integration, or dependency additions.
+
+## Evidence Matrix
+
+| Check | Expected | Actual | Status |
+| --- | --- | --- | --- |
+| Formatting | `cargo fmt --check` passes | Passed cleanly | OK |
+| Compilation | `cargo test --lib` passes | Passed cleanly | OK |
+| Tests | `cargo test` passes | Passed cleanly | OK |
+| Clean tree | `git diff --check` empty | Clean | OK |
+| Dependencies | no changes to `Cargo.toml` | Clean | OK |
+
+## Admission Guard Table
+
+| Guard | Requirement | Status |
+| --- | --- | --- |
+| WGPU / Tauri / winit | forbidden surface | OK (absent) |
+| Layout Solver / Geometry | forbidden surface | OK (absent) |
+| Event Dispatch | forbidden surface | OK (absent) |
+| Capability Admission | forbidden surface | OK (absent) |
+
+## Project #2 State
+
+| Issue/PR | Track | Wave | Gate | Status | Depends On |
+| --- | --- | --- | --- | --- | --- |
+| #978 | POST-UI | R12 | PRReady | Done | #977 |
+| #979 | POST-UI | R12 | PRReady | Done | #978 |
+| #980 | POST-UI | R12 | PRReady | Done | #979 |
+| #981 | POST-UI | R12 | Release Artifact | Done | #980 |
+
+## Recommended Next Gate
+
+R12-UI-RENDERER-LAYOUT-INSPECTION-PRESENTATION-LEDGER-AUDIT-PR
+
+## Final Decision
+
+PASS WITH CORRECTED RECOVERY LINEAGE.


### PR DESCRIPTION
## Summary

Corrective closeout for the R12 UI Renderer Layout Inspection Presentation seed line.

## Scope

- Overwrites `r12_ui_renderer_layout_inspection_presentation_closeout.md` with rigorous governance structure.

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #981
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT INSPECTION PRESENTATION RECOVERY CLOSEOUT
```
