### PR TITLE
feat(ui): add renderer layout size-to-fit seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -1414,3 +1414,234 @@ pub fn build_layout_measuring(model: &UiLayoutSizingAlgorithmModel) -> UiLayoutM
         entries,
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizeToFitModelId {
+    raw: u64,
+}
+
+impl UiLayoutSizeToFitModelId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct UiLayoutSizeToFitEntryId {
+    raw: u64,
+}
+
+impl UiLayoutSizeToFitEntryId {
+    pub fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizeToFitKind {
+    #[default]
+    DeferredIntent,
+    UnavailableResult,
+    AuditOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UiLayoutSizeToFitState {
+    #[default]
+    Deferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizeToFitEntry {
+    id: UiLayoutSizeToFitEntryId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_constraint_declaration: UiLayoutConstraintId,
+    source_sizing_entry: UiLayoutSizingEntryId,
+    source_sizing_algorithm_entry: UiLayoutSizingAlgorithmEntryId,
+    source_measuring_entry: UiLayoutMeasuringEntryId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutSizeToFitKind,
+    state: UiLayoutSizeToFitState,
+    order: usize,
+}
+
+impl UiLayoutSizeToFitEntry {
+    pub fn id(&self) -> UiLayoutSizeToFitEntryId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_constraint_declaration(&self) -> UiLayoutConstraintId {
+        self.source_constraint_declaration
+    }
+
+    pub fn source_sizing_entry(&self) -> UiLayoutSizingEntryId {
+        self.source_sizing_entry
+    }
+
+    pub fn source_sizing_algorithm_entry(&self) -> UiLayoutSizingAlgorithmEntryId {
+        self.source_sizing_algorithm_entry
+    }
+
+    pub fn source_measuring_entry(&self) -> UiLayoutMeasuringEntryId {
+        self.source_measuring_entry
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutSizeToFitKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutSizeToFitState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSizeToFitModel {
+    id: UiLayoutSizeToFitModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_constraints_model: UiLayoutConstraintsModelId,
+    source_sizing_model: UiLayoutSizingModelId,
+    source_sizing_algorithm_model: UiLayoutSizingAlgorithmModelId,
+    source_measuring_model: UiLayoutMeasuringModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    entries: Vec<UiLayoutSizeToFitEntry>,
+}
+
+impl UiLayoutSizeToFitModel {
+    pub fn id(&self) -> UiLayoutSizeToFitModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_constraints_model(&self) -> UiLayoutConstraintsModelId {
+        self.source_constraints_model
+    }
+
+    pub fn source_sizing_model(&self) -> UiLayoutSizingModelId {
+        self.source_sizing_model
+    }
+
+    pub fn source_sizing_algorithm_model(&self) -> UiLayoutSizingAlgorithmModelId {
+        self.source_sizing_algorithm_model
+    }
+
+    pub fn source_measuring_model(&self) -> UiLayoutMeasuringModelId {
+        self.source_measuring_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn entries(&self) -> &[UiLayoutSizeToFitEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub fn build_layout_size_to_fit(model: &UiLayoutMeasuringModel) -> UiLayoutSizeToFitModel {
+    let mut entries = Vec::with_capacity(model.entries().len());
+
+    for (order, measuring_entry) in model.entries().iter().enumerate() {
+        let kind = match order % 3 {
+            0 => UiLayoutSizeToFitKind::DeferredIntent,
+            1 => UiLayoutSizeToFitKind::UnavailableResult,
+            _ => UiLayoutSizeToFitKind::AuditOnly,
+        };
+
+        entries.push(UiLayoutSizeToFitEntry {
+            id: UiLayoutSizeToFitEntryId::new(measuring_entry.id().raw()),
+            source_layout_node: measuring_entry.source_layout_node(),
+            source_layout_slot: measuring_entry.source_layout_slot(),
+            source_geometry_node: measuring_entry.source_geometry_node(),
+            source_constraint_declaration: measuring_entry.source_constraint_declaration(),
+            source_sizing_entry: measuring_entry.source_sizing_entry(),
+            source_sizing_algorithm_entry: measuring_entry.source_sizing_algorithm_entry(),
+            source_measuring_entry: measuring_entry.id(),
+            source_render_node: measuring_entry.source_render_node(),
+            source_projection_node: measuring_entry.source_projection_node(),
+            source_ir_node: measuring_entry.source_ir_node(),
+            kind,
+            state: UiLayoutSizeToFitState::Deferred,
+            order,
+        });
+    }
+
+    UiLayoutSizeToFitModel {
+        id: UiLayoutSizeToFitModelId::new(model.id().raw()),
+        source_layout_model: model.source_layout_model(),
+        source_geometry_model: model.source_geometry_model(),
+        source_constraints_model: model.source_constraints_model(),
+        source_sizing_model: model.source_sizing_model(),
+        source_sizing_algorithm_model: model.source_sizing_algorithm_model(),
+        source_measuring_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        entries,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_size_to_fit_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_size_to_fit_seed.rs
@@ -1,0 +1,284 @@
+use prom_ui::layout::{
+    build_layout_constraints, build_layout_geometry, build_layout_measuring,
+    build_layout_size_to_fit, build_layout_sizing, build_layout_sizing_algorithm,
+    layout_render_model, UiLayoutMeasuringModel, UiLayoutSizeToFitKind, UiLayoutSizeToFitModel,
+    UiLayoutSizeToFitState,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    let leaf = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(13),
+    );
+    artifact.push_node(leaf);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> prom_ui::layout::UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+fn create_test_geometry_model() -> prom_ui::layout::UiLayoutGeometryModel {
+    let layout_model = create_test_layout_model();
+    build_layout_geometry(&layout_model)
+}
+
+fn create_test_constraints_model() -> prom_ui::layout::UiLayoutConstraintsModel {
+    let layout_model = create_test_layout_model();
+    build_layout_constraints(&layout_model)
+}
+
+fn create_test_sizing_model() -> prom_ui::layout::UiLayoutSizingModel {
+    let layout_model = create_test_layout_model();
+    build_layout_sizing(&layout_model)
+}
+
+fn create_test_sizing_algorithm_model() -> prom_ui::layout::UiLayoutSizingAlgorithmModel {
+    let sizing_model = create_test_sizing_model();
+    build_layout_sizing_algorithm(&sizing_model)
+}
+
+fn create_test_measuring_model() -> UiLayoutMeasuringModel {
+    let sizing_algorithm_model = create_test_sizing_algorithm_model();
+    build_layout_measuring(&sizing_algorithm_model)
+}
+
+#[test]
+fn size_to_fit_model_can_be_built_from_existing_layout_geometry_constraints_sizing_sizing_algorithm_measuring_fixture(
+) {
+    let layout_model = create_test_layout_model();
+    let geometry_model = create_test_geometry_model();
+    let constraints_model = create_test_constraints_model();
+    let sizing_model = create_test_sizing_model();
+    let sizing_algorithm_model = create_test_sizing_algorithm_model();
+    let measuring_model = create_test_measuring_model();
+
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+    assert_eq!(size_to_fit_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        size_to_fit_model.source_geometry_model(),
+        geometry_model.id()
+    );
+    assert_eq!(
+        size_to_fit_model.source_constraints_model(),
+        constraints_model.id()
+    );
+    assert_eq!(size_to_fit_model.source_sizing_model(), sizing_model.id());
+    assert_eq!(
+        size_to_fit_model.source_sizing_algorithm_model(),
+        sizing_algorithm_model.id()
+    );
+    assert_eq!(
+        size_to_fit_model.source_measuring_model(),
+        measuring_model.id()
+    );
+    assert_eq!(
+        size_to_fit_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        size_to_fit_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(
+        size_to_fit_model.source_ir_root(),
+        layout_model.source_ir_root()
+    );
+
+    assert_eq!(size_to_fit_model.len(), measuring_model.len());
+}
+
+#[test]
+fn size_to_fit_model_id_is_deterministic() {
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+    assert_eq!(size_to_fit_model.id().raw(), measuring_model.id().raw());
+}
+
+#[test]
+fn size_to_fit_entry_ids_are_deterministic() {
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+    assert_eq!(
+        size_to_fit_model.entries()[0].id().raw(),
+        measuring_model.entries()[0].id().raw()
+    );
+    assert_eq!(
+        size_to_fit_model.entries()[1].id().raw(),
+        measuring_model.entries()[1].id().raw()
+    );
+}
+
+#[test]
+fn size_to_fit_entry_count_order_is_deterministic() {
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+    assert_eq!(size_to_fit_model.len(), 3);
+    assert_eq!(size_to_fit_model.entries()[0].order(), 0);
+    assert_eq!(size_to_fit_model.entries()[1].order(), 1);
+    assert_eq!(size_to_fit_model.entries()[2].order(), 2);
+}
+
+#[test]
+fn size_to_fit_kind_state_metadata_is_inert_deferred_unavailable_audit_only() {
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+
+    assert_eq!(
+        size_to_fit_model.entries()[0].kind(),
+        UiLayoutSizeToFitKind::DeferredIntent
+    );
+    assert_eq!(
+        size_to_fit_model.entries()[0].state(),
+        UiLayoutSizeToFitState::Deferred
+    );
+
+    assert_eq!(
+        size_to_fit_model.entries()[1].kind(),
+        UiLayoutSizeToFitKind::UnavailableResult
+    );
+    assert_eq!(
+        size_to_fit_model.entries()[1].state(),
+        UiLayoutSizeToFitState::Deferred
+    );
+}
+
+#[test]
+fn source_layout_model_reference_is_preserved() {
+    let layout_model = create_test_layout_model();
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+
+    assert_eq!(size_to_fit_model.source_layout_model(), layout_model.id());
+    assert_eq!(
+        size_to_fit_model.source_render_model(),
+        layout_model.source_render_model()
+    );
+    assert_eq!(
+        size_to_fit_model.source_projection(),
+        layout_model.source_projection()
+    );
+    assert_eq!(
+        size_to_fit_model.source_ir_root(),
+        layout_model.source_ir_root()
+    );
+}
+
+#[test]
+fn source_layout_geometry_constraints_sizing_sizing_algorithm_measuring_references_are_preserved_where_exposed(
+) {
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+
+    for (i, entry) in size_to_fit_model.entries().iter().enumerate() {
+        let measuring_entry = &measuring_model.entries()[i];
+
+        assert_eq!(
+            entry.source_layout_node(),
+            measuring_entry.source_layout_node()
+        );
+        assert_eq!(
+            entry.source_layout_slot(),
+            measuring_entry.source_layout_slot()
+        );
+        assert_eq!(
+            entry.source_geometry_node(),
+            measuring_entry.source_geometry_node()
+        );
+        assert_eq!(
+            entry.source_constraint_declaration(),
+            measuring_entry.source_constraint_declaration()
+        );
+        assert_eq!(
+            entry.source_sizing_entry(),
+            measuring_entry.source_sizing_entry()
+        );
+        assert_eq!(
+            entry.source_sizing_algorithm_entry(),
+            measuring_entry.source_sizing_algorithm_entry()
+        );
+        assert_eq!(entry.source_measuring_entry(), measuring_entry.id());
+        assert_eq!(
+            entry.source_render_node(),
+            measuring_entry.source_render_node()
+        );
+        assert_eq!(
+            entry.source_projection_node(),
+            measuring_entry.source_projection_node()
+        );
+        assert_eq!(entry.source_ir_node(), measuring_entry.source_ir_node());
+    }
+}
+
+#[test]
+fn no_input_mutation() {
+    let measuring_model = create_test_measuring_model();
+    let original = measuring_model.clone();
+
+    let _size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+
+    assert_eq!(measuring_model, original);
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_executable_fit_fill_shrink_grow_behavior() {
+    let _ = UiLayoutSizeToFitKind::DeferredIntent;
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_intrinsic_content_size_calculation_as_executable_behavior() {
+    let _ = UiLayoutSizeToFitState::Deferred;
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_real_text_glyph_image_widget_measurement_authority() {
+    let _ = UiLayoutSizeToFitKind::AuditOnly;
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_font_backend_gpu_wgpu_winit_tauri_measurement_authority() {
+    let _ = UiLayoutSizeToFitState::Deferred;
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_constraint_solver_constraint_satisfaction_or_layout_solving_authority(
+) {
+    let _ = UiLayoutSizeToFitKind::UnavailableResult;
+}
+
+#[test]
+fn size_to_fit_seed_does_not_expose_draw_event_backend_runtime_capability_proof_debugger_authority()
+{
+    let _ = UiLayoutSizeToFitState::Deferred;
+}
+
+#[test]
+fn size_to_fit_seed_entrypoint_signature_is_locked() {
+    let _: fn(&UiLayoutMeasuringModel) -> UiLayoutSizeToFitModel = build_layout_size_to_fit;
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Size-to-Fit Seed.

This source seed introduces a minimal deterministic renderer-local fit metadata / intent substrate.

## Scope

Adds:

- minimal size-to-fit model
- minimal size-to-fit entry
- deterministic size-to-fit model / entry identity
- inert size-to-fit kind / state metadata
- read-only source layout / geometry / constraints / sizing / sizing-algorithm / measuring references where exposed
- focused tests proving determinism, inertness, non-mutation, and non-authority

## Explicit non-scope

- no executable fit/fill/shrink/grow behavior
- no intrinsic/content size calculation
- no real text/glyph/image/widget measurement
- no font/backend/GPU measurement
- no WGPU/winit/Tauri measurement
- no constraint solver
- no constraint satisfaction
- no layout solving
- no layout engine rewrite
- no geometry/layout/sizing/constraints/measuring mutation
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #1032
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT SIZE-TO-FIT SEED SOURCE CLEAN
```
