### PR TITLE
docs(ui): add renderer layout sizing boundary ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_ledger_audit.md
@@ -1,0 +1,163 @@
+# R12 UI Renderer Layout Sizing Boundary Ledger Audit
+
+## 1. Purpose
+This document records the ledger audit for the R12 UI Renderer Layout Sizing Boundary line after roadmap PR #1001, boundary PR #1002, and closeout PR #1003.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md present as repository fallback
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA files inspected:
+- docs/dna/SEMANTIC_UI_DNA.md
+- docs/DNA.md
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing boundary remains docs-only;
+- sizing remains future metadata/result declaration only;
+- no sizing source implementation;
+- no sizing algorithm authority;
+- no measuring algorithm authority;
+- no constraint solver authority;
+- no constraint satisfaction authority;
+- no layout solving authority;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+#1001 - roadmap selected sizing boundary
+#1002 - layout sizing boundary
+#1003 - layout sizing boundary closeout
+
+## 4. PR Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #1001 | docs(ui): select next post-ui lane after layout constraints seed audit | MERGED | 12f8474808babdee263332e67c8022d940885c0e | docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_seed_audit.md | Planning-only | PASS |
+| #1002 | docs(ui): define renderer layout sizing boundary | MERGED | bd2cc05eea34de0508435f5dd407fb9f53bd7854 | docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary.md | Docs-only | PASS |
+| #1003 | docs(ui): close out renderer layout sizing boundary | MERGED | 48433aa942359114882767645f99bae6bfef8ed2 | docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_closeout.md | Release Artifact | PASS |
+
+## 5. Changed File Surface
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---:|---:|---:|---:|---|
+| #1001 | docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_constraints_seed_audit.md | NO | NO | YES | NO | PASS |
+| #1002 | docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary.md | NO | NO | YES | NO | PASS |
+| #1003 | docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_boundary_closeout.md | NO | NO | YES | NO | PASS |
+
+## 6. Sizing Boundary Ledger
+| Area | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| sizing boundary document | Documented | IMPLEMENTED / DOCUMENTED | #1002 | PASS |
+| sizing boundary closeout | Documented | IMPLEMENTED / DOCUMENTED | #1003 | PASS |
+| recommended next gate | Documented | IMPLEMENTED / DOCUMENTED | #1003 closeout | PASS |
+| sizing source implementation | Absent | ABSENT / DEFERRED | Not implemented | PASS |
+| sizing structs | Absent | ABSENT / DEFERRED | Not implemented | PASS |
+| sizing IDs | Absent | ABSENT / DEFERRED | Not implemented | PASS |
+| sizing functions | Absent | ABSENT / DEFERRED | Not implemented | PASS |
+| sizing tests | Absent | ABSENT / DEFERRED | Not implemented | PASS |
+| sizing algorithm | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| measuring algorithm | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| size-to-fit algorithm | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| constraint solver | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| constraint satisfaction algorithm | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| layout solving | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+| layout engine rewrite | Absent | ABSENT / FORBIDDEN | Not implemented | PASS |
+
+## 7. Deferred Source Ledger
+| Deferred area | Final state | Classification | Status |
+|---|---|---|---|
+| sizing source | Absent | ABSENT / DEFERRED | PASS |
+| sizing structs | Absent | ABSENT / DEFERRED | PASS |
+| sizing IDs | Absent | ABSENT / DEFERRED | PASS |
+| sizing functions | Absent | ABSENT / DEFERRED | PASS |
+| sizing tests | Absent | ABSENT / DEFERRED | PASS |
+| sizing algorithm | Absent | ABSENT / FORBIDDEN | PASS |
+| measuring algorithm | Absent | ABSENT / FORBIDDEN | PASS |
+| size-to-fit algorithm | Absent | ABSENT / FORBIDDEN | PASS |
+| constraint solver | Absent | ABSENT / FORBIDDEN | PASS |
+| constraint satisfaction algorithm | Absent | ABSENT / FORBIDDEN | PASS |
+| layout solving | Absent | ABSENT / FORBIDDEN | PASS |
+| layout engine rewrite | Absent | ABSENT / FORBIDDEN | PASS |
+| draw commands | Absent | ABSENT / FORBIDDEN | PASS |
+| event dispatch | Absent | ABSENT / FORBIDDEN | PASS |
+| backend rendering | Absent | ABSENT / FORBIDDEN | PASS |
+| runtime/verifier/VM integration | Absent | ABSENT / FORBIDDEN | PASS |
+| capability admission | Absent | ABSENT / FORBIDDEN | PASS |
+| proof/debugger authority | Absent | ABSENT / FORBIDDEN | PASS |
+| Workbench/Studio integration | Absent | ABSENT / FORBIDDEN | PASS |
+
+## 8. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Item count | Duplicate count |
+|---|---|---|---|---|---|---|---|---|---|---:|---:|
+| #1001 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #1000 | 1 | 0 |
+| #1002 | Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | #1001 | 1 | 0 |
+| #1003 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #1002 | 1 | 0 |
+
+## 9. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| sizing source | NO | ABSENT | PASS |
+| sizing algorithm | NO | ABSENT | PASS |
+| measuring algorithm | NO | ABSENT | PASS |
+| size-to-fit algorithm | NO | ABSENT | PASS |
+| constraint solver | NO | ABSENT | PASS |
+| constraint satisfaction algorithm | NO | ABSENT | PASS |
+| layout solving | NO | ABSENT | PASS |
+| layout engine rewrite | NO | ABSENT | PASS |
+| draw/event/backend | NO | ABSENT | PASS |
+| WGPU/winit/Tauri | NO | ABSENT | PASS |
+| runtime/verifier/VM | NO | ABSENT | PASS |
+| capability admission | NO | ABSENT | PASS |
+| action execution | NO | ABSENT | PASS |
+| effect authorization | NO | ABSENT | PASS |
+| proof/debugger authority | NO | ABSENT | PASS |
+| Workbench/Studio | NO | ABSENT | PASS |
+| Cargo.toml / Cargo.lock | NO | ABSENT | PASS |
+| dependency additions | NO | ABSENT | PASS |
+| tracked pr_body artifacts | NO | ABSENT | PASS |
+
+## 10. Manifest / Dependency Ledger
+| Check | Result | Status |
+|---|---|---|
+| Cargo.toml changed | NO | PASS |
+| Cargo.lock changed | NO | PASS |
+| dependency additions | NONE | PASS |
+
+## 11. Local Validation
+| Command | Result | Status |
+|---|---|---|
+| git diff --check | PASS | PASS |
+| cargo fmt --check | PASS | PASS |
+| cargo test -p prom-ui --lib | PASS | PASS |
+| cargo test -p prom-ui | PASS | PASS |
+| tracked pr_body files | NO | PASS |
+
+## 12. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| sizing boundary | DOCUMENTED | ADMITTED | PASS |
+| sizing boundary closeout | DOCUMENTED | ADMITTED | PASS |
+| sizing source | ABSENT | DEFERRED | PASS |
+| sizing structs/IDs/functions/tests | ABSENT | DEFERRED | PASS |
+| sizing algorithm | ABSENT | FORBIDDEN | PASS |
+| measuring algorithm | ABSENT | FORBIDDEN | PASS |
+| size-to-fit algorithm | ABSENT | FORBIDDEN | PASS |
+| constraint solver | ABSENT | FORBIDDEN | PASS |
+| constraint satisfaction | ABSENT | FORBIDDEN | PASS |
+| layout solving | ABSENT | FORBIDDEN | PASS |
+| draw/event/backend | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| proof/debugger authority | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 13. Final Decision
+Final decision:
+PASS - R12 UI Renderer Layout Sizing Boundary ledger audit is clean after roadmap PR #1001, boundary PR #1002, and closeout PR #1003.
+
+The sizing boundary line is complete as docs-only boundary work. It documents future sizing metadata/result authority without implementing sizing source, sizing structs, sizing algorithm behavior, measuring algorithm behavior, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Sizing Boundary ledger audit.

This is a docs-only audit PR covering:

- #1001 - roadmap selected sizing boundary
- #1002 - layout sizing boundary document
- #1003 - layout sizing boundary closeout

## Scope

Audits:

- sizing boundary document
- sizing boundary closeout
- changed file surfaces
- deferred source state
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- DNA source resolution
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no sizing source implementation
- no sizing structs
- no sizing algorithm
- no measuring algorithm
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #1003

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS - R12 UI RENDERER LAYOUT SIZING BOUNDARY LEDGER AUDIT CLEAN