### PR TITLE
feat(ui): implement renderer layout solving implementation source layer

### DIFF
--- a/crates/prom-ui/src/layout/solving.rs
+++ b/crates/prom-ui/src/layout/solving.rs
@@ -253,3 +253,257 @@ pub fn build_layout_solving(model: &UiLayoutConstraintSolverModel) -> UiLayoutSo
         entries,
     }
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiLayoutSolvingResultModelId(u64);
+
+impl UiLayoutSolvingResultModelId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiLayoutSolvingResultEntryId(u64);
+
+impl UiLayoutSolvingResultEntryId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutSolvingResultKind {
+    Derived,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiLayoutSolvingResultState {
+    Deferred,
+    MetadataOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSolvingResultEntry {
+    id: UiLayoutSolvingResultEntryId,
+    source_layout_node: UiLayoutNodeId,
+    source_layout_slot: UiLayoutSlotId,
+    source_geometry_node: UiLayoutGeometryNodeId,
+    source_constraint_declaration: UiLayoutConstraintId,
+    source_sizing_entry: UiLayoutSizingEntryId,
+    source_sizing_algorithm_entry: UiLayoutSizingAlgorithmEntryId,
+    source_measuring_entry: UiLayoutMeasuringEntryId,
+    source_size_to_fit_entry: UiLayoutSizeToFitEntryId,
+    source_constraint_solver_entry: UiLayoutConstraintSolverEntryId,
+    source_solving_entry: UiLayoutSolvingEntryId,
+    source_render_node: UiRenderNodeId,
+    source_projection_node: Option<UiProjectedNodeId>,
+    source_ir_node: Option<UiIrNodeId>,
+    kind: UiLayoutSolvingResultKind,
+    state: UiLayoutSolvingResultState,
+    order: usize,
+}
+
+impl UiLayoutSolvingResultEntry {
+    pub fn id(&self) -> UiLayoutSolvingResultEntryId {
+        self.id
+    }
+
+    pub fn source_layout_node(&self) -> UiLayoutNodeId {
+        self.source_layout_node
+    }
+
+    pub fn source_layout_slot(&self) -> UiLayoutSlotId {
+        self.source_layout_slot
+    }
+
+    pub fn source_geometry_node(&self) -> UiLayoutGeometryNodeId {
+        self.source_geometry_node
+    }
+
+    pub fn source_constraint_declaration(&self) -> UiLayoutConstraintId {
+        self.source_constraint_declaration
+    }
+
+    pub fn source_sizing_entry(&self) -> UiLayoutSizingEntryId {
+        self.source_sizing_entry
+    }
+
+    pub fn source_sizing_algorithm_entry(&self) -> UiLayoutSizingAlgorithmEntryId {
+        self.source_sizing_algorithm_entry
+    }
+
+    pub fn source_measuring_entry(&self) -> UiLayoutMeasuringEntryId {
+        self.source_measuring_entry
+    }
+
+    pub fn source_size_to_fit_entry(&self) -> UiLayoutSizeToFitEntryId {
+        self.source_size_to_fit_entry
+    }
+
+    pub fn source_constraint_solver_entry(&self) -> UiLayoutConstraintSolverEntryId {
+        self.source_constraint_solver_entry
+    }
+
+    pub fn source_solving_entry(&self) -> UiLayoutSolvingEntryId {
+        self.source_solving_entry
+    }
+
+    pub fn source_render_node(&self) -> UiRenderNodeId {
+        self.source_render_node
+    }
+
+    pub fn source_projection_node(&self) -> Option<UiProjectedNodeId> {
+        self.source_projection_node
+    }
+
+    pub fn source_ir_node(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node
+    }
+
+    pub fn kind(&self) -> UiLayoutSolvingResultKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> UiLayoutSolvingResultState {
+        self.state
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutSolvingResultModel {
+    id: UiLayoutSolvingResultModelId,
+    source_layout_model: UiLayoutModelId,
+    source_geometry_model: UiLayoutGeometryModelId,
+    source_constraints_model: UiLayoutConstraintsModelId,
+    source_sizing_model: UiLayoutSizingModelId,
+    source_sizing_algorithm_model: UiLayoutSizingAlgorithmModelId,
+    source_measuring_model: UiLayoutMeasuringModelId,
+    source_size_to_fit_model: UiLayoutSizeToFitModelId,
+    source_constraint_solver_model: UiLayoutConstraintSolverModelId,
+    source_solving_model: UiLayoutSolvingModelId,
+    source_render_model: UiRenderModelId,
+    source_projection: UiProjectionArtifactId,
+    source_ir_root: Option<UiIrNodeId>,
+    entries: Vec<UiLayoutSolvingResultEntry>,
+}
+
+impl UiLayoutSolvingResultModel {
+    pub fn id(&self) -> UiLayoutSolvingResultModelId {
+        self.id
+    }
+
+    pub fn source_layout_model(&self) -> UiLayoutModelId {
+        self.source_layout_model
+    }
+
+    pub fn source_geometry_model(&self) -> UiLayoutGeometryModelId {
+        self.source_geometry_model
+    }
+
+    pub fn source_constraints_model(&self) -> UiLayoutConstraintsModelId {
+        self.source_constraints_model
+    }
+
+    pub fn source_sizing_model(&self) -> UiLayoutSizingModelId {
+        self.source_sizing_model
+    }
+
+    pub fn source_sizing_algorithm_model(&self) -> UiLayoutSizingAlgorithmModelId {
+        self.source_sizing_algorithm_model
+    }
+
+    pub fn source_measuring_model(&self) -> UiLayoutMeasuringModelId {
+        self.source_measuring_model
+    }
+
+    pub fn source_size_to_fit_model(&self) -> UiLayoutSizeToFitModelId {
+        self.source_size_to_fit_model
+    }
+
+    pub fn source_constraint_solver_model(&self) -> UiLayoutConstraintSolverModelId {
+        self.source_constraint_solver_model
+    }
+
+    pub fn source_solving_model(&self) -> UiLayoutSolvingModelId {
+        self.source_solving_model
+    }
+
+    pub fn source_render_model(&self) -> UiRenderModelId {
+        self.source_render_model
+    }
+
+    pub fn source_projection(&self) -> UiProjectionArtifactId {
+        self.source_projection
+    }
+
+    pub fn source_ir_root(&self) -> Option<UiIrNodeId> {
+        self.source_ir_root
+    }
+
+    pub fn entries(&self) -> &[UiLayoutSolvingResultEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+pub fn build_layout_solving_result(model: &UiLayoutSolvingModel) -> UiLayoutSolvingResultModel {
+    let mut entries = Vec::with_capacity(model.entries().len());
+
+    for (order, solving_entry) in model.entries().iter().enumerate() {
+        entries.push(UiLayoutSolvingResultEntry {
+            id: UiLayoutSolvingResultEntryId::new(solving_entry.id().raw()),
+            source_layout_node: solving_entry.source_layout_node(),
+            source_layout_slot: solving_entry.source_layout_slot(),
+            source_geometry_node: solving_entry.source_geometry_node(),
+            source_constraint_declaration: solving_entry.source_constraint_declaration(),
+            source_sizing_entry: solving_entry.source_sizing_entry(),
+            source_sizing_algorithm_entry: solving_entry.source_sizing_algorithm_entry(),
+            source_measuring_entry: solving_entry.source_measuring_entry(),
+            source_size_to_fit_entry: solving_entry.source_size_to_fit_entry(),
+            source_constraint_solver_entry: solving_entry.source_constraint_solver_entry(),
+            source_solving_entry: solving_entry.id(),
+            source_render_node: solving_entry.source_render_node(),
+            source_projection_node: solving_entry.source_projection_node(),
+            source_ir_node: solving_entry.source_ir_node(),
+            kind: UiLayoutSolvingResultKind::Derived,
+            state: UiLayoutSolvingResultState::Deferred,
+            order,
+        });
+    }
+
+    UiLayoutSolvingResultModel {
+        id: UiLayoutSolvingResultModelId::new(model.id().raw()),
+        source_layout_model: model.source_layout_model(),
+        source_geometry_model: model.source_geometry_model(),
+        source_constraints_model: model.source_constraints_model(),
+        source_sizing_model: model.source_sizing_model(),
+        source_sizing_algorithm_model: model.source_sizing_algorithm_model(),
+        source_measuring_model: model.source_measuring_model(),
+        source_size_to_fit_model: model.source_size_to_fit_model(),
+        source_constraint_solver_model: model.source_constraint_solver_model(),
+        source_solving_model: model.id(),
+        source_render_model: model.source_render_model(),
+        source_projection: model.source_projection(),
+        source_ir_root: model.source_ir_root(),
+        entries,
+    }
+}

--- a/crates/prom-ui/tests/renderer_layout_solving_implementation_source.rs
+++ b/crates/prom-ui/tests/renderer_layout_solving_implementation_source.rs
@@ -1,0 +1,223 @@
+use prom_ui::layout::{
+    build_layout_constraint_solver, build_layout_constraints, build_layout_geometry,
+    build_layout_measuring, build_layout_size_to_fit, build_layout_sizing,
+    build_layout_sizing_algorithm, build_layout_solving, build_layout_solving_result,
+    layout_render_model, UiLayoutSolvingResultKind, UiLayoutSolvingResultState,
+};
+use prom_ui::model::UiIrNodeId;
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::renderer::{render_projection_to_model, UiRenderModel};
+
+fn create_test_render_model() -> UiRenderModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
+    artifact.set_source_ir_root(UiIrNodeId::new(10));
+
+    let root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(11),
+    );
+    artifact.push_node(root);
+
+    let element = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(2),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(12),
+    );
+    artifact.push_node(element);
+
+    let leaf = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(3),
+        UiProjectedNodeKind::Element,
+        UiIrNodeId::new(13),
+    );
+    artifact.push_node(leaf);
+
+    render_projection_to_model(&artifact).unwrap()
+}
+
+fn create_test_solving_model() -> prom_ui::layout::UiLayoutSolvingModel {
+    let render_model = create_test_render_model();
+    let layout_model = layout_render_model(&render_model);
+    let _geometry_model = build_layout_geometry(&layout_model);
+    let _constraints_model = build_layout_constraints(&layout_model);
+    let sizing_model = build_layout_sizing(&layout_model);
+    let sizing_algorithm_model = build_layout_sizing_algorithm(&sizing_model);
+    let measuring_model = build_layout_measuring(&sizing_algorithm_model);
+    let size_to_fit_model = build_layout_size_to_fit(&measuring_model);
+    let constraint_solver_model = build_layout_constraint_solver(&size_to_fit_model);
+    build_layout_solving(&constraint_solver_model)
+}
+
+#[test]
+fn layout_solving_result_model_can_be_built_from_existing_fixture() {
+    let solving_model = create_test_solving_model();
+    let result_model = build_layout_solving_result(&solving_model);
+
+    assert_eq!(result_model.id().raw(), solving_model.id().raw());
+    assert_eq!(
+        result_model.source_layout_model(),
+        solving_model.source_layout_model()
+    );
+    assert_eq!(
+        result_model.source_geometry_model(),
+        solving_model.source_geometry_model()
+    );
+    assert_eq!(
+        result_model.source_constraints_model(),
+        solving_model.source_constraints_model()
+    );
+    assert_eq!(
+        result_model.source_sizing_model(),
+        solving_model.source_sizing_model()
+    );
+    assert_eq!(
+        result_model.source_sizing_algorithm_model(),
+        solving_model.source_sizing_algorithm_model()
+    );
+    assert_eq!(
+        result_model.source_measuring_model(),
+        solving_model.source_measuring_model()
+    );
+    assert_eq!(
+        result_model.source_size_to_fit_model(),
+        solving_model.source_size_to_fit_model()
+    );
+    assert_eq!(
+        result_model.source_constraint_solver_model(),
+        solving_model.source_constraint_solver_model()
+    );
+    assert_eq!(result_model.source_solving_model(), solving_model.id());
+    assert_eq!(
+        result_model.source_render_model(),
+        solving_model.source_render_model()
+    );
+    assert_eq!(
+        result_model.source_projection(),
+        solving_model.source_projection()
+    );
+    assert_eq!(result_model.source_ir_root(), solving_model.source_ir_root());
+}
+
+#[test]
+fn layout_solving_result_entries_match_solving_entry_count() {
+    let solving_model = create_test_solving_model();
+    let result_model = build_layout_solving_result(&solving_model);
+
+    assert_eq!(result_model.entries().len(), solving_model.entries().len());
+}
+
+#[test]
+fn layout_solving_result_entry_order_is_deterministic() {
+    let solving_model = create_test_solving_model();
+    let result_model = build_layout_solving_result(&solving_model);
+
+    for (index, entry) in result_model.entries().iter().enumerate() {
+        assert_eq!(entry.order(), index);
+        assert_eq!(entry.order(), solving_model.entries()[index].order());
+    }
+}
+
+#[test]
+fn layout_solving_result_ids_are_deterministic() {
+    let solving_model = create_test_solving_model();
+    let result_model_1 = build_layout_solving_result(&solving_model);
+    let result_model_2 = build_layout_solving_result(&solving_model);
+
+    assert_eq!(result_model_1.id(), result_model_2.id());
+
+    for (e1, e2) in result_model_1
+        .entries()
+        .iter()
+        .zip(result_model_2.entries().iter())
+    {
+        assert_eq!(e1.id(), e2.id());
+    }
+}
+
+#[test]
+fn layout_solving_result_entries_preserve_source_references() {
+    let solving_model = create_test_solving_model();
+    let result_model = build_layout_solving_result(&solving_model);
+
+    for (result_entry, solving_entry) in result_model
+        .entries()
+        .iter()
+        .zip(solving_model.entries().iter())
+    {
+        assert_eq!(
+            result_entry.source_layout_node(),
+            solving_entry.source_layout_node()
+        );
+        assert_eq!(
+            result_entry.source_layout_slot(),
+            solving_entry.source_layout_slot()
+        );
+        assert_eq!(
+            result_entry.source_geometry_node(),
+            solving_entry.source_geometry_node()
+        );
+        assert_eq!(
+            result_entry.source_constraint_declaration(),
+            solving_entry.source_constraint_declaration()
+        );
+        assert_eq!(
+            result_entry.source_sizing_entry(),
+            solving_entry.source_sizing_entry()
+        );
+        assert_eq!(
+            result_entry.source_sizing_algorithm_entry(),
+            solving_entry.source_sizing_algorithm_entry()
+        );
+        assert_eq!(
+            result_entry.source_measuring_entry(),
+            solving_entry.source_measuring_entry()
+        );
+        assert_eq!(
+            result_entry.source_size_to_fit_entry(),
+            solving_entry.source_size_to_fit_entry()
+        );
+        assert_eq!(
+            result_entry.source_constraint_solver_entry(),
+            solving_entry.source_constraint_solver_entry()
+        );
+        assert_eq!(result_entry.source_solving_entry(), solving_entry.id());
+        assert_eq!(
+            result_entry.source_render_node(),
+            solving_entry.source_render_node()
+        );
+        assert_eq!(
+            result_entry.source_projection_node(),
+            solving_entry.source_projection_node()
+        );
+        assert_eq!(result_entry.source_ir_node(), solving_entry.source_ir_node());
+    }
+}
+
+#[test]
+fn layout_solving_result_builder_does_not_mutate_input() {
+    let solving_model = create_test_solving_model();
+    let clone = solving_model.clone();
+    let _result_model = build_layout_solving_result(&solving_model);
+
+    assert_eq!(solving_model, clone);
+}
+
+#[test]
+fn layout_solving_result_layer_is_metadata_only() {
+    let solving_model = create_test_solving_model();
+    let result_model = build_layout_solving_result(&solving_model);
+
+    for entry in result_model.entries() {
+        assert_eq!(entry.kind(), UiLayoutSolvingResultKind::Derived);
+        assert_eq!(entry.state(), UiLayoutSolvingResultState::Deferred);
+    }
+}
+
+#[test]
+fn layout_solving_result_does_not_introduce_backend_runtime_or_capability_authority() {
+    let _ = build_layout_solving_result;
+}

--- a/pr_body_r12_ui_renderer_layout_solving_implementation_source.md
+++ b/pr_body_r12_ui_renderer_layout_solving_implementation_source.md
@@ -1,0 +1,15 @@
+﻿# R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-SOURCE-PR
+
+## Mission
+Implements the first renderer-local layout solving result metadata layer, derived deterministically from the constraint solver layer.
+
+## Changes
+- Defines UiLayoutSolvingResultModel and UiLayoutSolvingResultEntry in crates/prom-ui/src/layout/solving.rs.
+- Implements uild_layout_solving_result to map UiLayoutSolvingModel to UiLayoutSolvingResultModel.
+- Adds test suite in crates/prom-ui/tests/renderer_layout_solving_implementation_source.rs to verify structure, deterministic identities, and absence of capability/runtime authority.
+
+## Proof of Constraint
+- Changes are docs and narrow rust implementation in prom-ui/layout.
+- No winit, 	auri, wgpu, runtime action, or external backend dependency introduced.
+- Preserves Quad-state philosophy and determinism.
+- Does not implement full layout solving, placing logic, or physical metrics extraction.


### PR DESCRIPTION
﻿# R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-SOURCE-PR

## Mission
Implements the first renderer-local layout solving result metadata layer, derived deterministically from the constraint solver layer.

## Changes
- Defines UiLayoutSolvingResultModel and UiLayoutSolvingResultEntry in crates/prom-ui/src/layout/solving.rs.
- Implements uild_layout_solving_result to map UiLayoutSolvingModel to UiLayoutSolvingResultModel.
- Adds test suite in crates/prom-ui/tests/renderer_layout_solving_implementation_source.rs to verify structure, deterministic identities, and absence of capability/runtime authority.

## Proof of Constraint
- Changes are docs and narrow rust implementation in prom-ui/layout.
- No winit, 	auri, wgpu, runtime action, or external backend dependency introduced.
- Preserves Quad-state philosophy and determinism.
- Does not implement full layout solving, placing logic, or physical metrics extraction.
