### PR TITLE
docs(ui): close out renderer layout constraints boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_boundary_closeout.md
@@ -1,0 +1,113 @@
+# R12 UI Renderer Layout Constraints Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Constraints Boundary after the boundary PR.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected: SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints boundary remains planning/documentation only;
+- no constraints implementation;
+- no solver implementation;
+- no sizing implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+#994 — R12 UI Renderer Layout Constraints Boundary
+
+## 4. Implemented State
+Implemented:
+- constraints boundary document;
+- constraints pipeline position;
+- allowed future input categories;
+- allowed future output categories;
+- future conceptual constraint categories;
+- explicit non-authority rules;
+- deferred constraints seed gate.
+
+## 5. Deferred State
+Deferred:
+- constraints source implementation;
+- constraint structs;
+- constraint IDs;
+- constraint functions;
+- constraint tests;
+- constraint solver;
+- sizing algorithm;
+- layout solving;
+- layout engine rewrite;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+This closeout confirms that the boundary only defines future constraints authority and does not implement constraints behavior, solver behavior, sizing behavior, or layout solving.
+
+## 7. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Constraints boundary | Documented | ADMITTED | PASS |
+| Constraints implementation | Not implemented | DEFERRED | PASS |
+| Constraints seed | Future package only | DEFERRED | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Sizing algorithm | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future constraints metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current constraints implementation | absent | DEFERRED | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| sizing algorithm | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+Status: Done
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #994
+
+## 10. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-CONSTRAINTS-BOUNDARY-LEDGER-AUDIT-PR
+
+Alternative after audit:
+R12-UI-RENDERER-LAYOUT-CONSTRAINTS-SEED-LINE-FULL-PACKAGE
+
+## 11. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Constraints Boundary is complete as a docs-only boundary artifact.
+
+It defines future constraints only as deterministic renderer-local layout metadata declarations and does not implement constraints source, constraint structs, constraint solver behavior, sizing behavior, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Constraints Boundary line.

This is a docs-only closeout after the constraints boundary PR.

## Scope

Records:

- constraints boundary document
- constraints position in layout pipeline
- allowed future input categories
- allowed future output categories
- future conceptual constraint categories
- explicit non-authority rules
- deferred constraints seed gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no constraints implementation
- no solver implementation
- no sizing algorithm
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #994
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — R12 UI Renderer Layout Constraints Boundary is complete as a docs-only boundary artifact.
```