### PR TITLE
docs(ui): select next post-ui lane after layout solving seed audit

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_solving_seed_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_solving_seed_audit.md
@@ -1,0 +1,119 @@
+# POST-UI Roadmap Next Lane Selection After Layout Solving Seed Audit
+
+## 1. Purpose
+Select the next POST-UI roadmap lane after the completion and audit of the R12 UI Renderer Layout Solving Seed line.
+
+## 2. DNA Alignment
+*   DNA directory present: YES
+*   docs/dna/SEMANTIC_UI_DNA.md present: YES
+*   docs/DNA.md present: NO
+*   DNA conflicts detected: NO
+
+## 3. Closed Basis
+*   #1053 — roadmap selected layout solving seed
+*   #1054 — layout solving seed source
+*   #1055 — layout solving seed closeout
+*   #1056 — closeout evidence correction
+*   #1057 — layout solving seed ledger audit
+
+## 4. Layout Solving Seed State
+The layout solving seed introduces only deterministic renderer-local layout-solving metadata and intent substrate. It does not implement real layout solving, placement, or final rectangle production. It is verified and audited.
+
+## 5. Current Metadata Stack
+```text
+UiLayoutModel
+  ↓
+UiLayoutGeometryModel
+  ↓
+UiLayoutConstraintsModel
+  ↓
+UiLayoutSizingModel
+  ↓
+UiLayoutSizingAlgorithmModel
+  ↓
+UiLayoutMeasuringModel
+  ↓
+UiLayoutSizeToFitModel
+  ↓
+UiLayoutConstraintSolverModel
+  ↓
+UiLayoutSolvingModel
+```
+
+## 6. Candidate Lanes
+| Candidate                                                              | Classification       | Reason                                                                                                                                          |
+| ---------------------------------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `R12-UI-RENDERER-LAYOUT-SOLVING-METADATA-STACK-CONSOLIDATION-AUDIT-PR` | Selected             | Layout solving metadata now extends the stack. Before real layout behavior, consolidate the full metadata stack through `UiLayoutSolvingModel`. |
+| `R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE`                   | Deferred / too early | Real placement/final-rect solving is not authorized yet.                                                                                        |
+| `R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE`         | Deferred / too early | Constraint solver remains metadata-only.                                                                                                        |
+| `R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-BOUNDARY-PR`             | Alternative / later  | Useful if `layout.rs` growth becomes blocking, but should not replace stack consolidation.                                                      |
+| `R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE`                   | Deferred / too early | Backend authority should wait.                                                                                                                  |
+| `R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE`                              | Deferred / high-risk | Event/effect/capability surfaces remain higher-risk.                                                                                            |
+
+## 7. Selection Criteria
+Consolidation of the metadata stack must occur prior to implementing real layout solving behaviors. The stack depth requires re-verification to ensure structural integrity across 9 layers.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-SOLVING-METADATA-STACK-CONSOLIDATION-AUDIT-PR
+
+This selection is planning-only.
+This selection does not perform the layout solving metadata stack consolidation audit.
+This selection does not change source.
+This selection does not change tests.
+This selection does not implement real layout solving.
+This selection does not implement placement.
+This selection does not produce final rectangles.
+This selection does not mutate metadata.
+This selection does not introduce backend/runtime/capability authority.
+
+## 9. Deferred Lanes
+*   R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE
+*   R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE
+*   R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-BOUNDARY-PR
+*   R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE
+*   R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE
+
+## 10. Project #2 State
+Status: In Progress
+Track: POST-UI
+Wave: R12
+Type: Roadmap
+Risk: Medium
+Boundary: Renderer
+Gate: Planning-only
+Evidence: Roadmap doc
+Depends on: #1057
+
+## 11. Untracked Workspace Artifacts
+Tracked repository state remains clean for this roadmap selection. Pre-existing untracked local workspace artifacts are not staged, not committed, not deleted, and not merged.
+
+## 12. Admission Guard
+Admission to the next lane is restricted solely to the Layout Solving Metadata Stack Consolidation Audit. No other logic is authorized.
+
+## 13. Non-Scope
+* no source changes
+* no test changes
+* no consolidation audit performed in this PR
+* no real layout solving
+* no placement algorithm
+* no final rectangle production
+* no computed rectangle production
+* no geometry/layout mutation
+* no constraint satisfaction
+* no real solver behavior
+* no executable fit/fill/shrink/grow behavior
+* no intrinsic/content size calculation
+* no real measuring
+* no draw/event/backend/runtime/capability authority
+* no Workbench/Studio integration
+* no dependency additions
+* local untracked artifacts are not deleted
+
+## 14. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after layout solving seed audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-SOLVING-METADATA-STACK-CONSOLIDATION-AUDIT-PR.
+
+This selection is planning-only and does not perform the layout solving metadata stack consolidation audit, change source, change tests, implement real layout solving, implement placement algorithm, produce final rectangles, produce computed rectangles, mutate geometry/layout/sizing/sizing-algorithm/constraints/measuring/size-to-fit/constraint-solver/layout-solving metadata, implement real constraint satisfaction, implement real solver execution, introduce executable fit/fill/shrink/grow behavior, introduce intrinsic/content size calculation, introduce real measuring, introduce draw/event/backend systems, introduce runtime/verifier/VM integration, introduce capability admission, introduce proof/debugger authority, or introduce Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed and audited R12 UI Renderer Layout Solving Seed line.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-SOLVING-METADATA-STACK-CONSOLIDATION-AUDIT-PR
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* closed layout solving seed basis
* current metadata stack through `UiLayoutSolvingModel`
* candidate lane comparison
* selected next lane
* deferred lanes
* Project #2 state
* untracked local workspace artifact classification
* admission guard constraints

## Explicit non-scope

* no source changes
* no test changes
* no consolidation audit performed in this PR
* no real layout solving
* no placement algorithm
* no final rectangle production
* no computed rectangle production
* no geometry/layout mutation
* no constraint satisfaction
* no real solver behavior
* no executable fit/fill/shrink/grow behavior
* no intrinsic/content size calculation
* no real measuring
* no draw/event/backend/runtime/capability authority
* no Workbench/Studio integration
* no dependency additions
* local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #1057
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS WITH WARNINGS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT SOLVING SEED AUDIT CLEAN FOR TRACKED REPOSITORY STATE
```
