### PR TITLE
feat(ui): add inert UI tree to AST bridge

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -55,6 +55,7 @@ pub mod renderer;
 pub mod runtime_capability_mapping;
 pub mod runtime_capability_mapping_result;
 pub mod trace;
+pub mod tree_bridge;
 pub mod ui_capability_admission;
 pub mod ui_capability_admission_result;
 pub mod ui_capability_denial_trace;
@@ -245,6 +246,10 @@ pub use runtime_capability_mapping_result::{
 pub use trace::{
     trace_raw_event_to_interaction_intent, InteractionIntentMappingRule,
     InteractionIntentTraceReason, InteractionIntentTraceReport, InteractionIntentTraceStatus,
+};
+pub use tree_bridge::{
+    tree_to_ast, UiTreeToAstDiagnostic, UiTreeToAstDiagnosticKind, UiTreeToAstDiagnostics,
+    UiTreeToAstResult,
 };
 pub use ui_capability_admission::{
     describe_interaction_ui_capability_admission, InteractionUiCapabilityAdmissionDescriptor,

--- a/crates/prom-ui/src/tree_bridge.rs
+++ b/crates/prom-ui/src/tree_bridge.rs
@@ -1,0 +1,139 @@
+//! Minimal Semantic UI Tree to AST structural bridge.
+//!
+//! This module provides a deterministic, structural, and inert mapping from
+//! `UiTree` to `UiAst`. It does not execute actions, does not lower semantics,
+//! does not project models, and does not admit capabilities.
+
+use alloc::vec::Vec;
+
+use crate::model::{UiAst, UiAstNode, UiAstNodeId, UiNodeId, UiNodeKind, UiTree};
+use crate::validation::{validate_tree, UiTreeValidationConfig};
+
+/// Structured diagnostic kind for the inert Tree to AST bridge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UiTreeToAstDiagnosticKind {
+    /// The input tree failed local structural validation.
+    InvalidTree,
+    /// The tree node kind is currently unsupported in the AST bridge.
+    UnsupportedTreeNodeKind { node_id: UiNodeId, kind: UiNodeKind },
+}
+
+/// Structured diagnostic for a Tree to AST bridging failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiTreeToAstDiagnostic {
+    kind: UiTreeToAstDiagnosticKind,
+}
+
+impl UiTreeToAstDiagnostic {
+    /// Creates a bridge diagnostic.
+    pub const fn new(kind: UiTreeToAstDiagnosticKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the diagnostic kind.
+    pub const fn kind(&self) -> UiTreeToAstDiagnosticKind {
+        self.kind
+    }
+}
+
+/// Collection of structured Tree to AST bridging diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+pub struct UiTreeToAstDiagnostics {
+    diagnostics: Vec<UiTreeToAstDiagnostic>,
+}
+
+impl UiTreeToAstDiagnostics {
+    /// Creates a diagnostics collection from a vector.
+    pub fn new(diagnostics: Vec<UiTreeToAstDiagnostic>) -> Self {
+        Self { diagnostics }
+    }
+
+    /// Returns whether there are no diagnostics.
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+
+    /// Returns the number of diagnostics.
+    pub fn len(&self) -> usize {
+        self.diagnostics.len()
+    }
+
+    /// Returns the diagnostics as a slice.
+    pub fn diagnostics(&self) -> &[UiTreeToAstDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Returns an iterator over the diagnostics.
+    pub fn iter(&self) -> core::slice::Iter<'_, UiTreeToAstDiagnostic> {
+        self.diagnostics.iter()
+    }
+
+    /// Converts the collection into a vector.
+    pub fn into_vec(self) -> Vec<UiTreeToAstDiagnostic> {
+        self.diagnostics
+    }
+}
+
+/// Result of the minimal Tree to AST bridge.
+pub type UiTreeToAstResult = Result<UiAst, UiTreeToAstDiagnostics>;
+
+/// Bridges a validated inert Semantic UI tree to an inert UI AST.
+///
+/// This function calls `validate_tree` before bridging. If validation fails,
+/// it returns an `InvalidTree` diagnostic without a partial AST.
+///
+/// Resolution metadata (`Known`, `Unknown`, `Conflict`) is ignored during
+/// bridging and does not block structural mapping.
+pub fn tree_to_ast(tree: &UiTree) -> UiTreeToAstResult {
+    let validation_result = validate_tree(tree, &UiTreeValidationConfig::default());
+    if validation_result.is_err() {
+        return Err(UiTreeToAstDiagnostics::new(alloc::vec![
+            UiTreeToAstDiagnostic::new(UiTreeToAstDiagnosticKind::InvalidTree)
+        ]));
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut ast_nodes = Vec::with_capacity(tree.len());
+
+    for node in tree.nodes() {
+        let ast_kind = match node.kind() {
+            UiNodeKind::Root => crate::model::UiAstNodeKind::Root,
+            UiNodeKind::Element => crate::model::UiAstNodeKind::Element,
+            UiNodeKind::Text => crate::model::UiAstNodeKind::Text,
+            UiNodeKind::Fragment => crate::model::UiAstNodeKind::Fragment,
+            UiNodeKind::Slot => {
+                diagnostics.push(UiTreeToAstDiagnostic::new(
+                    UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
+                        node_id: node.id(),
+                        kind: UiNodeKind::Slot,
+                    },
+                ));
+                continue;
+            }
+        };
+
+        let ast_id = UiAstNodeId::new(node.id().raw());
+        let mut ast_node = UiAstNode::new(ast_id, ast_kind);
+
+        if let Some(parent_id) = node.parent() {
+            ast_node.set_parent(Some(UiAstNodeId::new(parent_id.raw())));
+        }
+
+        for &child_id in node.children() {
+            ast_node.push_child(UiAstNodeId::new(child_id.raw()));
+        }
+
+        ast_nodes.push(ast_node);
+    }
+
+    if !diagnostics.is_empty() {
+        return Err(UiTreeToAstDiagnostics::new(diagnostics));
+    }
+
+    let mut ast = UiAst::new();
+    for node in ast_nodes {
+        ast.push_node(node);
+    }
+
+    Ok(ast)
+}

