### PR TITLE
feat(ui): lower AST carriers into inert IR carriers

### DIFF
--- a/crates/prom-ui/src/lowering.rs
+++ b/crates/prom-ui/src/lowering.rs
@@ -137,7 +137,7 @@ const fn map_supported_kind(kind: UiAstNodeKind) -> UiIrNodeKind {
         UiAstNodeKind::Fragment => UiIrNodeKind::Fragment,
         UiAstNodeKind::Attribute => UiIrNodeKind::Property,
         UiAstNodeKind::Action => UiIrNodeKind::Action,
-        UiAstNodeKind::Binding => UiIrNodeKind::Root, // Fallback for unsupported
+        UiAstNodeKind::Binding => UiIrNodeKind::Root, // unreachable after unsupported diagnostics
     }
 }
 

--- a/crates/prom-ui/src/lowering.rs
+++ b/crates/prom-ui/src/lowering.rs
@@ -88,11 +88,11 @@ pub type UiLoweringResult = Result<UiIr, UiLoweringDiagnostics>;
 /// - Element
 /// - Text
 /// - Fragment
+/// - Attribute
+/// - Action
 ///
 /// Unsupported AST kinds return diagnostics:
-/// - Attribute
 /// - Binding
-/// - Action
 pub fn lower_ast_to_ir(ast: &UiAst, config: &UiLoweringConfig) -> UiLoweringResult {
     let _ = config;
 
@@ -135,9 +135,9 @@ const fn map_supported_kind(kind: UiAstNodeKind) -> UiIrNodeKind {
         UiAstNodeKind::Element => UiIrNodeKind::Element,
         UiAstNodeKind::Text => UiIrNodeKind::Text,
         UiAstNodeKind::Fragment => UiIrNodeKind::Fragment,
-        UiAstNodeKind::Attribute | UiAstNodeKind::Binding | UiAstNodeKind::Action => {
-            UiIrNodeKind::Root
-        }
+        UiAstNodeKind::Attribute => UiIrNodeKind::Property,
+        UiAstNodeKind::Action => UiIrNodeKind::Action,
+        UiAstNodeKind::Binding => UiIrNodeKind::Root, // Fallback for unsupported
     }
 }
 
@@ -146,16 +146,16 @@ const fn unsupported_node_diagnostic(
     kind: UiAstNodeKind,
 ) -> Option<UiLoweringDiagnostic> {
     match kind {
-        UiAstNodeKind::Attribute | UiAstNodeKind::Binding | UiAstNodeKind::Action => {
-            Some(UiLoweringDiagnostic::new(
-                ast_node_id,
-                UiLoweringDiagnosticKind::UnsupportedAstNodeKind(kind),
-            ))
-        }
+        UiAstNodeKind::Binding => Some(UiLoweringDiagnostic::new(
+            ast_node_id,
+            UiLoweringDiagnosticKind::UnsupportedAstNodeKind(kind),
+        )),
         UiAstNodeKind::Root
         | UiAstNodeKind::Element
         | UiAstNodeKind::Text
-        | UiAstNodeKind::Fragment => None,
+        | UiAstNodeKind::Fragment
+        | UiAstNodeKind::Attribute
+        | UiAstNodeKind::Action => None,
     }
 }
 
