### PR TITLE
feat(ui): bridge AST slot intent metadata to IR metadata

### DIFF
--- a/crates/prom-ui/src/ast_slot_ir_intent.rs
+++ b/crates/prom-ui/src/ast_slot_ir_intent.rs
@@ -1,0 +1,282 @@
+use crate::model::{
+    UiAstNodeId, UiAstNodeKind, UiIr, UiIrNodeId, UiIrNodeKind, UiNodeId, UiNodeKind,
+    UiNodeResolution, UiTreeId,
+};
+use crate::tree_slot_ast_intent::{UiTreeSlotAstIntentEntryId, UiTreeSlotAstIntentModel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiAstSlotIrIntentModelId(u64);
+
+impl UiAstSlotIrIntentModelId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiAstSlotIrIntentEntryId(u64);
+
+impl UiAstSlotIrIntentEntryId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiAstSlotIrIntentKind {
+    IrFragmentLinkedToAstSlotIntent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiAstSlotIrIntentState {
+    Deferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiAstSlotIrIntentEntry {
+    id: UiAstSlotIrIntentEntryId,
+    source_ast_intent_entry_id: UiTreeSlotAstIntentEntryId,
+    source_tree_intent_entry_id: crate::tree_slot_intent::UiTreeSlotCarrierIntentEntryId,
+    source_tree_id: UiTreeId,
+    source_tree_node_id: UiNodeId,
+    source_tree_node_kind: UiNodeKind,
+    source_tree_resolution: UiNodeResolution,
+    source_ast_node_id: UiAstNodeId,
+    source_ast_node_kind: UiAstNodeKind,
+    ir_node_id: UiIrNodeId,
+    ir_node_kind: UiIrNodeKind,
+    parent_tree_node_id: Option<UiNodeId>,
+    child_tree_node_ids: Vec<UiNodeId>,
+    parent_ast_node_id: Option<UiAstNodeId>,
+    child_ast_node_ids: Vec<UiAstNodeId>,
+    parent_ir_node_id: Option<UiIrNodeId>,
+    child_ir_node_ids: Vec<UiIrNodeId>,
+    kind: UiAstSlotIrIntentKind,
+    state: UiAstSlotIrIntentState,
+}
+
+impl UiAstSlotIrIntentEntry {
+    pub fn id(&self) -> UiAstSlotIrIntentEntryId {
+        self.id
+    }
+    pub fn source_ast_intent_entry_id(&self) -> UiTreeSlotAstIntentEntryId {
+        self.source_ast_intent_entry_id
+    }
+    pub fn source_tree_intent_entry_id(
+        &self,
+    ) -> crate::tree_slot_intent::UiTreeSlotCarrierIntentEntryId {
+        self.source_tree_intent_entry_id
+    }
+    pub fn source_tree_id(&self) -> UiTreeId {
+        self.source_tree_id
+    }
+    pub fn source_tree_node_id(&self) -> UiNodeId {
+        self.source_tree_node_id
+    }
+    pub fn source_tree_node_kind(&self) -> UiNodeKind {
+        self.source_tree_node_kind
+    }
+    pub fn source_tree_resolution(&self) -> UiNodeResolution {
+        self.source_tree_resolution
+    }
+    pub fn source_ast_node_id(&self) -> UiAstNodeId {
+        self.source_ast_node_id
+    }
+    pub fn source_ast_node_kind(&self) -> UiAstNodeKind {
+        self.source_ast_node_kind
+    }
+    pub fn ir_node_id(&self) -> UiIrNodeId {
+        self.ir_node_id
+    }
+    pub fn ir_node_kind(&self) -> UiIrNodeKind {
+        self.ir_node_kind
+    }
+    pub fn parent_tree_node_id(&self) -> Option<UiNodeId> {
+        self.parent_tree_node_id
+    }
+    pub fn child_tree_node_ids(&self) -> &[UiNodeId] {
+        &self.child_tree_node_ids
+    }
+    pub fn parent_ast_node_id(&self) -> Option<UiAstNodeId> {
+        self.parent_ast_node_id
+    }
+    pub fn child_ast_node_ids(&self) -> &[UiAstNodeId] {
+        &self.child_ast_node_ids
+    }
+    pub fn parent_ir_node_id(&self) -> Option<UiIrNodeId> {
+        self.parent_ir_node_id
+    }
+    pub fn child_ir_node_ids(&self) -> &[UiIrNodeId] {
+        &self.child_ir_node_ids
+    }
+    pub fn kind(&self) -> UiAstSlotIrIntentKind {
+        self.kind
+    }
+    pub fn state(&self) -> UiAstSlotIrIntentState {
+        self.state
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiAstSlotIrIntentModel {
+    id: UiAstSlotIrIntentModelId,
+    entries: Vec<UiAstSlotIrIntentEntry>,
+}
+
+impl UiAstSlotIrIntentModel {
+    pub fn new(id: UiAstSlotIrIntentModelId) -> Self {
+        Self {
+            id,
+            entries: Vec::new(),
+        }
+    }
+    pub fn id(&self) -> UiAstSlotIrIntentModelId {
+        self.id
+    }
+    pub fn entries(&self) -> &[UiAstSlotIrIntentEntry] {
+        &self.entries
+    }
+    pub fn push_entry(&mut self, entry: UiAstSlotIrIntentEntry) {
+        self.entries.push(entry);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UiAstSlotIrIntentDiagnosticKind {
+    MissingIrNode {
+        source_ast_node_id: UiAstNodeId,
+    },
+    UnexpectedIrNodeKind {
+        source_ast_node_id: UiAstNodeId,
+        ir_node_id: UiIrNodeId,
+        actual_kind: UiIrNodeKind,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiAstSlotIrIntentDiagnostic {
+    kind: UiAstSlotIrIntentDiagnosticKind,
+    message: String,
+}
+
+impl UiAstSlotIrIntentDiagnostic {
+    pub fn new(kind: UiAstSlotIrIntentDiagnosticKind, message: String) -> Self {
+        Self { kind, message }
+    }
+    pub fn kind(&self) -> &UiAstSlotIrIntentDiagnosticKind {
+        &self.kind
+    }
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiAstSlotIrIntentDiagnostics {
+    diagnostics: Vec<UiAstSlotIrIntentDiagnostic>,
+}
+
+impl UiAstSlotIrIntentDiagnostics {
+    pub fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+        }
+    }
+    pub fn push(&mut self, diagnostic: UiAstSlotIrIntentDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+    pub fn len(&self) -> usize {
+        self.diagnostics.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+    pub fn diagnostics(&self) -> &[UiAstSlotIrIntentDiagnostic] {
+        &self.diagnostics
+    }
+}
+
+impl Default for UiAstSlotIrIntentDiagnostics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub type UiAstSlotIrIntentResult = Result<UiAstSlotIrIntentModel, UiAstSlotIrIntentDiagnostics>;
+
+pub fn build_ast_slot_ir_intents(
+    ast_intents: &UiTreeSlotAstIntentModel,
+    ir: &UiIr,
+) -> UiAstSlotIrIntentResult {
+    let mut model = UiAstSlotIrIntentModel::new(UiAstSlotIrIntentModelId::new(1));
+    let mut diagnostics = UiAstSlotIrIntentDiagnostics::new();
+
+    for ast_entry in ast_intents.entries() {
+        let raw_id = ast_entry.ast_node_id().raw();
+        let target_ir_node_id = UiIrNodeId::new(raw_id);
+
+        let matching_ir_node = ir.nodes().iter().find(|n| n.id() == target_ir_node_id);
+
+        if let Some(ir_node) = matching_ir_node {
+            if ir_node.kind() == UiIrNodeKind::Fragment {
+                let parent_ir_node_id = ast_entry
+                    .parent_ast_node_id()
+                    .map(|id| UiIrNodeId::new(id.raw()));
+
+                let child_ir_node_ids = ast_entry
+                    .child_ast_node_ids()
+                    .iter()
+                    .map(|id| UiIrNodeId::new(id.raw()))
+                    .collect();
+
+                let entry = UiAstSlotIrIntentEntry {
+                    id: UiAstSlotIrIntentEntryId::new(raw_id),
+                    source_ast_intent_entry_id: ast_entry.id(),
+                    source_tree_intent_entry_id: ast_entry.source_tree_intent_entry_id(),
+                    source_tree_id: ast_entry.source_tree_id(),
+                    source_tree_node_id: ast_entry.source_tree_node_id(),
+                    source_tree_node_kind: ast_entry.source_tree_node_kind(),
+                    source_tree_resolution: ast_entry.source_tree_resolution(),
+                    source_ast_node_id: ast_entry.ast_node_id(),
+                    source_ast_node_kind: ast_entry.ast_node_kind(),
+                    ir_node_id: ir_node.id(),
+                    ir_node_kind: ir_node.kind(),
+                    parent_tree_node_id: ast_entry.parent_tree_node_id(),
+                    child_tree_node_ids: ast_entry.child_tree_node_ids().to_vec(),
+                    parent_ast_node_id: ast_entry.parent_ast_node_id(),
+                    child_ast_node_ids: ast_entry.child_ast_node_ids().to_vec(),
+                    parent_ir_node_id,
+                    child_ir_node_ids,
+                    kind: UiAstSlotIrIntentKind::IrFragmentLinkedToAstSlotIntent,
+                    state: UiAstSlotIrIntentState::Deferred,
+                };
+                model.push_entry(entry);
+            } else {
+                diagnostics.push(UiAstSlotIrIntentDiagnostic::new(
+                    UiAstSlotIrIntentDiagnosticKind::UnexpectedIrNodeKind {
+                        source_ast_node_id: ast_entry.ast_node_id(),
+                        ir_node_id: ir_node.id(),
+                        actual_kind: ir_node.kind(),
+                    },
+                    "IR node kind is not Fragment".to_string(),
+                ));
+            }
+        } else {
+            diagnostics.push(UiAstSlotIrIntentDiagnostic::new(
+                UiAstSlotIrIntentDiagnosticKind::MissingIrNode {
+                    source_ast_node_id: ast_entry.ast_node_id(),
+                },
+                "IR node matching AST node not found".to_string(),
+            ));
+        }
+    }
+
+    if !diagnostics.is_empty() {
+        Err(diagnostics)
+    } else {
+        Ok(model)
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -353,3 +353,11 @@ pub use tree_slot_ast_intent::{
     UiTreeSlotAstIntentKind, UiTreeSlotAstIntentModel, UiTreeSlotAstIntentModelId,
     UiTreeSlotAstIntentResult, UiTreeSlotAstIntentState,
 };
+
+pub mod ast_slot_ir_intent;
+pub use ast_slot_ir_intent::{
+    build_ast_slot_ir_intents, UiAstSlotIrIntentDiagnostic, UiAstSlotIrIntentDiagnosticKind,
+    UiAstSlotIrIntentDiagnostics, UiAstSlotIrIntentEntry, UiAstSlotIrIntentEntryId,
+    UiAstSlotIrIntentKind, UiAstSlotIrIntentModel, UiAstSlotIrIntentModelId,
+    UiAstSlotIrIntentResult, UiAstSlotIrIntentState,
+};

--- a/crates/prom-ui/tests/ui_ast_slot_carrier_intent_to_ir_metadata.rs
+++ b/crates/prom-ui/tests/ui_ast_slot_carrier_intent_to_ir_metadata.rs
@@ -1,0 +1,851 @@
+use prom_ui::ast_slot_ir_intent::{
+    build_ast_slot_ir_intents, UiAstSlotIrIntentDiagnosticKind, UiAstSlotIrIntentKind,
+    UiAstSlotIrIntentState,
+};
+use prom_ui::model::{
+    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind, UiNode,
+    UiNodeId, UiNodeKind, UiNodeResolution, UiTree, UiTreeId,
+};
+use prom_ui::tree_slot_ast_intent::build_tree_slot_ast_intents;
+use prom_ui::tree_slot_intent::build_tree_slot_carrier_intents;
+
+#[test]
+fn empty_ast_slot_intents_build_empty_ir_intent_model() {
+    let tree = UiTree::new(UiTreeId::new(1));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let ast = UiAst::new();
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let ir = UiIr::new();
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(ir_intents.entries().len(), 0);
+}
+
+#[test]
+fn single_ast_slot_intent_links_to_ir_fragment() {
+    let mut tree = UiTree::new(UiTreeId::new(2));
+    let slot = UiNode::with_resolution(UiNodeId::new(3), UiNodeKind::Slot, UiNodeResolution::Known);
+    tree.push_node(slot);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    let ast_fragment = UiAstNode::new(UiAstNodeId::new(3), UiAstNodeKind::Fragment);
+    ast.push_node(ast_fragment);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    let ir_fragment = UiIrNode::new(UiIrNodeId::new(3), UiIrNodeKind::Fragment);
+    ir.push_node(ir_fragment);
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(ir_intents.entries().len(), 1);
+    let entry = &ir_intents.entries()[0];
+    assert_eq!(entry.ir_node_id(), UiIrNodeId::new(3));
+    assert_eq!(entry.ir_node_kind(), UiIrNodeKind::Fragment);
+    assert_eq!(
+        entry.kind(),
+        UiAstSlotIrIntentKind::IrFragmentLinkedToAstSlotIntent
+    );
+    assert_eq!(entry.state(), UiAstSlotIrIntentState::Deferred);
+}
+
+#[test]
+fn multiple_ast_slot_intents_preserve_order() {
+    let mut tree = UiTree::new(UiTreeId::new(3));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(10),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(20),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(10),
+        UiAstNodeKind::Fragment,
+    ));
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(20),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(10), UiIrNodeKind::Fragment));
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(20), UiIrNodeKind::Fragment));
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(ir_intents.entries().len(), 2);
+    assert_eq!(ir_intents.entries()[0].ir_node_id(), UiIrNodeId::new(10));
+    assert_eq!(ir_intents.entries()[1].ir_node_id(), UiIrNodeId::new(20));
+}
+
+#[test]
+fn ir_intent_entry_id_is_deterministic() {
+    let mut tree = UiTree::new(UiTreeId::new(4));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(5),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(UiAstNodeId::new(5), UiAstNodeKind::Fragment));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(5), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let entry = &ir_intents.entries()[0];
+    assert_eq!(entry.id().raw(), 5);
+}
+
+#[test]
+fn ir_intent_preserves_source_ast_intent_entry_id() {
+    let mut tree = UiTree::new(UiTreeId::new(4));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(5),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(UiAstNodeId::new(5), UiAstNodeKind::Fragment));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(5), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let entry = &ir_intents.entries()[0];
+    assert_eq!(
+        entry.source_ast_intent_entry_id(),
+        ast_intents.entries()[0].id()
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_tree_intent_entry_id() {
+    let mut tree = UiTree::new(UiTreeId::new(4));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(5),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(UiAstNodeId::new(5), UiAstNodeKind::Fragment));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(5), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let entry = &ir_intents.entries()[0];
+    assert_eq!(
+        entry.source_tree_intent_entry_id(),
+        tree_intents.entries()[0].id()
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_tree_id() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(5),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(UiAstNodeId::new(5), UiAstNodeKind::Fragment));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(5), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(ir_intents.entries()[0].source_tree_id(), UiTreeId::new(42));
+}
+
+#[test]
+fn ir_intent_preserves_source_tree_node_id() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_tree_node_id(),
+        UiNodeId::new(50)
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_tree_node_kind() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_tree_node_kind(),
+        UiNodeKind::Slot
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_tree_resolution() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_tree_resolution(),
+        UiNodeResolution::Known
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_ast_node_id() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_ast_node_id(),
+        UiAstNodeId::new(50)
+    );
+}
+
+#[test]
+fn ir_intent_preserves_source_ast_node_kind_as_fragment() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_ast_node_kind(),
+        UiAstNodeKind::Fragment
+    );
+}
+
+#[test]
+fn ir_intent_preserves_ir_node_id() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(ir_intents.entries()[0].ir_node_id(), UiIrNodeId::new(50));
+}
+
+#[test]
+fn ir_intent_preserves_ir_node_kind_as_fragment() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].ir_node_kind(),
+        UiIrNodeKind::Fragment
+    );
+}
+
+#[test]
+fn ir_intent_preserves_parent_tree_handle() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(50));
+    tree.push_node(root);
+    tree.push_node(slot);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    ast_slot.set_parent(Some(UiAstNodeId::new(1)));
+    ast_root.push_child(UiAstNodeId::new(50));
+    ast.push_node(ast_root);
+    ast.push_node(ast_slot);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    ir_slot.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(50));
+    ir.push_node(ir_root);
+    ir.push_node(ir_slot);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].parent_tree_node_id(),
+        Some(UiNodeId::new(1))
+    );
+}
+
+#[test]
+fn ir_intent_preserves_child_tree_handles() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    let mut child = UiNode::new(UiNodeId::new(2), UiNodeKind::Element);
+    child.set_parent(Some(UiNodeId::new(50)));
+    slot.push_child(UiNodeId::new(2));
+    tree.push_node(slot);
+    tree.push_node(child);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    let mut ast_child = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Element);
+    ast_child.set_parent(Some(UiAstNodeId::new(50)));
+    ast_slot.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_slot);
+    ast.push_node(ast_child);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    let mut ir_child = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Element);
+    ir_child.set_parent(Some(UiIrNodeId::new(50)));
+    ir_slot.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_slot);
+    ir.push_node(ir_child);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].child_tree_node_ids(),
+        &[UiNodeId::new(2)]
+    );
+}
+
+#[test]
+fn ir_intent_preserves_parent_ast_handle() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(50));
+    tree.push_node(root);
+    tree.push_node(slot);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    ast_slot.set_parent(Some(UiAstNodeId::new(1)));
+    ast_root.push_child(UiAstNodeId::new(50));
+    ast.push_node(ast_root);
+    ast.push_node(ast_slot);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    ir_slot.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(50));
+    ir.push_node(ir_root);
+    ir.push_node(ir_slot);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].parent_ast_node_id(),
+        Some(UiAstNodeId::new(1))
+    );
+}
+
+#[test]
+fn ir_intent_preserves_child_ast_handles() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    let mut child = UiNode::new(UiNodeId::new(2), UiNodeKind::Element);
+    child.set_parent(Some(UiNodeId::new(50)));
+    slot.push_child(UiNodeId::new(2));
+    tree.push_node(slot);
+    tree.push_node(child);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    let mut ast_child = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Element);
+    ast_child.set_parent(Some(UiAstNodeId::new(50)));
+    ast_slot.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_slot);
+    ast.push_node(ast_child);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    let mut ir_child = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Element);
+    ir_child.set_parent(Some(UiIrNodeId::new(50)));
+    ir_slot.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_slot);
+    ir.push_node(ir_child);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].child_ast_node_ids(),
+        &[UiAstNodeId::new(2)]
+    );
+}
+
+#[test]
+fn ir_intent_preserves_parent_ir_handle() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(50));
+    tree.push_node(root);
+    tree.push_node(slot);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    ast_slot.set_parent(Some(UiAstNodeId::new(1)));
+    ast_root.push_child(UiAstNodeId::new(50));
+    ast.push_node(ast_root);
+    ast.push_node(ast_slot);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    ir_slot.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(50));
+    ir.push_node(ir_root);
+    ir.push_node(ir_slot);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].parent_ir_node_id(),
+        Some(UiIrNodeId::new(1))
+    );
+}
+
+#[test]
+fn ir_intent_preserves_child_ir_handles() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(50), UiNodeKind::Slot, UiNodeResolution::Known);
+    let mut child = UiNode::new(UiNodeId::new(2), UiNodeKind::Element);
+    child.set_parent(Some(UiNodeId::new(50)));
+    slot.push_child(UiNodeId::new(2));
+    tree.push_node(slot);
+    tree.push_node(child);
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    let mut ast_slot = UiAstNode::new(UiAstNodeId::new(50), UiAstNodeKind::Fragment);
+    let mut ast_child = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Element);
+    ast_child.set_parent(Some(UiAstNodeId::new(50)));
+    ast_slot.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_slot);
+    ast.push_node(ast_child);
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    let mut ir_slot = UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment);
+    let mut ir_child = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Element);
+    ir_child.set_parent(Some(UiIrNodeId::new(50)));
+    ir_slot.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_slot);
+    ir.push_node(ir_child);
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].child_ir_node_ids(),
+        &[UiIrNodeId::new(2)]
+    );
+}
+
+#[test]
+fn unknown_resolution_is_preserved() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Unknown,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_tree_resolution(),
+        UiNodeResolution::Unknown
+    );
+}
+
+#[test]
+fn conflict_resolution_is_preserved() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Conflict,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        ir_intents.entries()[0].source_tree_resolution(),
+        UiNodeResolution::Conflict
+    );
+}
+
+#[test]
+fn missing_ir_node_returns_diagnostic() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let ir = UiIr::new();
+    let err = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap_err();
+    assert_eq!(err.len(), 1);
+    match err.diagnostics()[0].kind() {
+        UiAstSlotIrIntentDiagnosticKind::MissingIrNode { source_ast_node_id } => {
+            assert_eq!(*source_ast_node_id, UiAstNodeId::new(50));
+        }
+        _ => panic!("expected missing ir node"),
+    }
+}
+
+#[test]
+fn non_fragment_ir_node_returns_diagnostic() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Element));
+    let err = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap_err();
+    assert_eq!(err.len(), 1);
+    match err.diagnostics()[0].kind() {
+        UiAstSlotIrIntentDiagnosticKind::UnexpectedIrNodeKind {
+            source_ast_node_id,
+            ir_node_id,
+            actual_kind,
+        } => {
+            assert_eq!(*source_ast_node_id, UiAstNodeId::new(50));
+            assert_eq!(*ir_node_id, UiIrNodeId::new(50));
+            assert_eq!(*actual_kind, UiIrNodeKind::Element);
+        }
+        _ => panic!("expected unexpected ir node kind"),
+    }
+}
+
+#[test]
+fn diagnostic_preserves_source_ast_node_id() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let ir = UiIr::new();
+    let err = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap_err();
+    match err.diagnostics()[0].kind() {
+        UiAstSlotIrIntentDiagnosticKind::MissingIrNode { source_ast_node_id } => {
+            assert_eq!(*source_ast_node_id, UiAstNodeId::new(50));
+        }
+        _ => panic!("unexpected"),
+    }
+}
+
+#[test]
+fn non_fragment_diagnostic_preserves_ir_node_id_and_kind() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Text));
+    let err = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap_err();
+    match err.diagnostics()[0].kind() {
+        UiAstSlotIrIntentDiagnosticKind::UnexpectedIrNodeKind {
+            ir_node_id,
+            actual_kind,
+            ..
+        } => {
+            assert_eq!(*ir_node_id, UiIrNodeId::new(50));
+            assert_eq!(*actual_kind, UiIrNodeKind::Text);
+        }
+        _ => panic!("unexpected"),
+    }
+}
+
+#[test]
+fn mismatched_input_returns_no_partial_model() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(51),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(51),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+    // missing 51
+    let err = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap_err();
+    assert_eq!(err.len(), 1);
+}
+
+#[test]
+fn builder_does_not_mutate_inputs() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+
+    let len_before = ir.nodes().len();
+    let _ = build_ast_slot_ir_intents(&ast_intents, &ir);
+    assert_eq!(ir.nodes().len(), len_before);
+}
+
+#[test]
+fn builder_does_not_call_lowering_or_render_pipeline() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+
+    let intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(intents.entries().len(), 1);
+}
+
+#[test]
+fn metadata_does_not_create_property_action_or_effect_boundary_semantics() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+
+    let intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        intents.entries()[0].kind(),
+        UiAstSlotIrIntentKind::IrFragmentLinkedToAstSlotIntent
+    );
+}
+
+#[test]
+fn metadata_does_not_create_carrier_or_effect_boundary() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+
+    let intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(
+        intents.entries()[0].state(),
+        UiAstSlotIrIntentState::Deferred
+    );
+}
+
+#[test]
+fn slot_ir_intent_is_inert_and_non_authoritative() {
+    let mut tree = UiTree::new(UiTreeId::new(42));
+    tree.push_node(UiNode::with_resolution(
+        UiNodeId::new(50),
+        UiNodeKind::Slot,
+        UiNodeResolution::Known,
+    ));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(
+        UiAstNodeId::new(50),
+        UiAstNodeKind::Fragment,
+    ));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(50), UiIrNodeKind::Fragment));
+
+    let len_before = ir.nodes().len();
+    let intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+    assert_eq!(intents.entries().len(), 1);
+    assert_eq!(ir.nodes().len(), len_before);
+}


