### PR TITLE
docs(ui): add renderer layout inspection presentation ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_inspection_presentation_ledger_audit.md
@@ -1,0 +1,205 @@
+# R12 UI Renderer Layout Inspection Presentation Ledger Audit
+
+## Purpose
+
+This document records the ledger audit for the R12 UI Renderer Layout Inspection Presentation line after source PR #978, recovery PRs #979/#980, original closeout PR #981, and corrective recovery closeout PR #982.
+
+## Recovery / Corrected Lineage Context
+
+The layout inspection presentation line required recovery because the initial source implementation #978 needed follow-up test fixes in #979 and #980 before the line reached the final green state.
+
+The accepted corrected lineage is:
+
+#977 — roadmap selected layout inspection presentation
+#978 — initial layout inspection presentation source
+#979 — recovery test fix 1
+#980 — recovery test fix 2 / final green state
+#981 — original closeout
+#982 — corrective recovery closeout
+
+This audit accepts the line only with the recovery context explicitly recorded.
+
+## DNA Alignment
+
+docs/dna inspected: YES
+DNA files inspected: SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout inspection presentation remains read-only observability;
+- no layout behavior expansion;
+- no layout engine;
+- no geometry solver;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## Closed Basis
+
+#977 — roadmap selection after layout API lock
+#978 — initial renderer layout inspection presentation source
+#979 — recovery test fix 1
+#980 — recovery test fix 2 / final green state
+#981 — original renderer layout inspection presentation closeout
+#982 — corrective renderer layout inspection presentation recovery closeout
+
+## PR Ledger
+
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #977 | docs(ui): select next post-ui lane after layout api lock | MERGED | e24c0ff85d5a6205632d56b5bee66508c0259637 | 1 | Lane selection | PASS |
+| #978 | feat(ui): add renderer layout inspection presentation | MERGED | f741b7f778c498414493211d1051ba054b458aea | 2 | Initial source implementation | PASS |
+| #979 | test(ui): fix compilation in layout inspection presentation tests | MERGED | 637af845a5c8355603f5fb7c7420d09712ce6f2b | 1 | Recovery test fix 1 | RECOVERY |
+| #980 | test(ui): fix compilation in layout inspection presentation tests correctly | MERGED | 70772ce90b269a0e15566d6798e6119ce75b03db | 1 | Recovery test fix 2 / final green state | FINAL GREEN |
+| #981 | docs(ui): close out renderer layout inspection presentation | MERGED | 1fb47b43d433b1953a931759467de9ba142187f0 | 1 | Original closeout | ORIGINAL CLOSEOUT |
+| #982 | docs(ui): corrective renderer layout inspection presentation closeout | MERGED | 4ea0300442cd298f982e3cb34c7b88c8c346dec6 | 1 | Corrective recovery closeout | PASS / RECOVERY CLOSEOUT |
+
+## Changed File Surface
+
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---|---|---|---|---|
+| #978 | layout.rs / renderer_layout_inspection_presentation.rs | YES | YES | NO | NO | PASS |
+| #979 | renderer_layout_inspection_presentation.rs | NO | YES | NO | NO | RECOVERY |
+| #980 | renderer_layout_inspection_presentation.rs | NO | YES | NO | NO | PASS / FINAL GREEN |
+| #981 | layout inspection closeout doc | NO | NO | YES | NO | ORIGINAL CLOSEOUT |
+| #982 | layout inspection closeout doc correction | NO | NO | YES | NO | PASS / RECOVERY CLOSEOUT |
+
+## Layout Inspection API Ledger
+
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| UiLayoutInspectionPresentationId | present | allowed | code review | OK |
+| UiLayoutInspectionSectionId | present | allowed | code review | OK |
+| UiLayoutInspectionItemId | present | allowed | code review | OK |
+| UiLayoutInspectionSectionKind | present | allowed | code review | OK |
+| UiLayoutInspectionItemKind | present | allowed | code review | OK |
+| UiLayoutInspectionSection | present | allowed | code review | OK |
+| UiLayoutInspectionItem | present | allowed | code review | OK |
+| UiLayoutInspectionPresentation | present | allowed | code review | OK |
+| present_layout_inspection | present | allowed | code review | OK |
+| layout engine | absent | forbidden | code scan | OK |
+| layout behavior expansion | absent | forbidden | code scan | OK |
+| geometry solver | absent | forbidden | code scan | OK |
+| coordinates/sizing | absent | forbidden | code scan | OK |
+| draw API | absent | forbidden | code scan | OK |
+| event API | absent | forbidden | code scan | OK |
+| backend API | absent | forbidden | code scan | OK |
+| runtime/verifier/VM API | absent | forbidden | code scan | OK |
+| capability admission API | absent | forbidden | code scan | OK |
+| Workbench/Studio API | absent | forbidden | code scan | OK |
+| proof/debugger API | absent | forbidden | code scan | OK |
+
+## Behavior Ledger
+
+| Behavior | Final state | Evidence | Status |
+|---|---|---|---|
+| read-only UiLayoutModel consumption | YES | code review | OK |
+| deterministic presentation ID | YES | code review | OK |
+| deterministic section IDs | YES | code review | OK |
+| deterministic item IDs | YES | code review | OK |
+| source layout model preservation | YES | code review | OK |
+| source render model preservation | YES | code review | OK |
+| source projection preservation | YES | code review | OK |
+| source IR root preservation where exposed | YES | code review | OK |
+| source layout slot preservation | YES | code review | OK |
+| source layout node preservation | YES | code review | OK |
+| source render node preservation | YES | code review | OK |
+| source projection node preservation where exposed | YES | code review | OK |
+| source IR node preservation where exposed | YES | code review | OK |
+| slot order preservation | YES | code review | OK |
+| node order preservation | YES | code review | OK |
+| repeated deterministic inspection | YES | code review | OK |
+| no random IDs | YES | code review | OK |
+| no timestamps | YES | code review | OK |
+| no global mutable state | YES | code review | OK |
+| no geometry | YES | code review | OK |
+| no draw/event/backend authority | YES | code review | OK |
+
+## Test Coverage Ledger
+
+| Test category | Present | Evidence | Status |
+|---|---|---|---|
+| layout model identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| source render model preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| source projection preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| source IR root preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| deterministic sections | YES | renderer_layout_inspection_presentation.rs | OK |
+| slot item identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| layout node identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| render node identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| projection node identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| source IR node identity preservation | YES | renderer_layout_inspection_presentation.rs | OK |
+| deterministic item order | YES | renderer_layout_inspection_presentation.rs | OK |
+| repeated deterministic inspection | YES | renderer_layout_inspection_presentation.rs | OK |
+| public API signature lock | YES | renderer_layout_inspection_presentation.rs | OK |
+| read-only observability | YES | renderer_layout_inspection_presentation.rs | OK |
+| no geometry/draw/event/backend authority | YES | renderer_layout_inspection_presentation.rs | OK |
+
+## Project #2 Ledger
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Duplicate |
+|---|---|---|---|---|---|---|---|---|---|---|
+| #977 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #976 | 0 |
+| #978 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #977 | 0 |
+| #979 | Done | POST-UI | R12 | Test | High | Renderer | PRReady | PR | #978 | 0 |
+| #980 | Done | POST-UI | R12 | Test | High | Renderer | PRReady | PR | #979 | 0 |
+| #981 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #980 | 0 |
+| #982 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #981 | 0 |
+
+## Forbidden Surface Ledger
+
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| layout behavior expansion | NO | FORBIDDEN | OK |
+| layout engine | NO | FORBIDDEN | OK |
+| geometry solver | NO | FORBIDDEN | OK |
+| coordinates/sizing | NO | FORBIDDEN | OK |
+| draw commands | NO | FORBIDDEN | OK |
+| backend/WGPU/winit/Tauri | NO | FORBIDDEN | OK |
+| event dispatch | NO | FORBIDDEN | OK |
+| action execution | NO | FORBIDDEN | OK |
+| effect authorization | NO | FORBIDDEN | OK |
+| runtime/verifier/VM | NO | FORBIDDEN | OK |
+| capability admission | NO | FORBIDDEN | OK |
+| Workbench/Studio | NO | FORBIDDEN | OK |
+| semantic truth authority | NO | FORBIDDEN | OK |
+| proof/debugger authority | NO | FORBIDDEN | OK |
+| Cargo.toml / Cargo.lock | NO | FORBIDDEN | OK |
+| dependency additions | NO | FORBIDDEN | OK |
+| tracked pr_body artifacts | NO | FORBIDDEN | OK |
+
+## Admission Guard Summary
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| layout inspection presentation | IMPLEMENTED | ADMITTED | OK |
+| recovery test fixes | DOCUMENTED | ADMITTED WITH RECOVERY | OK |
+| corrective recovery closeout | DOCUMENTED | ADMITTED | OK |
+| layout behavior expansion | ABSENT | FORBIDDEN | OK |
+| layout engine | ABSENT | DEFERRED | OK |
+| geometry solver | ABSENT | DEFERRED | OK |
+| coordinates/sizing | ABSENT | DEFERRED | OK |
+| draw commands | ABSENT | FORBIDDEN | OK |
+| event dispatch | ABSENT | FORBIDDEN | OK |
+| backend rendering | ABSENT | FORBIDDEN | OK |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | OK |
+| capability admission | ABSENT | FORBIDDEN | OK |
+| Workbench/Studio | ABSENT | FORBIDDEN | OK |
+| dependency additions | ABSENT | FORBIDDEN | OK |
+
+## Final Decision
+
+Final decision:
+PASS — R12 UI Renderer Layout Inspection Presentation ledger audit is clean after recovery correction.
+
+The accepted source implementation is PR #978, stabilized by recovery test-fix PRs #979 and #980.
+
+The original closeout PR is #981.
+
+The corrective recovery closeout PR is #982.
+
+The recovered lineage is explicitly documented and accepted.
+
+The layout inspection presentation is complete as inert deterministic read-only observability over UiLayoutModel.
+
+It does not implement layout behavior expansion, a layout engine, geometry solver, coordinates/sizing, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, Workbench/Studio integration, or dependency additions.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Inspection Presentation ledger audit.

This is a docs-only audit PR covering the recovered layout inspection presentation lineage:

- #977 — roadmap selected layout inspection presentation
- #978 — initial source implementation
- #979 — recovery test fix 1
- #980 — recovery test fix 2 / final green state
- #981 — original closeout
- #982 — corrective recovery closeout

## Scope

Audits:

- corrected lineage / recovery context
- source API surface
- deterministic read-only inspection behavior
- test coverage
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no layout behavior expansion
- no layout engine
- no geometry solver
- no coordinates/sizing
- no draw commands
- no backend/WGPU/winit/Tauri
- no event dispatch
- no action/effect execution
- no runtime/verifier/VM
- no capability admission
- no Workbench/Studio
- no proof/debugger authority

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #982
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT INSPECTION PRESENTATION LEDGER AUDIT CLEAN AFTER RECOVERY CORRECTION
```