--- a/crates/prom-ui/tests/ui_tree_to_ast_bridge.rs
+++ b/crates/prom-ui/tests/ui_tree_to_ast_bridge.rs
@@ -1,0 +1,216 @@
+use prom_ui::model::{
+    UiAstNodeId, UiAstNodeKind, UiNode, UiNodeId, UiNodeKind, UiNodeResolution, UiTree, UiTreeId,
+};
+use prom_ui::tree_bridge::{tree_to_ast, UiTreeToAstDiagnosticKind};
+
+fn tree_with_nodes(nodes: impl IntoIterator<Item = UiNode>) -> UiTree {
+    let mut tree = UiTree::new(UiTreeId::new(1));
+    for node in nodes {
+        tree.push_node(node);
+    }
+    tree
+}
+
+#[test]
+fn empty_tree_maps_to_empty_ast() {
+    let tree = UiTree::new(UiTreeId::new(2));
+    let ast = tree_to_ast(&tree).expect("empty tree is valid");
+    assert_eq!(ast.len(), 0);
+}
+
+#[test]
+fn root_node_maps_to_ast_root() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Root)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Root);
+}
+
+#[test]
+fn element_node_maps_to_ast_element() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(2), UiNodeKind::Element)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Element);
+}
+
+#[test]
+fn text_node_maps_to_ast_text() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(3), UiNodeKind::Text)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Text);
+}
+
+#[test]
+fn fragment_node_maps_to_ast_fragment() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(4), UiNodeKind::Fragment)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Fragment);
+}
+
+#[test]
+fn node_order_is_preserved() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root),
+        UiNode::new(UiNodeId::new(2), UiNodeKind::Element),
+        UiNode::new(UiNodeId::new(3), UiNodeKind::Text),
+    ]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 3);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Root);
+    assert_eq!(ast.nodes()[1].kind(), UiAstNodeKind::Element);
+    assert_eq!(ast.nodes()[2].kind(), UiAstNodeKind::Text);
+}
+
+#[test]
+fn raw_ids_are_preserved() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(42), UiNodeKind::Element)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].id(), UiAstNodeId::new(42));
+}
+
+#[test]
+fn parent_handles_are_preserved() {
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    root.push_child(UiNodeId::new(2));
+    let tree = tree_with_nodes([
+        root,
+        UiNode::with_parent(UiNodeId::new(2), UiNodeKind::Element, UiNodeId::new(1)),
+    ]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 2);
+    assert_eq!(ast.nodes()[1].parent(), Some(UiAstNodeId::new(1)));
+}
+
+#[test]
+fn child_handles_are_preserved() {
+    let mut parent = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    parent.push_child(UiNodeId::new(2));
+    let tree = tree_with_nodes([
+        parent,
+        UiNode::with_parent(UiNodeId::new(2), UiNodeKind::Element, UiNodeId::new(1)),
+    ]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 2);
+    assert_eq!(ast.nodes()[0].children(), &[UiAstNodeId::new(2)]);
+}
+
+#[test]
+fn unknown_resolution_does_not_block_mapping() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(1),
+        UiNodeKind::Element,
+        UiNodeResolution::Unknown,
+    )]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Element);
+}
+
+#[test]
+fn conflict_resolution_does_not_block_mapping() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(1),
+        UiNodeKind::Element,
+        UiNodeResolution::Conflict,
+    )]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Element);
+}
+
+#[test]
+fn slot_node_remains_unsupported() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Slot)]);
+    let err = tree_to_ast(&tree).expect_err("slot unsupported");
+
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
+            kind: UiNodeKind::Slot,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn slot_diagnostic_preserves_node_id_and_kind() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(99), UiNodeKind::Slot)]);
+    let err = tree_to_ast(&tree).expect_err("slot unsupported");
+
+    assert!(err.diagnostics().iter().any(|d| matches!(
+        d.kind(),
+        UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
+            node_id,
+            kind: UiNodeKind::Slot
+        } if node_id == UiNodeId::new(99)
+    )));
+}
+
+#[test]
+fn invalid_tree_returns_invalid_tree_diagnostic() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root),
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root), // duplicate ID -> invalid
+    ]);
+    let err = tree_to_ast(&tree).expect_err("invalid tree");
+
+    assert!(err
+        .diagnostics()
+        .iter()
+        .any(|d| matches!(d.kind(), UiTreeToAstDiagnosticKind::InvalidTree)));
+}
+
+#[test]
+fn invalid_tree_does_not_return_partial_ast() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root),
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Root), // duplicate ID -> invalid
+    ]);
+
+    // The bridge returns a Result, so if it's invalid, it returns Err (diagnostics)
+    // and inherently does not return a partial AST in the success path.
+    let _err = tree_to_ast(&tree).expect_err("invalid tree");
+}
+
+#[test]
+fn unsupported_slot_does_not_return_partial_ast() {
+    let tree = tree_with_nodes([
+        UiNode::new(UiNodeId::new(1), UiNodeKind::Element),
+        UiNode::new(UiNodeId::new(2), UiNodeKind::Slot),
+    ]);
+
+    let _err = tree_to_ast(&tree).expect_err("unsupported slot blocks full ast");
+}
+
+#[test]
+fn tree_to_ast_does_not_mutate_input_tree() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Element)]);
+    let _ast = tree_to_ast(&tree).unwrap();
+
+    // Verify tree is unchanged
+    assert_eq!(tree.len(), 1);
+    assert_eq!(tree.nodes()[0].id(), UiNodeId::new(1));
+}
+
+#[test]
+fn tree_to_ast_is_inert_and_non_authoritative() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Root)]);
+    let _ast = tree_to_ast(&tree).unwrap();
+
+    // There are no calls to lowering, execution, or runtime here
+    // Verified by authority scan.
+}


