### PR TITLE
docs(ui): select next post-ui lane after layout constraints boundary audit

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_boundary_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_boundary_audit.md
@@ -1,0 +1,96 @@
+# POST-UI Roadmap Next Lane Selection After Layout Constraints Boundary Audit
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Constraints Boundary line.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints boundary is closed and audited;
+- constraints seed must remain inert renderer-local layout metadata;
+- constraints seed must not introduce solver authority;
+- constraints seed must not introduce sizing authority;
+- constraints seed must not introduce layout solving;
+- constraints seed must not introduce draw/event/backend authority;
+- constraints seed must not introduce runtime/verifier/VM/capability authority;
+- constraints seed must not introduce proof/debugger authority;
+- constraints seed must not introduce Workbench/Studio integration;
+- this roadmap PR remains docs-only.
+
+## 3. Closed Basis
+- #993 — roadmap selected constraints boundary
+- #994 — layout constraints boundary
+- #995 — layout constraints boundary closeout
+- #996 — layout constraints boundary ledger audit
+
+## 4. Constraints Boundary State
+Constraints boundary is closed as docs-only boundary work. It documents future constraints metadata authority without implementing constraints source, constraint structs, constraint solver behavior, sizing behavior, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 5. Project #2 State
+Project #2 is currently clean for the closed constraints boundary line:
+- #993 = Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #992
+- #994 = Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | #993
+- #995 = Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #994
+- #996 = Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #995
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| Layout Constraints Seed | Selected | Constraints boundary is complete, so the next structurally valid step is a small inert source package for constraints metadata under strict non-solver constraints. | Medium | Selected |
+| Sizing Boundary | Deferred | Sizing should wait until minimal constraints metadata exists. | Medium | Deferred |
+| Constraint Solver Boundary | Deferred / too early | Solver boundary is premature until constraints seed establishes inert declarations. | High | Deferred |
+| Geometry Solver Boundary | Deferred / too early | Geometry solver should wait until constraints seed and sizing boundary are separately handled. | High | Deferred |
+| Event Boundary | Deferred / high-risk | Events remain close to action/effect/capability semantics and should wait until layout metadata layers are more mature. | High | Deferred |
+| Backend Boundary | Deferred / too early | Backend/WGPU/winit/Tauri remains outside current layout metadata work. | High | Deferred |
+| Layout Constraints Consolidation Audit | Deferred | Useful after constraints seed, not before it. | Medium | Deferred |
+
+## 7. Selection Criteria
+1. Must preserve DNA alignment.
+2. Must preserve renderer/layout/geometry inertness.
+3. Must not implement constraints in the roadmap selection PR.
+4. Must not introduce solver behavior.
+5. Must not introduce sizing behavior.
+6. Must not introduce layout solving.
+7. Must not introduce draw/event/backend.
+8. Must not introduce runtime/verifier/VM/capability authority.
+9. Must build naturally on closed constraints boundary and audit.
+10. Must be source-gated separately before implementation.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-CONSTRAINTS-SEED-LINE-FULL-PACKAGE
+
+This selection is planning-only.
+This selection does not implement constraints source.
+This selection does not implement constraint solver behavior.
+This selection does not implement sizing behavior.
+This selection does not implement layout solving.
+This selection only authorizes the next source package to be prepared under a separate gate.
+
+## 9. Deferred Lanes
+Deferred lanes are the remaining candidate paths:
+- Sizing Boundary
+- Constraint Solver Boundary
+- Geometry Solver Boundary
+- Event Boundary
+- Backend Boundary
+- Layout Constraints Consolidation Audit
+
+## 10. Admission Guard
+The next source package, if separately approved later, may only admit inert renderer-local constraints metadata and must not admit solver authority, sizing authority, layout solving, draw/event/backend authority, runtime/verifier/VM authority, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 11. Non-Scope
+This document does not implement constraints source, constraint structs, constraint IDs, constraint functions, constraint tests, constraint solver behavior, sizing behavior, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 12. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after layout constraints boundary audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-CONSTRAINTS-SEED-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement constraints source, constraint structs, constraint solver behavior, sizing behavior, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Constraints Boundary line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-CONSTRAINTS-SEED-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

- DNA alignment
- closed constraints boundary basis
- Project #2 state
- candidate lane comparison
- selected next lane
- deferred lanes
- admission guard constraints

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no constraints source implementation
- no constraint structs
- no constraint solver
- no sizing algorithm
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #996
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT CONSTRAINTS BOUNDARY AUDIT CLEAN
```
