### PR TITLE
docs(ui): close out renderer layout physical placement boundary

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_physical_placement_boundary_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_physical_placement_boundary_closeout.md
@@ -1,0 +1,143 @@
+# R12 UI Renderer Layout Physical Placement Boundary Closeout
+
+## 1. Purpose
+This document closes out the R12 UI Renderer Layout Physical Placement Boundary line after the docs-only boundary PR.
+
+## 2. DNA Alignment
+DNA inspected: YES
+DNA source path: `docs/dna/SEMANTIC_UI_DNA.md`
+docs/dna directory present: YES
+docs/DNA.md present: NO
+DNA conflicts detected: NONE
+DNA-driven constraints applied:
+- renderer/UI remains downstream;
+- layout metadata remains renderer-local;
+- layout solving result metadata remains renderer-local;
+- physical placement boundary remains docs-only;
+- physical placement source is not admitted;
+- final physical layout is not produced;
+- pixel/screen/viewport placement is not admitted;
+- backend/event/runtime/capability authority is not admitted;
+- Workbench/Studio remains out of scope.
+
+## 3. Closed Basis
+#1079 — layout solving implementation source ledger audit
+#1080 — selected layout solving implementation metadata stack consolidation audit
+#1081 — layout solving implementation metadata stack consolidation audit
+#1082 — selected physical placement boundary lane
+#1083 — layout physical placement boundary
+
+## 4. Boundary PR
+#1083 — docs(ui): define renderer layout physical placement boundary
+
+merge commit:
+ee4c44351b6e5a5181a110c4d2fb4ab543355eb2
+
+changed files:
+docs/roadmap/post_ui/r12_ui_renderer_layout_physical_placement_boundary.md
+
+## 5. Implemented State
+Implemented:
+- docs-only physical placement boundary;
+- future position after UiLayoutSolvingResultModel;
+- allowed future input/output categories;
+- explicit separation from backend, event, runtime, capability, Workbench, and Studio authority;
+- deferred physical placement source gate.
+
+## 6. Deferred State
+Deferred:
+- physical placement source;
+- final physical layout;
+- backend rectangles;
+- pixel/screen/viewport placement;
+- draw commands;
+- event dispatch;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- WGPU/winit/Tauri integration;
+- Workbench/Studio integration.
+
+## 7. Non-Authority Confirmation
+This boundary does not implement physical placement.
+This boundary does not produce final physical layout.
+This boundary does not produce backend rectangles.
+This boundary does not produce draw commands.
+This boundary does not introduce pixel/screen/viewport placement.
+This boundary does not introduce backend rendering.
+This boundary does not introduce event dispatch.
+This boundary does not introduce runtime/verifier/VM integration.
+This boundary does not introduce capability admission.
+This boundary does not introduce proof/debugger authority.
+This boundary does not introduce Workbench/Studio integration.
+
+## 8. Evidence Matrix
+
+| Area | Final state | Classification | Status |
+|---|---|---|---|
+| Physical placement boundary | Defined | DOCS-ONLY | PASS |
+| Physical placement source | Not implemented | DEFERRED | PASS |
+| Final physical layout | Not produced | DEFERRED | PASS |
+| Pixel/screen/viewport placement | Not implemented | DEFERRED | PASS |
+| Backend rendering | Not implemented | FORBIDDEN | PASS |
+| Event dispatch | Not implemented | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not introduced | FORBIDDEN | PASS |
+| Capability admission | Not introduced | FORBIDDEN | PASS |
+| Workbench/Studio | Not introduced | FORBIDDEN | PASS |
+| Source changes | None | FORBIDDEN | PASS |
+| Test changes | None | FORBIDDEN | PASS |
+| Manifest changes | None | FORBIDDEN | PASS |
+
+## 9. Admission Guard Table
+
+| Area | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| physical placement boundary | DOCUMENTED | ADMITTED | PASS |
+| physical placement source | DEFERRED | DEFERRED | PASS |
+| final physical layout | ABSENT | FORBIDDEN | PASS |
+| pixel/screen/viewport placement | ABSENT | FORBIDDEN | PASS |
+| backend rendering | ABSENT | FORBIDDEN | PASS |
+| event dispatch | ABSENT | FORBIDDEN | PASS |
+| runtime/verifier/VM | ABSENT | FORBIDDEN | PASS |
+| capability admission | ABSENT | FORBIDDEN | PASS |
+| proof/debugger authority | ABSENT | FORBIDDEN | PASS |
+| Workbench/Studio | ABSENT | FORBIDDEN | PASS |
+
+## 10. Project #2 State
+Project #2 state: VERIFIED
+Project #2 item count for #1083: 1
+Project #2 duplicate count for #1083: 0
+Project #2 metadata for #1083:
+- Status: Done
+- Track: POST-UI
+- Wave: R12
+- Type: Docs
+- Risk: High
+- Boundary: Renderer
+- Gate: Docs-only
+- Evidence: Roadmap doc
+- Depends on: #1082
+
+## 11. Untracked Workspace Artifacts
+Untracked workspace artifacts are treated as local-only, non-merged artifacts.
+They must not be staged, committed, deleted, or merged by this closeout PR.
+
+Known artifacts:
+
+- `.claude/`
+- `examples/baseline/`
+- `scratch/`
+
+## 12. Recommended Next Gate
+R12-UI-RENDERER-LAYOUT-PHYSICAL-PLACEMENT-BOUNDARY-LEDGER-AUDIT-PR
+
+Alternative after audit:
+POST-UI-ROADMAP-NEXT-LANE-SELECTION
+
+## 13. Final Decision
+Final decision:
+CLOSED — R12 UI Renderer Layout Physical Placement Boundary line is complete as docs-only boundary work.
+
+It defines the future boundary for renderer-local physical placement after UiLayoutSolvingResultModel and does not implement physical placement source, final physical layout, backend rectangles, pixel/screen/viewport placement, draw commands, event dispatch, runtime/verifier/VM integration, capability admission, proof/debugger authority, WGPU/winit/Tauri integration, or Workbench/Studio integration.
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, not deleted, and not merged.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Physical Placement Boundary line after the docs-only boundary PR.

## Scope

Records the docs-only boundary, the future position after UiLayoutSolvingResultModel, the allowed future input/output categories, the explicit separation from backend/event/runtime/capability/Workbench/Studio authority, and the deferred physical placement source gate.

## Explicit non-scope

- no source changes
- no test changes
- no physical placement source
- no final physical layout
- no backend rectangles
- no pixel/screen/viewport placement
- no draw commands
- no event dispatch
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no dependency additions
- local untracked artifacts are not deleted

## Project #2 metadata

```text
Track: POST-UI
Wave: R12
Type: Closeout
Risk: Medium
Boundary: Renderer
Gate: Release Artifact
Evidence: Roadmap doc
Depends on: #1083
```

## Validation

Local only:

- git diff --check: PASS
- cargo fmt --check: PASS
- cargo test -p prom-ui --lib: PASS
- cargo test -p prom-ui: PASS
- tracked pr_body files: NO
- GitHub CI used as evidence: NO

## Final decision

CLOSED — R12 UI Renderer Layout Physical Placement Boundary line is complete as docs-only boundary work.