### PR TITLE
feat(ui): add renderer layout constraints seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -619,3 +619,180 @@ pub fn build_layout_geometry(model: &UiLayoutModel) -> UiLayoutGeometryModel {
         nodes,
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutConstraintsModelId {
+    raw: u64,
+}
+
+impl UiLayoutConstraintsModelId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutConstraintId {
+    raw: u64,
+}
+
+impl UiLayoutConstraintId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutConstraintKind {
+    #[default]
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutConstraintState {
+    #[default]
+    Unresolved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutConstraintDeclaration {
+    id: UiLayoutConstraintId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutConstraintKind,
+    state: UiLayoutConstraintState,
+    order: usize,
+}
+
+impl UiLayoutConstraintDeclaration {
+    pub fn id(&self) -> UiLayoutConstraintId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutConstraintKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutConstraintState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutConstraintsModel {
+    id: UiLayoutConstraintsModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    declarations: Vec<UiLayoutConstraintDeclaration>,
+}
+
+impl UiLayoutConstraintsModel {
+    pub fn id(&self) -> UiLayoutConstraintsModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn declarations(&self) -> &[UiLayoutConstraintDeclaration] {
+        &self.declarations
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.declarations.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.declarations.len()
+    }
+}
+
+pub fn build_layout_constraints(model: &UiLayoutModel) -> UiLayoutConstraintsModel {
+    let geometry_model = build_layout_geometry(model);
+    let mut declarations = Vec::with_capacity(geometry_model.nodes().len());
+
+    for geometry_node in geometry_model.nodes() {
+        declarations.push(UiLayoutConstraintDeclaration {
+            id: UiLayoutConstraintId::new(geometry_node.id().raw()),
+            source_layout_node: geometry_node.source_layout_node(),
+            source_layout_slot: geometry_node.source_layout_slot(),
+            source_geometry_node: geometry_node.id(),
+            source_render_node: geometry_node.source_render_node(),
+            source_projection_node: geometry_node.source_projection_node(),
+            source_ir_node: geometry_node.source_ir_node(),
+            kind: UiLayoutConstraintKind::Unresolved,
+            state: UiLayoutConstraintState::Unresolved,
+            order: geometry_node.order(),
+        });
+    }
+
+    UiLayoutConstraintsModel {
+        id: UiLayoutConstraintsModelId::new(model.id().raw()),
+        source_layout_model: model.id(),
+        source_geometry_model: geometry_model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        declarations,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_constraints_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_constraints_seed.rs
@@ -1,0 +1,215 @@
+use prom_ui::layout::{
+    build_layout_constraints, build_layout_geometry, layout_render_model, UiLayoutConstraintKind,
+    UiLayoutConstraintState, UiLayoutConstraintsModel, UiLayoutModel,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+fn create_test_constraints_model() -> UiLayoutConstraintsModel {
+    let layout_model = create_test_layout_model();
+    build_layout_constraints(&layout_model)
+}
+
+#[test]
+fn constraints_model_can_be_built_from_existing_layout_model_fixture() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+
+    let constraints_model = build_layout_constraints(&layout_model);
+    assert_eq!(constraints_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        constraints_model.source_geometry_model(),
+        geometry_model.id()
+    );
+    assert_eq!(
+        constraints_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        constraints_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(
+        constraints_model.source_ir_root(),
+        layout_model.source_ir_root()
+    );
+    assert_eq!(constraints_model.len(), layout_model.nodes().len());
+}
+
+#[test]
+fn constraints_model_id_is_deterministic() {
+    let layout_model = create_test_layout_model();
+
+    let constraints_model_1 = build_layout_constraints(&layout_model);
+    let constraints_model_2 = build_layout_constraints(&layout_model);
+
+    assert_eq!(constraints_model_1.id(), constraints_model_2.id());
+    assert_eq!(constraints_model_1.id().raw(), layout_model.id().raw());
+}
+
+#[test]
+fn constraint_declaration_ids_are_deterministic() {
+    let constraints_model = create_test_constraints_model();
+    let second_constraints_model = create_test_constraints_model();
+
+    let ids_1: Vec<_> = constraints_model
+        .declarations()
+        .iter()
+        .map(|declaration| declaration.id())
+        .collect();
+    let ids_2: Vec<_> = second_constraints_model
+        .declarations()
+        .iter()
+        .map(|declaration| declaration.id())
+        .collect();
+
+    assert_eq!(ids_1, ids_2);
+}
+
+#[test]
+fn constraint_declaration_count_order_is_deterministic() {
+    let layout_model = create_test_layout_model();
+    let constraints_model = build_layout_constraints(&layout_model);
+
+    assert_eq!(
+        constraints_model.declarations().len(),
+        layout_model.nodes().len()
+    );
+    for (index, declaration) in constraints_model.declarations().iter().enumerate() {
+        assert_eq!(declaration.order(), index);
+        assert_eq!(
+            declaration.source_layout_node(),
+            layout_model.nodes()[index].id()
+        );
+    }
+}
+
+#[test]
+fn constraint_kind_state_metadata_is_inert_default_unresolved() {
+    let constraints_model = create_test_constraints_model();
+
+    for declaration in constraints_model.declarations() {
+        assert_eq!(declaration.kind(), UiLayoutConstraintKind::Unresolved);
+        assert_eq!(declaration.state(), UiLayoutConstraintState::Unresolved);
+    }
+}
+
+#[test]
+fn source_layout_model_reference_is_preserved() {
+    let layout_model = create_test_layout_model();
+
+    let constraints_model = build_layout_constraints(&layout_model);
+    assert_eq!(constraints_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        constraints_model.source_geometry_model(),
+        build_layout_geometry(&layout_model).id()
+    );
+}
+
+#[test]
+fn source_layout_geometry_references_are_preserved_where_exposed() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+
+    let constraints_model = build_layout_constraints(&layout_model);
+    for ((declaration, layout_node), geometry_node) in constraints_model
+        .declarations()
+        .iter()
+        .zip(layout_model.nodes())
+        .zip(geometry_model.nodes())
+    {
+        assert_eq!(declaration.source_layout_node(), layout_node.id());
+        assert_eq!(declaration.source_layout_slot(), layout_node.slot());
+        assert_eq!(declaration.source_geometry_node(), geometry_node.id());
+        assert_eq!(
+            declaration.source_render_node(),
+            layout_node.source_render_node()
+        );
+        assert_eq!(
+            declaration.source_projection_node(),
+            layout_node.source_projection_node()
+        );
+        assert_eq!(declaration.source_ir_node(), layout_node.source_ir_node());
+    }
+}
+
+#[test]
+fn no_input_mutation() {
+    let layout_model = create_test_layout_model();
+    let expected = layout_model.clone();
+
+    let _constraints_model = build_layout_constraints(&layout_model);
+
+    assert_eq!(layout_model, expected);
+}
+
+#[test]
+fn constraints_seed_does_not_expose_solver_sizing_layout_solving_or_effect_authority() {
+    let constraints_model = create_test_constraints_model();
+
+    assert!(!constraints_model.is_empty());
+    assert_eq!(
+        constraints_model.declarations()[0].kind(),
+        UiLayoutConstraintKind::Unresolved
+    );
+    assert_eq!(
+        constraints_model.declarations()[0].state(),
+        UiLayoutConstraintState::Unresolved
+    );
+}
+
+#[test]
+fn constraints_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority()
+{
+    let constraints_model = create_test_constraints_model();
+
+    assert_eq!(constraints_model.declarations().len(), 2);
+    assert_eq!(
+        constraints_model.declarations()[0].kind(),
+        UiLayoutConstraintKind::Unresolved
+    );
+    assert_eq!(
+        constraints_model.declarations()[1].state(),
+        UiLayoutConstraintState::Unresolved
+    );
+}
+
+#[test]
+fn constraints_seed_entrypoint_signature_is_locked() {
+    let layout_model = create_test_layout_model();
+    let f: fn(&prom_ui::layout::UiLayoutModel) -> prom_ui::layout::UiLayoutConstraintsModel =
+        build_layout_constraints;
+    let constraints_model = f(&layout_model);
+
+    assert_eq!(constraints_model.source_layout_model(), layout_model.id());
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Constraints Seed.

This source seed introduces minimal inert renderer-local constraints metadata for layout.

## Scope

Adds:

- minimal constraints model
- minimal constraint declaration
- deterministic constraints model/declaration identity
- inert constraint kind/state metadata
- read-only source layout/geometry references where exposed
- focused tests proving determinism and inertness

## Explicit non-scope

- no constraint solver
- no constraint satisfaction algorithm
- no sizing algorithm
- no layout solving
- no layout engine rewrite
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #997
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT CONSTRAINTS SEED SOURCE CLEAN
```
