### PR TITLE
docs(ui): close out renderer layout measuring boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_measuring_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_measuring_boundary_closeout.md
@@ -1,0 +1,158 @@
+# R12 UI Renderer Layout Measuring Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Measuring Boundary line after the boundary PR.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: docs/dna/SEMANTIC_UI_DNA.md; docs/DNA.md
+docs/dna directory present: YES
+docs/DNA.md present: YES
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- geometry seed remains inert renderer-local metadata;
+- constraints seed remains inert renderer-local metadata declarations;
+- sizing seed remains inert renderer-local metadata/result declarations;
+- sizing algorithm seed remains deterministic renderer-local metadata derivation substrate;
+- measuring boundary remains planning/documentation only;
+- no measuring source implementation;
+- no text/glyph/image/widget measurement;
+- no font/backend/GPU measurement;
+- no WGPU/winit/Tauri measurement;
+- no size-to-fit implementation;
+- no intrinsic/content size calculation as executable behavior;
+- no constraint solver implementation;
+- no constraint satisfaction implementation;
+- no layout solving implementation;
+- no draw/event/backend authority;
+- no runtime/verifier/VM/capability authority;
+- no proof/debugger authority;
+- no Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+- #1018 — roadmap selected measuring boundary
+- #1019 — layout measuring boundary document
+
+## 4. Implemented State
+Implemented:
+- measuring boundary document;
+- measuring pipeline position;
+- allowed future measuring input categories;
+- allowed future measuring output categories;
+- conceptual future measuring categories;
+- explicit separation from text/glyph/image/widget measurement;
+- explicit separation from font/backend/GPU authority;
+- explicit separation from size-to-fit;
+- explicit separation from constraint solver;
+- explicit separation from layout solving;
+- explicit non-authority rules;
+- deferred measuring source gate.
+
+## 5. Deferred State
+Deferred:
+- measuring source implementation;
+- measuring structs/IDs/functions/tests;
+- text measurement;
+- glyph measurement;
+- image measurement;
+- widget measurement;
+- font system integration;
+- backend/GPU measurement;
+- WGPU/winit/Tauri measurement;
+- size-to-fit behavior;
+- intrinsic/content size calculation as executable behavior;
+- constraint solver;
+- constraint satisfaction algorithm;
+- layout solving;
+- layout engine rewrite;
+- geometry mutation;
+- sizing metadata mutation;
+- constraint mutation;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+This closeout does not admit measuring authority, text/glyph/image/widget measurement authority, font/backend/GPU authority, size-to-fit authority, intrinsic/content size calculation as executable behavior, constraint solver authority, constraint satisfaction authority, or layout solving authority.
+
+## 7. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Measuring boundary | Documented | ADMITTED | PASS |
+| Measuring implementation | Not implemented | DEFERRED | PASS |
+| Measuring seed | Future package only | DEFERRED | PASS |
+| Text measurement | Not implemented | FORBIDDEN | PASS |
+| Glyph measurement | Not implemented | FORBIDDEN | PASS |
+| Image measurement | Not implemented | FORBIDDEN | PASS |
+| Widget measurement | Not implemented | FORBIDDEN | PASS |
+| Font system integration | Not implemented | FORBIDDEN | PASS |
+| Backend/GPU measurement | Not implemented | FORBIDDEN | PASS |
+| WGPU/winit/Tauri | Not implemented | FORBIDDEN | PASS |
+| Size-to-fit behavior | Not implemented | FORBIDDEN | PASS |
+| Intrinsic/content size calculation | Not implemented | FORBIDDEN | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Constraint satisfaction | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Layout engine rewrite | Not implemented | FORBIDDEN | PASS |
+| Geometry mutation | Not implemented | FORBIDDEN | PASS |
+| Sizing metadata mutation | Not implemented | FORBIDDEN | PASS |
+| Constraint mutation | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future deterministic measuring metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current measuring source | absent | DEFERRED | PASS |
+| text/glyph/image/widget measurement | forbidden | FORBIDDEN | PASS |
+| font/backend/GPU measurement | forbidden | FORBIDDEN | PASS |
+| WGPU/winit/Tauri measurement | forbidden | FORBIDDEN | PASS |
+| size-to-fit behavior | forbidden | FORBIDDEN | PASS |
+| intrinsic/content size calculation | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| layout engine rewrite | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+Project #2 item is Done for the boundary PR.
+
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #1019
+
+## 10. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-MEASURING-BOUNDARY-LEDGER-AUDIT-PR
+
+## 11. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Measuring Boundary is complete as a docs-only boundary artifact.
+
+It defines future measuring work only as a separately gated deterministic renderer-local metadata acquisition layer and does not implement measuring source, text/glyph/image/widget measurement, font/backend/GPU measurement, size-to-fit behavior, intrinsic/content size calculation as executable behavior, constraint solver behavior, constraint satisfaction, layout solving, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, and not merged.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Measuring Boundary line.

This is a docs-only closeout after the measuring boundary PR.

## Scope

Records:

- measuring boundary document
- measuring position in layout pipeline
- allowed future input categories
- allowed future output categories
- conceptual future measuring categories
- explicit separation from text/glyph/image/widget measurement
- explicit separation from font/backend/GPU authority
- explicit separation from size-to-fit, solver, and layout solving
- explicit non-authority rules
- deferred measuring source gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no measuring source implementation
- no text/glyph/image/widget measurement
- no font/backend/GPU measurement
- no size-to-fit behavior
- no intrinsic/content size calculation
- no constraint solver
- no constraint satisfaction
- no layout solving
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1019
```

## Validation

Local only:

- git diff --check: <PASS/FAIL>
- cargo fmt --check: <PASS/FAIL>
- cargo test -p prom-ui --lib: <PASS/FAIL>
- cargo test -p prom-ui: <PASS/FAIL>
- tracked pr_body files: NO
- GitHub CI used as evidence: NO

## Final decision

CLOSED — R12 UI Renderer Layout Measuring Boundary is complete as a docs-only boundary artifact.
