### PR TITLE
feat(ui): map inert tree slots to AST fragments

### DIFF
--- a/crates/prom-ui/src/tree_bridge.rs
+++ b/crates/prom-ui/src/tree_bridge.rs
@@ -92,7 +92,7 @@ pub fn tree_to_ast(tree: &UiTree) -> UiTreeToAstResult {
         ]));
     }
 
-    let mut diagnostics = Vec::new();
+    let diagnostics = Vec::new();
     let mut ast_nodes = Vec::with_capacity(tree.len());
 
     for node in tree.nodes() {
@@ -101,15 +101,7 @@ pub fn tree_to_ast(tree: &UiTree) -> UiTreeToAstResult {
             UiNodeKind::Element => crate::model::UiAstNodeKind::Element,
             UiNodeKind::Text => crate::model::UiAstNodeKind::Text,
             UiNodeKind::Fragment => crate::model::UiAstNodeKind::Fragment,
-            UiNodeKind::Slot => {
-                diagnostics.push(UiTreeToAstDiagnostic::new(
-                    UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
-                        node_id: node.id(),
-                        kind: UiNodeKind::Slot,
-                    },
-                ));
-                continue;
-            }
+            UiNodeKind::Slot => crate::model::UiAstNodeKind::Fragment,
         };
 
         let ast_id = UiAstNodeId::new(node.id().raw());

--- a/crates/prom-ui/tests/ui_tree_to_ast_bridge.rs
+++ b/crates/prom-ui/tests/ui_tree_to_ast_bridge.rs
@@ -133,31 +133,87 @@ fn conflict_resolution_does_not_block_mapping() {
 }
 
 #[test]
-fn slot_node_remains_unsupported() {
+fn slot_node_maps_to_ast_fragment() {
     let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Slot)]);
-    let err = tree_to_ast(&tree).expect_err("slot unsupported");
+    let ast = tree_to_ast(&tree).expect("valid tree");
 
-    assert!(err.diagnostics().iter().any(|d| matches!(
-        d.kind(),
-        UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
-            kind: UiNodeKind::Slot,
-            ..
-        }
-    )));
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Fragment);
 }
 
 #[test]
-fn slot_diagnostic_preserves_node_id_and_kind() {
+fn slot_node_preserves_raw_id() {
     let tree = tree_with_nodes([UiNode::new(UiNodeId::new(99), UiNodeKind::Slot)]);
-    let err = tree_to_ast(&tree).expect_err("slot unsupported");
+    let ast = tree_to_ast(&tree).expect("valid tree");
 
-    assert!(err.diagnostics().iter().any(|d| matches!(
-        d.kind(),
-        UiTreeToAstDiagnosticKind::UnsupportedTreeNodeKind {
-            node_id,
-            kind: UiNodeKind::Slot
-        } if node_id == UiNodeId::new(99)
-    )));
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].id(), UiAstNodeId::new(99));
+}
+
+#[test]
+fn slot_node_preserves_parent_handle() {
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    root.push_child(UiNodeId::new(2));
+    let tree = tree_with_nodes([
+        root,
+        UiNode::with_parent(UiNodeId::new(2), UiNodeKind::Slot, UiNodeId::new(1)),
+    ]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 2);
+    assert_eq!(ast.nodes()[1].parent(), Some(UiAstNodeId::new(1)));
+}
+
+#[test]
+fn slot_node_preserves_child_handles() {
+    let mut parent = UiNode::new(UiNodeId::new(1), UiNodeKind::Slot);
+    parent.push_child(UiNodeId::new(2));
+    let tree = tree_with_nodes([
+        parent,
+        UiNode::with_parent(UiNodeId::new(2), UiNodeKind::Element, UiNodeId::new(1)),
+    ]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 2);
+    assert_eq!(ast.nodes()[0].children(), &[UiAstNodeId::new(2)]);
+}
+
+#[test]
+fn unknown_slot_resolution_does_not_block_mapping() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(1),
+        UiNodeKind::Slot,
+        UiNodeResolution::Unknown,
+    )]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Fragment);
+}
+
+#[test]
+fn conflict_slot_resolution_does_not_block_mapping() {
+    let tree = tree_with_nodes([UiNode::with_resolution(
+        UiNodeId::new(1),
+        UiNodeKind::Slot,
+        UiNodeResolution::Conflict,
+    )]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Fragment);
+}
+
+#[test]
+fn slot_mapping_does_not_create_attribute_binding_or_action() {
+    let tree = tree_with_nodes([UiNode::new(UiNodeId::new(1), UiNodeKind::Slot)]);
+    let ast = tree_to_ast(&tree).expect("valid tree");
+
+    assert_eq!(ast.len(), 1);
+    let kind = ast.nodes()[0].kind();
+    assert_ne!(kind, UiAstNodeKind::Attribute);
+    assert_ne!(kind, UiAstNodeKind::Binding);
+    assert_ne!(kind, UiAstNodeKind::Action);
 }
 
 #[test]
