### PR TITLE
docs(ui): select wgpu as R12 draw backend foundation

### DIFF
--- a/crates/prom-ui-backend-native/Cargo.toml
+++ b/crates/prom-ui-backend-native/Cargo.toml
@@ -10,8 +10,10 @@ path = "src/lib.rs"
 default = ["std"]
 std = ["prom-ui-runtime/std"]
 winit-backend = ["std", "dep:winit"]
+wgpu-backend = ["std", "dep:wgpu"]
 
 [dependencies]
 prom-ui = { path = "../prom-ui", default-features = false }
 prom-ui-runtime = { path = "../prom-ui-runtime", default-features = false }
 winit = { version = "0.30.13", optional = true, default-features = false }
+wgpu = { version = "0.20", optional = true, default-features = false }

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -38,7 +38,26 @@ impl From<winit::error::EventLoopError> for NativeBackendWinitSmokeError {
 
 /// Returns whether this crate was compiled with the `winit-backend` feature.
 pub const fn winit_backend_feature_enabled() -> bool {
-    cfg!(feature = "winit-backend")
+    #[cfg(feature = "winit-backend")]
+    {
+        true
+    }
+    #[cfg(not(feature = "winit-backend"))]
+    {
+        false
+    }
+}
+
+/// Returns whether the `wgpu-backend` Cargo feature is enabled at compile time.
+pub const fn wgpu_backend_feature_enabled() -> bool {
+    #[cfg(feature = "wgpu-backend")]
+    {
+        true
+    }
+    #[cfg(not(feature = "wgpu-backend"))]
+    {
+        false
+    }
 }
 
 #[cfg(feature = "winit-backend")]
@@ -1487,4 +1506,9 @@ impl UiBackendAdapter for NativeBackend {
         self.submitted_frames = self.submitted_frames.saturating_add(1);
         Ok(())
     }
+}
+
+#[cfg(feature = "wgpu-backend")]
+pub fn selected_draw_backend_name() -> &'static str {
+    "wgpu"
 }

--- a/crates/prom-ui-backend-native/tests/native_backend_wgpu_feature_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_wgpu_feature_contract.rs
@@ -1,0 +1,9 @@
+#![cfg(feature = "wgpu-backend")]
+
+use prom_ui_backend_native::{selected_draw_backend_name, wgpu_backend_feature_enabled};
+
+#[test]
+fn wgpu_backend_feature_exposes_selected_draw_backend_name() {
+    assert!(wgpu_backend_feature_enabled());
+    assert_eq!(selected_draw_backend_name(), "wgpu");
+}

