### PR TITLE
feat(ui): add structural validation for inert UiTree layer

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -265,10 +265,12 @@ pub use ui_capability_denial_trace::{
     InteractionUiCapabilityDenialTraceStatus,
 };
 pub use validation::{
-    validate_ast, validate_ir, UiAstValidationConfig, UiAstValidationDiagnostic,
+    validate_ast, validate_ir, validate_tree, UiAstValidationConfig, UiAstValidationDiagnostic,
     UiAstValidationDiagnosticKind, UiAstValidationDiagnostics, UiAstValidationResult,
     UiIrValidationConfig, UiIrValidationDiagnostic, UiIrValidationDiagnosticKind,
-    UiIrValidationDiagnostics, UiIrValidationResult,
+    UiIrValidationDiagnostics, UiIrValidationResult, UiTreeValidationConfig,
+    UiTreeValidationDiagnostic, UiTreeValidationDiagnosticKind, UiTreeValidationDiagnostics,
+    UiTreeValidationResult,
 };
 
 /// Marker for the UI application boundary capability family.

--- a/crates/prom-ui/src/validation.rs
+++ b/crates/prom-ui/src/validation.rs
@@ -18,8 +18,278 @@
 use alloc::vec::Vec;
 
 use crate::model::{
-    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind,
+    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind, UiNode,
+    UiNodeId, UiNodeKind, UiTree,
 };