@@ -184,16 +240,6 @@ fn invalid_tree_does_not_return_partial_ast() {
     // The bridge returns a Result, so if it's invalid, it returns Err (diagnostics)
     // and inherently does not return a partial AST in the success path.
     let _err = tree_to_ast(&tree).expect_err("invalid tree");
-}
-
-#[test]
-fn unsupported_slot_does_not_return_partial_ast() {
-    let tree = tree_with_nodes([
-        UiNode::new(UiNodeId::new(1), UiNodeKind::Element),
-        UiNode::new(UiNodeId::new(2), UiNodeKind::Slot),
-    ]);
-
-    let _err = tree_to_ast(&tree).expect_err("unsupported slot blocks full ast");
 }
 
 #[test]

--- a/crates/prom-ui/tests/ui_tree_to_render_vertical_slice.rs
+++ b/crates/prom-ui/tests/ui_tree_to_render_vertical_slice.rs
@@ -1,6 +1,6 @@
 use prom_ui::lowering::{lower_ast_to_ir, UiLoweringConfig};
-use prom_ui::model::{UiNode, UiNodeId, UiNodeKind, UiTree, UiTreeId};
-use prom_ui::projection::project_ir_to_projection;
+use prom_ui::model::{UiAstNodeKind, UiIrNodeKind, UiNode, UiNodeId, UiNodeKind, UiTree, UiTreeId};
+use prom_ui::projection::{project_ir_to_projection, UiProjectedNodeKind};
 use prom_ui::renderer::{render_projection_to_model, UiRenderMarker, UiRenderNodeKind};
 use prom_ui::tree_bridge::tree_to_ast;
 use prom_ui::validation::{validate_tree, UiTreeValidationConfig};
@@ -87,11 +87,11 @@ fn vertical_slice_from_tree_to_render_model_builds_successfully() {
 }
 
 #[test]
