### PR TITLE
feat(ui): add renderer layout sizing seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -796,3 +796,199 @@ pub fn build_layout_constraints(model: &UiLayoutModel) -> UiLayoutConstraintsMod
         declarations,
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizingModelId {
+    raw: u64,
+}
+
+impl UiLayoutSizingModelId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizingEntryId {
+    raw: u64,
+}
+
+impl UiLayoutSizingEntryId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizingKind {
+    #[default]
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizingState {
+    #[default]
+    Unresolved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizingEntry {
+    id: UiLayoutSizingEntryId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_constraint_declaration: UiLayoutConstraintId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutSizingKind,
+    state: UiLayoutSizingState,
+    order: usize,
+}
+
+impl UiLayoutSizingEntry {
+    pub fn id(&self) -> UiLayoutSizingEntryId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_constraint_declaration(&self) -> UiLayoutConstraintId {
+        self.source_constraint_declaration
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutSizingKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutSizingState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizingModel {
+    id: UiLayoutSizingModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_constraints_model: UiLayoutConstraintsModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    entries: Vec<UiLayoutSizingEntry>,
+}
+
+impl UiLayoutSizingModel {
+    pub fn id(&self) -> UiLayoutSizingModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_constraints_model(&self) -> UiLayoutConstraintsModelId {
+        self.source_constraints_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn entries(&self) -> &[UiLayoutSizingEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub fn build_layout_sizing(model: &UiLayoutModel) -> UiLayoutSizingModel {
+    let geometry_model = build_layout_geometry(model);
+    let constraints_model = build_layout_constraints(model);
+    let mut entries = Vec::with_capacity(constraints_model.declarations().len());
+
+    for (index, ((declaration, layout_node), geometry_node)) in constraints_model
+        .declarations()
+        .iter()
+        .zip(model.nodes())
+        .zip(geometry_model.nodes())
+        .enumerate()
+    {
+        entries.push(UiLayoutSizingEntry {
+            id: UiLayoutSizingEntryId::new(declaration.id().raw()),
+            source_layout_node: layout_node.id(),
+            source_layout_slot: layout_node.slot(),
+            source_geometry_node: geometry_node.id(),
+            source_constraint_declaration: declaration.id(),
+            source_render_node: layout_node.source_render_node(),
+            source_projection_node: layout_node.source_projection_node(),
+            source_ir_node: layout_node.source_ir_node(),
+            kind: UiLayoutSizingKind::Unresolved,
+            state: UiLayoutSizingState::Unresolved,
+            order: index,
+        });
+    }
+
+    UiLayoutSizingModel {
+        id: UiLayoutSizingModelId::new(model.id().raw()),
+        source_layout_model: model.id(),
+        source_geometry_model: geometry_model.id(),
+        source_constraints_model: constraints_model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        entries,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_sizing_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_sizing_seed.rs
@@ -1,0 +1,233 @@
+use prom_ui::layout::{
+    build_layout_constraints, build_layout_geometry, build_layout_sizing, layout_render_model,
+    UiLayoutSizingKind, UiLayoutSizingModel, UiLayoutSizingState,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> prom_ui::layout::UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+fn create_test_geometry_model() -> prom_ui::layout::UiLayoutGeometryModel {
+    let layout_model = create_test_layout_model();
+    build_layout_geometry(&layout_model)
+}
+
+fn create_test_constraints_model() -> prom_ui::layout::UiLayoutConstraintsModel {
+    let layout_model = create_test_layout_model();
+    build_layout_constraints(&layout_model)
+}
+
+fn create_test_sizing_model() -> UiLayoutSizingModel {
+    let layout_model = create_test_layout_model();
+    build_layout_sizing(&layout_model)
+}
+
+#[test]
+fn sizing_model_can_be_built_from_existing_layout_geometry_constraints_fixture() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = create_test_geometry_model();
+    let constraints_model = create_test_constraints_model();
+
+    let sizing_model = build_layout_sizing(&layout_model);
+    assert_eq!(sizing_model.source_layout_model(), layout_model.id());
+    assert_eq!(sizing_model.source_geometry_model(), geometry_model.id());
+    assert_eq!(
+        sizing_model.source_constraints_model(),
+        constraints_model.id()
+    );
+    assert_eq!(
+        sizing_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        sizing_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(sizing_model.source_ir_root(), layout_model.source_ir_root());
+    assert_eq!(
+        sizing_model.entries().len(),
+        constraints_model.declarations().len()
+    );
+}
+
+#[test]
+fn sizing_model_id_is_deterministic() {
+    let layout_model = create_test_layout_model();
+
+    let sizing_model_1 = build_layout_sizing(&layout_model);
+    let sizing_model_2 = build_layout_sizing(&layout_model);
+
+    assert_eq!(sizing_model_1.id(), sizing_model_2.id());
+    assert_eq!(sizing_model_1.id().raw(), layout_model.id().raw());
+}
+
+#[test]
+fn sizing_entry_ids_are_deterministic() {
+    let sizing_model = create_test_sizing_model();
+    let second_sizing_model = create_test_sizing_model();
+
+    let ids_1: Vec<_> = sizing_model
+        .entries()
+        .iter()
+        .map(|entry| entry.id())
+        .collect();
+    let ids_2: Vec<_> = second_sizing_model
+        .entries()
+        .iter()
+        .map(|entry| entry.id())
+        .collect();
+
+    assert_eq!(ids_1, ids_2);
+}
+
+#[test]
+fn sizing_entry_count_order_is_deterministic() {
+    let layout_model = create_test_layout_model();
+    let constraints_model = create_test_constraints_model();
+    let sizing_model = build_layout_sizing(&layout_model);
+
+    assert_eq!(
+        sizing_model.entries().len(),
+        constraints_model.declarations().len()
+    );
+    for (index, entry) in sizing_model.entries().iter().enumerate() {
+        assert_eq!(entry.order(), index);
+        assert_eq!(
+            entry.source_constraint_declaration(),
+            constraints_model.declarations()[index].id()
+        );
+    }
+}
+
+#[test]
+fn sizing_kind_state_metadata_is_inert_default_unresolved() {
+    let sizing_model = create_test_sizing_model();
+
+    for entry in sizing_model.entries() {
+        assert_eq!(entry.kind(), UiLayoutSizingKind::Unresolved);
+        assert_eq!(entry.state(), UiLayoutSizingState::Unresolved);
+    }
+}
+
+#[test]
+fn source_layout_model_reference_is_preserved() {
+    let layout_model = create_test_layout_model();
+
+    let sizing_model = build_layout_sizing(&layout_model);
+    assert_eq!(sizing_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        sizing_model.source_geometry_model(),
+        build_layout_geometry(&layout_model).id()
+    );
+    assert_eq!(
+        sizing_model.source_constraints_model(),
+        build_layout_constraints(&layout_model).id()
+    );
+}
+
+#[test]
+fn source_layout_geometry_constraints_references_are_preserved_where_exposed() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+    let constraints_model = build_layout_constraints(&layout_model);
+
+    let sizing_model = build_layout_sizing(&layout_model);
+    for (((entry, layout_node), geometry_node), declaration) in sizing_model
+        .entries()
+        .iter()
+        .zip(layout_model.nodes())
+        .zip(geometry_model.nodes())
+        .zip(constraints_model.declarations())
+    {
+        assert_eq!(entry.source_layout_node(), layout_node.id());
+        assert_eq!(entry.source_layout_slot(), layout_node.slot());
+        assert_eq!(entry.source_geometry_node(), geometry_node.id());
+        assert_eq!(entry.source_constraint_declaration(), declaration.id());
+        assert_eq!(entry.source_render_node(), layout_node.source_render_node());
+        assert_eq!(
+            entry.source_projection_node(),
+            layout_node.source_projection_node()
+        );
+        assert_eq!(entry.source_ir_node(), layout_node.source_ir_node());
+    }
+}
+
+#[test]
+fn no_input_mutation() {
+    let layout_model = create_test_layout_model();
+    let expected = layout_model.clone();
+
+    let _sizing_model = build_layout_sizing(&layout_model);
+
+    assert_eq!(layout_model, expected);
+}
+
+#[test]
+fn sizing_seed_does_not_expose_sizing_algorithm_measuring_or_size_to_fit_authority() {
+    let sizing_model = create_test_sizing_model();
+
+    assert!(!sizing_model.is_empty());
+    assert_eq!(
+        sizing_model.entries()[0].kind(),
+        UiLayoutSizingKind::Unresolved
+    );
+    assert_eq!(
+        sizing_model.entries()[0].state(),
+        UiLayoutSizingState::Unresolved
+    );
+}
+
+#[test]
+fn sizing_seed_does_not_expose_constraint_solver_constraint_satisfaction_or_layout_solving_authority(
+) {
+    let sizing_model = create_test_sizing_model();
+
+    assert_eq!(sizing_model.entries().len(), 2);
+    assert_eq!(sizing_model.entries()[0].id().raw(), 1);
+    assert_eq!(sizing_model.entries()[1].id().raw(), 2);
+}
+
+#[test]
+fn sizing_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority() {
+    let sizing_model = create_test_sizing_model();
+
+    assert_eq!(sizing_model.entries()[0].source_layout_node().raw(), 1);
+    assert_eq!(sizing_model.entries()[1].source_layout_node().raw(), 2);
+}
+
+#[test]
+fn sizing_seed_entrypoint_signature_is_locked() {
+    let layout_model = create_test_layout_model();
+    let f: fn(&prom_ui::layout::UiLayoutModel) -> UiLayoutSizingModel = build_layout_sizing;
+    let sizing_model = f(&layout_model);
+
+    assert_eq!(sizing_model.source_layout_model(), layout_model.id());
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Sizing Seed.

This source seed introduces minimal inert renderer-local sizing metadata/result declarations for layout.

## Scope

Adds:

- minimal sizing model
- minimal sizing entry
- deterministic sizing model/entry identity
- inert sizing kind/state metadata
- read-only source layout/geometry/constraints references where exposed
- focused tests proving determinism and inertness

## Explicit non-scope

- no sizing algorithm
- no measuring algorithm
- no size-to-fit algorithm
- no constraint solver
- no constraint satisfaction algorithm
- no layout solving
- no layout engine rewrite
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #1005

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS — R12 UI RENDERER LAYOUT SIZING SEED SOURCE CLEAN