### PR TITLE
docs(ui): close out renderer layout size-to-fit boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_boundary_closeout.md
@@ -1,0 +1,169 @@
+# R12 UI Renderer Layout Size-to-Fit Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Size-to-Fit Boundary line.
+
+## 2. DNA Alignment
+- DNA inspected: YES
+- DNA source path: `docs/dna/SEMANTIC_UI_DNA.md`
+- docs/dna directory present: YES
+- docs/DNA.md present: NO
+- DNA conflicts detected: NONE
+- DNA-driven constraints applied:
+  - renderer/UI remains downstream;
+  - layout metadata stack remains renderer-local;
+  - geometry seed remains inert renderer-local metadata;
+  - constraints seed remains inert renderer-local metadata declarations;
+  - sizing seed remains inert renderer-local metadata/result declarations;
+  - sizing algorithm seed remains deterministic renderer-local metadata derivation substrate;
+  - measuring boundary remains docs-only and audited;
+  - measuring seed remains deterministic renderer-local measurement metadata/request substrate;
+  - metadata stack consolidation audit is complete;
+  - size-to-fit boundary remains docs-only;
+  - size-to-fit boundary must not introduce size-to-fit source;
+  - size-to-fit boundary must not introduce fit/fill/shrink/grow behavior;
+  - size-to-fit boundary must not introduce intrinsic/content size calculation as executable behavior;
+  - size-to-fit boundary must not introduce real measuring;
+  - size-to-fit boundary must not introduce font/backend/GPU/WGPU/winit/Tauri authority;
+  - size-to-fit boundary must not introduce constraint solver authority;
+  - size-to-fit boundary must not introduce constraint satisfaction authority;
+  - size-to-fit boundary must not introduce layout solving;
+  - size-to-fit boundary must not introduce geometry/layout/sizing/constraints/measuring mutation;
+  - size-to-fit boundary must not introduce draw/event/backend authority;
+  - size-to-fit boundary must not introduce runtime/verifier/VM/capability authority;
+  - size-to-fit boundary must not introduce proof/debugger authority;
+  - size-to-fit boundary must not introduce Workbench/Studio integration.
+
+## 3. Closed Boundary PR
+- #1029 — layout size-to-fit boundary
+
+## 4. Implemented State
+Implemented:
+- size-to-fit boundary document;
+- size-to-fit pipeline position;
+- allowed future size-to-fit input categories;
+- allowed future size-to-fit output categories;
+- conceptual future size-to-fit categories;
+- explicit separation from real measuring;
+- explicit separation from intrinsic/content size calculation;
+- explicit separation from constraint solver;
+- explicit separation from layout solving;
+- explicit separation from metadata mutation;
+- explicit non-authority rules;
+- deferred size-to-fit source gate.
+
+## 5. Deferred State
+Deferred:
+- size-to-fit source implementation;
+- size-to-fit structs/IDs/functions/tests;
+- fit/fill/shrink/grow behavior;
+- intrinsic/content size calculation as executable behavior;
+- real text measurement;
+- real glyph measurement;
+- real image measurement;
+- real widget measurement;
+- font system integration;
+- backend/GPU measurement;
+- WGPU/winit/Tauri measurement;
+- constraint solver;
+- constraint satisfaction algorithm;
+- layout solving;
+- layout engine rewrite;
+- geometry mutation;
+- layout mutation;
+- sizing metadata mutation;
+- constraint mutation;
+- measuring mutation;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 6. Non-Authority Confirmation
+This boundary does not implement size-to-fit source, fit/fill/shrink/grow behavior, intrinsic/content size calculation as executable behavior, real text/glyph/image/widget measurement, font/backend/GPU measurement, WGPU/winit/Tauri measurement, constraint solver behavior, constraint satisfaction, layout solving, layout engine rewrite, geometry/layout/sizing/constraints/measuring mutation, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+## 7. Evidence Matrix
+| Area | Current state | Classification | Status |
+|---|---|---|---|
+| Size-to-fit boundary | Documented | ADMITTED | PASS |
+| Size-to-fit implementation | Not implemented | DEFERRED | PASS |
+| Size-to-fit seed | Future package only | DEFERRED | PASS |
+| Fit/fill/shrink/grow behavior | Not implemented | FORBIDDEN | PASS |
+| Intrinsic/content size calculation | Not implemented | FORBIDDEN | PASS |
+| Real text measurement | Not implemented | FORBIDDEN | PASS |
+| Real glyph measurement | Not implemented | FORBIDDEN | PASS |
+| Real image measurement | Not implemented | FORBIDDEN | PASS |
+| Real widget measurement | Not implemented | FORBIDDEN | PASS |
+| Font system integration | Not implemented | FORBIDDEN | PASS |
+| Backend/GPU measurement | Not implemented | FORBIDDEN | PASS |
+| WGPU/winit/Tauri | Not implemented | FORBIDDEN | PASS |
+| Constraint solver | Not implemented | FORBIDDEN | PASS |
+| Constraint satisfaction | Not implemented | FORBIDDEN | PASS |
+| Layout solving | Not implemented | FORBIDDEN | PASS |
+| Layout engine rewrite | Not implemented | FORBIDDEN | PASS |
+| Geometry mutation | Not implemented | FORBIDDEN | PASS |
+| Layout mutation | Not implemented | FORBIDDEN | PASS |
+| Sizing metadata mutation | Not implemented | FORBIDDEN | PASS |
+| Constraint mutation | Not implemented | FORBIDDEN | PASS |
+| Measuring mutation | Not implemented | FORBIDDEN | PASS |
+| Draw/render backend | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Action execution | Not implemented | FORBIDDEN | PASS |
+| Effect authorization | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Proof/debugger authority | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Dependency additions | None | FORBIDDEN | PASS |
+
+## 8. Admission Guard Table
+| Surface | Boundary status | Admission classification | Status |
+|---|---|---|---|
+| future deterministic size-to-fit metadata | allowed only after source gate | ADMITTED FUTURE | PASS |
+| current size-to-fit source | absent | DEFERRED | PASS |
+| fit/fill/shrink/grow behavior | forbidden | FORBIDDEN | PASS |
+| intrinsic/content size calculation | forbidden | FORBIDDEN | PASS |
+| real text/glyph/image/widget measurement | forbidden | FORBIDDEN | PASS |
+| font/backend/GPU measurement | forbidden | FORBIDDEN | PASS |
+| WGPU/winit/Tauri measurement | forbidden | FORBIDDEN | PASS |
+| constraint solver | forbidden | FORBIDDEN | PASS |
+| constraint satisfaction | forbidden | FORBIDDEN | PASS |
+| layout solving | forbidden | FORBIDDEN | PASS |
+| layout engine rewrite | forbidden | FORBIDDEN | PASS |
+| geometry/layout/sizing/constraints/measuring mutation | forbidden | FORBIDDEN | PASS |
+| draw commands | forbidden | FORBIDDEN | PASS |
+| backend API | forbidden | FORBIDDEN | PASS |
+| event handlers | forbidden | FORBIDDEN | PASS |
+| runtime/verifier/VM | forbidden | FORBIDDEN | PASS |
+| capability admission | forbidden | FORBIDDEN | PASS |
+| semantic truth authority | forbidden | FORBIDDEN | PASS |
+| proof/debugger authority | forbidden | FORBIDDEN | PASS |
+
+## 9. Project #2 State
+- Project #2 item for this lane: pending creation under `#1029`
+- Current verified related item:
+  - `#1029` Done | POST-UI | R12 | Docs | High | Renderer | Docs-only | Roadmap doc | `#1028`
+
+## 10. Untracked Workspace Artifacts
+Untracked workspace artifacts are treated as local-only, non-merged artifacts.
+They must not be staged, committed, deleted, or merged by this closeout PR.
+
+Known artifacts:
+
+- `.claude/`
+- `examples/baseline/`
+- `scratch/`
+
+## 11. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-SIZE-TO-FIT-BOUNDARY-LEDGER-AUDIT-PR
+
+## 12. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Size-to-Fit Boundary is complete as a docs-only boundary artifact.
+
+It defines future size-to-fit work only as a separately gated deterministic renderer-local metadata interpretation layer and does not implement size-to-fit source, fit/fill/shrink/grow behavior, intrinsic/content size calculation as executable behavior, real text/glyph/image/widget measurement, font/backend/GPU measurement, WGPU/winit/Tauri measurement, constraint solver behavior, constraint satisfaction, layout solving, layout engine rewrite, geometry/layout/sizing/constraints/measuring mutation, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, not deleted, and not merged.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Size-to-Fit Boundary line.

This is a docs-only closeout after the size-to-fit boundary PR.

## Scope

Records:

- size-to-fit boundary document
- size-to-fit position in layout pipeline
- allowed future input categories
- allowed future output categories
- conceptual future size-to-fit categories
- explicit separation from real measuring
- explicit separation from intrinsic/content size calculation
- explicit separation from solver, layout solving, and metadata mutation
- explicit non-authority rules
- deferred size-to-fit source gate
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no size-to-fit source implementation
- no fit/fill/shrink/grow behavior
- no intrinsic/content size calculation
- no real measuring
- no constraint solver
- no constraint satisfaction
- no layout solving
- no geometry/layout/sizing/constraints/measuring mutation
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1029
```

## Validation

Local only:

- git diff --check: <PASS/FAIL>
- cargo fmt --check: <PASS/FAIL>
- cargo test -p prom-ui --lib: <PASS/FAIL>
- cargo test -p prom-ui: <PASS/FAIL>
- tracked pr_body files: NO
- GitHub CI used as evidence: NO

## Final decision

CLOSED — R12 UI Renderer Layout Size-to-Fit Boundary is complete as a docs-only boundary artifact.
