### PR TITLE
docs(ui): add renderer layout constraints seed ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_seed_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_seed_ledger_audit.md
@@ -1,0 +1,173 @@
+# R12 UI Renderer Layout Constraints Seed Ledger Audit
+
+## 1. Purpose
+This document records the ledger audit for the R12 UI Renderer Layout Constraints Seed line after roadmap PR #997, source PR #998, and closeout PR #999.
+
+## 2. DNA Alignment
+docs/dna inspected: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- no solver authority;
+- no constraint satisfaction authority;
+- no sizing algorithm authority;
+- no layout solving authority;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #997 — roadmap selected constraints seed
+- #998 — layout constraints seed source
+- #999 — layout constraints seed closeout
+
+## 4. PR Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #997 | docs(ui): select next post-ui lane after layout constraints boundary audit | MERGED | `341080b7f1cbf6016ac728c14cf83995619bcc23` | `docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_boundary_audit.md` | Roadmap | PASS |
+| #998 | feat(ui): add renderer layout constraints seed | MERGED | `b5d5998360f34217c47d1c2735d130f129edadb0` | `crates/prom-ui/src/layout.rs`, `crates/prom-ui/tests/renderer_layout_constraints_seed.rs` | Code | PASS |
+| #999 | docs(ui): close out renderer layout constraints seed | MERGED | `7603192e035dcd2f0011af54fc0a127c92c65adf` | `docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_seed_closeout.md` | Closeout | PASS |
+
+## 5. Changed File Surface
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---:|---:|---:|---:|---|
+| #997 | `docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_boundary_audit.md` | NO | NO | YES | NO | PASS |
+| #998 | `crates/prom-ui/src/layout.rs`, `crates/prom-ui/tests/renderer_layout_constraints_seed.rs` | YES | YES | NO | NO | PASS |
+| #999 | `docs/roadmap/post_ui/r12_ui_renderer_layout_constraints_seed_closeout.md` | NO | NO | YES | NO | PASS |
+
+## 6. Constraints Seed API Ledger
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| constraints model | Implemented | ADMITTED | `UiLayoutConstraintsModel` | PASS |
+| constraint declaration | Implemented | ADMITTED | `UiLayoutConstraintDeclaration` | PASS |
+| constraints model ID | Implemented | ADMITTED | `UiLayoutConstraintsModelId` | PASS |
+| constraint declaration ID | Implemented | ADMITTED | `UiLayoutConstraintId` | PASS |
+| constraint kind metadata | Implemented | ADMITTED | `UiLayoutConstraintKind` | PASS |
+| constraint state metadata | Implemented | ADMITTED | `UiLayoutConstraintState` | PASS |
+| constraints build entrypoint | Implemented | ADMITTED | `build_layout_constraints` | PASS |
+| source layout model reference | Implemented | ADMITTED | `source_layout_model()` | PASS |
+| source layout node reference | Implemented | ADMITTED | `source_layout_node()` and `source_layout_slot()` | PASS |
+| source geometry model reference | Implemented | ADMITTED | `source_geometry_model()` | PASS |
+| source geometry node reference | Implemented | ADMITTED | `source_geometry_node()` | PASS |
+
+## 7. Behavior Ledger
+| Behavior | Final state | Evidence | Status |
+|---|---|---|---|
+| deterministic model ID | Present | `constraints_model_1.id() == constraints_model_2.id()` | PASS |
+| deterministic declaration IDs | Present | `ids_1 == ids_2` | PASS |
+| deterministic declaration order/count | Present | `enumerate()` order matches `layout_model.nodes()` | PASS |
+| inert/default/unresolved declarations | Present | `UiLayoutConstraintKind::Unresolved`, `UiLayoutConstraintState::Unresolved` | PASS |
+| source layout model preservation | Present | `source_layout_model()` matches layout model ID | PASS |
+| source layout node preservation | Present | `source_layout_node()` matches layout nodes | PASS |
+| source geometry model preservation | Present | `source_geometry_model()` matches geometry model ID | PASS |
+| source geometry node preservation | Present | `source_geometry_node()` matches geometry nodes | PASS |
+| input mutation absence | Present | `layout_model == expected` after build | PASS |
+| floating point absence | Present | integer/raw IDs only; no float fields or calculations in seed | PASS |
+| randomness/time/global mutable state absence | Present | deterministic iteration only; no time/random/global state | PASS |
+
+## 8. Test Coverage Ledger
+| Test category | Evidence | Status |
+|---|---|---|
+| build from layout/geometry model | `constraints_model_can_be_built_from_existing_layout_model_fixture` | PASS |
+| model ID determinism | `constraints_model_id_is_deterministic` | PASS |
+| declaration ID determinism | `constraint_declaration_ids_are_deterministic` | PASS |
+| declaration order/count determinism | `constraint_declaration_count_order_is_deterministic` | PASS |
+| kind/state inertness | `constraint_kind_state_metadata_is_inert_default_unresolved` | PASS |
+| unresolved/default metadata | `constraint_kind_state_metadata_is_inert_default_unresolved` | PASS |
+| source preservation | `source_layout_model_reference_is_preserved`, `source_layout_geometry_references_are_preserved_where_exposed` | PASS |
+| public API signature lock | `constraints_seed_entrypoint_signature_is_locked` | PASS |
+| solver/sizing/layout-solving absence | `constraints_seed_does_not_expose_solver_sizing_layout_solving_or_effect_authority` | PASS |
+| forbidden authority absence | `constraints_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority` | PASS |
+
+## 9. Deferred Authority Ledger
+| Deferred area | Final state | Classification | Status |
+|---|---|---|---|
+| constraint solver | Not implemented | ABSENT / FORBIDDEN | PASS |
+| constraint satisfaction algorithm | Not implemented | ABSENT / FORBIDDEN | PASS |
+| sizing algorithm | Not implemented | ABSENT / FORBIDDEN | PASS |
+| layout solving | Not implemented | ABSENT / FORBIDDEN | PASS |
+| layout engine rewrite | Not implemented | ABSENT / FORBIDDEN | PASS |
+| draw commands | Not implemented | ABSENT / FORBIDDEN | PASS |
+| event dispatch | Not implemented | ABSENT / FORBIDDEN | PASS |
+| backend rendering | Not implemented | ABSENT / FORBIDDEN | PASS |
+| runtime/verifier/VM integration | Not implemented | ABSENT / FORBIDDEN | PASS |
+| capability admission | Not implemented | ABSENT / FORBIDDEN | PASS |
+| proof/debugger authority | Not implemented | ABSENT / FORBIDDEN | PASS |
+| Workbench/Studio integration | Not implemented | ABSENT / FORBIDDEN | PASS |
+
+## 10. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Item count | Duplicate count |
+|---|---|---|---|---|---|---|---|---|---|---:|---:|
+| #997 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #996 | 1 | 0 |
+| #998 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #997 | 1 | 0 |
+| #999 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #998 | 1 | 0 |
+
+## 11. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| constraint solver | Absent | FORBIDDEN | PASS |
+| constraint satisfaction algorithm | Absent | FORBIDDEN | PASS |
+| sizing algorithm | Absent | FORBIDDEN | PASS |
+| layout solving | Absent | FORBIDDEN | PASS |
+| layout engine rewrite | Absent | FORBIDDEN | PASS |
+| draw/event/backend | Absent | FORBIDDEN | PASS |
+| WGPU/winit/Tauri | Absent | FORBIDDEN | PASS |
+| runtime/verifier/VM | Absent | FORBIDDEN | PASS |
+| capability admission | Absent | FORBIDDEN | PASS |
+| action execution | Absent | FORBIDDEN | PASS |
+| effect authorization | Absent | FORBIDDEN | PASS |
+| proof/debugger authority | Absent | FORBIDDEN | PASS |
+| Workbench/Studio | Absent | FORBIDDEN | PASS |
+| floating point computation | Absent | FORBIDDEN | PASS |
+| randomness/time/global mutable state | Absent | FORBIDDEN | PASS |
+| Cargo.toml / Cargo.lock | Unchanged | FORBIDDEN | PASS |
+| dependency additions | None | FORBIDDEN | PASS |
+| tracked pr_body artifacts | None | FORBIDDEN | PASS |
+
+## 12. Manifest / Dependency Ledger
+| Surface | Detected | Status |
+|---|---|---|
+| Cargo.toml | Unchanged | PASS |
+| Cargo.lock | Unchanged | PASS |
+| dependency additions | None | PASS |
+| manifest drift | None | PASS |
+
+## 13. Local Validation
+| Check | Result | Status |
+|---|---|---|
+| `git diff --check` | PASS | PASS |
+| `cargo fmt --check` | PASS | PASS |
+| `cargo test -p prom-ui --lib` | PASS | PASS |
+| `cargo test -p prom-ui` | PASS | PASS |
+| tracked pr_body files | NO | PASS |
+
+## 14. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| constraints seed | IMPLEMENTED / ADMITTED | ADMITTED | PASS |
+| constraints model | IMPLEMENTED / ADMITTED | ADMITTED | PASS |
+| constraint declaration | IMPLEMENTED / ADMITTED | ADMITTED | PASS |
+| deterministic IDs | IMPLEMENTED / ADMITTED | ADMITTED | PASS |
+| kind/state metadata | IMPLEMENTED / ADMITTED | ADMITTED | PASS |
+| source references | IMPLEMENTED | ADMITTED | PASS |
+| constraint solver | ABSENT | FORBIDDEN | PASS |
+| constraint satisfaction | ABSENT | FORBIDDEN | PASS |
+| sizing algorithm | ABSENT | FORBIDDEN | PASS |
+| layout solving | ABSENT | FORBIDDEN | PASS |
+| draw/event/backend | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| proof/debugger authority | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 15. Final Decision
+Final decision:
+PASS — R12 UI Renderer Layout Constraints Seed ledger audit is clean after roadmap PR #997, source PR #998, and closeout PR #999.
+
+The constraints seed line is complete as minimal inert renderer-local layout constraints metadata. It implements deterministic constraint declarations and kind/state metadata without implementing constraint solver behavior, constraint satisfaction, sizing behavior, layout solving, layout engine rewrite, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Constraints Seed ledger audit.

This is a docs-only audit PR covering:

- #997 — roadmap selected constraints seed
- #998 — layout constraints seed source
- #999 — layout constraints seed closeout

## Scope

Audits:

- constraints seed source API
- deterministic identity policy
- inert kind/state metadata
- source layout/geometry reference preservation
- test coverage
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no constraint solver
- no constraint satisfaction algorithm
- no sizing algorithm
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #999
```

## Validation

Local only:

```text
git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT CONSTRAINTS SEED LEDGER AUDIT CLEAN
```
