### PR TITLE
docs(ui): define renderer layout constraints boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_boundary.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_boundary.md
@@ -1,0 +1,172 @@
+# R12 UI Renderer Layout Constraints Boundary
+
+## 1. Purpose
+This document defines the R12 UI Renderer Layout Constraints Boundary after the completed and audited renderer layout geometry seed line.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected: SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints boundary remains planning/documentation only;
+- no constraints implementation;
+- no solver implementation;
+- no sizing implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+#989 — roadmap selected geometry seed
+#990 — layout geometry seed source
+#991 — layout geometry seed closeout
+#992 — layout geometry seed ledger audit
+#993 — roadmap selected constraints boundary
+
+## 4. Constraints Position in Pipeline
+UiProjectionArtifact
+  ↓
+UiRenderModel
+  ↓
+Renderer presentation models
+  ↓
+UiLayoutModel
+  ↓
+UiLayoutGeometryModel
+  ↓
+Future constraints model
+  ↓
+Future sizing / solving / layout refinement layers, not part of this boundary
+  ↓
+Future draw/backend/event layers, not part of this boundary
+
+## 5. Constraints Boundary Definition
+Constraints Boundary defines where a future constraints layer may sit and what authority it must not receive.
+
+It does not implement constraints.
+
+It does not implement solver behavior.
+
+It does not implement sizing behavior.
+
+It does not implement layout solving.
+
+## 6. Allowed Future Inputs
+The boundary may admit future consumption of:
+
+- UiLayoutModel
+- UiLayoutGeometryModel
+- UiLayoutGeometryNode
+- UiLayoutGeometryRect
+- renderer/layout source references exposed by existing APIs
+
+No source code input contract is implemented in this PR.
+This is a boundary-level declaration only.
+
+## 7. Allowed Future Outputs
+The boundary may describe future constraints outputs as:
+
+- deterministic constraints model;
+- deterministic constraint declarations;
+- source layout/geometry references;
+- relation metadata;
+- bounds metadata;
+- preference metadata;
+- unresolved/deferred constraints metadata;
+- audit metadata for future solver admission.
+
+No constraint structs, constraint IDs, constraint declarations, constraint model, constraint functions, or constraint tests are implemented in this PR.
+
+## 8. Future Constraint Categories
+The boundary may name future categories, strictly as non-implemented concepts:
+
+- min/max bounds;
+- preferred bounds;
+- alignment preference;
+- relative relation;
+- containment relation;
+- ordering relation;
+- dependency relation;
+- unresolved constraint marker.
+
+These are future conceptual categories only.
+They are not implemented by this PR.
+
+## 9. Explicit Non-Authority Rules
+Forbidden constraints authority:
+
+- constraint solving;
+- sizing algorithm;
+- layout solving;
+- layout engine rewrite;
+- geometry mutation;
+- draw commands;
+- rasterization;
+- GPU/backend calls;
+- WGPU/winit/Tauri;
+- event dispatch;
+- callbacks/handlers;
+- action execution;
+- effect authorization;
+- runtime/verifier/VM calls;
+- capability admission;
+- semantic truth authority;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 10. Deferred Implementation
+Deferred to a future source package:
+R12-UI-RENDERER-LAYOUT-CONSTRAINTS-SEED-LINE-FULL-PACKAGE
+
+That future package must not proceed until this boundary is closed and audited.
+
+## 11. Candidate Future Seed
+The only future implementation allowed by this boundary is a separate constraints seed package under an explicit later source gate.
+
+This document does not authorize creating that source package.
+
+## 12. Admission Guard
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future constraints metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current constraints implementation | absent | DEFERRED | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| sizing algorithm | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 13. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Constraints boundary | Documented | ADMITTED | PASS |
+| Constraints implementation | Not implemented | DEFERRED | PASS |
+| Constraints seed | Future package only | DEFERRED | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Sizing algorithm | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 14. Final Decision
+Final decision:
+PASS — R12 UI Renderer Layout Constraints Boundary defined.
+
+This boundary admits future constraints only as deterministic renderer-local layout metadata declarations.
+
+This PR does not implement constraints source, constraint structs, constraint solver behavior, sizing behavior, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Defines the R12 UI Renderer Layout Constraints Boundary.

This is a docs-only boundary PR after the completed and audited renderer layout geometry seed line.

## Scope

Documents:

- constraints position in the layout pipeline
- allowed future constraints inputs
- allowed future constraints outputs
- future conceptual constraint categories
- explicit non-authority rules
- deferred implementation gate
- admission guard constraints

## Explicit non-scope

- no source changes
- no tests changes
- no constraints implementation
- no constraint structs
- no constraint solver
- no sizing algorithm
- no layout solving
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no docs/dna changes
- no agent skill changes

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Docs
Risk: High
Boundary: Renderer
Gate: Docs-only
Evidence: Roadmap doc
Depends on: #993
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT CONSTRAINTS BOUNDARY DEFINED
```