### PR TITLE
docs(ui): select next post-ui lane after layout sizing algorithm boundary audit

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_sizing_algorithm_boundary_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_sizing_algorithm_boundary_audit.md
@@ -1,0 +1,155 @@
+# POST-UI Roadmap Next Lane Selection After Layout Sizing Algorithm Boundary Audit
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Sizing Algorithm Boundary line.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md present as repository fallback
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing seed remains inert renderer-local metadata/result declarations;
+- sizing algorithm boundary is closed and audited for tracked repository state;
+- sizing algorithm seed may only introduce deterministic renderer-local metadata derivation substrate;
+- sizing algorithm seed must not introduce measuring algorithm authority;
+- sizing algorithm seed must not introduce size-to-fit authority;
+- sizing algorithm seed must not introduce intrinsic/content measurement authority;
+- sizing algorithm seed must not introduce constraint solver authority;
+- sizing algorithm seed must not introduce constraint satisfaction authority;
+- sizing algorithm seed must not introduce layout solving;
+- sizing algorithm seed must not introduce draw/event/backend authority;
+- sizing algorithm seed must not introduce runtime/verifier/VM/capability authority;
+- sizing algorithm seed must not introduce proof/debugger authority;
+- sizing algorithm seed must not introduce Workbench/Studio integration;
+- this roadmap PR must remain docs-only.
+
+## 3. Closed Basis
+- #1009 — roadmap selected sizing algorithm boundary
+- #1010 — layout sizing algorithm boundary
+- #1011 — layout sizing algorithm boundary closeout
+- #1012 — layout sizing algorithm boundary ledger audit
+
+## 4. Sizing Algorithm Boundary State
+Sizing algorithm boundary is closed as docs-only boundary work. It documents future sizing algorithm authority as a separately gated deterministic renderer-local metadata derivation layer without implementing sizing algorithm source, measuring algorithm source, size-to-fit behavior, intrinsic/content size calculation, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 5. Project #2 State
+- #1009: Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #1008
+- #1010: Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | #1009
+- #1011: Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #1010
+- #1012: Done | POST-UI | R12 | Audit | Medium | Renderer | FullPreflight | Roadmap doc | #1011
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason | Risk | Decision |
+|---|---|---|---|---|
+| Layout Sizing Algorithm Seed | Selected | Sizing algorithm boundary has been selected, documented, closed out, and ledger-audited. The next structurally valid step is a small source seed for deterministic renderer-local sizing metadata derivation, still without measuring, size-to-fit, solver, or layout-solving authority. | Medium | Selected |
+| Measuring Boundary | Deferred | Measuring remains separate from sizing algorithm seed and should not be mixed into the next source step. | Medium | Deferred |
+| Size-to-Fit Boundary | Deferred | Fit/fill/shrink/grow behavior is higher-authority than inert algorithm metadata derivation and should be separately bounded later. | Medium | Deferred |
+| Constraint Solver Boundary | Deferred / too early | Constraint solver boundary remains premature until algorithm seed exists and solver authority remains explicitly separated. | High | Deferred |
+| Layout Solving Boundary | Deferred / too early | Layout solving is higher-authority and should wait until algorithm and solver boundaries are separately handled. | High | Deferred |
+| Event Boundary | Deferred / high-risk | Events remain close to action/effect/capability semantics and should wait until layout metadata and algorithm boundaries are more mature. | High | Deferred |
+| Backend Boundary | Deferred / too early | Backend/WGPU/winit/Tauri remains outside current layout metadata and algorithm work. | High | Deferred |
+| Layout Metadata / Algorithm Consolidation Audit | Deferred | Useful later, but the immediate architectural pressure point is creating the minimal sizing algorithm seed. | Medium | Deferred |
+
+## 7. Selection Criteria
+1. Must preserve DNA alignment.
+2. Must preserve renderer/layout/geometry/constraints/sizing seed inertness.
+3. Must not implement algorithm source in the roadmap selection PR.
+4. Must not introduce measuring algorithm behavior.
+5. Must not introduce size-to-fit behavior.
+6. Must not introduce intrinsic/content size calculation.
+7. Must not introduce constraint solver behavior.
+8. Must not introduce constraint satisfaction behavior.
+9. Must not introduce layout solving.
+10. Must not introduce draw/event/backend.
+11. Must not introduce runtime/verifier/VM/capability authority.
+12. Must build naturally on closed sizing algorithm boundary and audit.
+13. Must be source-gated separately before implementation.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-SIZING-ALGORITHM-SEED-LINE-FULL-PACKAGE
+
+This selection is planning-only.
+This selection does not implement sizing algorithm source.
+This selection does not implement measuring algorithm source.
+This selection does not implement size-to-fit behavior.
+This selection does not implement intrinsic/content size calculation.
+This selection does not implement constraint solver behavior.
+This selection does not implement constraint satisfaction.
+This selection does not implement layout solving.
+This selection only authorizes the next source package to be prepared under a separate gate.
+
+## 9. Deferred Lanes
+- Measuring Boundary
+- Size-to-Fit Boundary
+- Constraint Solver Boundary
+- Layout Solving Boundary
+- Event Boundary
+- Backend Boundary
+- Layout Metadata / Algorithm Consolidation Audit
+
+## 10. Untracked Workspace Artifacts
+Untracked workspace artifacts were present in the prior audit and are treated as local-only, non-merged artifacts.
+They must not be staged or committed by this roadmap selection PR.
+
+Known artifacts:
+
+- .claude/
+- examples/baseline/
+- scratch/
+
+## 11. Admission Guard
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future deterministic sizing derivation | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current sizing algorithm implementation | absent | DEFERRED | PASS |
+| measuring algorithm | forbidden | FORBIDDEN | PASS |
+| size-to-fit behavior | forbidden | FORBIDDEN | PASS |
+| intrinsic/content size calculation | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| layout engine rewrite | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 12. Non-Scope
+- no source changes
+- no test changes
+- no docs/DNA.md changes
+- no docs/dna changes
+- no agent skill changes
+- no Cargo.toml / Cargo.lock changes
+- no dependency additions
+- no sizing algorithm source
+- no measuring algorithm source
+- no size-to-fit behavior
+- no intrinsic/content size calculation
+- no constraint solver
+- no constraint satisfaction
+- no layout solving
+- no draw/event/backend implementation
+- no runtime/verifier/VM integration
+- no capability admission
+- no proof/debugger authority
+- no Workbench/Studio integration
+
+## 13. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after layout sizing algorithm boundary audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-SIZING-ALGORITHM-SEED-LINE-FULL-PACKAGE.
+
+This selection is planning-only and does not implement sizing algorithm source, measuring algorithm source, size-to-fit behavior, intrinsic/content size calculation, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+Tracked repository state remains clean for this roadmap selection. Pre-existing untracked local workspace artifacts are not staged, not committed, and not merged.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Sizing Algorithm Boundary line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-SIZING-ALGORITHM-SEED-LINE-FULL-PACKAGE
```

## Scope

This is a docs-only planning PR.

It records:

- DNA alignment
- closed sizing algorithm boundary basis
- Project #2 state
- candidate lane comparison
- selected next lane
- deferred lanes
- untracked local workspace artifact classification
- admission guard constraints

## Explicit non-scope

- no source changes
- no test changes
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no sizing algorithm source
- no measuring algorithm source
- no size-to-fit behavior
- no intrinsic/content size calculation
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #1012

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT SIZING ALGORITHM BOUNDARY AUDIT CLEAN FOR TRACKED REPOSITORY STATE
```