### PR DESCRIPTION
## Summary  Adds an inert IR-side metadata bridge for AST Slot carrier intent metadata.  This PR links existing `UiTreeSlotAstIntentEntry` records to existing IR Fragment nodes by raw node id.  It does not change AST -> IR lowering behavior.  ## Scope  Adds:  - `ast_slot_ir_intent` module - `build_ast_slot_ir_intents(...)` - `UiAstSlotIrIntentModel` - `UiAstSlotIrIntentEntry` - deterministic IR intent entry IDs - source Tree Slot intent preservation - AST Slot intent preservation - IR node reference preservation - parent/child handle preservation across Tree, AST, and IR metadata - diagnostics for missing IR nodes - diagnostics for unexpected IR node kinds - integration tests for inert AST Slot intent -> IR metadata bridge  ## Explicit non-scope  - no Tree -> AST bridge changes - no AST -> IR lowering changes - no projection changes - no renderer changes - no layout behavior - no Property semantics - no Action semantics - no EffectBoundary semantics - no PropertyCarrier generation - no ActionCarrier generation - no EffectBoundary generation - no event dispatch - no action execution - no effect execution - no capability admission - no runtime/VM/Host ABI authority - no backend draw - no Workbench/Studio integration - no docs - no dependency additions - no Cargo.toml / Cargo.lock changes - no Admission Guard changes - no GitHub CI evidence  ## Validation  Local only:  ```text cargo fmt: PASS cargo fmt --check: PASS cargo test -p prom-ui --lib: PASS cargo test -p prom-ui --test ui_ast_slot_carrier_intent_to_ir_metadata: PASS cargo test -p prom-ui: PASS git diff --check: PASS tracked pr_body files: NO Admission Guard executed: YES Admission Guard result: FAIL - ENVIRONMENT PATHING Admission Guard changed: NO GitHub CI used: NO ```  ## Final status  ```text PASS WITH WARNINGS - R12 UI AST SLOT CARRIER INTENT TO IR METADATA BRIDGE SOURCE PR CLEAN FOR TRACKED REPOSITORY STATE ``` 