### PR TITLE
feat(ui): add backend frame sink trait

### DIFF
--- a/crates/prom-ui-backend-native/src/frame_sink.rs
+++ b/crates/prom-ui-backend-native/src/frame_sink.rs
@@ -1,0 +1,78 @@
+use alloc::vec::Vec;
+use prom_ui::{UiIrNodeId, UiLayoutRect, UiProjectedNodeId, UiRenderNodeId, UiRenderNodeKind};
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct UiBackendFrame {
+    entries: Vec<UiBackendFrameEntry>,
+}
+
+impl UiBackendFrame {
+    pub fn new(entries: Vec<UiBackendFrameEntry>) -> Self {
+        Self { entries }
+    }
+
+    pub fn entries(&self) -> &[UiBackendFrameEntry] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UiBackendFrameEntry {
+    render_node_id: UiRenderNodeId,
+    source_projection_node_id: UiProjectedNodeId,
+    source_ir_node_id: Option<UiIrNodeId>,
+    rect: UiLayoutRect,
+    kind: UiRenderNodeKind,
+}
+
+impl UiBackendFrameEntry {
+    pub fn new(
+        render_node_id: UiRenderNodeId,
+        source_projection_node_id: UiProjectedNodeId,
+        source_ir_node_id: Option<UiIrNodeId>,
+        rect: UiLayoutRect,
+        kind: UiRenderNodeKind,
+    ) -> Self {
+        Self {
+            render_node_id,
+            source_projection_node_id,
+            source_ir_node_id,
+            rect,
+            kind,
+        }
+    }
+
+    pub const fn render_node_id(&self) -> UiRenderNodeId {
+        self.render_node_id
+    }
+
+    pub const fn source_projection_node_id(&self) -> UiProjectedNodeId {
+        self.source_projection_node_id
+    }
+
+    pub const fn source_ir_node_id(&self) -> Option<UiIrNodeId> {
+        self.source_ir_node_id
+    }
+
+    pub const fn rect(&self) -> UiLayoutRect {
+        self.rect
+    }
+
+    pub const fn kind(&self) -> UiRenderNodeKind {
+        self.kind
+    }
+}
+
+pub trait UiFrameSink {
+    type Error;
+
+    fn submit_frame(&mut self, frame: &UiBackendFrame) -> Result<(), Self::Error>;
+}

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -18,6 +18,10 @@ use prom_ui_runtime::{
     WindowConfig,
 };
 
+pub mod frame_sink;
+
+pub use frame_sink::{UiBackendFrame, UiBackendFrameEntry, UiFrameSink};
+
 #[cfg(feature = "winit-backend")]
 #[derive(Debug)]
 pub enum NativeBackendWinitSmokeError {

--- a/crates/prom-ui-backend-native/tests/backend_frame_sink_trait.rs
+++ b/crates/prom-ui-backend-native/tests/backend_frame_sink_trait.rs
@@ -1,0 +1,155 @@
+use core::convert::Infallible;
+
+use prom_ui::{UiIrNodeId, UiLayoutRect, UiProjectedNodeId, UiRenderNodeId, UiRenderNodeKind};
+use prom_ui_backend_native::{UiBackendFrame, UiBackendFrameEntry, UiFrameSink};
+
+fn sample_entry() -> UiBackendFrameEntry {
+    UiBackendFrameEntry::new(
+        UiRenderNodeId::new(11),
+        UiProjectedNodeId::new(22),
+        Some(UiIrNodeId::new(33)),
+        UiLayoutRect::new(-4, 8, 120, 48),
+        UiRenderNodeKind::Element,
+    )
+}
+
+fn entry_signature(
+    entry: &UiBackendFrameEntry,
+) -> (u64, u64, Option<u64>, i32, i32, u32, u32, UiRenderNodeKind) {
+    let rect = entry.rect();
+    (
+        entry.render_node_id().raw(),
+        entry.source_projection_node_id().raw(),
+        entry.source_ir_node_id().map(UiIrNodeId::raw),
+        rect.x(),
+        rect.y(),
+        rect.width(),
+        rect.height(),
+        entry.kind(),
+    )
+}
+
+fn frame_signature(
+    frame: &UiBackendFrame,
+) -> Vec<(u64, u64, Option<u64>, i32, i32, u32, u32, UiRenderNodeKind)> {
+    frame.entries().iter().map(entry_signature).collect()
+}
+
+#[test]
+fn backend_frame_entry_preserves_render_layout_source_evidence() {
+    let entry = sample_entry();
+
+    assert_eq!(entry.render_node_id(), UiRenderNodeId::new(11));
+    assert_eq!(
+        entry.source_projection_node_id(),
+        UiProjectedNodeId::new(22)
+    );
+    assert_eq!(entry.source_ir_node_id(), Some(UiIrNodeId::new(33)));
+    assert_eq!(entry.rect(), UiLayoutRect::new(-4, 8, 120, 48));
+    assert_eq!(entry.kind(), UiRenderNodeKind::Element);
+}
+
+#[test]
+fn backend_frame_preserves_entry_order() {
+    let first = sample_entry();
+    let second = UiBackendFrameEntry::new(
+        UiRenderNodeId::new(44),
+        UiProjectedNodeId::new(55),
+        None,
+        UiLayoutRect::new(0, 0, 1, 2),
+        UiRenderNodeKind::Text,
+    );
+
+    let frame = UiBackendFrame::new(vec![first.clone(), second.clone()]);
+
+    assert_eq!(frame.entries(), &[first, second]);
+}
+
+#[test]
+fn backend_frame_empty_state_is_explicit() {
+    let frame = UiBackendFrame::new(Vec::new());
+
+    assert_eq!(frame.len(), 0);
+    assert!(frame.is_empty());
+    assert!(frame.entries().is_empty());
+}
+
+#[test]
+fn backend_frame_clone_and_equality_are_stable() {
+    let entry = sample_entry();
+    let frame = UiBackendFrame::new(vec![entry]);
+
+    assert_eq!(frame.clone(), frame);
+    assert_eq!(frame.entries()[0].clone(), frame.entries()[0]);
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    submitted: Vec<UiBackendFrame>,
+}
+
+impl UiFrameSink for RecordingSink {
+    type Error = Infallible;
+
+    fn submit_frame(&mut self, frame: &UiBackendFrame) -> Result<(), Self::Error> {
+        self.submitted.push(frame.clone());
+        Ok(())
+    }
+}
+
+#[test]
+fn frame_sink_trait_accepts_inert_frame_evidence() {
+    let mut sink = RecordingSink::default();
+    let frame = UiBackendFrame::new(vec![sample_entry()]);
+
+    sink.submit_frame(&frame).unwrap();
+
+    assert_eq!(sink.submitted.len(), 1);
+    assert_eq!(sink.submitted[0], frame);
+}
+
+#[test]
+fn frame_sink_submission_does_not_mutate_submitted_frame() {
+    let mut sink = RecordingSink::default();
+    let frame = UiBackendFrame::new(vec![sample_entry()]);
+    let before = frame_signature(&frame);
+
+    sink.submit_frame(&frame).unwrap();
+
+    let after = frame_signature(&frame);
+    assert_eq!(before, after);
+    assert_eq!(sink.submitted[0], frame);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TestSinkError {
+    Rejected,
+}
+
+struct RejectingSink;
+
+impl UiFrameSink for RejectingSink {
+    type Error = TestSinkError;
+
+    fn submit_frame(&mut self, _frame: &UiBackendFrame) -> Result<(), Self::Error> {
+        Err(TestSinkError::Rejected)
+    }
+}
+
+#[test]
+fn frame_sink_trait_supports_typed_error_without_execution() {
+    let mut sink = RejectingSink;
+    let frame = UiBackendFrame::new(vec![sample_entry()]);
+
+    assert_eq!(sink.submit_frame(&frame), Err(TestSinkError::Rejected));
+}
+
+#[test]
+fn frame_sink_boundary_exposes_no_drawing_window_or_runtime_api() {
+    let entry = sample_entry();
+    let frame = UiBackendFrame::new(vec![entry.clone()]);
+
+    assert_eq!(frame.len(), 1);
+    assert_eq!(frame.entries()[0], entry);
+    assert_eq!(frame.entries()[0].kind(), UiRenderNodeKind::Element);
+}


### PR DESCRIPTION
## Summary

Adds the first inert backend frame sink boundary to `prom-ui-backend-native`.

This PR introduces frame evidence and a frame sink trait only. It does not draw, create windows, present frames, handle events, perform hit testing, execute actions/effects, perform runtime handoff, or introduce capability admission.

## Scope

Source + test boundary PR.

Changed files:

```text
crates/prom-ui-backend-native/src/frame_sink.rs
crates/prom-ui-backend-native/src/lib.rs
crates/prom-ui-backend-native/tests/backend_frame_sink_trait.rs
```

Explicit non-scope

- no wgpu
- no new winit usage
- no drawing
- no windowing
- no surface creation
- no frame presentation
- no event loop changes
- no hit testing
- no interaction
- no runtime handoff
- no action execution
- no effect execution
- no capability admission
- no Cargo changes
- no dependency changes
- no docs changes
- no DNA changes
- no Admission Guard changes
- no GitHub CI evidence

SEMANTIC_UI_DNA

This PR preserves the UI DNA canon:

- frame evidence is inert projection/layout evidence;
- frame sink submission is not semantic execution;
- backend-native remains a boundary crate;
- prom-ui core remains backend-free;
- no semantic model mutation is introduced;
- no action/effect/runtime/capability path is introduced.

Validation

Local only:

- `cargo fmt`: PASS
- `cargo fmt --check`: PASS
- `cargo test -p prom-ui --lib`: PASS
- `cargo test -p prom-ui`: PASS
- `cargo test -p prom-ui-backend-native`: PASS
- `cargo test -p prom-ui-backend-native --test backend_frame_sink_trait`: PASS
- `git diff --check`: PASS
- tracked `pr_body` files: NO
- Admission Guard executed: YES
- Admission Guard result: FAIL - ENVIRONMENT PATHING
- Admission Guard changed: NO
- GitHub CI used: NO

Final status

PASS WITH WARNINGS - R12 UI BACKEND FRAME SINK TRAIT READY
