### PR TITLE
docs(ui): add renderer layout sizing seed ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_seed_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_seed_ledger_audit.md
@@ -1,0 +1,189 @@
+# R12 UI Renderer Layout Sizing Seed Ledger Audit
+
+## 1. Purpose
+This document records the ledger audit for the R12 UI Renderer Layout Sizing Seed line after roadmap PR #1005, source PR #1006, and closeout PR #1007.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md present as repository fallback
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing seed remains inert renderer-local metadata/result declarations;
+- no sizing algorithm authority;
+- no measuring algorithm authority;
+- no size-to-fit authority;
+- no constraint solver authority;
+- no constraint satisfaction authority;
+- no layout solving authority;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Basis
+- #1005 — roadmap selected sizing seed
+- #1006 — layout sizing seed source
+- #1007 — layout sizing seed closeout
+
+## 4. PR Ledger
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #1005 | docs(ui): select next post-ui lane after layout sizing boundary audit | MERGED | `9f07f8ee3c2c2168ba169111dfa541f44fe045c8` | `docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_sizing_boundary_audit.md` | Roadmap | PASS |
+| #1006 | feat(ui): add renderer layout sizing seed | MERGED | `3278c758caddb51dad356c1214cc9312378590b0` | `crates/prom-ui/src/layout.rs`, `crates/prom-ui/tests/renderer_layout_sizing_seed.rs` | Code | PASS |
+| #1007 | docs(ui): close out renderer layout sizing seed | MERGED | `9b77ff76fc0c2c7412a43e232fed9decf07991ab` | `docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_seed_closeout.md` | Closeout | PASS |
+
+## 5. Changed File Surface
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---:|---:|---:|---:|---|
+| #1005 | 1 roadmap doc | NO | NO | YES | NO | PASS |
+| #1006 | `crates/prom-ui/src/layout.rs`, `crates/prom-ui/tests/renderer_layout_sizing_seed.rs` | YES | YES | NO | NO | PASS |
+| #1007 | 1 closeout doc | NO | NO | YES | NO | PASS |
+
+## 6. Sizing Seed API Ledger
+| API / Surface | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| sizing model | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing entry | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing model ID | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing entry ID | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing kind metadata | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing state metadata | implemented | ADMITTED | source PR #1006 | PASS |
+| sizing build entrypoint | implemented | ADMITTED | source PR #1006 | PASS |
+| source layout model reference | preserved | ADMITTED | source PR #1006 + tests | PASS |
+| source layout node reference | preserved where exposed | ADMITTED | source PR #1006 + tests | PASS |
+| source geometry model reference | preserved | ADMITTED | source PR #1006 + tests | PASS |
+| source geometry node reference | preserved where exposed | ADMITTED | source PR #1006 + tests | PASS |
+| source constraints model reference | preserved | ADMITTED | source PR #1006 + tests | PASS |
+| source constraint declaration reference | preserved where exposed | ADMITTED | source PR #1006 + tests | PASS |
+
+## 7. Behavior Ledger
+| Behavior | Final state | Evidence | Status |
+|---|---|---|---|
+| deterministic model ID | YES | `UiLayoutSizingModelId` tests | PASS |
+| deterministic entry IDs | YES | `UiLayoutSizingEntryId` tests | PASS |
+| deterministic entry order/count | YES | entry ordering tests | PASS |
+| inert/default/unresolved entries | YES | kind/state tests | PASS |
+| source layout model preservation | YES | source model reference tests | PASS |
+| source layout node preservation | YES | node reference tests | PASS |
+| source geometry model preservation | YES | geometry model reference tests | PASS |
+| source geometry node preservation | YES | geometry node reference tests | PASS |
+| source constraints model preservation | YES | constraints model reference tests | PASS |
+| source constraint declaration preservation | YES | declaration reference tests | PASS |
+| input mutation absence | YES | clone/equality test | PASS |
+| floating point absence | YES | source scan | PASS |
+| randomness/time/global mutable state absence | YES | source scan | PASS |
+
+## 8. Test Coverage Ledger
+| Test category | Evidence | Status |
+|---|---|---|
+| build from layout/geometry/constraints model | `renderer_layout_sizing_seed.rs` | PASS |
+| model ID determinism | `renderer_layout_sizing_seed.rs` | PASS |
+| entry ID determinism | `renderer_layout_sizing_seed.rs` | PASS |
+| entry order/count determinism | `renderer_layout_sizing_seed.rs` | PASS |
+| kind/state inertness | `renderer_layout_sizing_seed.rs` | PASS |
+| unresolved/default metadata | `renderer_layout_sizing_seed.rs` | PASS |
+| source layout preservation | `renderer_layout_sizing_seed.rs` | PASS |
+| source geometry preservation | `renderer_layout_sizing_seed.rs` | PASS |
+| source constraints preservation | `renderer_layout_sizing_seed.rs` | PASS |
+| public API signature lock | `renderer_layout_sizing_seed.rs` | PASS |
+| sizing algorithm / measuring / size-to-fit absence | `renderer_layout_sizing_seed.rs` | PASS |
+| solver / constraint satisfaction / layout-solving absence | `renderer_layout_sizing_seed.rs` | PASS |
+| forbidden authority absence | `renderer_layout_sizing_seed.rs` | PASS |
+
+## 9. Deferred Authority Ledger
+| Deferred area | Final state | Classification | Status |
+|---|---|---|---|
+| sizing algorithm | absent | FORBIDDEN | PASS |
+| measuring algorithm | absent | FORBIDDEN | PASS |
+| size-to-fit algorithm | absent | FORBIDDEN | PASS |
+| constraint solver | absent | FORBIDDEN | PASS |
+| constraint satisfaction algorithm | absent | FORBIDDEN | PASS |
+| layout solving | absent | FORBIDDEN | PASS |
+| layout engine rewrite | absent | FORBIDDEN | PASS |
+| draw commands | absent | FORBIDDEN | PASS |
+| event dispatch | absent | FORBIDDEN | PASS |
+| backend rendering | absent | FORBIDDEN | PASS |
+| runtime/verifier/VM integration | absent | FORBIDDEN | PASS |
+| capability admission | absent | FORBIDDEN | PASS |
+| proof/debugger authority | absent | FORBIDDEN | PASS |
+| Workbench/Studio integration | absent | FORBIDDEN | PASS |
+
+## 10. Project #2 Ledger
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Item count | Duplicate count |
+|---|---|---|---|---|---|---|---|---|---|---:|---:|
+| #1005 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #1004 | 1 | 0 |
+| #1006 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #1005 | 1 | 0 |
+| #1007 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #1006 | 1 | 0 |
+
+## 11. Forbidden Surface Ledger
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| sizing algorithm | NO | FORBIDDEN | PASS |
+| measuring algorithm | NO | FORBIDDEN | PASS |
+| size-to-fit algorithm | NO | FORBIDDEN | PASS |
+| constraint solver | NO | FORBIDDEN | PASS |
+| constraint satisfaction algorithm | NO | FORBIDDEN | PASS |
+| layout solving | NO | FORBIDDEN | PASS |
+| layout engine rewrite | NO | FORBIDDEN | PASS |
+| draw/event/backend | NO | FORBIDDEN | PASS |
+| WGPU/winit/Tauri | NO | FORBIDDEN | PASS |
+| runtime/verifier/VM | NO | FORBIDDEN | PASS |
+| capability admission | NO | FORBIDDEN | PASS |
+| action execution | NO | FORBIDDEN | PASS |
+| effect authorization | NO | FORBIDDEN | PASS |
+| proof/debugger authority | NO | FORBIDDEN | PASS |
+| Workbench/Studio | NO | FORBIDDEN | PASS |
+| floating point computation | NO | FORBIDDEN | PASS |
+| randomness/time/global mutable state | NO | FORBIDDEN | PASS |
+| Cargo.toml / Cargo.lock | NO | FORBIDDEN | PASS |
+| dependency additions | NO | FORBIDDEN | PASS |
+| tracked pr_body artifacts | NO | FORBIDDEN | PASS |
+
+## 12. Manifest / Dependency Ledger
+| Check | Result | Evidence | Status |
+|---|---|---|---|
+| Cargo.toml changed | NO | git diff / merge surfaces | PASS |
+| Cargo.lock changed | NO | git diff / merge surfaces | PASS |
+| dependency additions | NONE | git log / diff scan | PASS |
+
+## 13. Local Validation
+| Command | Result | Status |
+|---|---|---|
+| `cargo fmt --check` | PASS | PASS |
+| `cargo test -p prom-ui --lib` | PASS | PASS |
+| `cargo test -p prom-ui` | PASS | PASS |
+| `git diff --check` | PASS | PASS |
+| tracked `pr_body` files | NO | PASS |
+
+## 14. Admission Guard Summary
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| sizing seed | IMPLEMENTED | ADMITTED | PASS |
+| sizing model | IMPLEMENTED | ADMITTED | PASS |
+| sizing entry | IMPLEMENTED | ADMITTED | PASS |
+| deterministic IDs | IMPLEMENTED | ADMITTED | PASS |
+| kind/state metadata | IMPLEMENTED | ADMITTED | PASS |
+| source references | IMPLEMENTED | ADMITTED | PASS |
+| sizing algorithm | ABSENT | FORBIDDEN | PASS |
+| measuring algorithm | ABSENT | FORBIDDEN | PASS |
+| size-to-fit algorithm | ABSENT | FORBIDDEN | PASS |
+| constraint solver | ABSENT | FORBIDDEN | PASS |
+| constraint satisfaction | ABSENT | FORBIDDEN | PASS |
+| layout solving | ABSENT | FORBIDDEN | PASS |
+| draw/event/backend | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| proof/debugger authority | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 15. Final Decision
+Final decision:
+PASS — R12 UI Renderer Layout Sizing Seed ledger audit is clean after roadmap PR #1005, source PR #1006, and closeout PR #1007.
+
+The sizing seed line is complete as minimal inert renderer-local layout sizing metadata/result declarations. It implements deterministic sizing entries and kind/state metadata without implementing sizing algorithm behavior, measuring algorithm behavior, size-to-fit behavior, constraint solver behavior, constraint satisfaction, layout solving, layout engine rewrite, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Sizing Seed ledger audit.

This is a docs-only audit PR covering:

- #1005 — roadmap selected sizing seed
- #1006 — layout sizing seed source
- #1007 — layout sizing seed closeout

## Scope

Audits:

- sizing seed source API
- deterministic identity policy
- inert kind/state metadata
- source layout/geometry/constraints reference preservation
- test coverage
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no sizing algorithm
- no measuring algorithm
- no size-to-fit algorithm
- no constraint solver
- no constraint satisfaction algorithm
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #1007

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS — R12 UI RENDERER LAYOUT SIZING SEED LEDGER AUDIT CLEAN
