### PR TITLE
feat(ui): add renderer layout sizing algorithm seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -992,3 +992,205 @@ pub fn build_layout_sizing(model: &UiLayoutModel) -> UiLayoutSizingModel {
         entries,
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizingAlgorithmModelId {
+    raw: u64,
+}
+
+impl UiLayoutSizingAlgorithmModelId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizingAlgorithmEntryId {
+    raw: u64,
+}
+
+impl UiLayoutSizingAlgorithmEntryId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizingAlgorithmKind {
+    #[default]
+    PassThrough,
+    Unresolved,
+    AuditOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizingAlgorithmState {
+    #[default]
+    Deferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizingAlgorithmEntry {
+    id: UiLayoutSizingAlgorithmEntryId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_constraint_declaration: UiLayoutConstraintId,
+    source_sizing_entry: UiLayoutSizingEntryId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutSizingAlgorithmKind,
+    state: UiLayoutSizingAlgorithmState,
+    order: usize,
+}
+
+impl UiLayoutSizingAlgorithmEntry {
+    pub fn id(&self) -> UiLayoutSizingAlgorithmEntryId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_constraint_declaration(&self) -> UiLayoutConstraintId {
+        self.source_constraint_declaration
+    }
+
+    pub fn source_sizing_entry(&self) -> UiLayoutSizingEntryId {
+        self.source_sizing_entry
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutSizingAlgorithmKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutSizingAlgorithmState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizingAlgorithmModel {
+    id: UiLayoutSizingAlgorithmModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_constraints_model: UiLayoutConstraintsModelId,
+    source_sizing_model: UiLayoutSizingModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    entries: Vec<UiLayoutSizingAlgorithmEntry>,
+}
+
+impl UiLayoutSizingAlgorithmModel {
+    pub fn id(&self) -> UiLayoutSizingAlgorithmModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_constraints_model(&self) -> UiLayoutConstraintsModelId {
+        self.source_constraints_model
+    }
+
+    pub fn source_sizing_model(&self) -> UiLayoutSizingModelId {
+        self.source_sizing_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn entries(&self) -> &[UiLayoutSizingAlgorithmEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub fn build_layout_sizing_algorithm(model: &UiLayoutSizingModel) -> UiLayoutSizingAlgorithmModel {
+    let mut entries = Vec::with_capacity(model.entries().len());
+
+    for (order, sizing_entry) in model.entries().iter().enumerate() {
+        entries.push(UiLayoutSizingAlgorithmEntry {
+            id: UiLayoutSizingAlgorithmEntryId::new(sizing_entry.id().raw()),
+            source_layout_node: sizing_entry.source_layout_node(),
+            source_layout_slot: sizing_entry.source_layout_slot(),
+            source_geometry_node: sizing_entry.source_geometry_node(),
+            source_constraint_declaration: sizing_entry.source_constraint_declaration(),
+            source_sizing_entry: sizing_entry.id(),
+            source_render_node: sizing_entry.source_render_node(),
+            source_projection_node: sizing_entry.source_projection_node(),
+            source_ir_node: sizing_entry.source_ir_node(),
+            kind: UiLayoutSizingAlgorithmKind::PassThrough,
+            state: UiLayoutSizingAlgorithmState::Deferred,
+            order,
+        });
+    }
+
+    UiLayoutSizingAlgorithmModel {
+        id: UiLayoutSizingAlgorithmModelId::new(model.id().raw()),
+        source_layout_model: model.source_layout_model(),
+        source_geometry_model: model.source_geometry_model(),
+        source_constraints_model: model.source_constraints_model(),
+        source_sizing_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        entries,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_sizing_algorithm_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_sizing_algorithm_seed.rs
@@ -1,0 +1,258 @@
+use prom_ui::layout::{
+    build_layout_constraints, build_layout_geometry, build_layout_sizing,
+    build_layout_sizing_algorithm, layout_render_model, UiLayoutSizingAlgorithmKind,
+    UiLayoutSizingAlgorithmModel, UiLayoutSizingAlgorithmState,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> prom_ui::layout::UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+fn create_test_geometry_model() -> prom_ui::layout::UiLayoutGeometryModel {
+    let layout_model = create_test_layout_model();
+    build_layout_geometry(&layout_model)
+}
+
+fn create_test_constraints_model() -> prom_ui::layout::UiLayoutConstraintsModel {
+    let layout_model = create_test_layout_model();
+    build_layout_constraints(&layout_model)
+}
+
+fn create_test_sizing_model() -> prom_ui::layout::UiLayoutSizingModel {
+    let layout_model = create_test_layout_model();
+    build_layout_sizing(&layout_model)
+}
+
+fn create_test_algorithm_model() -> UiLayoutSizingAlgorithmModel {
+    let sizing_model = create_test_sizing_model();
+    build_layout_sizing_algorithm(&sizing_model)
+}
+
+#[test]
+fn sizing_algorithm_model_can_be_built_from_existing_layout_geometry_constraints_sizing_fixture() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = create_test_geometry_model();
+    let constraints_model = create_test_constraints_model();
+    let sizing_model = create_test_sizing_model();
+
+    let algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+    assert_eq!(algorithm_model.source_layout_model(), layout_model.id());
+    assert_eq!(algorithm_model.source_geometry_model(), geometry_model.id());
+    assert_eq!(
+        algorithm_model.source_constraints_model(),
+        constraints_model.id()
+    );
+    assert_eq!(algorithm_model.source_sizing_model(), sizing_model.id());
+    assert_eq!(
+        algorithm_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        algorithm_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(
+        algorithm_model.source_ir_root(),
+        layout_model.source_ir_root()
+    );
+    assert_eq!(
+        algorithm_model.entries().len(),
+        sizing_model.entries().len()
+    );
+}
+
+#[test]
+fn sizing_algorithm_model_id_is_deterministic() {
+    let sizing_model = create_test_sizing_model();
+
+    let first = build_layout_sizing_algorithm(&sizing_model);
+    let second = build_layout_sizing_algorithm(&sizing_model);
+
+    assert_eq!(first.id(), second.id());
+    assert_eq!(first.id().raw(), sizing_model.id().raw());
+}
+
+#[test]
+fn sizing_algorithm_entry_ids_are_deterministic() {
+    let first = create_test_algorithm_model();
+    let second = create_test_algorithm_model();
+
+    let ids_1: Vec<_> = first.entries().iter().map(|entry| entry.id()).collect();
+    let ids_2: Vec<_> = second.entries().iter().map(|entry| entry.id()).collect();
+
+    assert_eq!(ids_1, ids_2);
+}
+
+#[test]
+fn sizing_algorithm_entry_count_order_is_deterministic() {
+    let sizing_model = create_test_sizing_model();
+    let algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+
+    assert_eq!(
+        algorithm_model.entries().len(),
+        sizing_model.entries().len()
+    );
+    for (index, (algorithm_entry, sizing_entry)) in algorithm_model
+        .entries()
+        .iter()
+        .zip(sizing_model.entries())
+        .enumerate()
+    {
+        assert_eq!(algorithm_entry.order(), index);
+        assert_eq!(algorithm_entry.source_sizing_entry(), sizing_entry.id());
+    }
+}
+
+#[test]
+fn sizing_algorithm_kind_state_metadata_is_inert_pass_through_deferred() {
+    let algorithm_model = create_test_algorithm_model();
+
+    for entry in algorithm_model.entries() {
+        assert_eq!(entry.kind(), UiLayoutSizingAlgorithmKind::PassThrough);
+        assert_eq!(entry.state(), UiLayoutSizingAlgorithmState::Deferred);
+    }
+}
+
+#[test]
+fn source_layout_model_reference_is_preserved() {
+    let layout_model = create_test_layout_model();
+    let sizing_model = build_layout_sizing(&layout_model);
+
+    let algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+    assert_eq!(algorithm_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        algorithm_model.source_geometry_model(),
+        build_layout_geometry(&layout_model).id()
+    );
+    assert_eq!(
+        algorithm_model.source_constraints_model(),
+        build_layout_constraints(&layout_model).id()
+    );
+    assert_eq!(algorithm_model.source_sizing_model(), sizing_model.id());
+}
+
+#[test]
+fn source_layout_geometry_constraints_sizing_references_are_preserved_where_exposed() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = build_layout_geometry(&layout_model);
+    let constraints_model = build_layout_constraints(&layout_model);
+    let sizing_model = build_layout_sizing(&layout_model);
+
+    let algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+    for ((((algorithm_entry, layout_node), geometry_node), declaration), sizing_entry) in
+        algorithm_model
+            .entries()
+            .iter()
+            .zip(layout_model.nodes())
+            .zip(geometry_model.nodes())
+            .zip(constraints_model.declarations())
+            .zip(sizing_model.entries())
+    {
+        assert_eq!(algorithm_entry.source_layout_node(), layout_node.id());
+        assert_eq!(algorithm_entry.source_layout_slot(), layout_node.slot());
+        assert_eq!(algorithm_entry.source_geometry_node(), geometry_node.id());
+        assert_eq!(
+            algorithm_entry.source_constraint_declaration(),
+            declaration.id()
+        );
+        assert_eq!(algorithm_entry.source_sizing_entry(), sizing_entry.id());
+        assert_eq!(
+            algorithm_entry.source_render_node(),
+            layout_node.source_render_node()
+        );
+        assert_eq!(
+            algorithm_entry.source_projection_node(),
+            layout_node.source_projection_node()
+        );
+        assert_eq!(
+            algorithm_entry.source_ir_node(),
+            layout_node.source_ir_node()
+        );
+    }
+}
+
+#[test]
+fn no_input_mutation() {
+    let layout_model = create_test_layout_model();
+    let expected_layout = layout_model.clone();
+    let sizing_model = build_layout_sizing(&layout_model);
+    let expected_sizing = sizing_model.clone();
+
+    let _algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+
+    assert_eq!(layout_model, expected_layout);
+    assert_eq!(sizing_model, expected_sizing);
+}
+
+#[test]
+fn sizing_algorithm_seed_does_not_expose_measuring_size_to_fit_intrinsic_content_measurement_authority(
+) {
+    let algorithm_model = create_test_algorithm_model();
+
+    assert!(!algorithm_model.is_empty());
+    assert_eq!(
+        algorithm_model.entries()[0].kind(),
+        UiLayoutSizingAlgorithmKind::PassThrough
+    );
+    assert_eq!(
+        algorithm_model.entries()[0].state(),
+        UiLayoutSizingAlgorithmState::Deferred
+    );
+}
+
+#[test]
+fn sizing_algorithm_seed_does_not_expose_constraint_solver_constraint_satisfaction_or_layout_solving_authority(
+) {
+    let algorithm_model = create_test_algorithm_model();
+
+    assert_eq!(algorithm_model.entries().len(), 2);
+    assert_eq!(algorithm_model.entries()[0].source_sizing_entry().raw(), 1);
+    assert_eq!(algorithm_model.entries()[1].source_sizing_entry().raw(), 2);
+}
+
+#[test]
+fn sizing_algorithm_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority(
+) {
+    let algorithm_model = create_test_algorithm_model();
+
+    assert_eq!(algorithm_model.entries()[0].source_layout_node().raw(), 1);
+    assert_eq!(algorithm_model.entries()[1].source_layout_node().raw(), 2);
+}
+
+#[test]
+fn sizing_algorithm_seed_entrypoint_signature_is_locked() {
+    let sizing_model = create_test_sizing_model();
+    let f: fn(&prom_ui::layout::UiLayoutSizingModel) -> UiLayoutSizingAlgorithmModel =
+        build_layout_sizing_algorithm;
+    let algorithm_model = f(&sizing_model);
+
+    assert_eq!(algorithm_model.source_sizing_model(), sizing_model.id());
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Sizing Algorithm Seed.

This source seed introduces a minimal deterministic renderer-local sizing metadata derivation substrate.

## Scope

Adds:

- minimal sizing algorithm model
- minimal sizing algorithm entry
- deterministic sizing algorithm model/entry identity
- inert algorithm kind/state metadata
- read-only source layout/geometry/constraints/sizing references where exposed
- focused tests proving determinism, inertness, and non-authority

## Explicit non-scope

- no measuring algorithm
- no size-to-fit behavior
- no intrinsic/content size calculation
- no glyph/text/image/widget measurement
- no constraint solver
- no constraint satisfaction algorithm
- no layout solving
- no layout engine rewrite
- no draw commands
- no event dispatch
- no backend/WGPU/winit/Tauri
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #1013

Validation

Local only:

git diff --check: <PASS/FAIL>
cargo fmt --check: <PASS/FAIL>
cargo test -p prom-ui --lib: <PASS/FAIL>
cargo test -p prom-ui: <PASS/FAIL>
tracked pr_body files: NO
GitHub CI used as evidence: NO

Final status

PASS — R12 UI RENDERER LAYOUT SIZING ALGORITHM SEED SOURCE CLEAN
```
