### PR TITLE
docs(ui): close out renderer layout solving implementation source

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_solving_implementation_source_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_solving_implementation_source_closeout.md
@@ -1,0 +1,150 @@
+# R12 UI Renderer Layout Solving Implementation Source Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Solving Implementation Source line after source PR #1075 and validation repair PRs #1076 and #1077.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: `docs/dna/SEMANTIC_UI_DNA.md`
+docs/dna directory present: YES
+docs/DNA.md present: NO
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout solving result metadata remains renderer-local;
+- metadata remains deterministic;
+- metadata remains source-reference-preserving where exposed;
+- closeout remains docs-only;
+- no full layout solving authority is added by closeout;
+- no placing logic is added by closeout;
+- no physical metrics extraction is added by closeout;
+- no backend/event/runtime/capability authority is added by closeout;
+- no Workbench/Studio integration is added by closeout.
+
+## 3. Closed Basis
+- #1071 — layout solving implementation boundary
+- #1072 — layout solving implementation boundary closeout
+- #1073 — layout solving implementation boundary ledger audit
+- #1074 — roadmap selected layout solving implementation source
+- #1075 — layout solving implementation source
+- #1076 — layout solving implementation source fmt repair
+- #1077 — layout solving implementation source pr_body cleanup
+
+## 4. Source PR
+- #1075 — `feat(ui): implement renderer layout solving implementation source layer`
+- merge commit: `5d5f162275ada98fa7387316c9909fa6e1eeb5ae`
+- changed files: `3`
+- source changed: YES
+- tests changed: YES
+- docs changed: NO
+- manifest changed: NO
+- dependency additions: NO
+
+## 5. Validation Repairs
+- #1076 fixed pre-existing rustfmt drift in `crates/prom-ui/tests/renderer_layout_solving_implementation_source.rs`.
+- #1077 removed tracked PR body artifact `pr_body_r12_ui_renderer_layout_solving_implementation_source.md`.
+- After #1076 and #1077, `cargo fmt --check` passes.
+- After #1077, tracked `pr_body` files are absent.
+
+## 6. Implemented State
+Implemented:
+- first renderer-local layout solving result metadata layer;
+- `UiLayoutSolvingResultModel`;
+- `UiLayoutSolvingResultEntry`;
+- `build_layout_solving_result` entrypoint;
+- deterministic result metadata derivation as implemented in #1075;
+- focused tests for result metadata structure, deterministic identity, source reference preservation, and absence of backend/runtime/capability authority.
+
+## 7. Deferred State
+Deferred:
+- full layout solving;
+- placing logic;
+- physical metrics extraction;
+- pixel/screen/viewport placement;
+- real constraint satisfaction;
+- equation solving;
+- relation solving;
+- iterative convergence;
+- fixed-point solving;
+- graph solving;
+- layout engine rewrite;
+- backend rendering;
+- event dispatch;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- Workbench/Studio integration;
+- WGPU/winit/Tauri integration unless separately gated.
+
+## 8. Non-Authority Confirmation
+This source line does not grant full layout-solving authority.
+
+It records deterministic renderer-local result metadata only.
+
+It does not make renderer layout solving operational as final physical layout placement.
+
+It does not introduce backend/event/runtime/capability authority.
+
+## 9. Evidence Matrix
+
+| Area | Final state | Classification | Status |
+|---|---|---|---|
+| `UiLayoutSolvingResultModel` | Implemented | ADMITTED SOURCE | PASS |
+| `UiLayoutSolvingResultEntry` | Implemented | ADMITTED SOURCE | PASS |
+| `build_layout_solving_result` | Implemented | ADMITTED SOURCE | PASS |
+| Source tests | Implemented | ADMITTED TESTS | PASS |
+| Full layout solving | Not implemented | DEFERRED | PASS |
+| Placing logic | Not implemented | DEFERRED | PASS |
+| Physical metrics extraction | Not implemented | DEFERRED | PASS |
+| Pixel/screen/viewport placement | Not implemented | DEFERRED | PASS |
+| Backend rendering | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not implemented | FORBIDDEN | PASS |
+| Capability admission | Not implemented | FORBIDDEN | PASS |
+| Workbench/Studio | Not implemented | FORBIDDEN | PASS |
+| Manifest/dependency changes | None | FORBIDDEN | PASS |
+
+## 10. Admission Guard Table
+
+| Surface | Closeout classification | Status |
+|---|---|---|
+| renderer-local result metadata | ADMITTED | PASS |
+| deterministic result identity | ADMITTED | PASS |
+| source reference preservation | ADMITTED | PASS |
+| full layout solving | DEFERRED | PASS |
+| placing logic | DEFERRED | PASS |
+| physical metrics extraction | DEFERRED | PASS |
+| final physical layout | DEFERRED | PASS |
+| backend rendering | FORBIDDEN | PASS |
+| event dispatch | FORBIDDEN | PASS |
+| runtime/verifier/VM | FORBIDDEN | PASS |
+| capability admission | FORBIDDEN | PASS |
+| proof/debugger authority | FORBIDDEN | PASS |
+| Workbench/Studio | FORBIDDEN | PASS |
+
+## 11. Project #2 State
+
+| Item | Status | Track | Wave | Type | Risk | Boundary | Gate | Evidence | Depends on |
+|---|---|---|---|---|---|---|---|---|---|
+| #1075 | Done | POST-UI | R12 | Code | High | Renderer | PRReady | PR | #1074 |
+| #1076 | Done | POST-UI | R12 | Test | Low | Renderer | PRReady | PR | #1075 |
+| #1077 | Done | POST-UI | R12 | Docs | Low | Renderer | PRReady | PR | #1076 |
+
+## 12. Untracked Workspace Artifacts
+
+| Artifact | State | Classification | Merged | Status |
+|---|---|---|---:|---|
+| `.claude/` | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+| `examples/baseline/` | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+| `scratch/` | present | PRE-EXISTING / LOCAL WORKSPACE ONLY | NO | NON-BLOCKING WARNING |
+
+## 13. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-SOLVING-IMPLEMENTATION-SOURCE-LEDGER-AUDIT-PR
+
+## 14. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Solving Implementation Source is complete as the first deterministic renderer-local layout solving result metadata layer.
+
+It records result metadata derived from the layout solving / constraint solver metadata layer as implemented in #1075 and does not implement full layout solving, placing logic, physical metrics extraction, pixel/screen/viewport placement, backend rendering, event dispatch, runtime/verifier/VM integration, capability admission, proof/debugger authority, WGPU/winit/Tauri integration, or Workbench/Studio integration.
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, not deleted, and not merged.


### PR DESCRIPTION
Closes out the renderer layout solving implementation source line after #1075, with validation repair PRs #1076 and #1077 recorded. Docs-only closeout. No source, test, manifest, dependency, backend, event, runtime, capability, Workbench, or Studio changes.