+
+/// Inert configuration placeholder for the minimal UI tree validation seed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct UiTreeValidationConfig;
+
+/// Structured diagnostic kind for the minimal UI tree validation seed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiTreeValidationDiagnosticKind {
+    /// A node identifier appears more than once in the tree.
+    DuplicateNodeId(UiNodeId),
+    /// A node references a missing parent node.
+    MissingParentTarget {
+        node_id: UiNodeId,
+        parent_id: UiNodeId,
+    },
+    /// A node references a missing child node.
+    MissingChildTarget {
+        node_id: UiNodeId,
+        child_id: UiNodeId,
+    },
+    /// The parent/child relationship is inconsistent in the tree.
+    InconsistentParentChild {
+        parent_id: UiNodeId,
+        child_id: UiNodeId,
+    },
+    /// A node names itself as its own parent.
+    SelfParent(UiNodeId),
+    /// A node names itself as one of its children.
+    SelfChild(UiNodeId),
+    /// More than one root node exists in the tree.
+    MultipleRoots,
+}
+
+/// Structured diagnostic for a tree validation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiTreeValidationDiagnostic {
+    node_id: Option<UiNodeId>,
+    kind: UiTreeValidationDiagnosticKind,
+}
+
+impl UiTreeValidationDiagnostic {
+    /// Creates a validation diagnostic for a specific tree node.
+    pub const fn new(node_id: Option<UiNodeId>, kind: UiTreeValidationDiagnosticKind) -> Self {
+        Self { node_id, kind }
+    }
+
+    /// Returns the tree node id associated with the diagnostic, if any.
+    pub const fn node_id(&self) -> Option<UiNodeId> {
+        self.node_id
+    }
+
+    /// Returns the diagnostic kind.
+    pub const fn kind(&self) -> UiTreeValidationDiagnosticKind {
+        self.kind
+    }
+}
+
+/// Collection of structured tree validation diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+pub struct UiTreeValidationDiagnostics {
+    diagnostics: Vec<UiTreeValidationDiagnostic>,
+}
+
+impl UiTreeValidationDiagnostics {
+    /// Creates a diagnostics collection from a vector.
+    pub fn new(diagnostics: Vec<UiTreeValidationDiagnostic>) -> Self {
+        Self { diagnostics }
+    }
+
+    /// Returns whether there are no diagnostics.
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+
+    /// Returns the number of diagnostics.
+    pub fn len(&self) -> usize {
+        self.diagnostics.len()
+    }
+
+    /// Returns the diagnostics as a slice.
+    pub fn diagnostics(&self) -> &[UiTreeValidationDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Returns an iterator over the diagnostics.
+    pub fn iter(&self) -> core::slice::Iter<'_, UiTreeValidationDiagnostic> {
+        self.diagnostics.iter()
+    }
+
+    /// Returns the first diagnostic, if any.
+    pub fn first(&self) -> Option<&UiTreeValidationDiagnostic> {
+        self.diagnostics.first()
+    }
+
+    /// Converts the collection into a vector.
+    pub fn into_vec(self) -> Vec<UiTreeValidationDiagnostic> {
+        self.diagnostics
+    }
+}
+
+/// Result of the minimal tree validation seed.
+pub type UiTreeValidationResult = Result<(), UiTreeValidationDiagnostics>;
+
+/// Validates a minimal inert Semantic UI tree.
+///
+/// The first seed validates local structural properties only.
+/// Resolution metadata (Known/Unknown/Conflict) is preserved but does not affect structural validity.
+pub fn validate_tree(tree: &UiTree, config: &UiTreeValidationConfig) -> UiTreeValidationResult {
+    let _ = config;
+
+    if tree.is_empty() {
+        return Ok(());
+    }
+
+    let nodes = tree.nodes();
+    let mut diagnostics = Vec::new();
+    let mut seen_inconsistent_pairs: Vec<(UiNodeId, UiNodeId)> = Vec::new();
+    let mut seen_root = false;
+
+    for (index, node) in nodes.iter().enumerate() {
+        if nodes[..index]
+            .iter()
+            .any(|previous| previous.id() == node.id())
+        {
+            diagnostics.push(UiTreeValidationDiagnostic::new(
+                Some(node.id()),
+                UiTreeValidationDiagnosticKind::DuplicateNodeId(node.id()),
+            ));
+        }
+
+        if node.kind() == UiNodeKind::Root {
+            if seen_root {
+                diagnostics.push(UiTreeValidationDiagnostic::new(
+                    Some(node.id()),
+                    UiTreeValidationDiagnosticKind::MultipleRoots,
+                ));
+            } else {
+                seen_root = true;
+            }
+        }
+
+        validate_tree_parent_relationship(
+            nodes,
+            node,
+            &mut diagnostics,
+            &mut seen_inconsistent_pairs,
+        );
+        validate_tree_child_relationships(
+            nodes,
+            node,
+            &mut diagnostics,
+            &mut seen_inconsistent_pairs,
+        );
+    }
+
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(UiTreeValidationDiagnostics::new(diagnostics))
+    }
+}
+
+fn validate_tree_parent_relationship(
+    nodes: &[UiNode],
+    node: &UiNode,
+    diagnostics: &mut Vec<UiTreeValidationDiagnostic>,
+    seen_inconsistent_pairs: &mut Vec<(UiNodeId, UiNodeId)>,
+) {
+    let Some(parent_id) = node.parent() else {
+        return;
+    };
+
+    if parent_id == node.id() {
+        diagnostics.push(UiTreeValidationDiagnostic::new(
+            Some(node.id()),
+            UiTreeValidationDiagnosticKind::SelfParent(node.id()),
+        ));
+        return;
+    }
+
+    let Some(parent_node) = find_tree_node(nodes, parent_id) else {
+        diagnostics.push(UiTreeValidationDiagnostic::new(
+            Some(node.id()),
+            UiTreeValidationDiagnosticKind::MissingParentTarget {
+                node_id: node.id(),
+                parent_id,
+            },
+        ));
+        return;
+    };
+
+    if !parent_node.children().contains(&node.id()) {
+        push_tree_inconsistent_pair(
+            diagnostics,
+            seen_inconsistent_pairs,
+            parent_id,
+            node.id(),
+            Some(node.id()),
+        );
+    }
+}
+
+fn validate_tree_child_relationships(
+    nodes: &[UiNode],
+    node: &UiNode,
+    diagnostics: &mut Vec<UiTreeValidationDiagnostic>,
+    seen_inconsistent_pairs: &mut Vec<(UiNodeId, UiNodeId)>,
+) {
+    for &child_id in node.children() {
+        if child_id == node.id() {
+            diagnostics.push(UiTreeValidationDiagnostic::new(
+                Some(node.id()),
+                UiTreeValidationDiagnosticKind::SelfChild(node.id()),
+            ));
+            continue;
+        }
+
+        let Some(child_node) = find_tree_node(nodes, child_id) else {
+            diagnostics.push(UiTreeValidationDiagnostic::new(
+                Some(node.id()),
+                UiTreeValidationDiagnosticKind::MissingChildTarget {
+                    node_id: node.id(),
+                    child_id,
+                },
+            ));
+            continue;
+        };
+
+        if child_node.parent() != Some(node.id()) {
+            push_tree_inconsistent_pair(
+                diagnostics,
+                seen_inconsistent_pairs,
+                node.id(),
+                child_id,
+                Some(node.id()),
+            );
+        }
+    }
+}
+
+fn push_tree_inconsistent_pair(
+    diagnostics: &mut Vec<UiTreeValidationDiagnostic>,
+    seen_inconsistent_pairs: &mut Vec<(UiNodeId, UiNodeId)>,
+    parent_id: UiNodeId,
+    child_id: UiNodeId,
+    node_id: Option<UiNodeId>,
+) {
+    if seen_inconsistent_pairs
+        .iter()
+        .any(|&(seen_parent_id, seen_child_id)| {
+            seen_parent_id == parent_id && seen_child_id == child_id
+        })
+    {
+        return;
+    }
+
+    seen_inconsistent_pairs.push((parent_id, child_id));
+    diagnostics.push(UiTreeValidationDiagnostic::new(
+        node_id,
+        UiTreeValidationDiagnosticKind::InconsistentParentChild {
+            parent_id,
+            child_id,
+        },
+    ));
+}
+
+fn find_tree_node(nodes: &[UiNode], id: UiNodeId) -> Option<&UiNode> {
+    nodes.iter().find(|node| node.id() == id)
+}
 
 /// Inert configuration placeholder for the minimal AST validation seed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]

