### PR TITLE
docs(ui): select next post-ui lane after layout metadata module split consolidation

### DIFF
--- a/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_metadata_module_split_consolidation_audit.md
+++ b/docs/roadmap/post_ui/post_ui_roadmap_next_lane_selection_after_layout_metadata_module_split_consolidation_audit.md
@@ -1,0 +1,96 @@
+# POST-UI Roadmap Next Lane Selection After Layout Metadata Module Split Consolidation Audit
+
+## 1. Purpose
+This document records the selection of the next POST-UI roadmap lane after the completion and audit of the renderer layout metadata module split consolidation.
+
+## 2. DNA Alignment
+The selection aligns with Semantic UI DNA by ensuring strict, explicitly bounded evolution. It defers unproven implementation of backend, runtime, and capability authorities until the foundational layout boundary is established. 
+
+## 3. Closed Basis
+*   #1064 — roadmap selected layout metadata module split source lane
+*   #1065 — source PR: split renderer layout metadata into modules
+*   #1066 — closeout PR: close out renderer layout metadata module split source
+*   #1067 — source ledger audit: audit renderer layout metadata module split source
+*   #1068 — roadmap selected post-split consolidation audit
+*   #1069 — post-split module tree consolidation audit
+
+## 4. Current Canonical Layout Module Tree
+The layout metadata module tree is fully consolidated under `crates/prom-ui/src/layout/` as the canonical source of truth for renderer-local layout. `layout/mod.rs` provides the public façade, and all nine ownership modules (`base.rs`, `geometry.rs`, `constraints.rs`, `sizing.rs`, `sizing_algorithm.rs`, `measuring.rs`, `size_to_fit.rs`, `constraint_solver.rs`, `solving.rs`) are present.
+
+## 5. Current Metadata Stack
+The metadata stack is fully represented across the module tree from `UiLayoutModel` to `UiLayoutSolvingModel`. Real layout solving behavior and executable placement logic remain absent.
+
+## 6. Candidate Lanes
+
+| Candidate | Classification | Reason |
+|---|---|---|
+| `R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-BOUNDARY-PR` | Selected | The post-split layout module tree is consolidated. Before any real layout solving behavior, define a strict boundary for allowed/forbidden implementation authority. |
+| `R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE` | Deferred / too early | Real placement/final-rectangle behavior must not start before explicit boundary, closeout, and ledger audit. |
+| `R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-BOUNDARY-PR` | Alternative / later | Constraint solver behavior is also important, but layout solving boundary should define final-rect/placement authority first. |
+| `R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE` | Deferred / too early | Constraint solver remains metadata-only and should not be implemented without its own boundary. |
+| `R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE` | Deferred / too early | Backend authority should wait until renderer-local layout behavior boundaries are clear. |
+| `R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE` | Deferred / high-risk | Event/effect/capability surfaces remain higher-risk. |
+
+## 7. Selection Criteria
+The selection criteria emphasize protecting the Semantic UI Tree from uncontrolled authority spread. We must define the boundary for real layout solving behavior (producing final and computed rectangles) before allowing any layout solving implementation to begin.
+
+## 8. Selected Next Lane
+Selected next lane:
+R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-BOUNDARY-PR
+
+This selection is planning-only.
+This selection does not create the layout solving implementation boundary document.
+This selection does not implement real layout solving.
+This selection does not implement placement.
+This selection does not produce final rectangles.
+This selection does not produce computed rectangles.
+This selection does not change source.
+This selection does not change tests.
+This selection does not mutate metadata.
+This selection does not introduce backend/runtime/capability authority.
+
+## 9. Deferred Lanes
+* R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-LINE
+* R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-BOUNDARY-PR
+* R12-UI-RENDERER-LAYOUT-CONSTRAINT-SOLVER-IMPLEMENTATION-LINE
+* R12-UI-RENDERER-BACKEND-BOUNDARY-LINE-FULL-PACKAGE
+* R12-UI-EVENT-BOUNDARY-LINE-FULL-PACKAGE
+
+## 10. Project #2 State
+Project #2 state remains observed.
+
+## 11. Untracked Workspace Artifacts
+Tracked repository state remains clean for this roadmap selection. Pre-existing untracked local workspace artifacts are not staged, not committed, not deleted, and not merged.
+
+## 12. Admission Guard
+The admission guard ensures that this selection remains planning-only. No behavior, tests, source files, or boundary documents are permitted in this lane selection.
+
+## 13. Non-Scope
+* no source changes
+* no test changes
+* no boundary document created in this PR
+* no implementation work
+* no layout solving algorithm
+* no placement algorithm
+* no final rectangle production
+* no computed rectangle production
+* no geometry/layout mutation
+* no constraint satisfaction
+* no real solver execution
+* no executable fit/fill/shrink/grow behavior
+* no intrinsic/content size calculation
+* no real measuring
+* no draw/event/backend/runtime/capability authority
+* no Workbench/Studio integration
+* no dependency additions
+
+## 14. Final Decision
+
+Final decision:
+PASS — POST-UI next lane selected after layout metadata module split consolidation audit.
+
+The next selected lane is R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-BOUNDARY-PR.
+
+This selection is planning-only and does not create the layout solving implementation boundary document, change source, change tests, refactor modules, move files, change public APIs, change behavior, implement real layout solving, implement placement algorithm, produce final rectangles, produce computed rectangles, mutate geometry/layout/sizing/sizing-algorithm/constraints/measuring/size-to-fit/constraint-solver/layout-solving metadata, introduce backend systems, introduce runtime/verifier/VM integration, introduce capability admission, introduce proof/debugger authority, or introduce Workbench/Studio integration.
+
+Tracked repository state remains clean for this roadmap selection. Pre-existing untracked local workspace artifacts are not staged, not committed, not deleted, and not merged.


### PR DESCRIPTION
## Summary

Selects the next POST-UI roadmap lane after the completed R12 UI Renderer Layout Metadata Module Split Consolidation Audit.

Selected next lane:

```text
R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-BOUNDARY-PR
```

## Scope

This is a docs-only planning PR.

It records:

* DNA alignment
* closed post-split module consolidation basis
* current canonical layout module tree
* current metadata stack
* candidate lane comparison
* selected next lane
* deferred lanes
* Project #2 state
* untracked local workspace artifact classification
* admission guard constraints

## Explicit non-scope

* no source changes
* no test changes
* no layout solving implementation boundary document created in this PR
* no real layout solving
* no placement algorithm
* no final rectangle production
* no computed rectangle production
* no metadata mutation
* no draw/event/backend/runtime/capability authority
* no Workbench/Studio integration
* no dependency additions
* local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Roadmap
Risk: Medium
Boundary: Renderer
Gate: Planning-only
Evidence: Roadmap doc
Depends on: #1069
```

## Validation

Local only:

```text
git diff --check: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui: PASS
tracked pr_body files: NO
GitHub CI used as evidence: NO
```

## Final status

```text
PASS WITH WARNINGS — POST-UI ROADMAP NEXT LANE SELECTION AFTER LAYOUT METADATA MODULE SPLIT CONSOLIDATION AUDIT CLEAN FOR TRACKED REPOSITORY STATE
```
