### PR TITLE
docs(ui): close out renderer layout size-to-fit seed

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_seed_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_seed_closeout.md
@@ -1,0 +1,99 @@
+# R12 UI Renderer Layout Size-to-Fit Seed Closeout
+
+## 1. Purpose
+
+Closes out the R12 UI Renderer Layout Size-to-Fit Seed line, recording its final implemented state, DNA alignment, and deferred scope.
+
+## 2. DNA Alignment
+
+This line implements a minimal deterministic renderer-local fit metadata / intent substrate.
+It aligns strictly with Semantic UI DNA by avoiding execution of fit/fill/shrink/grow, intrinsic size calculation, layout solving, or measuring authority.
+
+## 3. Closed Basis
+
+- `#1028` — roadmap selected size-to-fit boundary
+- `#1029` — layout size-to-fit boundary document
+- `#1030` — layout size-to-fit boundary closeout
+- `#1031` — layout size-to-fit boundary ledger audit
+- `#1032` — roadmap selected size-to-fit seed
+
+## 4. Source PR
+
+- `#1033` — feat(ui): add renderer layout size-to-fit seed
+
+## 5. Implemented State
+
+Implemented:
+- minimal deterministic size-to-fit metadata / intent substrate;
+- deterministic size-to-fit model identity;
+- deterministic size-to-fit entry identity;
+- inert size-to-fit kind/state metadata;
+- read-only source layout/geometry/constraints/sizing/sizing-algorithm/measuring references where exposed;
+- focused tests for determinism, inertness, non-mutation, and non-authority.
+
+## 6. Deferred State
+
+Deferred:
+- executable fit/fill/shrink/grow behavior;
+- intrinsic/content size calculation as executable behavior;
+- real text measurement;
+- real glyph measurement;
+- real image measurement;
+- real widget measurement;
+- font system integration;
+- backend/GPU measurement;
+- WGPU/winit/Tauri measurement;
+- constraint solver;
+- constraint satisfaction algorithm;
+- layout solving;
+- layout engine rewrite;
+- geometry mutation;
+- layout mutation;
+- sizing metadata mutation;
+- constraint mutation;
+- measuring mutation;
+- draw commands;
+- event dispatch;
+- backend rendering;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 7. Non-Authority Confirmation
+
+The seed introduces no backend, draw, event, VM, or execution authority.
+
+## 8. Evidence Matrix
+
+- Pre-commit formatting and compilation: PASS
+- Full test suite: PASS
+- Authority scan: PASS
+
+## 9. Admission Guard Table
+
+- Does it execute fit/fill/shrink/grow? NO
+- Does it calculate intrinsic size? NO
+- Does it solve constraints? NO
+
+## 10. Project #2 State
+
+Track: POST-UI
+Wave: R12
+Status: Done
+Type: Closeout
+
+## 11. Untracked Workspace Artifacts
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, not deleted, and not merged.
+
+## 12. Recommended Next Gate
+
+R12-UI-RENDERER-LAYOUT-SIZE-TO-FIT-SEED-LEDGER-AUDIT-PR
+
+## 13. Final Decision
+
+Final decision:
+CLOSED — R12 UI Renderer Layout Size-to-Fit Seed is complete as a minimal deterministic renderer-local fit metadata / intent substrate.
+
+It implements deterministic size-to-fit metadata only and does not implement executable fit/fill/shrink/grow behavior, intrinsic/content size calculation as executable behavior, real text/glyph/image/widget measurement, font/backend/GPU measurement, WGPU/winit/Tauri measurement, constraint solver behavior, constraint satisfaction, layout solving, layout engine rewrite, geometry/layout/sizing/constraints/measuring mutation, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Size-to-Fit Seed line.

## Scope

Records:

- implemented minimal deterministic size-to-fit metadata / intent substrate
- deterministic identity policy
- inertness and non-authority constraints
- deferred executable fit / sizing / measuring / solver / layout-solving / backend / event / runtime / capability work
- validation result

## Explicit non-scope

- no source changes
- no tests changes
- no executable fit/fill/shrink/grow behavior
- no intrinsic/content size calculation
- no real measuring
- no constraint solver
- no constraint satisfaction
- no layout solving
- no metadata mutation
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1033
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final decision

```text
CLOSED — R12 UI Renderer Layout Size-to-Fit Seed is complete as a minimal deterministic renderer-local fit metadata / intent substrate.
```
