### PR TITLE
docs(ui): close out renderer layout sizing algorithm boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_algorithm_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_sizing_algorithm_boundary_closeout.md
@@ -1,0 +1,142 @@
+# R12 UI Renderer Layout Sizing Algorithm Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Sizing Algorithm Boundary line after boundary PR #1010.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md present as repository fallback
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing seed remains inert renderer-local metadata/result declarations;
+- sizing algorithm boundary remains docs-only;
+- no sizing algorithm implementation;
+- no measuring algorithm implementation;
+- no size-to-fit implementation;
+- no intrinsic/content size calculation;
+- no constraint solver implementation;
+- no constraint satisfaction implementation;
+- no layout solving implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+- #1005 — roadmap selected sizing seed
+- #1006 — layout sizing seed source
+- #1007 — layout sizing seed closeout
+- #1008 — layout sizing seed ledger audit
+- #1009 — roadmap selected sizing algorithm boundary
+- #1010 — layout sizing algorithm boundary document
+
+## 4. Implemented State
+Implemented:
+- sizing algorithm boundary document;
+- sizing algorithm pipeline position;
+- allowed future algorithm input categories;
+- allowed future algorithm output categories;
+- conceptual future algorithm categories;
+- explicit separation from measuring;
+- explicit separation from size-to-fit;
+- explicit separation from constraint solver;
+- explicit separation from layout solving;
+- explicit non-authority rules;
+- deferred sizing algorithm source gate.
+
+## 5. Deferred State
+Deferred:
+- sizing algorithm source implementation;
+- measuring algorithm source implementation;
+- size-to-fit behavior;
+- intrinsic/content size calculation;
+- constraint solver;
+- constraint satisfaction algorithm;
+- layout solving;
+- layout engine rewrite;
+- geometry mutation;
+- sizing metadata mutation;
+- constraint mutation;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+This closeout records a completed boundary artifact only.
+
+It does not implement sizing algorithm source, measuring algorithm source, size-to-fit behavior, intrinsic/content size calculation, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 7. Evidence Matrix
+| Area | Final state | Classification | Status |
+|---|---|---|---|
+| Sizing algorithm boundary | Documented | ADMITTED | PASS |
+| Sizing algorithm implementation | Not implemented | DEFERRED | PASS |
+| Sizing algorithm seed | Future package only | DEFERRED | PASS |
+| Measuring algorithm | Not implemented | FORBIDDEN | PASS |
+| Size-to-fit behavior | Not implemented | FORBIDDEN | PASS |
+| Intrinsic/content size calculation | Not implemented | FORBIDDEN | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Constraint satisfaction | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Layout engine rewrite | Not implemented | FORBIDDEN | PASS |
+| Geometry mutation | Not implemented | FORBIDDEN | PASS |
+| Sizing metadata mutation | Not implemented | FORBIDDEN | PASS |
+| Constraint mutation | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future deterministic sizing derivation | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current sizing algorithm implementation | absent | DEFERRED | PASS |
+| measuring algorithm | forbidden | FORBIDDEN | PASS |
+| size-to-fit behavior | forbidden | FORBIDDEN | PASS |
+| intrinsic/content size calculation | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| layout engine rewrite | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #1010
+
+## 10. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-SIZING-ALGORITHM-LEDGER-AUDIT-PR
+
+Alternative after audit:
+R12-UI-RENDERER-LAYOUT-SIZING-ALGORITHM-SEED-LINE-FULL-PACKAGE
+
+## 11. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Sizing Algorithm Boundary is complete as a docs-only boundary artifact.
+
+It defines future sizing algorithm work only as a separately gated deterministic renderer-local metadata derivation layer and does not implement sizing algorithm source, measuring algorithm source, size-to-fit behavior, intrinsic/content size calculation, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Sizing Algorithm Boundary line.

This is a docs-only closeout after the sizing algorithm boundary PR.

## Scope

Records:

- sizing algorithm boundary document
- sizing algorithm position in layout pipeline
- allowed future input categories
- allowed future output categories
- conceptual future algorithm categories
- explicit separation from measuring, size-to-fit, solver, and layout solving
- explicit non-authority rules
- deferred sizing algorithm source gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no sizing algorithm implementation
- no measuring algorithm implementation
- no size-to-fit behavior
- no intrinsic/content size calculation
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1010
```

## Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

## Final decision

CLOSED — R12 UI Renderer Layout Sizing Algorithm Boundary is complete as a docs-only boundary artifact.
