### PR TITLE
feat(ui): add renderer layout geometry seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -1,5 +1,6 @@
 use crate::model::UiIrNodeId;
 use crate::projection::UiProjectedNodeId;
+use crate::projection::UiProjectionArtifactId;
 use crate::renderer::{UiRenderModel, UiRenderModelId, UiRenderNodeId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -435,5 +436,186 @@ pub fn present_layout_inspection(model: &UiLayoutModel) -> UiLayoutInspectionPre
         source_ir_root: model.source_ir_root(),
         sections,
         items,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutGeometryModelId {
+    raw: u64,
+}
+
+impl UiLayoutGeometryModelId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutGeometryNodeId {
+    raw: u64,
+}
+
+impl UiLayoutGeometryNodeId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct UiLayoutGeometryRect {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+impl UiLayoutGeometryRect {
+    pub fn new(x: i32, y: i32, width: u32, height: u32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub fn x(&self) -> i32 {
+        self.x
+    }
+
+    pub fn y(&self) -> i32 {
+        self.y
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutGeometryNode {
+    id: UiLayoutGeometryNodeId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    rect: UiLayoutGeometryRect,
+    order: usize,
+}
+
+impl UiLayoutGeometryNode {
+    pub fn id(&self) -> UiLayoutGeometryNodeId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn rect(&self) -> UiLayoutGeometryRect {
+        self.rect
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutGeometryModel {
+    id: UiLayoutGeometryModelId,
+    source_layout_model: UiLayoutModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    nodes: Vec<UiLayoutGeometryNode>,
+}
+
+impl UiLayoutGeometryModel {
+    pub fn id(&self) -> UiLayoutGeometryModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn nodes(&self) -> &[UiLayoutGeometryNode] {
+        &self.nodes
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+}
+
+pub fn build_layout_geometry(model: &UiLayoutModel) -> UiLayoutGeometryModel {
+    let mut nodes = Vec::with_capacity(model.nodes().len());
+
+    for layout_node in model.nodes() {
+        nodes.push(UiLayoutGeometryNode {
+            id: UiLayoutGeometryNodeId::new(layout_node.id().raw()),
+            source_layout_node: layout_node.id(),
+            source_layout_slot: layout_node.slot(),
+            source_render_node: layout_node.source_render_node(),
+            source_projection_node: layout_node.source_projection_node(),
+            source_ir_node: layout_node.source_ir_node(),
+            rect: UiLayoutGeometryRect::default(),
+            order: layout_node.order(),
+        });
+    }
+
+    UiLayoutGeometryModel {
+        id: UiLayoutGeometryModelId::new(model.id().raw()),
+        source_layout_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        nodes,
     }
 }

--- a/crates/prom-ui/tests/renderer_layout_geometry_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_geometry_seed.rs
@@ -1,0 +1,178 @@
+use prom_ui::layout::{build_layout_geometry, layout_render_model, UiLayoutGeometryRect};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> prom_ui::layout::UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+#[test]
+fn geometry_model_can_be_built_from_existing_layout_model_fixture() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model = build_layout_geometry(&layout_model);
+    assert_eq!(geometry_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        geometry_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        geometry_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(
+        geometry_model.source_ir_root(),
+        layout_model.source_ir_root()
+    );
+    assert_eq!(geometry_model.nodes().len(), layout_model.nodes().len());
+}
+
+#[test]
+fn geometry_model_id_is_deterministic() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model_1 = build_layout_geometry(&layout_model);
+    let geometry_model_2 = build_layout_geometry(&layout_model);
+
+    assert_eq!(geometry_model_1.id(), geometry_model_2.id());
+    assert_eq!(geometry_model_1.id().raw(), layout_model.id().raw());
+}
+
+#[test]
+fn geometry_node_ids_are_deterministic() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model_1 = build_layout_geometry(&layout_model);
+    let geometry_model_2 = build_layout_geometry(&layout_model);
+
+    let ids_1: Vec<_> = geometry_model_1
+        .nodes()
+        .iter()
+        .map(|node| node.id())
+        .collect();
+    let ids_2: Vec<_> = geometry_model_2
+        .nodes()
+        .iter()
+        .map(|node| node.id())
+        .collect();
+
+    assert_eq!(ids_1, ids_2);
+}
+
+#[test]
+fn geometry_node_count_order_is_deterministic() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model = build_layout_geometry(&layout_model);
+
+    assert_eq!(geometry_model.nodes().len(), layout_model.nodes().len());
+    for (index, node) in geometry_model.nodes().iter().enumerate() {
+        assert_eq!(node.order(), index);
+        assert_eq!(node.source_layout_node(), layout_model.nodes()[index].id());
+    }
+}
+
+#[test]
+fn geometry_rect_metadata_is_inert_default_unresolved() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+
+    for node in geometry_model.nodes() {
+        let rect = node.rect();
+        assert_eq!(rect, UiLayoutGeometryRect::default());
+        assert_eq!(rect.x(), 0);
+        assert_eq!(rect.y(), 0);
+        assert_eq!(rect.width(), 0);
+        assert_eq!(rect.height(), 0);
+    }
+}
+
+#[test]
+fn source_layout_model_reference_is_preserved() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model = build_layout_geometry(&layout_model);
+    assert_eq!(geometry_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        geometry_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+}
+
+#[test]
+fn source_layout_node_references_are_preserved_where_exposed() {
+    let layout_model = create_test_layout_model();
+
+    let geometry_model = build_layout_geometry(&layout_model);
+    for (geometry_node, layout_node) in geometry_model.nodes().iter().zip(layout_model.nodes()) {
+        assert_eq!(geometry_node.source_layout_node(), layout_node.id());
+        assert_eq!(geometry_node.source_layout_slot(), layout_node.slot());
+        assert_eq!(
+            geometry_node.source_render_node(),
+            layout_node.source_render_node()
+        );
+        assert_eq!(
+            geometry_node.source_projection_node(),
+            layout_node.source_projection_node()
+        );
+        assert_eq!(geometry_node.source_ir_node(), layout_node.source_ir_node());
+    }
+}
+
+#[test]
+fn no_input_mutation() {
+    let layout_model = create_test_layout_model();
+    let expected = layout_model.clone();
+
+    let _geometry_model = build_layout_geometry(&layout_model);
+
+    assert_eq!(layout_model, expected);
+}
+
+#[test]
+fn geometry_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+
+    assert!(!geometry_model.is_empty());
+    assert_eq!(
+        geometry_model.nodes()[0].rect(),
+        UiLayoutGeometryRect::default()
+    );
+}
+
+#[test]
+fn geometry_seed_entrypoint_signature_is_locked() {
+    let layout_model = create_test_layout_model();
+    let f: fn(&prom_ui::layout::UiLayoutModel) -> prom_ui::layout::UiLayoutGeometryModel =
+        build_layout_geometry;
+    let geometry_model = f(&layout_model);
+
+    assert_eq!(geometry_model.source_layout_model(), layout_model.id());
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Geometry Seed.

This source seed introduces minimal inert renderer-local geometry metadata for layout.

## Scope

Adds:

- minimal geometry model
- minimal geometry node
- deterministic geometry model/node identity
- integer-only inert geometry rect metadata
- read-only source layout references where exposed
- focused tests proving determinism and inertness

## Explicit non-scope

- no full geometry solver
- no constraint solver
- no sizing algorithm
- no layout engine rewrite
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #989
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT GEOMETRY SEED SOURCE CLEAN
```
