### PR TITLE
docs(ui): close out renderer layout sizing boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_closeout.md
@@ -1,0 +1,123 @@
+# R12 UI Renderer Layout Sizing Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Sizing Boundary after the boundary PR.
+
+## 2. DNA Alignment
+docs/dna inspected: NO directory in this repository
+DNA files inspected:
+- docs/DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing boundary remains planning/documentation only;
+- no sizing implementation;
+- no sizing algorithm implementation;
+- no measuring algorithm implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+#1002 — R12 UI Renderer Layout Sizing Boundary
+
+## 4. Implemented State
+Implemented:
+- sizing boundary document;
+- sizing pipeline position;
+- allowed future input categories;
+- allowed future output categories;
+- future conceptual sizing categories;
+- explicit non-authority rules;
+- deferred sizing seed gate.
+
+## 5. Deferred State
+Deferred:
+- sizing source implementation;
+- sizing structs;
+- sizing IDs;
+- sizing functions;
+- sizing tests;
+- sizing algorithm;
+- measuring algorithm;
+- size-to-fit algorithm;
+- constraint solver;
+- constraint satisfaction algorithm;
+- layout solving;
+- layout engine rewrite;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+This closeout confirms that the boundary only defines future sizing authority and does not implement sizing behavior, solver behavior, measuring behavior, or layout solving.
+
+## 7. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Sizing boundary | Documented | ADMITTED | PASS |
+| Sizing implementation | Not implemented | DEFERRED | PASS |
+| Sizing seed | Future package only | DEFERRED | PASS |
+| Sizing algorithm | Not implemented | FORBIDDEN | PASS |
+| Measuring algorithm | Not implemented | FORBIDDEN | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Constraint satisfaction | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Layout engine rewrite | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future sizing metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current sizing implementation | absent | DEFERRED | PASS |
+| sizing algorithm | forbidden | FORBIDDEN | PASS |
+| measuring algorithm | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+Status: Done
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #1002
+
+## 10. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-SIZING-BOUNDARY-LEDGER-AUDIT-PR
+
+Alternative after audit:
+R12-UI-RENDERER-LAYOUT-SIZING-SEED-LINE-FULL-PACKAGE
+
+## 11. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Sizing Boundary is complete as a docs-only boundary artifact.
+
+It defines future sizing only as deterministic renderer-local layout metadata/result declarations and does not implement sizing source, sizing structs, sizing algorithm behavior, measuring algorithm behavior, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Sizing Boundary line.

## Scope

Records:

- sizing boundary document
- sizing position in layout pipeline
- allowed future input categories
- allowed future output categories
- future conceptual sizing categories
- explicit non-authority rules
- deferred sizing seed gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no sizing implementation
- no sizing algorithm
- no measuring algorithm
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1002
```

## Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final decision

CLOSED — R12 UI Renderer Layout Sizing Boundary is complete as a docs-only boundary artifact.