### PR TITLE
docs(ui): close out renderer layout physical placement seed

### DIFF
--- a/docs/roadmap/post_ui/r12_ui_renderer_layout_physical_placement_seed_closeout.md
+++ b/docs/roadmap/post_ui/r12_ui_renderer_layout_physical_placement_seed_closeout.md
@@ -1,0 +1,146 @@
+# R12 UI Renderer Layout Physical Placement Seed Closeout
+
+## Purpose
+This document closes out the R12 UI Renderer Layout Physical Placement Seed line after the source seed PR.
+
+## DNA Alignment
+The seed line remains aligned with renderer/UI downstream ownership.
+
+The physical placement seed is metadata-only and follows the audited layout solving result stack.
+
+It does not change physical placement authority boundaries.
+
+## Closed Basis
+- #1082 -- roadmap selected physical placement boundary lane
+- #1083 -- physical placement boundary document
+- #1084 -- physical placement boundary closeout
+- #1085 -- physical placement boundary ledger audit
+- #1086 -- roadmap selected physical placement seed line
+
+## Source PR
+#1087 -- feat(ui): add renderer layout physical placement seed
+
+merge commit:
+`934dc6d8704b4e7a04fb566142e869669172117a`
+
+changed files:
+- `crates/prom-ui/src/layout/mod.rs`
+- `crates/prom-ui/src/layout/physical_placement.rs`
+- `crates/prom-ui/tests/renderer_layout_physical_placement_seed.rs`
+
+source changed:
+YES
+
+tests changed:
+YES
+
+docs changed:
+NO
+
+manifest changed:
+NO
+
+dependency additions:
+NO
+
+## Implemented State
+Implemented:
+- deterministic renderer-local physical placement metadata seed;
+- `UiLayoutPhysicalPlacementModelId`;
+- `UiLayoutPhysicalPlacementEntryId`;
+- `UiLayoutPhysicalPlacementKind`;
+- `UiLayoutPhysicalPlacementState`;
+- `UiLayoutPhysicalPlacementEntry`;
+- `UiLayoutPhysicalPlacementModel`;
+- `build_layout_physical_placement` entrypoint from `UiLayoutSolvingResultModel`;
+- source solving result reference preservation;
+- deterministic entry order and identity;
+- inert tests for metadata-only behavior and absence of placement authority.
+
+## Deferred State
+Deferred:
+- real physical placement implementation;
+- final physical layout;
+- backend rectangles;
+- pixel/screen/viewport placement;
+- draw commands;
+- event dispatch;
+- runtime/verifier/VM integration;
+- capability admission;
+- proof/debugger authority;
+- WGPU/winit/Tauri integration;
+- Workbench/Studio integration.
+
+## Non-Authority Confirmation
+This seed line does not grant physical placement authority.
+
+It records deterministic renderer-local placement metadata only.
+
+It does not produce final physical layout, backend rectangles, pixels, viewport placement, draw commands, event targets, runtime actions, capability admission, or Workbench/Studio authority.
+
+## Evidence Matrix
+| Area | Final state | Classification | Status |
+|---|---|---|---|
+| Physical placement seed model | Implemented | ADMITTED SOURCE | PASS |
+| Physical placement seed entry | Implemented | ADMITTED SOURCE | PASS |
+| Physical placement build entrypoint | Implemented | ADMITTED SOURCE | PASS |
+| Source tests | Implemented | ADMITTED TESTS | PASS |
+| Real physical placement | Not implemented | DEFERRED | PASS |
+| Final physical layout | Not produced | DEFERRED | PASS |
+| Backend rectangles | Not produced | FORBIDDEN | PASS |
+| Pixel/screen/viewport placement | Not implemented | FORBIDDEN | PASS |
+| Draw commands | Not introduced | FORBIDDEN | PASS |
+| Event dispatch | Not introduced | FORBIDDEN | PASS |
+| Runtime/verifier/VM | Not introduced | FORBIDDEN | PASS |
+| Capability admission | Not introduced | FORBIDDEN | PASS |
+| Workbench/Studio | Not introduced | FORBIDDEN | PASS |
+| Manifest/dependency changes | None | FORBIDDEN | PASS |
+
+## Admission Guard Table
+| Surface | Final state | Admission Guard classification | Status |
+|---|---|---|---|
+| physical placement seed | defined | metadata-only | PASS |
+| real physical placement | absent | deferred | PASS |
+| final physical layout | absent | deferred | PASS |
+| backend rectangles | absent | forbidden | PASS |
+| pixel/screen/viewport placement | absent | forbidden | PASS |
+| draw commands | absent | forbidden | PASS |
+| event dispatch | absent | forbidden | PASS |
+| runtime/verifier/VM | absent | forbidden | PASS |
+| capability admission | absent | forbidden | PASS |
+| proof/debugger authority | absent | forbidden | PASS |
+| Workbench/Studio | absent | forbidden | PASS |
+
+## Project #2 State
+```text
+Status: In Progress
+Track: POST-UI
+Wave: R12
+Type: Closeout
+Risk: Medium
+Boundary: Renderer
+Gate: Release Artifact
+Evidence: Roadmap doc
+Depends on: #1087
+```
+
+## Untracked Workspace Artifacts
+Pre-existing local workspace artifacts remain present:
+
+- `.claude/`
+- `examples/baseline/`
+- `scratch/`
+
+Classification:
+
+`PRE-EXISTING / LOCAL WORKSPACE ONLY / NOT MERGED`
+
+## Recommended Next Gate
+`R12-UI-RENDERER-LAYOUT-PHYSICAL-PLACEMENT-SEED-LEDGER-AUDIT-PR`
+
+## Final Decision
+CLOSED -- R12 UI Renderer Layout Physical Placement Seed is complete as a deterministic renderer-local placement metadata substrate.
+
+It records placement metadata derived after UiLayoutSolvingResultModel and does not implement real physical placement, final physical layout, backend rectangles, pixel/screen/viewport placement, draw commands, event dispatch, runtime/verifier/VM integration, capability admission, proof/debugger authority, WGPU/winit/Tauri integration, or Workbench/Studio integration.
+
+Tracked repository state remains clean. Pre-existing untracked local workspace artifacts were not staged, not committed, not deleted, and not merged.


### PR DESCRIPTION
## Summary

Closes out the R12 UI Renderer Layout Physical Placement Seed line after the source seed PR.

## Scope

Records the deterministic renderer-local physical placement metadata seed, the model/entry/ID/state surface, the build entrypoint, source-reference preservation, the inert test surface, deferred authority, and validation.

## Explicit non-scope

- no real physical placement implementation
- no final physical layout
- no backend rectangles
- no pixel/screen/viewport placement
- no draw commands
- no event dispatch
- no runtime/verifier/VM integration
- no capability admission
- no proof/debugger authority
- no Workbench/Studio integration
- no manifest or dependency changes
- local untracked artifacts are not deleted

## Final decision

CLOSED - R12 UI Renderer Layout Physical Placement Seed is complete as a deterministic renderer-local placement metadata substrate.
