### PR TITLE
test(ui): remove layout seed unused mut warning

### DIFF
--- a/crates/prom-ui/tests/renderer_layout_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_seed.rs
@@ -10,7 +10,7 @@ fn create_test_render_model() -> UiRenderModel {
     let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
     artifact.set_source_ir_root(UiIrNodeId::new(10));
 
-    let mut root = UiProjectedNode::with_source_ir_node(
+    let root = UiProjectedNode::with_source_ir_node(
         UiProjectedNodeId::new(1),
         UiProjectedNodeKind::Root,
         UiIrNodeId::new(11),


### PR DESCRIPTION
## Summary

Removes an existing non-blocking `unused_mut` warning from:

```text
crates/prom-ui/tests/renderer_layout_seed.rs
```

## Scope

This is a tiny test hygiene cleanup PR.

## Explicit non-scope

- no production source changes
- no test logic changes
- no layout implementation
- no geometry implementation
- no docs changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no backend/draw/event/runtime/capability changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Test
Risk: Low
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #987
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT SEED TEST HYGIENE CLEANUP CLEAN
```
