### PR TITLE
docs(ui): add renderer layout geometry seed ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_geometry_seed_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_geometry_seed_ledger_audit.md
@@ -1,0 +1,158 @@
+# R12 UI Renderer Layout Geometry Seed Ledger Audit
+
+## 1. Purpose
+This document records the ledger audit for the R12 UI Renderer Layout Geometry Seed line after roadmap PR #989, source PR #990, and closeout PR #991.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected: SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains renderer-local structural metadata;
+- geometry seed remains inert metadata only;
+- no solver authority;
+- no constraints authority;
+- no sizing algorithm authority;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+#989 — roadmap selected geometry seed
+#990 — layout geometry seed source
+#991 — layout geometry seed closeout
+
+## 4. PR Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #989 | docs(ui): select next post-ui lane after layout geometry boundary audit | MERGED | e132ea4980a6266477a918863753094469a19c60 | 1 | Roadmap | PASS |
+| #990 | feat(ui): add renderer layout geometry seed | MERGED | e08a256b2c3731b658520008b957eb1f50ed4f60 | 2 | Code | PASS |
+| #991 | docs(ui): close out renderer layout geometry seed | MERGED | 192bd4a71c3e3f46fa58f0bbd3afc4148f279393 | 1 | Closeout | PASS |
+
+## 5. Changed File Surface
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---:|---:|---:|---:|---|
+| #989 | 1 | 0 | 0 | 1 | 0 | PASS |
+| #990 | 2 | 1 | 1 | 0 | 0 | PASS |
+| #991 | 1 | 0 | 0 | 1 | 0 | PASS |
+
+## 6. Geometry Seed API Ledger
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| geometry model | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryModel` | PASS |
+| geometry node | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryNode` | PASS |
+| geometry model ID | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryModelId` | PASS |
+| geometry node ID | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryNodeId` | PASS |
+| geometry rect metadata | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryRect` | PASS |
+| geometry build entrypoint | present | IMPLEMENTED / ADMITTED | `build_layout_geometry` | PASS |
+| source layout model reference | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryModel::source_layout_model()` | PASS |
+| source layout node reference | present | IMPLEMENTED / ADMITTED | `UiLayoutGeometryNode::source_layout_node()` and source references | PASS |
+
+## 7. Behavior Ledger
+| Behavior | Final state | Evidence | Status |
+|---|---|---|---|
+| deterministic model ID | present | ID derived from source layout model ID | PASS |
+| deterministic node IDs | present | node IDs derived from source layout node IDs | PASS |
+| deterministic node order/count | present | tests compare node order and length | PASS |
+| integer-only geometry | present | `i32` / `u32` rect fields | PASS |
+| floating point absence | present | no floating point geometry fields or math | PASS |
+| randomness absence | present | no random/time-based geometry policy | PASS |
+| source layout model preservation | present | preserved by geometry model accessors | PASS |
+| source layout node preservation | present | preserved where exposed by layout API | PASS |
+| input mutation absence | present | geometry build uses borrowed input and tests assert equality | PASS |
+| inert/default/unresolved rect metadata | present | default rects remain zero/unresolved | PASS |
+
+## 8. Test Coverage Ledger
+| Test category | Evidence | Status |
+|---|---|---|
+| build from layout model | `geometry_model_can_be_built_from_existing_layout_model_fixture` | PASS |
+| model ID determinism | `geometry_model_id_is_deterministic` | PASS |
+| node ID determinism | `geometry_node_ids_are_deterministic` | PASS |
+| node order/count determinism | `geometry_node_count_order_is_deterministic` | PASS |
+| rect metadata inertness | `geometry_rect_metadata_is_inert_default_unresolved` | PASS |
+| integer-only geometry | rect fields asserted as zero/default integer values | PASS |
+| source preservation | `source_layout_model_reference_is_preserved` | PASS |
+| source node preservation | `source_layout_node_references_are_preserved_where_exposed` | PASS |
+| forbidden authority absence | `geometry_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority` | PASS |
+| public API signature lock | `geometry_seed_entrypoint_signature_is_locked` | PASS |
+
+## 9. Deferred Authority Ledger
+| Deferred area | Final state | Classification | Status |
+|---|---|---|---|
+| full geometry solver | absent | DEFERRED | PASS |
+| constraint solver | absent | DEFERRED | PASS |
+| sizing algorithm | absent | DEFERRED | PASS |
+| layout engine rewrite | absent | DEFERRED | PASS |
+| draw commands | absent | FORBIDDEN | PASS |
+| event dispatch | absent | FORBIDDEN | PASS |
+| backend rendering | absent | FORBIDDEN | PASS |
+| runtime/verifier/VM integration | absent | FORBIDDEN | PASS |
+| capability admission | absent | FORBIDDEN | PASS |
+| proof/debugger authority | absent | FORBIDDEN | PASS |
+| Workbench/Studio integration | absent | FORBIDDEN | PASS |
+
+## 10. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Item count | Duplicate count |
+|---|---|---|---|---|---|---|---|---|---|---:|---:|
+| #989 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #988 | 1 | 0 |
+| #990 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #989 | 1 | 0 |
+| #991 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #990 | 1 | 0 |
+
+## 11. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| draw/event/backend | No | FORBIDDEN / ABSENT | PASS |
+| WGPU/winit/Tauri | No | FORBIDDEN / ABSENT | PASS |
+| runtime/verifier/VM | No | FORBIDDEN / ABSENT | PASS |
+| capability admission | No | FORBIDDEN / ABSENT | PASS |
+| action execution | No | FORBIDDEN / ABSENT | PASS |
+| effect authorization | No | FORBIDDEN / ABSENT | PASS |
+| Workbench/Studio | No | FORBIDDEN / ABSENT | PASS |
+| proof/debugger authority | No | FORBIDDEN / ABSENT | PASS |
+| solver/constraints/sizing | No | FORBIDDEN / ABSENT | PASS |
+| floating point geometry computation | No | FORBIDDEN / ABSENT | PASS |
+| randomness/time/global mutable state | No | FORBIDDEN / ABSENT | PASS |
+| Cargo.toml / Cargo.lock | No | FORBIDDEN / ABSENT | PASS |
+| dependency additions | No | FORBIDDEN / ABSENT | PASS |
+| tracked pr_body artifacts | No | FORBIDDEN / ABSENT | PASS |
+
+## 12. Manifest / Dependency Ledger
+| Check | Result | Evidence | Status |
+|---|---|---|---|
+| Cargo.toml changed | No | PR #990 and #991 file surfaces | PASS |
+| Cargo.lock changed | No | PR #990 and #991 file surfaces | PASS |
+| dependency additions | No | no manifest drift in source/closeout line | PASS |
+
+## 13. Local Validation
+| Check | Result | Status |
+|---|---|---|
+| git diff --check | PASS | PASS |
+| cargo fmt --check | PASS | PASS |
+| cargo test -p prom-ui --lib | PASS | PASS |
+| cargo test -p prom-ui | PASS | PASS |
+| tracked pr_body files | NO | PASS |
+
+## 14. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| geometry seed | IMPLEMENTED | ADMITTED | PASS |
+| geometry model | IMPLEMENTED | ADMITTED | PASS |
+| geometry node | IMPLEMENTED | ADMITTED | PASS |
+| geometry rect metadata | IMPLEMENTED | ADMITTED | PASS |
+| deterministic IDs | IMPLEMENTED | ADMITTED | PASS |
+| integer-only metadata | IMPLEMENTED | ADMITTED | PASS |
+| solver | ABSENT | DEFERRED | PASS |
+| constraints | ABSENT | DEFERRED | PASS |
+| sizing algorithm | ABSENT | DEFERRED | PASS |
+| draw/event/backend | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 15. Final Decision
+Final decision:
+PASS — R12 UI Renderer Layout Geometry Seed ledger audit is clean after roadmap PR #989, source PR #990, and closeout PR #991.
+
+The geometry seed line is complete as minimal inert renderer-local geometry metadata. It implements deterministic geometry model/node identity and integer-only rect metadata without implementing a full geometry solver, constraint solver, sizing algorithm, layout engine rewrite, draw commands, event dispatch, backend rendering, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Geometry Seed ledger audit.

This is a docs-only audit PR covering:

- #989 — roadmap selected geometry seed
- #990 — layout geometry seed source
- #991 — layout geometry seed closeout

## Scope

Audits:

- geometry seed source API
- deterministic identity policy
- integer-only rect metadata
- source layout reference preservation
- test coverage
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no solver implementation
- no constraint implementation
- no sizing algorithm
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #991
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT GEOMETRY SEED LEDGER AUDIT CLEAN
```