--- a/crates/prom-ui/tests/ui_tree_validation.rs
+++ b/crates/prom-ui/tests/ui_tree_validation.rs
@@ -1,0 +1,248 @@
+use prom_ui::model::{UiNode, UiNodeId, UiNodeKind, UiNodeResolution, UiTree, UiTreeId};
+use prom_ui::validation::{validate_tree, UiTreeValidationConfig, UiTreeValidationDiagnosticKind};
+
+fn tree_with_nodes(nodes: impl IntoIterator<Item = UiNode>) -> UiTree {
+    let mut tree = UiTree::new(UiTreeId::new(1));
+    for node in nodes {
+        tree.push_node(node);
+    }
+    tree
+}
+
+#[test]
+fn empty_tree_is_valid() {
+    let tree = UiTree::new(UiTreeId::new(2));
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn single_root_tree_is_valid() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Root)]);
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn zero_root_non_empty_tree_is_valid_in_first_seed() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(2), UiNodeKind::Element)]);
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn multiple_roots_returns_diagnostic() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root),
+        UiNode::new(UiNodeId::new(2), UiNodeKind::Root),
+    ]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("multiple roots");
+    assert!(err
+        .diagnostics()
+        .iter()
+        .any(|d| matches!(d.kind(), UiTreeValidationDiagnosticKind::MultipleRoots)));
+}
+
+#[test]
+fn duplicate_node_id_returns_diagnostic() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(3), UiNodeKind::Root),
+        UiNode::new(UiNodeId::new(3), UiNodeKind::Element),
+    ]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("duplicate id");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::DuplicateNodeId(id) if id == UiNodeId::new(3)
+    )));
+}
+
+#[test]
+fn missing_parent_target_returns_diagnostic() {
+    let tree = tree_with_nodes([UiNode::with_parent(
+        UiNodeId::new(4),
+        UiNodeKind::Element,
+        UiNodeId::new(99),
+    )]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("missing parent");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::MissingParentTarget { node_id, parent_id }
+        if node_id == UiNodeId::new(4) && parent_id == UiNodeId::new(99)
+    )));
+}
+
+#[test]
+fn missing_child_target_returns_diagnostic() {
+    let mut node = UiNode::new(UiNodeId::new(5), UiNodeKind::Root);
+    node.push_child(UiNodeId::new(100));
+    let tree = tree_with_nodes([node]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("missing child");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::MissingChildTarget { node_id, child_id }
+        if node_id == UiNodeId::new(5) && child_id == UiNodeId::new(100)
+    )));
+}
+
+#[test]
+fn consistent_parent_child_relationship_is_valid() {
+    let mut parent = UiNode::new(UiNodeId::new(6), UiNodeKind::Root);
+    parent.push_child(UiNodeId::new(7));
+    let child = UiNode::with_parent(UiNodeId::new(7), UiNodeKind::Element, UiNodeId::new(6));
+    let tree = tree_with_nodes([parent, child]);
+
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn parent_without_matching_child_returns_diagnostic() {
+    let parent = UiNode::new(UiNodeId::new(8), UiNodeKind::Root);
+    let child = UiNode::with_parent(UiNodeId::new(9), UiNodeKind::Element, UiNodeId::new(8));
+    let tree = tree_with_nodes([parent, child]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default())
+        .expect_err("inconsistent relationship");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::InconsistentParentChild { parent_id, child_id }
+        if parent_id == UiNodeId::new(8) && child_id == UiNodeId::new(9)
+    )));
+}
+
+#[test]
+fn child_without_matching_parent_returns_diagnostic() {
+    let mut parent = UiNode::new(UiNodeId::new(10), UiNodeKind::Root);
+    parent.push_child(UiNodeId::new(11));
+    let child = UiNode::new(UiNodeId::new(11), UiNodeKind::Element);
+    let tree = tree_with_nodes([parent, child]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default())
+        .expect_err("inconsistent relationship");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::InconsistentParentChild { parent_id, child_id }
+        if parent_id == UiNodeId::new(10) && child_id == UiNodeId::new(11)
+    )));
+}
+
+#[test]
+fn self_parent_returns_diagnostic() {
+    let tree = tree_with_nodes([UiNode::with_parent(
+        UiNodeId::new(12),
+        UiNodeKind::Element,
+        UiNodeId::new(12),
+    )]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("self parent");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::SelfParent(id) if id == UiNodeId::new(12)
+    )));
+}
+
+#[test]
+fn self_child_returns_diagnostic() {
+    let mut node = UiNode::new(UiNodeId::new(13), UiNodeKind::Root);
+    node.push_child(UiNodeId::new(13));
+    let tree = tree_with_nodes([node]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("self child");
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeValidationDiagnosticKind::SelfChild(id) if id == UiNodeId::new(13)
+    )));
+}
+
+#[test]
+fn unknown_resolution_does_not_invalidate_tree() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(14),
+        UiNodeKind::Element,
+        UiNodeResolution::Unknown,
+    )]);
+
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn conflict_resolution_does_not_invalidate_tree() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(15),
+        UiNodeKind::Element,
+        UiNodeResolution::Conflict,
+    )]);
+
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn validation_does_not_mutate_input_tree() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(16), UiNodeKind::Element)]);
+
+    let _ = validate_tree(&tree, &UiTreeValidationConfig::default());
+
+    assert_eq!(tree.len(), 1);
+    assert_eq!(tree.nodes()[0].id(), UiNodeId::new(16));
+}
+
+#[test]
+fn diagnostics_preserve_node_ids() {
+    let tree = tree_with_nodes([UiNode::with_parent(
+        UiNodeId::new(17),
+        UiNodeKind::Element,
+        UiNodeId::new(18),
+    )]);
+
+    let err = validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("missing parent");
+    assert_eq!(err.diagnostics()[0].node_id(), Some(UiNodeId::new(17)));
+}
+
+#[test]
+fn diagnostic_order_is_deterministic() {
+    let mut node = UiNode::new(UiNodeId::new(19), UiNodeKind::Root);
+    node.push_child(UiNodeId::new(20)); // missing child
+    let mut node2 = UiNode::new(
+        UiNodeId::new(19), // duplicate id
+        UiNodeKind::Element,
+    );
+    node2.push_child(UiNodeId::new(21)); // missing child
+
+    let tree = tree_with_nodes([node, node2]);
+
+    let err =
+        validate_tree(&tree, &UiTreeValidationConfig::default()).expect_err("multiple errors");
+
+    // Order should follow traversal:
+    // Node 19 (first): MissingChildTarget (20)
+    // Node 19 (second): DuplicateNodeId (19), MissingChildTarget (21)
+
+    let mut iter = err.diagnostics().iter();
+    assert!(matches!(
+        iter.next().unwrap().kind(),
+        UiTreeValidationDiagnosticKind::MissingChildTarget { child_id, .. } if child_id == UiNodeId::new(20)
+    ));
+    assert!(matches!(
+        iter.next().unwrap().kind(),
+        UiTreeValidationDiagnosticKind::DuplicateNodeId(id) if id == UiNodeId::new(19)
+    ));
+    assert!(matches!(
+        iter.next().unwrap().kind(),
+        UiTreeValidationDiagnosticKind::MissingChildTarget { child_id, .. } if child_id == UiNodeId::new(21)
+    ));
+}
+
+#[test]
+fn tree_validation_is_inert_and_non_authoritative() {
+    let _config = UiTreeValidationConfig;
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(22), UiNodeKind::Root)]);
+
+    let result = validate_tree(&tree, &UiTreeValidationConfig::default());
+    assert_eq!(result, Ok(()));
+}


### PR DESCRIPTION
## Summary

Adds structural validation for the existing inert UiTree layer in prom-ui.

This PR introduces validate_tree(...) and tree validation diagnostics for local graph integrity only.

## Scope

Adds:
- UiTreeValidationConfig
- UiTreeValidationDiagnosticKind
- UiTreeValidationDiagnostic
- UiTreeValidationDiagnostics
- UiTreeValidationResult
- validate_tree(...)
- integration tests for tree structural validation

Validates:
- duplicate node IDs
- missing parent targets
- missing child targets
- inconsistent parent/child relationships
- self-parent
- self-child
- multiple roots
- resolution metadata does not affect structural validity

## Explicit non-scope

- no AST lowering
- no IR lowering
- no projection changes
- no renderer changes
- no layout behavior
- no event dispatch
- no action execution
- no effect execution
- no capability admission
- no runtime/VM/Host ABI authority
- no backend draw
- no Workbench/Studio integration
- no docs
- no dependency additions
- no Cargo.toml / Cargo.lock changes
- no Admission Guard changes
- no GitHub CI evidence
