### PR TITLE
test(ui): expose public ast source evidence accessor

### DIFF
--- a/crates/prom-ui/src/lowering.rs
+++ b/crates/prom-ui/src/lowering.rs
@@ -118,6 +118,7 @@ pub fn lower_ast_to_ir(ast: &UiAst, config: &UiLoweringConfig) -> UiLoweringResu
             ),
             None => UiIrNode::new(UiIrNodeId::new(node.id().raw()), ir_kind),
         };
+        ir_node.set_source_ast_node_id(Some(node.id()));
 
         for child in node.children() {
             ir_node.push_child(UiIrNodeId::new(child.raw()));

--- a/crates/prom-ui/src/model.rs
+++ b/crates/prom-ui/src/model.rs
@@ -338,6 +338,7 @@ pub enum UiIrNodeKind {
 pub struct UiIrNode {
     id: UiIrNodeId,
     kind: UiIrNodeKind,
+    source_ast_node_id: Option<UiAstNodeId>,
     parent: Option<UiIrNodeId>,
     children: Vec<UiIrNodeId>,
 }
@@ -348,6 +349,7 @@ impl UiIrNode {
         Self {
             id,
             kind,
+            source_ast_node_id: None,
             parent: None,
             children: Vec::new(),
         }
@@ -358,6 +360,7 @@ impl UiIrNode {
         Self {
             id,
             kind,
+            source_ast_node_id: None,
             parent: Some(parent),
             children: Vec::new(),
         }
@@ -376,6 +379,16 @@ impl UiIrNode {
     /// Returns the IR node kind.
     pub const fn kind(&self) -> UiIrNodeKind {
         self.kind
+    }
+
+    /// Returns the source AST node handle when the IR node was lowered from AST.
+    pub const fn source_ast_node_id(&self) -> Option<UiAstNodeId> {
+        self.source_ast_node_id
+    }
+
+    /// Updates the source AST node handle without adding semantics.
+    pub(crate) fn set_source_ast_node_id(&mut self, source_ast_node_id: Option<UiAstNodeId>) {
+        self.source_ast_node_id = source_ast_node_id;
     }
 
     /// Returns the child handles.

--- a/crates/prom-ui/tests/ui_foundation_public_ast_source_evidence_accessor.rs
+++ b/crates/prom-ui/tests/ui_foundation_public_ast_source_evidence_accessor.rs
@@ -1,0 +1,85 @@
+use prom_ui::{
+    lower_ast_to_ir, tree_to_ast, UiAstNodeId, UiAstNodeKind, UiIrNodeId, UiIrNodeKind,
+    UiLoweringConfig, UiNode, UiNodeId, UiNodeKind, UiTree, UiTreeId,
+};
+
+fn foundation_tree() -> UiTree {
+    let mut tree = UiTree::new(UiTreeId::new(1));
+
+    let mut root = UiNode::new(UiNodeId::new(1), UiNodeKind::Root);
+    root.push_child(UiNodeId::new(2));
+    tree.push_node(root);
+
+    let mut element = UiNode::with_parent(UiNodeId::new(2), UiNodeKind::Element, UiNodeId::new(1));
+    element.push_child(UiNodeId::new(3));
+    tree.push_node(element);
+
+    tree.push_node(UiNode::with_parent(
+        UiNodeId::new(3),
+        UiNodeKind::Text,
+        UiNodeId::new(2),
+    ));
+
+    tree
+}
+
+#[test]
+fn foundation_public_ir_nodes_expose_source_ast_node_ids() {
+    let tree = foundation_tree();
+    let ast = tree_to_ast(&tree).expect("tree_to_ast should succeed");
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("lower_ast_to_ir should succeed");
+
+    assert_eq!(ast.len(), 3);
+    assert_eq!(ir.len(), 3);
+
+    let expected = [
+        (
+            UiIrNodeId::new(1),
+            UiIrNodeKind::Root,
+            Some(UiAstNodeId::new(1)),
+        ),
+        (
+            UiIrNodeId::new(2),
+            UiIrNodeKind::Element,
+            Some(UiAstNodeId::new(2)),
+        ),
+        (
+            UiIrNodeId::new(3),
+            UiIrNodeKind::Text,
+            Some(UiAstNodeId::new(3)),
+        ),
+    ];
+
+    for (node, (expected_id, expected_kind, expected_source_ast_id)) in
+        ir.nodes().iter().zip(expected)
+    {
+        assert_eq!(node.id(), expected_id);
+        assert_eq!(node.kind(), expected_kind);
+        assert_eq!(node.source_ast_node_id(), expected_source_ast_id);
+    }
+}
+
+#[test]
+fn foundation_public_api_surface_is_callable_through_crate_facade() {
+    let tree = foundation_tree();
+
+    let ast = tree_to_ast(&tree).expect("tree_to_ast should succeed");
+    let ir = lower_ast_to_ir(&ast, &UiLoweringConfig).expect("lower_ast_to_ir should succeed");
+
+    assert_eq!(tree.id(), UiTreeId::new(1));
+    assert_eq!(ast.nodes()[0].kind(), UiAstNodeKind::Root);
+    assert_eq!(ast.nodes()[1].kind(), UiAstNodeKind::Element);
+    assert_eq!(ast.nodes()[2].kind(), UiAstNodeKind::Text);
+    assert_eq!(
+        ir.nodes()[0].source_ast_node_id(),
+        Some(UiAstNodeId::new(1))
+    );
+    assert_eq!(
+        ir.nodes()[1].source_ast_node_id(),
+        Some(UiAstNodeId::new(2))
+    );
+    assert_eq!(
+        ir.nodes()[2].source_ast_node_id(),
+        Some(UiAstNodeId::new(3))
+    );
+}


### PR DESCRIPTION
## Summary

Adds the minimal public AST-source evidence accessor required to keep the Semantic UI Foundation API externally usable by integration tests.

This PR threads AST-source evidence into `UiIrNode` without changing lowering semantics or the render/projection pipeline.

## Scope

Source + test PR.

Changed files:

- `crates/prom-ui/src/model.rs`
- `crates/prom-ui/src/lowering.rs`
- `crates/prom-ui/tests/ui_foundation_public_ast_source_evidence_accessor.rs`

## Explicit non-scope

- no projection changes
- no render changes
- no layout changes
- no backend changes
- no runtime changes
- no capability changes
- no action/effect changes
- no Cargo changes
- no dependency additions
- no docs changes
- no DNA changes
- no Admission Guard changes

## SEMANTIC_UI_DNA

This PR preserves the UI DNA canon:

- UI remains projection/cache, not semantic authority.
- Evidence remains source-linked and externally inspectable.
- Renderer boundary remains non-authoritative.
- No action/effect/runtime/capability path is introduced.
- Unknown/Conflict semantics are not flattened or altered.

## Validation

Local only:

- `cargo fmt`: PASS
- `cargo fmt --check`: PASS
- `cargo test -p prom-ui --lib`: PASS
- `cargo test -p prom-ui --test ui_foundation_public_ast_source_evidence_accessor`: PASS
- `cargo test -p prom-ui`: PASS
- `git diff --check`: PASS
- `tracked pr_body files`: NO
- `Admission Guard executed`: YES
- `Admission Guard result`: FAIL - ENVIRONMENT PATHING
- `Admission Guard changed`: NO
- `GitHub CI used`: NO

## Final status

PASS WITH WARNINGS - R12 UI FOUNDATION PUBLIC AST SOURCE EVIDENCE ACCESSOR READY
