### PR TITLE
docs(ui): close out renderer layout solving boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_solving_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_solving_boundary_closeout.md
@@ -1,0 +1,64 @@
+# R12 UI Renderer Layout Solving Boundary Closeout
+
+## 1. Purpose
+
+This document formally closes out the R12 UI Renderer Layout Solving Boundary definition phase.
+
+## 2. Closed Basis
+
+#1049 — selected layout solving boundary lane
+#1050 — defined renderer layout solving boundary
+
+## 3. Implemented State
+
+Implemented:
+- layout solving boundary document;
+- pipeline position for future layout solving authority;
+- strict separation between metadata intent and executable layout solving;
+- explicit non-authority rules;
+- deferred source gate for future layout solving seed/source.
+
+## 4. Deferred State
+
+Deferred:
+- layout solving source;
+- placement algorithm;
+- final rectangle production;
+- geometry mutation;
+- layout mutation;
+- constraint satisfaction;
+- real solver behavior;
+- executable fit/fill/shrink/grow behavior;
+- intrinsic/content size calculation;
+- real measuring;
+- draw/event/backend/runtime/capability authority;
+- proof/debugger authority;
+- Workbench/Studio integration.
+
+## 5. Non-Authority Confirmation
+
+The boundary definition confirmed strictly no implementation of layout solving authority, keeping it purely as a structural planning artifact.
+
+## 6. Project #2 State
+
+Project #2 state: OBSERVED / CORRECTED
+
+## 7. Untracked Workspace Artifacts
+
+Untracked workspace artifacts remain strictly local and uncommitted.
+
+## 8. Validation
+
+Local tests: PASS
+Tracked pre-existing state: CLEAN
+
+## 9. Recommended Next Gate
+
+R12-UI-RENDERER-LAYOUT-SOLVING-BOUNDARY-LEDGER-AUDIT-PR
+
+## 10. Final Decision
+
+Final decision:
+CLOSED — R12 UI Renderer Layout Solving Boundary is complete as a docs-only boundary artifact.
+
+It defines future layout solving work only as a separately gated renderer-local authority boundary and does not implement layout solving source, placement algorithm, final rectangle production, geometry/layout/sizing/constraints/measuring/size-to-fit/constraint-solver mutation, real constraint satisfaction, executable fit/fill/shrink/grow behavior, intrinsic/content size calculation, real measuring, draw/event/backend systems, runtime/verifier/VM integration, capability admission, proof/debugger authority, or Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Solving Boundary.

## Status

Boundary is completely docs-only, defining strict limits. No source code or actual layout solving logic is introduced.

## Project #2 metadata

```text
Status: In Progress
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1050
```