-fn vertical_slice_rejects_unsupported_slot_nodes() {
+fn vertical_slice_accepts_inert_slot_as_fragment() {
     let mut tree = UiTree::new(UiTreeId::new(200));
 
     let root_id = UiNodeId::new(201);
-    let slot_id = UiNodeId::new(202); // Slot cannot be bridged
+    let slot_id = UiNodeId::new(202);
 
     let mut root_node = UiNode::new(root_id, UiNodeKind::Root);
     root_node.push_child(slot_id);
@@ -101,16 +101,96 @@ fn vertical_slice_rejects_unsupported_slot_nodes() {
     tree.push_node(root_node);
     tree.push_node(slot_node);
 
-    // Validation might pass structurally
     let validation_result = validate_tree(&tree, &UiTreeValidationConfig::default());
     assert!(validation_result.is_ok());
 
-    // Bridge Tree to AST must fail due to unsupported Slot
-    let tree_to_ast_result = tree_to_ast(&tree);
-    assert!(
-        tree_to_ast_result.is_err(),
-        "Tree to AST bridge must reject unsupported Slot node"
-    );
+    let ast = tree_to_ast(&tree).expect("bridge to succeed");
+
+    let ast_slot = ast
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == slot_id.raw())
+        .expect("AST node missing");
+    assert_eq!(ast_slot.kind(), UiAstNodeKind::Fragment);
+
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("lowering to succeed");
+
+    let ir_slot = ir
+        .nodes()
+        .iter()
+        .find(|n| n.id().raw() == slot_id.raw())
+        .expect("IR node missing");
+    assert_eq!(ir_slot.kind(), UiIrNodeKind::Fragment);
+
+    let projection = project_ir_to_projection(&ir).expect("projection to succeed");
+
+    let proj_slot = projection
+        .nodes()
+        .iter()
+        .find(|n| n.source_ir_node_id() == Some(ir_slot.id()))
+        .expect("Projection node missing");
+    assert_eq!(proj_slot.kind(), UiProjectedNodeKind::Fragment);
+
+    let render_model = render_projection_to_model(&projection).expect("render to succeed");
+
+    let render_slot = render_model
+        .nodes()
+        .iter()
+        .find(|n| n.source_ir_node() == Some(ir_slot.id()))
+        .expect("Render node missing");
+    assert_eq!(render_slot.kind(), UiRenderNodeKind::Fragment);
+}
+
+#[test]
+fn slot_vertical_slice_does_not_produce_property_or_action_markers() {
+    let mut tree = UiTree::new(UiTreeId::new(300));
+    let root_id = UiNodeId::new(301);
+    let slot_id = UiNodeId::new(302);
+    let mut root_node = UiNode::new(root_id, UiNodeKind::Root);
+    root_node.push_child(slot_id);
+    let slot_node = UiNode::with_parent(slot_id, UiNodeKind::Slot, root_id);
+    tree.push_node(root_node);
+    tree.push_node(slot_node);
+
+    let ast = tree_to_ast(&tree).expect("bridge");
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("lowering");
+    let projection = project_ir_to_projection(&ir).expect("projection");
+    let render_model = render_projection_to_model(&projection).expect("render");
+
+    for node in render_model.nodes() {
+        for marker in node.markers() {
+            assert!(
+                !matches!(marker, UiRenderMarker::Property | UiRenderMarker::Action),
+                "Slot should not produce property or action markers"
+            );
+        }
+    }
+}
+
+#[test]
+fn slot_vertical_slice_does_not_produce_effect_boundary_marker() {
+    let mut tree = UiTree::new(UiTreeId::new(400));
+    let root_id = UiNodeId::new(401);
+    let slot_id = UiNodeId::new(402);
+    let mut root_node = UiNode::new(root_id, UiNodeKind::Root);
+    root_node.push_child(slot_id);
+    let slot_node = UiNode::with_parent(slot_id, UiNodeKind::Slot, root_id);
+    tree.push_node(root_node);
+    tree.push_node(slot_node);
+
+    let ast = tree_to_ast(&tree).expect("bridge");
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("lowering");
+    let projection = project_ir_to_projection(&ir).expect("projection");
+    let render_model = render_projection_to_model(&projection).expect("render");
+
+    for node in render_model.nodes() {
+        for marker in node.markers() {
+            assert!(
+                !matches!(marker, UiRenderMarker::EffectBoundary),
+                "Slot should not produce effect boundary marker"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary

Adds the first inert structural semantics for `UiNodeKind::Slot`.

This PR changes the `UiTree` -> `UiAst` bridge so that Slot maps to AST Fragment as a structural placeholder/container boundary.

## Scope

Adds / updates:

- `UiNodeKind::Slot -> UiAstNodeKind::Fragment`
- tests proving Slot preserves raw IDs
- tests proving Slot preserves parent/child handles
- tests proving Unknown/Conflict Slot resolution does not block mapping
- vertical slice tests proving Slot can traverse Tree -> AST -> IR -> Projection -> Render as inert Fragment

## Explicit non-scope

- no `UiAstNodeKind::Slot`
- no `UiIrNodeKind::Slot`
- no render Slot marker
- no Attribute semantics
- no Binding semantics
- no Action semantics
- no effect boundary semantics
- no event dispatch
- no action execution
- no effect execution
- no capability admission
- no runtime/VM/Host ABI authority
- no backend draw
- no layout behavior
- no docs
- no dependency additions
- no Cargo.toml / Cargo.lock changes
- no Admission Guard changes
- no GitHub CI evidence

## Validation

Local only:

```text
cargo fmt: PASS
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui --test ui_tree_to_ast_bridge: PASS
cargo test -p prom-ui --test ui_tree_to_render_vertical_slice: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
tracked pr_body files: NO
Admission Guard executed: YES
Admission Guard result: FAIL - ENVIRONMENT PATHING
Admission Guard changed: NO
GitHub CI used: NO
```

## Final status

```text
PASS WITH WARNINGS - R12 UI TREE SLOT SEMANTICS BOUNDARY SOURCE PR CLEAN FOR TRACKED REPOSITORY STATE
```