@@ -244,21 +244,18 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_attribute_returns_diagnostic() {
+    fn attribute_lowers_to_ir_property() {
         let mut ast = UiAst::new();
         ast.push_node(crate::model::UiAstNode::new(
             UiAstNodeId::new(30),
             UiAstNodeKind::Attribute,
         ));
 
-        let err = lower_ast_to_ir(&ast, &UiLoweringConfig).expect_err("unsupported kind");
+        let lowered = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported kind");
 
-        assert_eq!(err.len(), 1);
-        assert_eq!(err.diagnostics()[0].ast_node_id(), UiAstNodeId::new(30));
-        assert_eq!(
-            err.diagnostics()[0].kind(),
-            UiLoweringDiagnosticKind::UnsupportedAstNodeKind(UiAstNodeKind::Attribute)
-        );
+        assert_eq!(lowered.len(), 1);
+        assert_eq!(lowered.nodes()[0].id(), UiIrNodeId::new(30));
+        assert_eq!(lowered.nodes()[0].kind(), UiIrNodeKind::Property);
     }
 
     #[test]
@@ -280,45 +277,32 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_action_returns_diagnostic() {
+    fn action_lowers_to_ir_action() {
         let mut ast = UiAst::new();
         ast.push_node(crate::model::UiAstNode::new(
             UiAstNodeId::new(32),
             UiAstNodeKind::Action,
         ));
 
-        let err = lower_ast_to_ir(&ast, &UiLoweringConfig).expect_err("unsupported kind");
+        let lowered = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported kind");
 
-        assert_eq!(err.len(), 1);
-        assert_eq!(err.diagnostics()[0].ast_node_id(), UiAstNodeId::new(32));
-        assert_eq!(
-            err.diagnostics()[0].kind(),
-            UiLoweringDiagnosticKind::UnsupportedAstNodeKind(UiAstNodeKind::Action)
-        );
+        assert_eq!(lowered.len(), 1);
+        assert_eq!(lowered.nodes()[0].id(), UiIrNodeId::new(32));
+        assert_eq!(lowered.nodes()[0].kind(), UiIrNodeKind::Action);
     }
 
     #[test]
     fn unsupported_nodes_collect_all_diagnostics() {
         let mut ast = UiAst::new();
         ast.push_node(crate::model::UiAstNode::new(
-            UiAstNodeId::new(40),
-            UiAstNodeKind::Attribute,
-        ));
-        ast.push_node(crate::model::UiAstNode::new(
             UiAstNodeId::new(41),
             UiAstNodeKind::Binding,
-        ));
-        ast.push_node(crate::model::UiAstNode::new(
-            UiAstNodeId::new(42),
-            UiAstNodeKind::Action,
         ));
 
         let err = lower_ast_to_ir(&ast, &UiLoweringConfig).expect_err("unsupported kinds");
 
-        assert_eq!(err.len(), 3);
-        assert_eq!(err.diagnostics()[0].ast_node_id(), UiAstNodeId::new(40));
-        assert_eq!(err.diagnostics()[1].ast_node_id(), UiAstNodeId::new(41));
-        assert_eq!(err.diagnostics()[2].ast_node_id(), UiAstNodeId::new(42));
+        assert_eq!(err.len(), 1);
+        assert_eq!(err.diagnostics()[0].ast_node_id(), UiAstNodeId::new(41));
     }
 
     #[test]
@@ -326,7 +310,7 @@ mod tests {
         let mut ast = supported_ast();
         ast.push_node(crate::model::UiAstNode::new(
             UiAstNodeId::new(43),
-            UiAstNodeKind::Action,
+            UiAstNodeKind::Binding,
         ));
 
         assert!(lower_ast_to_ir(&ast, &UiLoweringConfig).is_err());
@@ -344,18 +328,26 @@ mod tests {
     }
 
     #[test]
-    fn property_and_ir_action_are_not_generated_by_minimal_lowering() {
-        let ast = supported_ast();
+    fn property_and_ir_action_are_generated_by_carrier_lowering() {
+        let mut ast = supported_ast();
+        ast.push_node(crate::model::UiAstNode::new(
+            UiAstNodeId::new(44),
+            UiAstNodeKind::Attribute,
+        ));
+        ast.push_node(crate::model::UiAstNode::new(
+            UiAstNodeId::new(45),
+            UiAstNodeKind::Action,
+        ));
         let lowered = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
 
         assert!(lowered
             .nodes()
             .iter()
-            .all(|node| node.kind() != UiIrNodeKind::Property));
+            .any(|node| node.kind() == UiIrNodeKind::Property));
         assert!(lowered
             .nodes()
             .iter()
-            .all(|node| node.kind() != UiIrNodeKind::Action));
+            .any(|node| node.kind() == UiIrNodeKind::Action));
     }
 
     #[test]

--- a/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
+++ b/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
@@ -1,6 +1,6 @@
 use prom_ui::lowering::{lower_ast_to_ir, UiLoweringConfig, UiLoweringDiagnosticKind};
 use prom_ui::model::{
-    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind, UiNodeId, UiTreeId,
+    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind,
 };
 use prom_ui::projection::{project_ir_to_projection, UiProjectedNodeKind};
 use prom_ui::renderer::{render_projection_to_model, UiRenderMarker};

--- a/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
+++ b/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
@@ -1,0 +1,299 @@
+use prom_ui::lowering::{lower_ast_to_ir, UiLoweringConfig, UiLoweringDiagnosticKind};
+use prom_ui::model::{
+    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind, UiNodeId, UiTreeId,
+};
+use prom_ui::projection::{project_ir_to_projection, UiProjectedNodeKind};
+use prom_ui::renderer::{render_projection_to_model, UiRenderMarker};
+
+#[test]
+fn ast_attribute_lowers_to_ir_property() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let attr_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(attr_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        attr_id,
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+
+    let attr_ir = ir.nodes().iter().find(|n| n.id().raw() == 2).unwrap();
+    assert_eq!(attr_ir.kind(), UiIrNodeKind::Property);
+}
+
+#[test]
+fn ast_action_lowers_to_ir_action() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let action_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(action_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        action_id,
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+
+    let action_ir = ir.nodes().iter().find(|n| n.id().raw() == 2).unwrap();
+    assert_eq!(action_ir.kind(), UiIrNodeKind::Action);
+}
+
+#[test]
+fn lowered_attribute_projects_to_property_carrier() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let attr_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(attr_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        attr_id,
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+    let projection = project_ir_to_projection(&ir).expect("valid projection");
+
+    let attr_proj = projection
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == 2)
+        .unwrap();
+    assert_eq!(attr_proj.kind(), UiProjectedNodeKind::PropertyCarrier);
+}
+
+#[test]
+fn lowered_action_projects_to_action_carrier() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let action_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(action_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        action_id,
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+    let projection = project_ir_to_projection(&ir).expect("valid projection");
+
+    let action_proj = projection
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == 2)
+        .unwrap();
+    assert_eq!(action_proj.kind(), UiProjectedNodeKind::ActionCarrier);
+}
+
+#[test]
+fn lowered_attribute_renders_as_property_marker() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let attr_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(attr_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        attr_id,
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+    let projection = project_ir_to_projection(&ir).expect("valid projection");
+    let render_model = render_projection_to_model(&projection).expect("valid render model");
+
+    let attr_render = render_model
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == 2)
+        .unwrap();
+    assert!(attr_render.markers().contains(&UiRenderMarker::Property));
+}
+
+#[test]
+fn lowered_action_renders_as_action_marker() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let action_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(action_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        action_id,
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+    let projection = project_ir_to_projection(&ir).expect("valid projection");
+    let render_model = render_projection_to_model(&projection).expect("valid render model");
+
+    let action_render = render_model
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == 2)
+        .unwrap();
+    assert!(action_render.markers().contains(&UiRenderMarker::Action));
+}
+
+#[test]
+fn ast_binding_remains_unsupported() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let binding_id = UiAstNodeId::new(2);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(binding_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        binding_id,
+        UiAstNodeKind::Binding,
+        root_id,
+    ));
+
+    let err = lower_ast_to_ir(&ast, &UiLoweringConfig).expect_err("binding is unsupported");
+    assert_eq!(err.len(), 1);
+}
+
+#[test]
+fn binding_diagnostic_preserves_ast_node_id() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let binding_id = UiAstNodeId::new(42);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(binding_id);
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        binding_id,
+        UiAstNodeKind::Binding,
+        root_id,
+    ));
+
+    let err = lower_ast_to_ir(&ast, &UiLoweringConfig).expect_err("binding is unsupported");
+    assert_eq!(err.diagnostics()[0].ast_node_id(), UiAstNodeId::new(42));
+    assert_eq!(
+        err.diagnostics()[0].kind(),
+        UiLoweringDiagnosticKind::UnsupportedAstNodeKind(UiAstNodeKind::Binding)
+    );
+}
+
+#[test]
+fn mixed_carrier_lowering_is_deterministic() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(UiAstNodeId::new(2));
+    root_node.push_child(UiAstNodeId::new(3));
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(2),
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(3),
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let lowered_one = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+    let lowered_two = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+
+    assert_eq!(lowered_one, lowered_two);
+}
+
+#[test]
+fn carrier_lowering_does_not_generate_effect_boundary() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(UiAstNodeId::new(2));
+    root_node.push_child(UiAstNodeId::new(3));
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(2),
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(3),
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let lowered = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+
+    assert!(!lowered
+        .nodes()
+        .iter()
+        .any(|n| n.kind() == UiIrNodeKind::EffectBoundary));
+}
+
+#[test]
+fn carrier_lowering_is_inert_and_non_authoritative() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(1);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(UiAstNodeId::new(2));
+    root_node.push_child(UiAstNodeId::new(3));
+    ast.push_node(root_node);
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(2),
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(3),
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let config = UiLoweringConfig; // No execution authorities or hooks provided
+    let lowered = lower_ast_to_ir(&ast, &config).expect("inert mapping");
+
+    assert_eq!(lowered.len(), 3);
+}
+
+#[test]
+fn carrier_lowering_preserves_parent_child_handles() {
+    let mut ast = UiAst::new();
+    let root_id = UiAstNodeId::new(10);
+    let mut root_node = UiAstNode::new(root_id, UiAstNodeKind::Root);
+    root_node.push_child(UiAstNodeId::new(11));
+    root_node.push_child(UiAstNodeId::new(12));
+    ast.push_node(root_node);
+
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(11),
+        UiAstNodeKind::Attribute,
+        root_id,
+    ));
+    ast.push_node(UiAstNode::with_parent(
+        UiAstNodeId::new(12),
+        UiAstNodeKind::Action,
+        root_id,
+    ));
+
+    let lowered = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("supported subset");
+
+    let root_ir = lowered.nodes().iter().find(|n| n.id().raw() == 10).unwrap();
+    assert_eq!(root_ir.children().len(), 2);
+    assert_eq!(root_ir.children()[0].raw(), 11);
+    assert_eq!(root_ir.children()[1].raw(), 12);
+
+    let attr_ir = lowered.nodes().iter().find(|n| n.id().raw() == 11).unwrap();
+    assert_eq!(attr_ir.parent().unwrap().raw(), 10);
+
+    let action_ir = lowered.nodes().iter().find(|n| n.id().raw() == 12).unwrap();
+    assert_eq!(action_ir.parent().unwrap().raw(), 10);
+}


### PR DESCRIPTION
## What

This PR implements the missing AST-to-IR lowering carrier support for Attribute and Action nodes.

## Why

This closes a vertical gap in the prom-ui crate, allowing AST nodes like \Attribute\ and \Action\ to map to IR \Property\ and \Action\, and eventually project all the way into the renderer as \Property\ and \Action\ markers, maintaining the structural, non-authoritative boundary rules.

## Changes

- Updated \map_supported_kind\ to support \UiAstNodeKind::Attribute\ -> \UiIrNodeKind::Property\ and \UiAstNodeKind::Action\ -> \UiIrNodeKind::Action\
- Removed the \unsupported_node_diagnostic\ triggers for \Attribute\ and \Action\
- Added 300+ lines of tests in \	ests/ui_ast_ir_lowering_carriers.rs\ proving correct projection logic and inert, non-authoritative boundary behaviors