--- a/docs/roadmap/post_ui/r12_ui_draw_backend_selection.md
+++ b/docs/roadmap/post_ui/r12_ui_draw_backend_selection.md
@@ -1,0 +1,82 @@
+# R12 UI Draw Backend Selection
+
+## 1. Purpose
+This boundary document officially selects the draw backend for Semantic UI.
+It resolves the previously deferred draw backend dependency gate.
+
+It does not implement actual drawing, frame presentation, rendering logic, or runtime mutations.
+
+## 2. Closed Basis
+| PR | Role | Status |
+|----|------|--------|
+| #1120 | First Visible Surface Boundary | MERGED |
+| #1122 | Backend Native Baseline Ledger | MERGED |
+| #1123 | Backend Frame Sink Trait | MERGED |
+| #1124 | Offscreen Static Frame Test | MERGED |
+| #1125 | Windowing Boundary | MERGED |
+| #1132 | Winit Window Seed Reality Ledger | MERGED |
+| #1133 | Winit Run Loop Integration Boundary | MERGED |
+| TBD  | Winit Run Loop Integration Source | MERGED |
+
+## 3. Selected Draw Backend
+The selected draw backend is **`wgpu`**.
+
+Reasoning:
+- `wgpu` provides the foundation for the cross-platform Rust GPU-accelerated graphics API. It is the canonical R12 draw backend foundation.
+- `softbuffer` is deferred. It remains a possible future deterministic CPU/reference backend, not the canonical R12 draw backend, as it is a framebuffer path, not a scalable renderer foundation.
+- `vello` is deferred. It remains a later 2D renderer candidate built on top of `wgpu`. Including it now would mix the backend selection boundary with renderer architecture.
+
+## 4. SEMANTIC_UI_DNA Compliance
+PASS - UI remains projection/cache, not semantic authority.
+PASS - The renderer is treated as an inert output sink.
+PASS - `wgpu` integration does not leak into `prom-ui` core.
+PASS - `wgpu` does not mutate the Semantic AST, IR, or Runtime.
+PASS - Action/Effect boundaries remain strictly unaffected.
+
+docs/dna inspected: YES
+DNA files inspected:
+- [SEMANTIC_UI_DNA.md](../../dna/SEMANTIC_UI_DNA.md)
+
+DNA alignment:
+- The backend crate may securely encapsulate `wgpu` types.
+- Semantic projection contracts do not depend on `wgpu`.
+
+## 5. Dependency Boundary Rules
+- `prom-ui-backend-native` adds `wgpu` as an optional dependency behind the `wgpu-backend` feature.
+- `prom-ui` core must **not** depend on `wgpu`.
+- `prom-ui-runtime` must **not** depend on `wgpu`.
+
+## 6. Forbidden Semantics
+Forbidden in this boundary and immediate future core source gates:
+- No rendering or drawing logic is implemented in this PR.
+- No frame presentation or swapchain configuration is implemented in this PR.
+- No semantic state mutation.
+- No hit testing or interaction mapping.
+- No execution of actions or effects.
+
+## 7. Future-Gated Work
+- `R12-UI-DRAW-BACKEND-MINIMAL-SOURCE-PR`
+  - Implements the minimal `wgpu` draw behavior in the backend-native layer.
+- `R12-UI-FRAME-PRESENTATION-BOUNDARY-PR`
+  - Defines when and how physical pixels are swapped/presented.
+- `R12-UI-STATIC-VISIBLE-DEMO-PR`
+  - Runs a static visible demo without interaction.
+
+## 8. Repository Scope
+- source files changed: YES (Cargo.toml, lib.rs minimal scaffolds)
+- test files changed: YES (new wgpu feature contract)
+- docs changed: YES
+- `Cargo.lock` changed: YES (wgpu dependency graph added)
+- `docs/dna` changed: NO
+- Admission Guard changed: NO
+
+## 9. Validation
+- `pwsh -File scripts/local_ci.ps1`: PASS
+- `cargo test -p prom-ui-backend-native --features wgpu-backend`: PASS
+
+## 10. Final Decision
+PASS — R12 UI Draw Backend selected (`wgpu`).
+The `wgpu-backend` feature and placeholder module establish the dependency boundary.
+
+## 11. Recommended Next Lane
+`R12-UI-DRAW-BACKEND-MINIMAL-SOURCE-PR`


### PR DESCRIPTION
## Summary

Selects `wgpu` as the canonical R12 native draw backend foundation for `prom-ui-backend-native`.

This PR is intentionally limited to a Boundary & Dependency Decision. It records the renderer foundation decision, adds the optional dependency behind a feature flag, and adds a minimal feature-gated scaffold proving the selected backend is resolvable without exposing `wgpu` types through public backend API.

## Selected backend

```text
canonical native draw backend: wgpu
feature flag: wgpu-backend
role: GPU draw backend foundation
```

## Boundary discipline

This PR does **not** implement rendering.

Allowed in this PR:

- add optional `wgpu` dependency;
- add `wgpu-backend` feature flag;
- expose a minimal feature-gated backend selection descriptor;
- add a contract test proving the selected backend name;
- document the architectural backend decision.

Forbidden in this PR:

- no actual drawing;
- no frame presentation;
- no swapchain/surface lifecycle wiring;
- no renderer object stored in `NativeBackend` state;
- no changes to `UiBackendAdapter::run_event_loop(...)`;
- no semantic mutation;
- no UI runtime widening;
- no `vello`, `tiny-skia`, or `softbuffer` dependency yet.

## Backend ladder

This PR freezes only the first backend decision:

```text
wgpu      = canonical native GPU backend foundation
softbuffer = possible future deterministic CPU/reference fallback
vello      = possible future high-level 2D renderer layer on top of wgpu
```

## Files changed

- `crates/prom-ui-backend-native/Cargo.toml`
- `crates/prom-ui-backend-native/src/lib.rs`
- `crates/prom-ui-backend-native/tests/native_backend_wgpu_feature_contract.rs`
- `docs/roadmap/post_ui/r12_ui_draw_backend_selection.md`
- `Cargo.lock`

## Verification

Reported local verification:

```text
cargo test -p prom-ui-backend-native --features wgpu-backend
cargo fmt --all
pwsh -File scripts/local_ci.ps1
```

Result:

```text
Admission Guard / local CI: green
```

## Out of scope

The next implementation gate should be a separate narrow PR, likely `R12-UI-DRAW-BACKEND-MINIMAL-SOURCE-PR`, and should remain focused on minimal source scaffolding only.