### PR TITLE
style(ui): repair preexisting fmt drift

### DIFF
--- a/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
+++ b/crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
@@ -1,7 +1,5 @@
 use prom_ui::lowering::{lower_ast_to_ir, UiLoweringConfig, UiLoweringDiagnosticKind};
-use prom_ui::model::{
-    UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind,
-};
+use prom_ui::model::{UiAst, UiAstNode, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind};
 use prom_ui::projection::{project_ir_to_projection, UiProjectedNodeKind};
 use prom_ui::renderer::{render_projection_to_model, UiRenderMarker};
 


### PR DESCRIPTION
## Summary

Repairs the pre-existing rustfmt drift that was blocking clean `cargo fmt --check`.

Affected file:

```text
crates/prom-ui/tests/ui_ast_ir_lowering_carriers.rs
```

## Scope

Format-only PR.

## Explicit non-scope

- no source changes
- no semantic test changes
- no new tests
- no docs changes
- no Cargo changes
- no dependency changes
- no DNA changes
- no Admission Guard changes
- no UI behavior changes
- no Project board schema changes

## SEMANTIC_UI_DNA

This PR preserves the UI DNA canon:

- no UI authority changes
- no action/effect execution
- no runtime/capability bypass
- no source evidence changes
- formatting only

## Validation

Local only:

```text
cargo fmt --check: PASS
cargo test -p prom-ui --lib: PASS
cargo test -p prom-ui --test ui_ast_ir_lowering_carriers: PASS
cargo test -p prom-ui: PASS
git diff --check: PASS
tracked pr_body files: NO
Admission Guard executed: YES
Admission Guard result: FAIL - ENVIRONMENT PATHING
Admission Guard changed: NO
GitHub CI used: NO
```

## Final status

PASS WITH WARNINGS - R12 UI PREEXISTING FMT DRIFT REPAIR READY
