### PR TITLE
feat(ui): bridge IR slot intent metadata to Projection metadata (#1100)

### DIFF
--- a/crates/prom-ui/src/ir_slot_projection_intent.rs
+++ b/crates/prom-ui/src/ir_slot_projection_intent.rs
@@ -1,0 +1,283 @@
+use crate::ast_slot_ir_intent::{UiAstSlotIrIntentEntryId, UiAstSlotIrIntentModel};
+use crate::model::{
+    UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind, UiNodeId, UiNodeKind, UiNodeResolution,
+    UiTreeId,
+};
+use crate::projection::{UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact};
+use crate::tree_slot_ast_intent::UiTreeSlotAstIntentEntryId;
+use crate::tree_slot_intent::UiTreeSlotCarrierIntentEntryId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiIrSlotProjectionIntentModelId(u64);
+
+impl UiIrSlotProjectionIntentModelId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UiIrSlotProjectionIntentEntryId(u64);
+
+impl UiIrSlotProjectionIntentEntryId {
+    pub fn new(id: u64) -> Self {
+        Self(id)
+    }
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiIrSlotProjectionIntentKind {
+    ProjectedFragmentLinkedToIrSlotIntent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiIrSlotProjectionIntentState {
+    Deferred,
+}
+
+#[derive(Debug, Clone)]
+pub struct UiIrSlotProjectionIntentEntry {
+    id: UiIrSlotProjectionIntentEntryId,
+    source_ir_intent_entry_id: UiAstSlotIrIntentEntryId,
+    source_ast_intent_entry_id: UiTreeSlotAstIntentEntryId,
+    source_tree_intent_entry_id: UiTreeSlotCarrierIntentEntryId,
+    source_tree_id: UiTreeId,
+    source_tree_node_id: UiNodeId,
+    source_tree_node_kind: UiNodeKind,
+    source_tree_resolution: UiNodeResolution,
+    source_ast_node_id: UiAstNodeId,
+    source_ast_node_kind: UiAstNodeKind,
+    source_ir_node_id: UiIrNodeId,
+    source_ir_node_kind: UiIrNodeKind,
+    projected_node_id: UiProjectedNodeId,
+    projected_node_kind: UiProjectedNodeKind,
+    parent_tree_node_id: Option<UiNodeId>,
+    child_tree_node_ids: Vec<UiNodeId>,
+    parent_ast_node_id: Option<UiAstNodeId>,
+    child_ast_node_ids: Vec<UiAstNodeId>,
+    parent_ir_node_id: Option<UiIrNodeId>,
+    child_ir_node_ids: Vec<UiIrNodeId>,
+    parent_projected_node_id: Option<UiProjectedNodeId>,
+    child_projected_node_ids: Vec<UiProjectedNodeId>,
+    kind: UiIrSlotProjectionIntentKind,
+    state: UiIrSlotProjectionIntentState,
+}
+
+impl UiIrSlotProjectionIntentEntry {
+    pub fn id(&self) -> UiIrSlotProjectionIntentEntryId {
+        self.id
+    }
+    pub fn source_ir_intent_entry_id(&self) -> UiAstSlotIrIntentEntryId {
+        self.source_ir_intent_entry_id
+    }
+    pub fn source_ast_intent_entry_id(&self) -> UiTreeSlotAstIntentEntryId {
+        self.source_ast_intent_entry_id
+    }
+    pub fn source_tree_intent_entry_id(&self) -> UiTreeSlotCarrierIntentEntryId {
+        self.source_tree_intent_entry_id
+    }
+    pub fn source_tree_id(&self) -> UiTreeId {
+        self.source_tree_id
+    }
+    pub fn source_tree_node_id(&self) -> UiNodeId {
+        self.source_tree_node_id
+    }
+    pub fn source_tree_node_kind(&self) -> UiNodeKind {
+        self.source_tree_node_kind
+    }
+    pub fn source_tree_resolution(&self) -> UiNodeResolution {
+        self.source_tree_resolution
+    }
+    pub fn source_ast_node_id(&self) -> UiAstNodeId {
+        self.source_ast_node_id
+    }
+    pub fn source_ast_node_kind(&self) -> UiAstNodeKind {
+        self.source_ast_node_kind
+    }
+    pub fn source_ir_node_id(&self) -> UiIrNodeId {
+        self.source_ir_node_id
+    }
+    pub fn source_ir_node_kind(&self) -> UiIrNodeKind {
+        self.source_ir_node_kind
+    }
+    pub fn projected_node_id(&self) -> UiProjectedNodeId {
+        self.projected_node_id
+    }
+    pub fn projected_node_kind(&self) -> UiProjectedNodeKind {
+        self.projected_node_kind
+    }
+    pub fn parent_tree_node_id(&self) -> Option<UiNodeId> {
+        self.parent_tree_node_id
+    }
+    pub fn child_tree_node_ids(&self) -> &[UiNodeId] {
+        &self.child_tree_node_ids
+    }
+    pub fn parent_ast_node_id(&self) -> Option<UiAstNodeId> {
+        self.parent_ast_node_id
+    }
+    pub fn child_ast_node_ids(&self) -> &[UiAstNodeId] {
+        &self.child_ast_node_ids
+    }
+    pub fn parent_ir_node_id(&self) -> Option<UiIrNodeId> {
+        self.parent_ir_node_id
+    }
+    pub fn child_ir_node_ids(&self) -> &[UiIrNodeId] {
+        &self.child_ir_node_ids
+    }
+    pub fn parent_projected_node_id(&self) -> Option<UiProjectedNodeId> {
+        self.parent_projected_node_id
+    }
+    pub fn child_projected_node_ids(&self) -> &[UiProjectedNodeId] {
+        &self.child_projected_node_ids
+    }
+    pub fn kind(&self) -> UiIrSlotProjectionIntentKind {
+        self.kind
+    }
+    pub fn state(&self) -> UiIrSlotProjectionIntentState {
+        self.state
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UiIrSlotProjectionIntentModel {
+    id: UiIrSlotProjectionIntentModelId,
+    entries: Vec<UiIrSlotProjectionIntentEntry>,
+}
+
+impl UiIrSlotProjectionIntentModel {
+    pub fn id(&self) -> UiIrSlotProjectionIntentModelId {
+        self.id
+    }
+    pub fn entries(&self) -> &[UiIrSlotProjectionIntentEntry] {
+        &self.entries
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UiIrSlotProjectionIntentDiagnosticKind {
+    MissingProjectedNode {
+        source_ir_node_id: UiIrNodeId,
+    },
+    UnexpectedProjectedNodeKind {
+        source_ir_node_id: UiIrNodeId,
+        projected_node_id: UiProjectedNodeId,
+        actual_kind: UiProjectedNodeKind,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct UiIrSlotProjectionIntentDiagnostic {
+    kind: UiIrSlotProjectionIntentDiagnosticKind,
+}
+
+impl UiIrSlotProjectionIntentDiagnostic {
+    pub fn kind(&self) -> &UiIrSlotProjectionIntentDiagnosticKind {
+        &self.kind
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct UiIrSlotProjectionIntentDiagnostics {
+    diagnostics: Vec<UiIrSlotProjectionIntentDiagnostic>,
+}
+
+impl UiIrSlotProjectionIntentDiagnostics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn push(&mut self, diagnostic: UiIrSlotProjectionIntentDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &UiIrSlotProjectionIntentDiagnostic> {
+        self.diagnostics.iter()
+    }
+}
+
+pub type UiIrSlotProjectionIntentResult =
+    Result<UiIrSlotProjectionIntentModel, UiIrSlotProjectionIntentDiagnostics>;
+
+pub fn build_ir_slot_projection_intents(
+    ir_intents: &UiAstSlotIrIntentModel,
+    projection: &UiProjectionArtifact,
+) -> UiIrSlotProjectionIntentResult {
+    let mut diagnostics = UiIrSlotProjectionIntentDiagnostics::new();
+    let mut entries = Vec::new();
+
+    for ir_intent in ir_intents.entries() {
+        let ir_node_id = ir_intent.ir_node_id();
+
+        // Find the matching projected node
+        let mut matched_projected_node = None;
+        for projected_node in projection.nodes() {
+            if projected_node.source_ir_node_id() == Some(ir_node_id) {
+                matched_projected_node = Some(projected_node);
+                break;
+            }
+        }
+
+        if let Some(projected_node) = matched_projected_node {
+            if projected_node.kind() != UiProjectedNodeKind::Fragment {
+                diagnostics.push(UiIrSlotProjectionIntentDiagnostic {
+                    kind: UiIrSlotProjectionIntentDiagnosticKind::UnexpectedProjectedNodeKind {
+                        source_ir_node_id: ir_node_id,
+                        projected_node_id: projected_node.id(),
+                        actual_kind: projected_node.kind(),
+                    },
+                });
+            } else {
+                let entry_id = UiIrSlotProjectionIntentEntryId::new(ir_node_id.raw());
+                let parent_projected_node_id = projected_node.parent();
+                let child_projected_node_ids = projected_node.children().to_vec();
+
+                let entry = UiIrSlotProjectionIntentEntry {
+                    id: entry_id,
+                    source_ir_intent_entry_id: ir_intent.id(),
+                    source_ast_intent_entry_id: ir_intent.source_ast_intent_entry_id(),
+                    source_tree_intent_entry_id: ir_intent.source_tree_intent_entry_id(),
+                    source_tree_id: ir_intent.source_tree_id(),
+                    source_tree_node_id: ir_intent.source_tree_node_id(),
+                    source_tree_node_kind: ir_intent.source_tree_node_kind(),
+                    source_tree_resolution: ir_intent.source_tree_resolution(),
+                    source_ast_node_id: ir_intent.source_ast_node_id(),
+                    source_ast_node_kind: ir_intent.source_ast_node_kind(),
+                    source_ir_node_id: ir_intent.ir_node_id(),
+                    source_ir_node_kind: ir_intent.ir_node_kind(),
+                    projected_node_id: projected_node.id(),
+                    projected_node_kind: projected_node.kind(),
+                    parent_tree_node_id: ir_intent.parent_tree_node_id(),
+                    child_tree_node_ids: ir_intent.child_tree_node_ids().to_vec(),
+                    parent_ast_node_id: ir_intent.parent_ast_node_id(),
+                    child_ast_node_ids: ir_intent.child_ast_node_ids().to_vec(),
+                    parent_ir_node_id: ir_intent.parent_ir_node_id(),
+                    child_ir_node_ids: ir_intent.child_ir_node_ids().to_vec(),
+                    parent_projected_node_id,
+                    child_projected_node_ids,
+                    kind: UiIrSlotProjectionIntentKind::ProjectedFragmentLinkedToIrSlotIntent,
+                    state: UiIrSlotProjectionIntentState::Deferred,
+                };
+                entries.push(entry);
+            }
+        } else {
+            diagnostics.push(UiIrSlotProjectionIntentDiagnostic {
+                kind: UiIrSlotProjectionIntentDiagnosticKind::MissingProjectedNode {
+                    source_ir_node_id: ir_node_id,
+                },
+            });
+        }
+    }
+
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+
+    Ok(UiIrSlotProjectionIntentModel {
+        id: UiIrSlotProjectionIntentModelId::new(1),
+        entries,
+    })
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -361,3 +361,12 @@ pub use ast_slot_ir_intent::{
     UiAstSlotIrIntentKind, UiAstSlotIrIntentModel, UiAstSlotIrIntentModelId,
     UiAstSlotIrIntentResult, UiAstSlotIrIntentState,
 };
+
+pub mod ir_slot_projection_intent;
+pub use ir_slot_projection_intent::{
+    build_ir_slot_projection_intents, UiIrSlotProjectionIntentDiagnostic,
+    UiIrSlotProjectionIntentDiagnosticKind, UiIrSlotProjectionIntentDiagnostics,
+    UiIrSlotProjectionIntentEntry, UiIrSlotProjectionIntentEntryId, UiIrSlotProjectionIntentKind,
+    UiIrSlotProjectionIntentModel, UiIrSlotProjectionIntentModelId, UiIrSlotProjectionIntentResult,
+    UiIrSlotProjectionIntentState,
+};

--- a/crates/prom-ui/tests/ui_ir_slot_carrier_intent_to_projection_metadata.rs
+++ b/crates/prom-ui/tests/ui_ir_slot_carrier_intent_to_projection_metadata.rs
@@ -1,0 +1,663 @@
+use prom_ui::ast_slot_ir_intent::{build_ast_slot_ir_intents, UiAstSlotIrIntentModel};
+use prom_ui::ir_slot_projection_intent::{
+    build_ir_slot_projection_intents, UiIrSlotProjectionIntentDiagnosticKind,
+    UiIrSlotProjectionIntentKind, UiIrSlotProjectionIntentState,
+};
+use prom_ui::model::{
+    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind, UiNode,
+    UiNodeId, UiNodeKind, UiNodeResolution, UiTree, UiTreeId,
+};
+use prom_ui::projection::{
+    UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+    UiProjectionArtifactId,
+};
+use prom_ui::tree_slot_ast_intent::build_tree_slot_ast_intents;
+use prom_ui::tree_slot_intent::build_tree_slot_carrier_intents;
+
+fn build_baseline_artifact() -> (
+    UiAstSlotIrIntentModel,
+    UiProjectionArtifact,
+    UiProjectedNodeId,
+    UiProjectedNodeId,
+) {
+    let mut tree = UiTree::new(UiTreeId::new(10));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot =
+        UiNode::with_resolution(UiNodeId::new(2), UiNodeKind::Slot, UiNodeResolution::Known);
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(2));
+    tree.push_node(root);
+    tree.push_node(slot);
+
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(3), UiAstNodeKind::Root);
+    let mut ast_frag = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Fragment);
+    ast_frag.set_parent(Some(UiAstNodeId::new(3)));
+    ast_root.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_root);
+    ast.push_node(ast_frag);
+
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_frag = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Fragment);
+    ir_frag.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_root);
+    ir.push_node(ir_frag);
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let mut projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let mut proj_root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(7),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(1),
+    );
+    let mut proj_frag = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(8),
+        UiProjectedNodeKind::Fragment,
+        UiIrNodeId::new(2),
+    );
+    proj_frag.set_parent(UiProjectedNodeId::new(7));
+    proj_root.push_child(UiProjectedNodeId::new(8));
+
+    projection.push_node(proj_root);
+    projection.push_node(proj_frag);
+
+    (
+        ir_intents,
+        projection,
+        UiProjectedNodeId::new(7),
+        UiProjectedNodeId::new(8),
+    )
+}
+
+#[test]
+fn empty_ir_slot_intents_build_empty_projection_intent_model() {
+    let mut tree = UiTree::new(UiTreeId::new(1));
+    tree.push_node(UiNode::new(UiNodeId::new(1), UiNodeKind::Root));
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+
+    let mut ast = UiAst::new();
+    ast.push_node(UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root));
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    ir.push_node(UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root));
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+
+    let result = build_ir_slot_projection_intents(&ir_intents, &projection);
+    let model = result.unwrap();
+    assert_eq!(model.entries().len(), 0);
+}
+
+#[test]
+fn single_ir_slot_intent_links_to_projected_fragment() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+
+    assert_eq!(model.entries().len(), 1);
+    let entry = &model.entries()[0];
+    assert_eq!(entry.projected_node_kind(), UiProjectedNodeKind::Fragment);
+    assert_eq!(
+        entry.kind(),
+        UiIrSlotProjectionIntentKind::ProjectedFragmentLinkedToIrSlotIntent
+    );
+}
+
+#[test]
+fn multiple_ir_slot_intents_preserve_order() {
+    let mut tree = UiTree::new(UiTreeId::new(10));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot1 =
+        UiNode::with_resolution(UiNodeId::new(2), UiNodeKind::Slot, UiNodeResolution::Known);
+    let mut slot2 =
+        UiNode::with_resolution(UiNodeId::new(3), UiNodeKind::Slot, UiNodeResolution::Known);
+    slot1.set_parent(Some(UiNodeId::new(1)));
+    slot2.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(2));
+    root.push_child(UiNodeId::new(3));
+    tree.push_node(root);
+    tree.push_node(slot1);
+    tree.push_node(slot2);
+
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(1), UiAstNodeKind::Root);
+    let mut ast_frag1 = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Fragment);
+    let mut ast_frag2 = UiAstNode::new(UiAstNodeId::new(3), UiAstNodeKind::Fragment);
+    ast_frag1.set_parent(Some(UiAstNodeId::new(1)));
+    ast_frag2.set_parent(Some(UiAstNodeId::new(1)));
+    ast_root.push_child(UiAstNodeId::new(2));
+    ast_root.push_child(UiAstNodeId::new(3));
+    ast.push_node(ast_root);
+    ast.push_node(ast_frag1);
+    ast.push_node(ast_frag2);
+
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_frag1 = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Fragment);
+    let mut ir_frag2 = UiIrNode::new(UiIrNodeId::new(3), UiIrNodeKind::Fragment);
+    ir_frag1.set_parent(Some(UiIrNodeId::new(1)));
+    ir_frag2.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(2));
+    ir_root.push_child(UiIrNodeId::new(3));
+    ir.push_node(ir_root);
+    ir.push_node(ir_frag1);
+    ir.push_node(ir_frag2);
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let mut projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let mut proj_root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(31),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(1),
+    );
+
+    let mut proj_frag1 = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(32),
+        UiProjectedNodeKind::Fragment,
+        UiIrNodeId::new(2),
+    );
+    proj_frag1.set_parent(UiProjectedNodeId::new(31));
+
+    let mut proj_frag2 = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(33),
+        UiProjectedNodeKind::Fragment,
+        UiIrNodeId::new(3),
+    );
+    proj_frag2.set_parent(UiProjectedNodeId::new(31));
+
+    proj_root.push_child(UiProjectedNodeId::new(32));
+    proj_root.push_child(UiProjectedNodeId::new(33));
+
+    projection.push_node(proj_root);
+    projection.push_node(proj_frag1);
+    projection.push_node(proj_frag2);
+
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+
+    assert_eq!(model.entries().len(), 2);
+    assert_eq!(model.entries()[0].source_tree_node_id(), UiNodeId::new(2));
+    assert_eq!(model.entries()[1].source_tree_node_id(), UiNodeId::new(3));
+}
+
+#[test]
+fn projection_intent_entry_id_is_deterministic() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.id().raw(), 2);
+}
+
+#[test]
+fn projection_intent_preserves_source_ir_intent_entry_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let source_id = ir_intents.entries()[0].id();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ir_intent_entry_id(), source_id);
+}
+
+#[test]
+fn projection_intent_preserves_source_ast_intent_entry_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let source_id = ir_intents.entries()[0].source_ast_intent_entry_id();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ast_intent_entry_id(), source_id);
+}
+
+#[test]
+fn projection_intent_preserves_source_tree_intent_entry_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let source_id = ir_intents.entries()[0].source_tree_intent_entry_id();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_tree_intent_entry_id(), source_id);
+}
+
+#[test]
+fn projection_intent_preserves_source_tree_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_tree_id(), UiTreeId::new(10));
+}
+
+#[test]
+fn projection_intent_preserves_source_tree_node_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_tree_node_id(), UiNodeId::new(2));
+}
+
+#[test]
+fn projection_intent_preserves_source_tree_node_kind() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_tree_node_kind(), UiNodeKind::Slot);
+}
+
+#[test]
+fn projection_intent_preserves_source_tree_resolution() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_tree_resolution(), UiNodeResolution::Known);
+}
+
+#[test]
+fn projection_intent_preserves_source_ast_node_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ast_node_id(), UiAstNodeId::new(2));
+}
+
+#[test]
+fn projection_intent_preserves_source_ast_node_kind_as_fragment() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ast_node_kind(), UiAstNodeKind::Fragment);
+}
+
+#[test]
+fn projection_intent_preserves_source_ir_node_id() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ir_node_id(), UiIrNodeId::new(2));
+}
+
+#[test]
+fn projection_intent_preserves_source_ir_node_kind_as_fragment() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.source_ir_node_kind(), UiIrNodeKind::Fragment);
+}
+
+#[test]
+fn projection_intent_preserves_projected_node_id() {
+    let (ir_intents, projection, _, proj_frag_id) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.projected_node_id(), proj_frag_id);
+}
+
+#[test]
+fn projection_intent_preserves_projected_node_kind_as_fragment() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.projected_node_kind(), UiProjectedNodeKind::Fragment);
+}
+
+#[test]
+fn projection_intent_preserves_parent_tree_handle() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.parent_tree_node_id(), Some(UiNodeId::new(1)));
+}
+
+#[test]
+fn projection_intent_preserves_child_tree_handles() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.child_tree_node_ids().len(), 0);
+}
+
+#[test]
+fn projection_intent_preserves_parent_ast_handle() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.parent_ast_node_id(), Some(UiAstNodeId::new(1)));
+}
+
+#[test]
+fn projection_intent_preserves_child_ast_handles() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.child_ast_node_ids().len(), 0);
+}
+
+#[test]
+fn projection_intent_preserves_parent_ir_handle() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.parent_ir_node_id(), Some(UiIrNodeId::new(1)));
+}
+
+#[test]
+fn projection_intent_preserves_child_ir_handles() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.child_ir_node_ids().len(), 0);
+}
+
+#[test]
+fn projection_intent_preserves_parent_projected_handle() {
+    let (ir_intents, projection, proj_root_id, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.parent_projected_node_id(), Some(proj_root_id));
+}
+
+#[test]
+fn projection_intent_preserves_child_projected_handles() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    let entry = &model.entries()[0];
+    assert_eq!(entry.child_projected_node_ids().len(), 0);
+}
+
+#[test]
+fn unknown_resolution_is_preserved() {
+    let mut tree = UiTree::new(UiTreeId::new(10));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot = UiNode::with_resolution(
+        UiNodeId::new(2),
+        UiNodeKind::Slot,
+        UiNodeResolution::Unknown,
+    );
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(2));
+    tree.push_node(root);
+    tree.push_node(slot);
+
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(3), UiAstNodeKind::Root);
+    let mut ast_frag = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Fragment);
+    ast_frag.set_parent(Some(UiAstNodeId::new(3)));
+    ast_root.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_root);
+    ast.push_node(ast_frag);
+
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_frag = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Fragment);
+    ir_frag.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_root);
+    ir.push_node(ir_frag);
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let mut projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let mut proj_root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(7),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(1),
+    );
+    let mut proj_frag = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(8),
+        UiProjectedNodeKind::Fragment,
+        UiIrNodeId::new(2),
+    );
+    proj_frag.set_parent(UiProjectedNodeId::new(7));
+    proj_root.push_child(UiProjectedNodeId::new(8));
+
+    projection.push_node(proj_root);
+    projection.push_node(proj_frag);
+
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+
+    assert_eq!(
+        model.entries()[0].source_tree_resolution(),
+        UiNodeResolution::Unknown
+    );
+}
+
+#[test]
+fn conflict_resolution_is_preserved() {
+    let mut tree = UiTree::new(UiTreeId::new(10));
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    let mut slot = UiNode::with_resolution(
+        UiNodeId::new(2),
+        UiNodeKind::Slot,
+        UiNodeResolution::Conflict,
+    );
+    slot.set_parent(Some(UiNodeId::new(1)));
+    root.push_child(UiNodeId::new(2));
+    tree.push_node(root);
+    tree.push_node(slot);
+
+    let mut ast = UiAst::new();
+    let mut ast_root = UiAstNode::new(UiAstNodeId::new(3), UiAstNodeKind::Root);
+    let mut ast_frag = UiAstNode::new(UiAstNodeId::new(2), UiAstNodeKind::Fragment);
+    ast_frag.set_parent(Some(UiAstNodeId::new(3)));
+    ast_root.push_child(UiAstNodeId::new(2));
+    ast.push_node(ast_root);
+    ast.push_node(ast_frag);
+
+    let tree_intents = build_tree_slot_carrier_intents(&tree).unwrap();
+    let ast_intents = build_tree_slot_ast_intents(&tree_intents, &ast).unwrap();
+
+    let mut ir = UiIr::new();
+    let mut ir_root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    let mut ir_frag = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Fragment);
+    ir_frag.set_parent(Some(UiIrNodeId::new(1)));
+    ir_root.push_child(UiIrNodeId::new(2));
+    ir.push_node(ir_root);
+    ir.push_node(ir_frag);
+
+    let ir_intents = build_ast_slot_ir_intents(&ast_intents, &ir).unwrap();
+
+    let mut projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    let mut proj_root = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(7),
+        UiProjectedNodeKind::Root,
+        UiIrNodeId::new(1),
+    );
+    let mut proj_frag = UiProjectedNode::with_source_ir_node(
+        UiProjectedNodeId::new(8),
+        UiProjectedNodeKind::Fragment,
+        UiIrNodeId::new(2),
+    );
+    proj_frag.set_parent(UiProjectedNodeId::new(7));
+    proj_root.push_child(UiProjectedNodeId::new(8));
+
+    projection.push_node(proj_root);
+    projection.push_node(proj_frag);
+
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+
+    assert_eq!(
+        model.entries()[0].source_tree_resolution(),
+        UiNodeResolution::Conflict
+    );
+}
+
+#[test]
+fn missing_projected_node_returns_diagnostic() {
+    let (ir_intents, mut projection, _, _) = build_baseline_artifact();
+
+    // Create a new projection with only the root, missing the fragment
+    let mut new_projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    for node in projection.nodes() {
+        if node.kind() == UiProjectedNodeKind::Root {
+            new_projection.push_node(node.clone());
+        }
+    }
+
+    let result = build_ir_slot_projection_intents(&ir_intents, &new_projection);
+    assert!(result.is_err());
+    let diagnostics = result.unwrap_err();
+    let mut iter = diagnostics.iter();
+    let diag = iter.next().unwrap();
+    match diag.kind() {
+        UiIrSlotProjectionIntentDiagnosticKind::MissingProjectedNode { source_ir_node_id } => {
+            assert_eq!(*source_ir_node_id, UiIrNodeId::new(2));
+        }
+        _ => panic!("Expected MissingProjectedNode"),
+    }
+}
+
+#[test]
+fn non_fragment_projected_node_returns_diagnostic() {
+    let (ir_intents, mut projection, _, _) = build_baseline_artifact();
+
+    let mut new_projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    for node in projection.nodes() {
+        if node.kind() == UiProjectedNodeKind::Fragment {
+            let mut new_bad = UiProjectedNode::with_source_ir_node(
+                node.id(),
+                UiProjectedNodeKind::PropertyCarrier,
+                node.source_ir_node_id().unwrap(),
+            );
+            if let Some(p) = node.parent() {
+                new_bad.set_parent(p);
+            }
+            new_projection.push_node(new_bad);
+        } else {
+            new_projection.push_node(node.clone());
+        }
+    }
+
+    let result = build_ir_slot_projection_intents(&ir_intents, &new_projection);
+    assert!(result.is_err());
+}
+
+#[test]
+fn diagnostic_preserves_source_ir_node_id() {
+    let (ir_intents, _, _, _) = build_baseline_artifact();
+    let new_projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1)); // missing node
+    let result = build_ir_slot_projection_intents(&ir_intents, &new_projection);
+    let diagnostics = result.unwrap_err();
+    let diag = diagnostics.iter().next().unwrap();
+    match diag.kind() {
+        UiIrSlotProjectionIntentDiagnosticKind::MissingProjectedNode { source_ir_node_id } => {
+            assert_eq!(*source_ir_node_id, UiIrNodeId::new(2));
+        }
+        _ => panic!("Expected MissingProjectedNode"),
+    }
+}
+
+#[test]
+fn non_fragment_diagnostic_preserves_projected_node_id_and_kind() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let mut new_projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    for node in projection.nodes() {
+        if node.kind() == UiProjectedNodeKind::Fragment {
+            let new_bad = UiProjectedNode::with_source_ir_node(
+                node.id(),
+                UiProjectedNodeKind::PropertyCarrier,
+                node.source_ir_node_id().unwrap(),
+            );
+            new_projection.push_node(new_bad);
+        } else {
+            new_projection.push_node(node.clone());
+        }
+    }
+
+    let result = build_ir_slot_projection_intents(&ir_intents, &new_projection);
+    let diagnostics = result.unwrap_err();
+    let diag = diagnostics.iter().next().unwrap();
+    match diag.kind() {
+        UiIrSlotProjectionIntentDiagnosticKind::UnexpectedProjectedNodeKind {
+            source_ir_node_id,
+            projected_node_id,
+            actual_kind,
+        } => {
+            assert_eq!(*source_ir_node_id, UiIrNodeId::new(2));
+            assert_eq!(*projected_node_id, UiProjectedNodeId::new(8));
+            assert_eq!(*actual_kind, UiProjectedNodeKind::PropertyCarrier);
+        }
+        _ => panic!("Expected UnexpectedProjectedNodeKind"),
+    }
+}
+
+#[test]
+fn mismatched_input_returns_no_partial_model() {
+    let (ir_intents, _, _, _) = build_baseline_artifact();
+    let new_projection = UiProjectionArtifact::new(UiProjectionArtifactId::new(1)); // missing node
+    let result = build_ir_slot_projection_intents(&ir_intents, &new_projection);
+    assert!(result.is_err()); // It doesn't return a partial model, it returns Err
+}
+
+#[test]
+fn builder_does_not_mutate_inputs() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let intents_clone = ir_intents.clone();
+    let projection_clone = projection.clone();
+
+    let _ = build_ir_slot_projection_intents(&ir_intents, &projection);
+
+    assert_eq!(ir_intents.entries().len(), intents_clone.entries().len());
+    assert_eq!(projection.nodes().len(), projection_clone.nodes().len());
+}
+
+#[test]
+fn builder_does_not_call_projection_or_render_pipeline() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+
+    let projection_len_before = projection.nodes().len();
+    let projected_node_id_before = projection.nodes()[0].id();
+
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+
+    assert_eq!(model.entries().len(), 1);
+    let entry = &model.entries()[0];
+
+    assert_eq!(
+        entry.kind(),
+        UiIrSlotProjectionIntentKind::ProjectedFragmentLinkedToIrSlotIntent
+    );
+    assert_eq!(entry.state(), UiIrSlotProjectionIntentState::Deferred);
+    assert_eq!(entry.projected_node_kind(), UiProjectedNodeKind::Fragment);
+    assert_eq!(entry.source_ir_node_kind(), UiIrNodeKind::Fragment);
+
+    assert_eq!(projection.nodes().len(), projection_len_before);
+    assert_eq!(projection.nodes()[0].id(), projected_node_id_before);
+}
+
+#[test]
+fn metadata_does_not_create_projection_carriers() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    for entry in model.entries() {
+        assert_eq!(entry.projected_node_kind(), UiProjectedNodeKind::Fragment);
+        assert_ne!(
+            entry.projected_node_kind(),
+            UiProjectedNodeKind::PropertyCarrier
+        );
+        assert_ne!(
+            entry.projected_node_kind(),
+            UiProjectedNodeKind::ActionCarrier
+        );
+        assert_ne!(
+            entry.projected_node_kind(),
+            UiProjectedNodeKind::EffectBoundaryMarker
+        );
+    }
+}
+
+#[test]
+fn slot_projection_intent_is_inert_and_non_authoritative() {
+    let (ir_intents, projection, _, _) = build_baseline_artifact();
+    let model = build_ir_slot_projection_intents(&ir_intents, &projection).unwrap();
+    for entry in model.entries() {
+        assert_eq!(entry.state(), UiIrSlotProjectionIntentState::Deferred);
+    }
+}


### PR DESCRIPTION
# Description

This PR implements the R12 gate: **IR Slot Carrier Intent to Projection Metadata Bridge**.
It bridges IR-side Slot carrier intents to Projection metadata without introducing Action, Property, EffectBoundary semantics, or changing the lowering pipeline.

## Admission Guard result
Admission Guard result: FAIL - ENVIRONMENT PATHING

## Changes
- `crates/prom-ui/src/lib.rs` - Export ir_slot_projection_intent
- `crates/prom-ui/src/ir_slot_projection_intent.rs` - The bridge logic that maps IR slot intents to Projection artifact fragments
- `crates/prom-ui/tests/ui_ir_slot_carrier_intent_to_projection_metadata.rs` - Integration tests validating metadata projection integrity and structural constraints

## Verification
- Run `cargo fmt --check`
- Run `cargo test -p prom-ui --test ui_ir_slot_carrier_intent_to_projection_metadata`
- Evaluated structural non-authority metrics
