### PR TITLE
docs(ui): add renderer layout size-to-fit seed ledger audit

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_seed_ledger_audit.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_size_to_fit_seed_ledger_audit.md
@@ -1,0 +1,243 @@
+# R12 UI Renderer Layout Size-to-Fit Seed Ledger Audit
+
+## 1. Purpose
+
+This document records the ledger audit for the R12 UI Renderer Layout Size-to-Fit Seed line after roadmap PR #1032, source PR #1033, and closeout PR #1034.
+
+## 2. DNA Alignment
+
+DNA inspected: YES
+DNA source path: docs/dna
+docs/dna directory present: YES
+docs/DNA.md present: NO
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout metadata stack remains renderer-local;
+- size-to-fit boundary remains docs-only and audited;
+- size-to-fit seed remains deterministic renderer-local fit metadata / intent substrate;
+- size-to-fit seed does not implement executable fit/fill/shrink/grow behavior;
+- size-to-fit seed does not implement intrinsic/content size calculation as executable behavior;
+- size-to-fit seed does not implement real text/glyph/image/widget measurement;
+- size-to-fit seed does not introduce font/backend/GPU/WGPU/winit/Tauri authority;
+- size-to-fit seed does not introduce constraint solver authority;
+- size-to-fit seed does not introduce constraint satisfaction authority;
+- size-to-fit seed does not introduce layout solving;
+- size-to-fit seed does not introduce geometry/layout/sizing/constraints/measuring mutation;
+- size-to-fit seed does not introduce draw/event/backend authority;
+- size-to-fit seed does not introduce runtime/verifier/VM/capability authority;
+- size-to-fit seed does not introduce proof/debugger authority;
+- size-to-fit seed does not introduce Workbench/Studio integration.
+
+## 3. Closed Basis
+
+#1032 — roadmap selected size-to-fit seed
+#1033 — layout size-to-fit seed source
+#1034 — layout size-to-fit seed closeout
+
+## 4. PR Ledger
+
+| PR | Title | State | Merge commit | Changed files | Classification | Status |
+|---|---|---|---|---|---|---|
+| #1032 | docs(ui): select next post-ui lane after layout size-to-fit boundary audit | MERGED | 4bf620e81b3e2e85d8771318218ade8638cd754c | 1 | ROADMAP | PASS |
+| #1033 | feat(ui): add renderer layout size-to-fit seed | MERGED | 1dd40a3e9682af9e6e422cdad0a65456dd77b54f | 2 | SOURCE | PASS |
+| #1034 | docs(ui): close out renderer layout size-to-fit seed | MERGED | 386193f3f87b878ac2367dc9eb27c5662abde984 | 1 | CLOSEOUT | PASS |
+
+## 5. Changed File Surface
+
+| PR | Changed files | Source changed | Tests changed | Docs changed | Manifest changed | Status |
+|---|---|---:|---:|---:|---:|---|
+| #1032 | 1 | NO | NO | YES | NO | PASS |
+| #1033 | 2 | YES | YES | NO | NO | PASS |
+| #1034 | 1 | NO | NO | YES | NO | PASS |
+
+## 6. Size-to-Fit Seed API Ledger
+
+| Area | Final state | Classification | Evidence | Status |
+|---|---|---|---|---|
+| size-to-fit model | implemented | IMPLEMENTED | layout.rs | PASS |
+| size-to-fit entry | implemented | IMPLEMENTED | layout.rs | PASS |
+| size-to-fit model ID | implemented | IMPLEMENTED | layout.rs | PASS |
+| size-to-fit entry ID | implemented | IMPLEMENTED | layout.rs | PASS |
+| size-to-fit kind metadata | implemented | INERT METADATA | layout.rs | PASS |
+| size-to-fit state metadata | implemented | INERT METADATA | layout.rs | PASS |
+| build entrypoint | implemented | IMPLEMENTED | layout.rs | PASS |
+| deterministic model ID | implemented | IMPLEMENTED | renderer_layout_size_to_fit_seed.rs | PASS |
+| deterministic entry IDs | implemented | IMPLEMENTED | renderer_layout_size_to_fit_seed.rs | PASS |
+| deterministic entry order/count | implemented | IMPLEMENTED | renderer_layout_size_to_fit_seed.rs | PASS |
+| source layout model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source layout node references | preserved | IMPLEMENTED | layout.rs | PASS |
+| source geometry model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source geometry node references | preserved | IMPLEMENTED | layout.rs | PASS |
+| source constraints model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source constraint declaration references | preserved | IMPLEMENTED | layout.rs | PASS |
+| source sizing model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source sizing entry references | preserved | IMPLEMENTED | layout.rs | PASS |
+| source sizing algorithm model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source sizing algorithm entry references | preserved | IMPLEMENTED | layout.rs | PASS |
+| source measuring model reference | preserved | IMPLEMENTED | layout.rs | PASS |
+| source measuring entry references | preserved | IMPLEMENTED | layout.rs | PASS |
+
+## 7. Behavior Ledger
+
+| Behavior | Final state | Classification | Status |
+|---|---|---|---|
+| input mutation | NOT DETECTED | ABSENT | PASS |
+| floating point computation | NOT DETECTED | ABSENT | PASS |
+| randomness | NOT DETECTED | ABSENT | PASS |
+| system time | NOT DETECTED | ABSENT | PASS |
+| global mutable state | NOT DETECTED | ABSENT | PASS |
+| executable fit/fill/shrink/grow behavior | NOT DETECTED | FORBIDDEN | PASS |
+| intrinsic/content size calculation | NOT DETECTED | FORBIDDEN | PASS |
+| real text/glyph/image/widget measurement | NOT DETECTED | FORBIDDEN | PASS |
+| font/backend/GPU measurement | NOT DETECTED | FORBIDDEN | PASS |
+| WGPU/winit/Tauri measurement | NOT DETECTED | FORBIDDEN | PASS |
+| constraint solver | NOT DETECTED | FORBIDDEN | PASS |
+| constraint satisfaction algorithm | NOT DETECTED | FORBIDDEN | PASS |
+| layout solving | NOT DETECTED | FORBIDDEN | PASS |
+| layout engine rewrite | NOT DETECTED | FORBIDDEN | PASS |
+| geometry mutation | NOT DETECTED | FORBIDDEN | PASS |
+| layout mutation | NOT DETECTED | FORBIDDEN | PASS |
+| sizing metadata mutation | NOT DETECTED | FORBIDDEN | PASS |
+| constraint mutation | NOT DETECTED | FORBIDDEN | PASS |
+| measuring mutation | NOT DETECTED | FORBIDDEN | PASS |
+| draw/event/backend | NOT DETECTED | FORBIDDEN | PASS |
+| runtime/verifier/VM | NOT DETECTED | FORBIDDEN | PASS |
+| capability admission | NOT DETECTED | FORBIDDEN | PASS |
+| proof/debugger authority | NOT DETECTED | FORBIDDEN | PASS |
+| Workbench/Studio | NOT DETECTED | FORBIDDEN | PASS |
+
+## 8. Test Coverage Ledger
+
+| Test area | Covered | Evidence | Status |
+|---|---:|---|---|
+| model build | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| deterministic model ID | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| deterministic entry IDs | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| deterministic order/count | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| kind/state inertness | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source layout preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source geometry preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source constraints preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source sizing preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source sizing algorithm preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| source measuring preservation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| input non-mutation | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| executable fit absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| intrinsic/content calculation absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| real measuring absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| font/backend/GPU authority absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| solver/layout-solving absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| draw/event/backend/runtime/capability absence | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+| public API signature lock | YES | renderer_layout_size_to_fit_seed.rs | PASS |
+
+## 9. Deferred Authority Ledger
+
+| Deferred area | Final state | Classification | Status |
+|---|---|---|---|
+| executable fit behavior | DEFERRED | ABSENT | PASS |
+| fill behavior | DEFERRED | ABSENT | PASS |
+| shrink behavior | DEFERRED | ABSENT | PASS |
+| grow behavior | DEFERRED | ABSENT | PASS |
+| intrinsic size calculation | DEFERRED | ABSENT | PASS |
+| content size calculation | DEFERRED | ABSENT | PASS |
+| real text measurement | DEFERRED | ABSENT | PASS |
+| real glyph measurement | DEFERRED | ABSENT | PASS |
+| real image measurement | DEFERRED | ABSENT | PASS |
+| real widget measurement | DEFERRED | ABSENT | PASS |
+| font system integration | DEFERRED | ABSENT | PASS |
+| backend/GPU measurement | DEFERRED | ABSENT | PASS |
+| WGPU/winit/Tauri measurement | DEFERRED | ABSENT | PASS |
+| constraint solver | DEFERRED | ABSENT | PASS |
+| constraint satisfaction algorithm | DEFERRED | ABSENT | PASS |
+| layout solving | DEFERRED | ABSENT | PASS |
+| layout engine rewrite | DEFERRED | ABSENT | PASS |
+| geometry/layout/sizing/constraints/measuring mutation | DEFERRED | ABSENT | PASS |
+| draw commands | DEFERRED | ABSENT | PASS |
+| event dispatch | DEFERRED | ABSENT | PASS |
+| backend rendering | DEFERRED | ABSENT | PASS |
+| runtime/verifier/VM integration | DEFERRED | ABSENT | PASS |
+| capability admission | DEFERRED | ABSENT | PASS |
+| proof/debugger authority | DEFERRED | ABSENT | PASS |
+| Workbench/Studio integration | DEFERRED | ABSENT | PASS |
+
+## 10. Project #2 Ledger
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on | Item count | Duplicate count |
+|---|---|---|---|---|---|---|---|---|---|---:|---:|
+| #1032 | Done | POST-UI | R12 | Roadmap | Medium | Renderer | Planning-only | Roadmap doc | #1031 | 1 | 0 |
+| #1033 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #1032 | 1 | 0 |
+| #1034 | Done | POST-UI | R12 | Closeout | Medium | Renderer | Release Artifact | Roadmap doc | #1033 | 1 | 0 |
+
+## 11. Forbidden Surface Ledger
+
+| Surface | Detected | Classification | Status |
+|---|---|---|---|
+| executable fit/fill/shrink/grow behavior | NO | ABSENT | PASS |
+| intrinsic/content size calculation | NO | ABSENT | PASS |
+| real text/glyph/image/widget measurement | NO | ABSENT | PASS |
+| font/backend/GPU measurement | NO | ABSENT | PASS |
+| WGPU/winit/Tauri | NO | ABSENT | PASS |
+| constraint solver | NO | ABSENT | PASS |
+| constraint satisfaction algorithm | NO | ABSENT | PASS |
+| layout solving | NO | ABSENT | PASS |
+| layout engine rewrite | NO | ABSENT | PASS |
+| geometry/layout/sizing/constraints/measuring mutation | NO | ABSENT | PASS |
+| draw/event/backend | NO | ABSENT | PASS |
+| runtime/verifier/VM | NO | ABSENT | PASS |
+| capability admission | NO | ABSENT | PASS |
+| action execution | NO | ABSENT | PASS |
+| effect authorization | NO | ABSENT | PASS |
+| proof/debugger authority | NO | ABSENT | PASS |
+| Workbench/Studio | NO | ABSENT | PASS |
+| Cargo.toml / Cargo.lock | NO | ABSENT | PASS |
+| dependency additions | NO | ABSENT | PASS |
+| tracked pr_body artifacts | NO | ABSENT | PASS |
+
+## 12. Manifest / Dependency Ledger
+
+Manifest drift detected: NO
+
+## 13. Local Validation
+
+Validation passed: YES
+
+## 14. Untracked Workspace Artifacts
+
+| Artifact | State | Classification | Merged | Status |
+|---|---|---|---:|---|
+| .claude/ | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+| examples/baseline/ | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+| scratch/ | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+
+## 15. Admission Guard Summary
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| size-to-fit seed source | IMPLEMENTED | ADMITTED INERT METADATA | PASS |
+| size-to-fit seed closeout | DOCUMENTED | ADMITTED | PASS |
+| executable fit/fill/shrink/grow behavior | ABSENT | FORBIDDEN | PASS |
+| intrinsic/content size calculation | ABSENT | FORBIDDEN | PASS |
+| real measuring | ABSENT | FORBIDDEN | PASS |
+| font/backend/GPU measurement | ABSENT | FORBIDDEN | PASS |
+| WGPU/winit/Tauri | ABSENT | FORBIDDEN | PASS |
+| constraint solver | ABSENT | FORBIDDEN | PASS |
+| constraint satisfaction | ABSENT | FORBIDDEN | PASS |
+| layout solving | ABSENT | FORBIDDEN | PASS |
+| metadata mutation | ABSENT | FORBIDDEN | PASS |
+| draw/event/backend | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| proof/debugger authority | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+| dependency additions | ABSENT | FORBIDDEN | PASS |
+
+## 16. Final Decision
+
+Final decision:
+PASS WITH WARNINGS — R12 UI Renderer Layout Size-to-Fit Seed ledger audit is clean for tracked repository state after roadmap PR #1032, source PR #1033, and closeout PR #1034.
+
+Warning:
+Pre-existing untracked local workspace artifacts remain present but were not staged, not committed, not deleted, and not merged.
+
+The size-to-fit seed line is complete as a minimal deterministic renderer-local fit metadata / intent substrate. It implements deterministic size-to-fit metadata only and does not implement executable fit/fill/shrink/grow behavior, intrinsic/content size calculation as executable behavior, real text/glyph/image/widget measurement, font/backend/GPU measurement, WGPU/winit/Tauri measurement, constraint solver behavior, constraint satisfaction, layout solving, layout engine rewrite, geometry/layout/sizing/constraints/measuring mutation, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Size-to-Fit Seed ledger audit.

This is a docs-only audit PR covering:

- #1032 — roadmap selected size-to-fit seed
- #1033 — layout size-to-fit seed source
- #1034 — layout size-to-fit seed closeout

## Scope

Audits:

- size-to-fit seed source API
- size-to-fit seed deterministic behavior
- size-to-fit seed test coverage
- changed file surfaces
- deferred authority state
- Project #2 metadata
- forbidden authority surface
- manifest/dependency drift
- untracked local workspace artifact classification
- local validation

## Explicit non-scope

- no source changes
- no test changes
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- no executable fit/fill/shrink/grow behavior
- no intrinsic/content size calculation
- no real text/glyph/image/widget measurement
- no font/backend/GPU measurement
- no WGPU/winit/Tauri measurement
- no constraint solver
- no constraint satisfaction
- no layout solving
- no metadata mutation
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Audit
Risk: Medium
Boundary: Renderer
Gate: FullPreflight
Evidence: Roadmap doc
Depends on: #1034
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS WITH WARNINGS — R12 UI RENDERER LAYOUT SIZE-TO-FIT SEED LEDGER AUDIT CLEAN FOR TRACKED REPOSITORY STATE
```
