### PR TITLE
feat(ui): add layout rect model

### DIFF
--- a/crates/prom-ui/src/layout_rect.rs
+++ b/crates/prom-ui/src/layout_rect.rs
@@ -1,0 +1,108 @@
+use crate::model::UiIrNodeId;
+use crate::projection::UiProjectedNodeId;
+use crate::renderer::UiRenderNodeId;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct UiLayoutRect {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+impl UiLayoutRect {
+    pub const fn new(x: i32, y: i32, width: u32, height: u32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    pub const fn x(&self) -> i32 {
+        self.x
+    }
+
+    pub const fn y(&self) -> i32 {
+        self.y
+    }
+
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiLayoutRectEntry {
+    render_node_id: UiRenderNodeId,
+    source_projection_node_id: UiProjectedNodeId,
+    source_ir_node_id: Option<UiIrNodeId>,
+    rect: UiLayoutRect,
+}
+
+impl UiLayoutRectEntry {
+    pub fn new(
+        render_node_id: UiRenderNodeId,
+        source_projection_node_id: UiProjectedNodeId,
+        source_ir_node_id: Option<UiIrNodeId>,
+        rect: UiLayoutRect,
+    ) -> Self {
+        Self {
+            render_node_id,
+            source_projection_node_id,
+            source_ir_node_id,
+            rect,
+        }
+    }
+
+    pub const fn render_node_id(&self) -> UiRenderNodeId {
+        self.render_node_id
+    }
+
+    pub const fn source_projection_node_id(&self) -> UiProjectedNodeId {
+        self.source_projection_node_id
+    }
+
+    pub const fn source_ir_node_id(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node_id
+    }
+
+    pub const fn rect(&self) -> UiLayoutRect {
+        self.rect
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UiLayoutRectModel {
+    entries: Vec<UiLayoutRectEntry>,
+}
+
+impl UiLayoutRectModel {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn push_entry(&mut self, entry: UiLayoutRectEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn entries(&self) -> &[UiLayoutRectEntry] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -45,6 +45,7 @@ pub mod host_runtime_effect_result;
 pub mod intent_stream;
 pub mod interaction;
 pub mod layout;
+pub mod layout_rect;
 pub mod lowering;
 pub mod model;
 pub mod prepared_effect;
@@ -191,6 +192,7 @@ pub use interaction::{
     ElementId, InteractionIntentDescriptor, InteractionIntentId, InteractionIntentKind,
     InteractionModifiers, InteractionSource, InteractionTarget, RegionId, SurfaceId, WindowId,
 };
+pub use layout_rect::{UiLayoutRect, UiLayoutRectEntry, UiLayoutRectModel};
 pub use lowering::{
     lower_ast_to_ir, UiLoweringConfig, UiLoweringDiagnostic, UiLoweringDiagnosticKind,
     UiLoweringDiagnostics, UiLoweringResult,

--- a/crates/prom-ui/tests/ui_layout_rect_model.rs
+++ b/crates/prom-ui/tests/ui_layout_rect_model.rs
@@ -1,0 +1,157 @@
+use prom_ui::{
+    UiIrNodeId, UiLayoutRect, UiLayoutRectEntry, UiLayoutRectModel, UiProjectedNodeId,
+    UiRenderNodeId,
+};
+
+fn entry(
+    render_node_id: u64,
+    projection_node_id: u64,
+    ir_node_id: Option<u64>,
+    rect: UiLayoutRect,
+) -> UiLayoutRectEntry {
+    UiLayoutRectEntry::new(
+        UiRenderNodeId::new(render_node_id),
+        UiProjectedNodeId::new(projection_node_id),
+        ir_node_id.map(UiIrNodeId::new),
+        rect,
+    )
+}
+
+#[test]
+fn layout_rect_preserves_integer_geometry() {
+    let rect = UiLayoutRect::new(-12, 34, 0, 56);
+
+    assert_eq!(rect.x(), -12);
+    assert_eq!(rect.y(), 34);
+    assert_eq!(rect.width(), 0);
+    assert_eq!(rect.height(), 56);
+}
+
+#[test]
+fn layout_rect_entry_preserves_render_projection_ir_evidence() {
+    let rect = UiLayoutRect::new(7, -8, 9, 10);
+    let entry = entry(11, 12, Some(13), rect);
+
+    assert_eq!(entry.render_node_id(), UiRenderNodeId::new(11));
+    assert_eq!(
+        entry.source_projection_node_id(),
+        UiProjectedNodeId::new(12)
+    );
+    assert_eq!(entry.source_ir_node_id(), Some(UiIrNodeId::new(13)));
+    assert_eq!(entry.rect(), rect);
+}
+
+#[test]
+fn layout_rect_entry_supports_missing_ir_evidence_explicitly() {
+    let rect = UiLayoutRect::new(1, 2, 3, 4);
+    let entry = entry(20, 21, None, rect);
+
+    assert_eq!(entry.render_node_id(), UiRenderNodeId::new(20));
+    assert_eq!(
+        entry.source_projection_node_id(),
+        UiProjectedNodeId::new(21)
+    );
+    assert_eq!(entry.source_ir_node_id(), None);
+    assert_eq!(entry.rect(), rect);
+}
+
+#[test]
+fn layout_rect_model_preserves_insertion_order() {
+    let rect_a = UiLayoutRect::new(0, 0, 1, 1);
+    let rect_b = UiLayoutRect::new(2, 3, 4, 5);
+    let rect_c = UiLayoutRect::new(6, 7, 8, 9);
+
+    let mut model = UiLayoutRectModel::new();
+    model.push_entry(entry(1, 101, Some(201), rect_a));
+    model.push_entry(entry(2, 102, Some(202), rect_b));
+    model.push_entry(entry(3, 103, None, rect_c));
+
+    let entries = model.entries();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].render_node_id(), UiRenderNodeId::new(1));
+    assert_eq!(entries[1].render_node_id(), UiRenderNodeId::new(2));
+    assert_eq!(entries[2].render_node_id(), UiRenderNodeId::new(3));
+    assert_eq!(entries[0].rect(), rect_a);
+    assert_eq!(entries[1].rect(), rect_b);
+    assert_eq!(entries[2].rect(), rect_c);
+}
+
+#[test]
+fn layout_rect_model_reports_len_and_empty_state() {
+    let mut model = UiLayoutRectModel::new();
+
+    assert!(model.is_empty());
+    assert_eq!(model.len(), 0);
+    assert!(model.entries().is_empty());
+
+    model.push_entry(entry(9, 10, Some(11), UiLayoutRect::new(1, 1, 1, 1)));
+
+    assert!(!model.is_empty());
+    assert_eq!(model.len(), 1);
+    assert_eq!(model.entries().len(), 1);
+}
+
+#[test]
+fn zero_sized_rect_is_explicit_layout_evidence_not_absence() {
+    let mut model = UiLayoutRectModel::new();
+    let rect = UiLayoutRect::new(5, 6, 0, 0);
+    model.push_entry(entry(30, 31, Some(32), rect));
+
+    assert_eq!(model.len(), 1);
+    assert_eq!(model.entries()[0].rect(), rect);
+    assert_eq!(model.entries()[0].rect().width(), 0);
+    assert_eq!(model.entries()[0].rect().height(), 0);
+}
+
+#[test]
+fn layout_rect_model_public_api_is_externally_usable() {
+    let rect = UiLayoutRect::new(-1, -2, 3, 4);
+    let mut model = UiLayoutRectModel::new();
+    model.push_entry(entry(40, 41, Some(42), rect));
+
+    let stored = &model.entries()[0];
+    assert_eq!(stored.render_node_id(), UiRenderNodeId::new(40));
+    assert_eq!(
+        stored.source_projection_node_id(),
+        UiProjectedNodeId::new(41)
+    );
+    assert_eq!(stored.source_ir_node_id(), Some(UiIrNodeId::new(42)));
+    assert_eq!(stored.rect(), rect);
+}
+
+#[test]
+fn layout_rect_model_does_not_create_authority_or_backend_behavior() {
+    let rect = UiLayoutRect::new(12, 13, 14, 15);
+    let mut model = UiLayoutRectModel::new();
+    model.push_entry(entry(50, 51, None, rect));
+
+    let stored = &model.entries()[0];
+    assert_eq!(stored.render_node_id(), UiRenderNodeId::new(50));
+    assert_eq!(
+        stored.source_projection_node_id(),
+        UiProjectedNodeId::new(51)
+    );
+    assert_eq!(stored.source_ir_node_id(), None);
+    assert_eq!(stored.rect(), rect);
+    assert_eq!(model.len(), 1);
+    assert_eq!(
+        model
+            .entries()
+            .iter()
+            .map(|entry| entry.rect())
+            .collect::<Vec<_>>(),
+        vec![rect]
+    );
+}
+
+#[test]
+fn layout_rect_model_is_cloneable_and_comparable() {
+    let mut model = UiLayoutRectModel::new();
+    model.push_entry(entry(60, 61, Some(62), UiLayoutRect::new(1, 2, 3, 4)));
+    model.push_entry(entry(63, 64, None, UiLayoutRect::new(5, 6, 7, 8)));
+
+    let cloned = model.clone();
+    assert_eq!(cloned, model);
+    assert_eq!(cloned.entries().len(), 2);
+    assert_eq!(cloned.entries()[1].source_ir_node_id(), None);
+}


### PR DESCRIPTION
## Summary

Adds the inert `UiLayoutRectModel` source data model defined by the layout rect boundary gate.

This PR introduces:

- `UiLayoutRect`
- `UiLayoutRectEntry`
- `UiLayoutRectModel`

The model is integer-only, source-linked, deterministic, backend-free, runtime-free, effect-free, and non-authoritative.

## Scope

Source + tests PR.

Changed files:

```text
crates/prom-ui/src/layout_rect.rs
crates/prom-ui/src/lib.rs
crates/prom-ui/tests/ui_layout_rect_model.rs
```

Explicit non-scope

- no solver
- no layout algorithm
- no flexbox/grid
- no text measurement
- no font access
- no OS access
- no backend draw
- no windowing
- no hit testing
- no interaction
- no runtime handoff
- no action execution
- no effect execution
- no capability admission
- no dependency additions
- no docs changes
- no DNA changes
- no Admission Guard changes
- no GitHub CI evidence

SEMANTIC_UI_DNA

This PR preserves the UI DNA canon:

- layout rectangles are inert geometry evidence;
- UI remains projection/cache, not semantic authority;
- source references are preserved;
- renderer/backend/runtime boundaries remain non-authoritative;
- no action/effect/runtime/capability path is introduced.

Validation

Local only:

- cargo fmt: PASS
- cargo fmt --check: PASS
- cargo test -p prom-ui --lib: PASS
- cargo test -p prom-ui --test ui_layout_rect_model: PASS
- cargo test -p prom-ui: PASS
- git diff --check: PASS
- tracked pr_body files: NO
- Admission Guard executed: YES
- Admission Guard result: FAIL - ENVIRONMENT PATHING
- Admission Guard changed: NO
- GitHub CI used: NO

Final status

PASS WITH WARNINGS - R12 UI LAYOUT RECT MODEL SOURCE READY
