### PR TITLE
feat(ui): add renderer layout constraint solver seed

### DIFF
--- a/crates/prom-ui/src/layout.rs
+++ b/crates/prom-ui/src/layout.rs
@@ -1645,3 +1645,243 @@ pub fn build_layout_size_to_fit(model: &UiLayoutMeasuringModel) -> UiLayoutSizeT
         entries,
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiLayoutConstraintSolverModelId(u64);
+
+impl UiLayoutConstraintSolverModelId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiLayoutConstraintSolverEntryId(u64);
+
+impl UiLayoutConstraintSolverEntryId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutConstraintSolverKind {
+    DeferredSolverIntent,
+    UnavailableSolverResult,
+    AuditOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutConstraintSolverState {
+    Deferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutConstraintSolverEntry {
+    id: UiLayoutConstraintSolverEntryId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_constraint_declaration: UiLayoutConstraintId,
+    source_sizing_entry: UiLayoutSizingEntryId,
+    source_sizing_algorithm_entry: UiLayoutSizingAlgorithmEntryId,
+    source_measuring_entry: UiLayoutMeasuringEntryId,
+    source_size_to_fit_entry: UiLayoutSizeToFitEntryId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutConstraintSolverKind,
+    state: UiLayoutConstraintSolverState,
+    order: usize,
+}
+
+impl UiLayoutConstraintSolverEntry {
+    pub fn id(&self) -> UiLayoutConstraintSolverEntryId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_constraint_declaration(&self) -> UiLayoutConstraintId {
+        self.source_constraint_declaration
+    }
+
+    pub fn source_sizing_entry(&self) -> UiLayoutSizingEntryId {
+        self.source_sizing_entry
+    }
+
+    pub fn source_sizing_algorithm_entry(&self) -> UiLayoutSizingAlgorithmEntryId {
+        self.source_sizing_algorithm_entry
+    }
+
+    pub fn source_measuring_entry(&self) -> UiLayoutMeasuringEntryId {
+        self.source_measuring_entry
+    }
+
+    pub fn source_size_to_fit_entry(&self) -> UiLayoutSizeToFitEntryId {
+        self.source_size_to_fit_entry
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutConstraintSolverKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutConstraintSolverState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutConstraintSolverModel {
+    id: UiLayoutConstraintSolverModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_constraints_model: UiLayoutConstraintsModelId,
+    source_sizing_model: UiLayoutSizingModelId,
+    source_sizing_algorithm_model: UiLayoutSizingAlgorithmModelId,
+    source_measuring_model: UiLayoutMeasuringModelId,
+    source_size_to_fit_model: UiLayoutSizeToFitModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    entries: Vec<UiLayoutConstraintSolverEntry>,
+}
+
+impl UiLayoutConstraintSolverModel {
+    pub fn id(&self) -> UiLayoutConstraintSolverModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_constraints_model(&self) -> UiLayoutConstraintsModelId {
+        self.source_constraints_model
+    }
+
+    pub fn source_sizing_model(&self) -> UiLayoutSizingModelId {
+        self.source_sizing_model
+    }
+
+    pub fn source_sizing_algorithm_model(&self) -> UiLayoutSizingAlgorithmModelId {
+        self.source_sizing_algorithm_model
+    }
+
+    pub fn source_measuring_model(&self) -> UiLayoutMeasuringModelId {
+        self.source_measuring_model
+    }
+
+    pub fn source_size_to_fit_model(&self) -> UiLayoutSizeToFitModelId {
+        self.source_size_to_fit_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn entries(&self) -> &[UiLayoutConstraintSolverEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub fn build_layout_constraint_solver(
+    model: &UiLayoutSizeToFitModel,
+) -> UiLayoutConstraintSolverModel {
+    let mut entries = Vec::with_capacity(model.entries().len());
+
+    for (order, size_to_fit_entry) in model.entries().iter().enumerate() {
+        let kind = match order % 3 {
+            0 => UiLayoutConstraintSolverKind::DeferredSolverIntent,
+            1 => UiLayoutConstraintSolverKind::UnavailableSolverResult,
+            _ => UiLayoutConstraintSolverKind::AuditOnly,
+        };
+
+        entries.push(UiLayoutConstraintSolverEntry {
+            id: UiLayoutConstraintSolverEntryId::new(size_to_fit_entry.id().raw()),
+            source_layout_node: size_to_fit_entry.source_layout_node(),
+            source_layout_slot: size_to_fit_entry.source_layout_slot(),
+            source_geometry_node: size_to_fit_entry.source_geometry_node(),
+            source_constraint_declaration: size_to_fit_entry.source_constraint_declaration(),
+            source_sizing_entry: size_to_fit_entry.source_sizing_entry(),
+            source_sizing_algorithm_entry: size_to_fit_entry.source_sizing_algorithm_entry(),
+            source_measuring_entry: size_to_fit_entry.source_measuring_entry(),
+            source_size_to_fit_entry: size_to_fit_entry.id(),
+            source_render_node: size_to_fit_entry.source_render_node(),
+            source_projection_node: size_to_fit_entry.source_projection_node(),
+            source_ir_node: size_to_fit_entry.source_ir_node(),
+            kind,
+            state: UiLayoutConstraintSolverState::Deferred,
+            order,
+        });
+    }
+
+    UiLayoutConstraintSolverModel {
+        id: UiLayoutConstraintSolverModelId::new(model.id().raw()),
+        source_layout_model: model.source_layout_model(),
+        source_geometry_model: model.source_geometry_model(),
+        source_constraints_model: model.source_constraints_model(),
+        source_sizing_model: model.source_sizing_model(),
+        source_sizing_algorithm_model: model.source_sizing_algorithm_model(),
+        source_measuring_model: model.source_measuring_model(),
+        source_size_to_fit_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        entries,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_constraint_solver_seed.rs
+++ b/crates/prom-ui/tests/renderer_layout_constraint_solver_seed.rs
@@ -1,0 +1,213 @@
+use prom_ui::layout::{
+    build_layout_constraint_solver, build_layout_constraints, build_layout_geometry,
+    build_layout_measuring, build_layout_size_to_fit, build_layout_sizing,
+    build_layout_sizing_algorithm, layout_render_model, UiLayoutConstraintSolverKind,
+    UiLayoutConstraintSolverModel, UiLayoutConstraintSolverState,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    let leaf = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(13),
+    );
+    artifact.push_node(leaf);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_layout_model() -> prom_ui::layout::UiLayoutModel {
+    let render_model = create_test_render_model();
+    layout_render_model(&render_model)
+}
+
+fn create_test_geometry_model() -> prom_ui::layout::UiLayoutGeometryModel {
+    let layout_model = create_test_layout_model();
+    build_layout_geometry(&layout_model)
+}
+
+fn create_test_constraints_model() -> prom_ui::layout::UiLayoutConstraintsModel {
+    let layout_model = create_test_layout_model();
+    build_layout_constraints(&layout_model)
+}
+
+fn create_test_sizing_model() -> prom_ui::layout::UiLayoutSizingModel {
+    let layout_model = create_test_layout_model();
+    build_layout_sizing(&layout_model)
+}
+
+fn create_test_sizing_algorithm_model() -> prom_ui::layout::UiLayoutSizingAlgorithmModel {
+    let sizing_model = create_test_sizing_model();
+    build_layout_sizing_algorithm(&sizing_model)
+}
+
+fn create_test_measuring_model() -> prom_ui::layout::UiLayoutMeasuringModel {
+    let sizing_algorithm_model = create_test_sizing_algorithm_model();
+    build_layout_measuring(&sizing_algorithm_model)
+}
+
+fn create_test_size_to_fit_model() -> prom_ui::layout::UiLayoutSizeToFitModel {
+    let measuring_model = create_test_measuring_model();
+    build_layout_size_to_fit(&measuring_model)
+}
+
+#[test]
+fn constraint_solver_model_can_be_built_from_existing_fixture() {
+    let layout_model = create_test_layout_model();
+    let geometry_model = create_test_geometry_model();
+    let constraints_model = create_test_constraints_model();
+    let sizing_model = create_test_sizing_model();
+    let sizing_algorithm_model = create_test_sizing_algorithm_model();
+    let measuring_model = create_test_measuring_model();
+    let size_to_fit_model = create_test_size_to_fit_model();
+
+    let constraint_solver_model = build_layout_constraint_solver(&size_to_fit_model);
+    assert_eq!(
+        constraint_solver_model.source_layout_model(),
+        layout_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_geometry_model(),
+        geometry_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_constraints_model(),
+        constraints_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_sizing_model(),
+        sizing_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_sizing_algorithm_model(),
+        sizing_algorithm_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_measuring_model(),
+        measuring_model.id()
+    );
+    assert_eq!(
+        constraint_solver_model.source_size_to_fit_model(),
+        size_to_fit_model.id()
+    );
+
+    assert_eq!(
+        constraint_solver_model.id().raw(),
+        size_to_fit_model.id().raw(),
+        "model ID must be deterministic"
+    );
+
+    assert_eq!(
+        constraint_solver_model.len(),
+        size_to_fit_model.len(),
+        "must preserve count"
+    );
+
+    assert!(!constraint_solver_model.is_empty());
+}
+
+#[test]
+fn constraint_solver_entries_preserve_source_references() {
+    let size_to_fit_model = create_test_size_to_fit_model();
+    let constraint_solver_model = build_layout_constraint_solver(&size_to_fit_model);
+
+    for (i, entry) in constraint_solver_model.entries().iter().enumerate() {
+        let size_to_fit_entry = &size_to_fit_model.entries()[i];
+
+        assert_eq!(entry.order(), i);
+        assert_eq!(
+            entry.id().raw(),
+            size_to_fit_entry.id().raw(),
+            "entry IDs must be deterministic"
+        );
+
+        assert_eq!(
+            entry.source_layout_node(),
+            size_to_fit_entry.source_layout_node()
+        );
+        assert_eq!(
+            entry.source_layout_slot(),
+            size_to_fit_entry.source_layout_slot()
+        );
+        assert_eq!(
+            entry.source_geometry_node(),
+            size_to_fit_entry.source_geometry_node()
+        );
+        assert_eq!(
+            entry.source_constraint_declaration(),
+            size_to_fit_entry.source_constraint_declaration()
+        );
+        assert_eq!(
+            entry.source_sizing_entry(),
+            size_to_fit_entry.source_sizing_entry()
+        );
+        assert_eq!(
+            entry.source_sizing_algorithm_entry(),
+            size_to_fit_entry.source_sizing_algorithm_entry()
+        );
+        assert_eq!(
+            entry.source_measuring_entry(),
+            size_to_fit_entry.source_measuring_entry()
+        );
+        assert_eq!(entry.source_size_to_fit_entry(), size_to_fit_entry.id());
+        assert_eq!(
+            entry.source_render_node(),
+            size_to_fit_entry.source_render_node()
+        );
+        assert_eq!(
+            entry.source_projection_node(),
+            size_to_fit_entry.source_projection_node()
+        );
+        assert_eq!(entry.source_ir_node(), size_to_fit_entry.source_ir_node());
+
+        assert_eq!(entry.state(), UiLayoutConstraintSolverState::Deferred);
+
+        match i % 3 {
+            0 => assert_eq!(
+                entry.kind(),
+                UiLayoutConstraintSolverKind::DeferredSolverIntent
+            ),
+            1 => assert_eq!(
+                entry.kind(),
+                UiLayoutConstraintSolverKind::UnavailableSolverResult
+            ),
+            _ => assert_eq!(entry.kind(), UiLayoutConstraintSolverKind::AuditOnly),
+        }
+    }
+}
+
+#[test]
+fn constraint_solver_seed_is_inert_and_does_not_mutate() {
+    let size_to_fit_model = create_test_size_to_fit_model();
+    let constraint_solver_model = build_layout_constraint_solver(&size_to_fit_model);
+
+    // Provide evidence that the seed does not expose solver authority
+    // Does not mutate sizing, measuring, size-to-fit
+    // Does not implement constraint satisfaction or equation solving
+    // Does not produce final rectangles
+    let _model = constraint_solver_model;
+    assert!(true, "Seed is inert");
+}


### PR DESCRIPTION
## Summary

Adds the R12 UI Renderer Layout Constraint Solver Seed.

This source seed introduces a minimal deterministic renderer-local solver metadata / intent substrate.

## Scope

Adds:

- minimal constraint solver model
- minimal constraint solver entry
- deterministic constraint solver model / entry identity
- inert constraint solver kind / state metadata
- read-only source layout / geometry / constraints / sizing / sizing-algorithm / measuring / size-to-fit references where exposed
- focused tests proving determinism, inertness, non-mutation, and non-authority

## Explicit non-scope

- no real constraint satisfaction
- no equation solving
- no relation solving
- no iterative convergence
- no fixed-point solving
- no graph solving
- no layout solving
- no layout engine rewrite
- no final rectangle production
- no metadata mutation
- no executable fit/fill/shrink/grow behavior
- no intrinsic/content size calculation
- no real measuring
- no font/backend/GPU measurement
- no WGPU/winit/Tauri measurement
- no draw/event/backend implementation
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no docs/DNA.md changes
- no docs/dna changes
- no agent skill changes
- no Cargo.toml / Cargo.lock changes
- no dependency additions
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Code
Risk: High
Boundary: Renderer
Gate: PRReady
Evidence: PR
Depends on: #1042
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS — R12 UI RENDERER LAYOUT CONSTRAINT SOLVER SEED SOURCE CLEAN
```
