### PR TITLE
docs(ui): select next post-ui lane after layout metadata module split audit

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_metadata_module_split_boundary_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_metadata_module_split_boundary_audit.md
@@ -1,0 +1,121 @@
+# POST-UI Roadmap Next Lane Selection After Layout Metadata Module Split Boundary Audit
+
+## 1. Purpose
+This document selects the next POST-UI roadmap lane after the completion of the R12 UI Renderer Layout Metadata Module Split Boundary line (boundary selection, definition, closeout, and ledger audit).
+
+## 2. DNA Alignment
+*   DNA directory present: YES
+*   docs/dna/SEMANTIC_UI_DNA.md present: YES
+*   docs/DNA.md present: NO
+*   DNA conflicts detected: NO
+
+## 3. Closed Basis
+*   #1060 — roadmap selected layout metadata module split boundary
+*   #1061 — renderer layout metadata module split boundary document
+*   #1062 — renderer layout metadata module split boundary closeout
+*   #1063 — renderer layout metadata module split boundary ledger audit
+
+## 4. Module Split Boundary State
+*   module split boundary selected: YES
+*   module split boundary document present: YES
+*   module split boundary closeout present: YES
+*   module split boundary ledger audit clean: YES
+*   future module ownership map present: YES
+*   allowed future split scope present: YES
+*   forbidden scope present: YES
+*   public API compatibility boundary present: YES
+*   test surface boundary present: YES
+*   recommended next gate present: YES
+*   actual module split performed: NO
+*   file moves performed: NO
+*   source refactor performed: NO
+*   public API changes introduced: NO
+*   behavior changes introduced: NO
+
+## 5. Current Metadata Stack
+```text
+UiLayoutModel
+  ↓
+UiLayoutGeometryModel
+  ↓
+UiLayoutConstraintsModel
+  ↓
+UiLayoutSizingModel
+  ↓
+UiLayoutSizingAlgorithmModel
+  ↓
+UiLayoutMeasuringModel
+  ↓
+UiLayoutSizeToFitModel
+  ↓
+UiLayoutConstraintSolverModel
+  ↓
+UiLayoutSolvingModel
+```
+
+## 6. Candidate Lanes
+| Candidate | Classification | Reason |
+|---|---|---|
+| `R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-SOURCE-PR` | Selected | Boundary is selected, documented, closed, and ledger-audited. Next valid step is a behavior-preserving source split. |
+| `R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-IMPLEMENTATION-WITH-BEHAVIOR` | Deferred / forbidden | Module split source PR must preserve behavior and must not introduce behavior. |
+| `R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE` | Deferred / too early | Real placement/final-rectangle solving remains unauthorized. |
+| `R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE` | Deferred / too early | Constraint solver remains metadata-only. |
+| `R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE` | Deferred / too early | Backend authority should wait until renderer-local layout structure is stable. |
+| `R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE` | Deferred / high-risk | Event/effect/capability surfaces remain higher-risk. |
+
+## 7. Selection Criteria
+The selection criteria strongly favors pure structural refactoring bounded by existing documentation before introducing new executable behavior. The module split boundary allows a safe, behavior-preserving file decomposition of `layout.rs`.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-SOURCE-PR
+
+This selection is planning-only.
+This selection does not perform the module split source PR.
+This selection does not split layout.rs.
+This selection does not move files.
+This selection does not refactor source.
+This selection does not change public APIs.
+This selection does not change behavior.
+This selection does not change source.
+This selection does not change tests.
+
+## 9. Deferred Lanes
+*   R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-IMPLEMENTATION-WITH-BEHAVIOR
+*   R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE
+*   R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE
+*   R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE
+*   R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE
+
+## 10. Project #2 State
+Project #2 state: OBSERVED / PARTIAL API EVIDENCE
+
+## 11. Untracked Workspace Artifacts
+Tracked repository state remains clean for this roadmap selection. Pre-existing untracked local workspace artifacts are not staged, not committed, not deleted, and not merged.
+
+## 12. Admission Guard
+Admission to layout source behavior remains blocked. Admission to structural splitting of layout source files is permitted only under the selected `R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-SOURCE-PR` gate, bounded by the completed boundary line.
+
+## 13. Non-Scope
+*   no source changes
+*   no test changes
+*   no module split
+*   no file moves
+*   no refactor
+*   no public API changes
+*   no behavior changes
+*   no real layout solving
+*   no placement algorithm
+*   no final rectangle production
+*   no computed rectangle production
+*   no metadata mutation
+*   no backend/runtime/capability authority
+*   no Workbench/Studio integration
+
+## 14. Final Decision
+Final decision:
+PASS — POST-UI next lane selected after layout metadata module split boundary audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-SOURCE-PR.
+
+This selection is planning-only and does not perform the module split source PR, split layout.rs, move files, refactor source, change public APIs, change behavior, change source, change tests, implement real layout solving, implement placement algorithm, produce final rectangles, produce computed rectangles, mutate geometry/layout/sizing/sizing-algorithm/constraints/measuring/size-to-fit/constraint-solver/layout-solving metadata, introduce backend systems, introduce runtime/verifier/VM integration, introduce capability admission, introduce proof/debugger authority, or introduce Workbench/Studio integration.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed R12 UI Renderer Layout Metadata Module Split Boundary ledger audit.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-METADATA-MODULE-SPLIT-SOURCE-PR
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* closed module split boundary basis
* current metadata stack through `UiLayoutSolvingModel`
* candidate lane comparison
* selected next lane
* deferred lanes
* Project #2 state
* untracked local workspace artifact classification
* admission guard constraints

## Explicit non-scope

* no source changes
* no test changes
* no module split performed in this PR
* no layout.rs split
* no file moves
* no refactor
* no public API changes
* no behavior changes
* no real layout solving
* no placement algorithm
* no final rectangle production
* no computed rectangle production
* no metadata mutation
* no draw/event/backend/runtime/capability authority
* no Workbench/Studio integration
* no dependency additions
* local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #1063
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS WITH WARNINGS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT METADATA MODULE SPLIT BOUNDARY AUDIT CLEAN FOR TRACKED REPOSITORY STATE
```