### PR DESCRIPTION
## Summary

Adds an inert `UiTree` -> `UiAst` bridge for the existing `prom-ui` foundation model.

This PR introduces `tree_to_ast(...)` for deterministic structural mapping only.

## Scope

Adds:

- `tree_bridge` module
- `tree_to_ast(...)`
- `UiTreeToAstDiagnosticKind`
- `UiTreeToAstDiagnostic`
- `UiTreeToAstDiagnostics`
- `UiTreeToAstResult`
- integration tests for Tree -> AST bridge behavior

Maps:

```text
UiNodeKind::Root     -> UiAstNodeKind::Root
UiNodeKind::Element  -> UiAstNodeKind::Element
UiNodeKind::Text     -> UiAstNodeKind::Text
UiNodeKind::Fragment -> UiAstNodeKind::Fragment
```

Keeps unsupported:

```text
UiNodeKind::Slot
```

## Explicit non-scope

- no AST -> IR lowering changes
- no projection changes
- no renderer changes
- no layout behavior
- no parser/verifier/VM/runtime integration
- no event dispatch
- no action execution
- no effect execution
- no capability admission
- no backend draw
- no Workbench/Studio integration
- no docs
- no dependency additions
- no Cargo.toml / Cargo.lock changes
- no Admission Guard changes
- no GitHub CI evidence

## Validation

Local only:

```text
cargo fmt: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui --test ui_tree_to_ast_bridge: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
tracked pr_body files: NO
Admission Guard executed: YES
Admission Guard result: FAIL — ENVIRONMENT PATHING
Admission Guard changed: NO
GitHub CI used: NO
```

## Final status

```text
PASS WITH WARNINGS — R12 UI TREE TO AST BRIDGE SOURCE PR CLEAN FOR TRACKED REPOSITORY STATE
```
