### PR TITLE
docs(ui): select next post-ui lane after layout sizing boundary audit

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_sizing_boundary_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_sizing_boundary_audit.md
@@ -1,0 +1,127 @@
+# POST-UI Roadmap Next Lane Selection After Layout Sizing Boundary Audit
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Sizing Boundary line.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md present as repository fallback
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing boundary is closed and audited;
+- sizing seed may only introduce inert renderer-local metadata/result declarations;
+- sizing seed must not introduce sizing algorithm authority;
+- sizing seed must not introduce measuring algorithm authority;
+- sizing seed must not introduce constraint solver authority;
+- sizing seed must not introduce constraint satisfaction authority;
+- sizing seed must not introduce layout solving;
+- sizing seed must not introduce draw/event/backend authority;
+- sizing seed must not introduce runtime/verifier/VM/capability authority;
+- sizing seed must not introduce proof/debugger authority;
+- sizing seed must not introduce Workbench/Studio integration;
+- this roadmap PR must remain docs-only.
+
+## 3. Closed Basis
+#1001 — roadmap selected sizing boundary
+#1002 — layout sizing boundary
+#1003 — layout sizing boundary closeout
+#1004 — layout sizing boundary ledger audit
+
+## 4. Sizing Boundary State
+Sizing boundary is closed as docs-only boundary work. It documents future sizing metadata/result authority without implementing sizing source, sizing structs, sizing algorithm behavior, measuring algorithm behavior, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 5. Project #2 State
+#1001:
+Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #1000
+
+#1002:
+Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | #1001
+
+#1003:
+Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #1002
+
+#1004:
+Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #1003
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| Layout Sizing Seed | Selected | Sizing boundary is complete; the next structurally valid step is a small source seed for inert sizing metadata/result declarations under strict non-algorithmic constraints. | Medium | Selected |
+| Sizing Algorithm Boundary | Deferred / too early | Sizing algorithm boundary is premature until sizing seed establishes inert sizing metadata/result declarations. | High | Deferred |
+| Constraint Solver Boundary | Deferred / too early | Constraint solver boundary remains premature until sizing seed exists and the difference between sizing metadata and solver authority is audited. | High | Deferred |
+| Layout Solving Boundary | Deferred / too early | Layout solving is too high-authority and should wait until sizing seed and later solver boundaries are separately handled. | High | Deferred |
+| Geometry Solver Boundary | Deferred / too early | Geometry solver should wait until sizing metadata exists and solver authority is explicitly separated. | High | Deferred |
+| Event Boundary | Deferred / high-risk | Events remain close to action/effect/capability semantics and should wait until layout metadata layers are more mature. | High | Deferred |
+| Backend Boundary | Deferred / too early | Backend/WGPU/winit/Tauri remains outside current layout metadata work. | High | Deferred |
+| Layout Metadata Consolidation Audit | Deferred | Useful later, but the immediate architectural pressure point is sizing seed. | Medium | Deferred |
+
+## 7. Selection Criteria
+1. Must preserve DNA alignment.
+2. Must preserve renderer/layout/geometry/constraints/sizing boundary inertness.
+3. Must not implement sizing in the roadmap selection PR.
+4. Must not introduce sizing algorithm behavior.
+5. Must not introduce measuring algorithm behavior.
+6. Must not introduce constraint solver behavior.
+7. Must not introduce constraint satisfaction behavior.
+8. Must not introduce layout solving.
+9. Must not introduce draw/event/backend.
+10. Must not introduce runtime/verifier/VM/capability authority.
+11. Must build naturally on closed sizing boundary and audit.
+12. Must be source-gated separately before implementation.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-SIZING-SEED-LINE-FULL-PACKAGE
+
+## 9. Deferred Lanes
+- Sizing Algorithm Boundary
+- Constraint Solver Boundary
+- Layout Solving Boundary
+- Geometry Solver Boundary
+- Event Boundary
+- Backend Boundary
+- Layout Metadata Consolidation Audit
+
+## 10. Admission Guard
+| Area | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future sizing metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current sizing implementation | absent | DEFERRED | PASS |
+| sizing algorithm | forbidden | FORBIDDEN | PASS |
+| measuring algorithm | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 11. Non-Scope
+This selection is planning-only.
+This selection does not implement sizing source.
+This selection does not implement sizing structs.
+This selection does not implement sizing functions.
+This selection does not implement sizing tests.
+This selection does not implement sizing algorithm behavior.
+This selection does not implement measuring algorithm behavior.
+This selection does not implement constraint solver behavior.
+This selection does not implement constraint satisfaction.
+This selection does not implement layout solving.
+This selection only authorizes the next source package to be prepared under a separate gate.
+
+## 12. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after layout sizing boundary audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-SIZING-SEED-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement sizing source, sizing structs, sizing functions, sizing tests, sizing algorithm behavior, measuring algorithm behavior, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Sizing Boundary line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-SIZING-SEED-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

- DNA alignment
- closed sizing boundary basis
- Project #2 state
- candidate lane comparison
- selected next lane
- deferred lanes
- admission guard constraints

## Explicit non-scope

- no source changes
- no test changes
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no sizing source implementation
- no sizing structs
- no sizing tests
- no sizing algorithm
- no measuring algorithm
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #1004

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT SIZING BOUNDARY AUDIT CLEAN