### PR TITLE
feat(ui): implement minimal wgpu source behavior

### DIFF
--- a/crates/prom-ui-backend-native/Cargo.toml
+++ b/crates/prom-ui-backend-native/Cargo.toml
@@ -10,10 +10,11 @@ path = "src/lib.rs"
 default = ["std"]
 std = ["prom-ui-runtime/std"]
 winit-backend = ["std", "dep:winit"]
-wgpu-backend = ["std", "dep:wgpu"]
+wgpu-backend = ["std", "dep:wgpu", "dep:pollster"]
 
 [dependencies]
 prom-ui = { path = "../prom-ui", default-features = false }
 prom-ui-runtime = { path = "../prom-ui-runtime", default-features = false }
 winit = { version = "0.30.13", optional = true, default-features = false }
 wgpu = { version = "0.20", optional = true, default-features = false }
+pollster = { version = "0.3", optional = true }

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -1512,3 +1512,111 @@ impl UiBackendAdapter for NativeBackend {
 pub fn selected_draw_backend_name() -> &'static str {
     "wgpu"
 }
+
+#[cfg(feature = "wgpu-backend")]
+pub mod wgpu_integration {
+    //! Feature-gated minimal wgpu integration.
+    //!
+    //! This proves wgpu initialization without wiring it into the live run loop
+    //! and without surface presentation logic.
+
+    use wgpu::{Adapter, Device, Instance, Queue};
+
+    /// Encapsulates the core wgpu primitives.
+    #[derive(Debug)]
+    pub struct NativeBackendWgpuContext {
+        pub instance: Instance,
+        pub adapter: Adapter,
+        pub device: Device,
+        pub queue: Queue,
+    }
+
+    impl NativeBackendWgpuContext {
+        /// Initializes the wgpu context asynchronously and blocks using `pollster`.
+        ///
+        /// This creates the instance, requests the default adapter, and requests the device.
+        pub fn new() -> Option<Self> {
+            let instance = Instance::default();
+
+            // Block on adapter request
+            let adapter =
+                pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(),
+                    force_fallback_adapter: false,
+                    compatible_surface: None, // No surface yet
+                }))?;
+
+            // Block on device request
+            let (device, queue) = pollster::block_on(adapter.request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("NativeBackend Minimal Device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::downlevel_defaults(),
+                },
+                None,
+            ))
+            .ok()?;
+
+            Some(Self {
+                instance,
+                adapter,
+                device,
+                queue,
+            })
+        }
+
+        /// Proves minimal draw execution by clearing a dummy texture offscreen.
+        ///
+        /// This records a minimal `RenderPass` without swapchain presentation.
+        pub fn execute_minimal_draw_pass(&self) {
+            let texture_size = wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            };
+
+            let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("Minimal Draw Dummy Texture"),
+                size: texture_size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[],
+            });
+
+            let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Minimal Draw Encoder"),
+                });
+
+            {
+                let _render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Minimal Draw Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &texture_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color {
+                                r: 0.1,
+                                g: 0.2,
+                                b: 0.3,
+                                a: 1.0,
+                            }),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+            }
+
+            self.queue.submit(core::iter::once(encoder.finish()));
+        }
+    }
+}

--- a/crates/prom-ui-backend-native/tests/native_backend_wgpu_feature_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_wgpu_feature_contract.rs
@@ -7,3 +7,20 @@ fn wgpu_backend_feature_exposes_selected_draw_backend_name() {
     assert!(wgpu_backend_feature_enabled());
     assert_eq!(selected_draw_backend_name(), "wgpu");
 }
+
+#[test]
+fn native_backend_wgpu_context_minimal_draw_smoke() {
+    // Attempt to initialize the wgpu context.
+    // In headless CI environments without a GPU or Lavapipe, this might legitimately return None.
+    // We gracefully skip the test if no adapter is found, rather than panicking.
+    if let Some(context) = prom_ui_backend_native::wgpu_integration::NativeBackendWgpuContext::new()
+    {
+        // Execute the minimal draw pass. This proves we can create a dummy texture,
+        // begin a render pass, clear it, and submit the encoder to the queue.
+        context.execute_minimal_draw_pass();
+    } else {
+        println!(
+            "Skipping wgpu draw smoke test: No suitable GPU adapter found in this environment."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the minimal `wgpu` source behavior for the R12 draw backend after the backend selection gate.

This PR is intentionally scoped as `R12-UI-DRAW-BACKEND-MINIMAL-SOURCE-PR`: it proves that a `wgpu` context can be initialized and can execute an offscreen minimal draw pass without introducing frame presentation, surface lifecycle, or renderer ownership inside `NativeBackend`.

## Dependency

Depends on:

- #1134 — `docs(ui): select wgpu as R12 draw backend foundation`

Do not merge this PR before #1134. It is a follow-up gate and may include the backend-selection foundation in its diff until #1134 lands on `main`.

## Behavior added

- Adds `pollster` behind the `wgpu-backend` feature.
- Adds `NativeBackendWgpuContext` as a minimal feature-gated wgpu source context.
- Initializes `wgpu` without a window surface:

```text
compatible_surface: None
```

- Adds an offscreen `execute_minimal_draw_pass()` path using a dummy 1x1 texture.
- Submits a minimal render pass to the queue without presenting frames.
- Keeps headless/no-adapter environments safe by skipping rather than panicking.

## Boundary discipline

Allowed in this PR:

- initialize a minimal offscreen `wgpu` context;
- create adapter/device/queue in a feature-gated source path;
- execute a tiny offscreen draw pass into a dummy texture;
- add smoke contract coverage for the minimal source behavior.

Forbidden in this PR:

- no `Surface` lifecycle;
- no swapchain configuration;
- no frame acquisition;
- no frame presentation;
- no window drawing;
- no renderer object stored in `NativeBackend` state;
- no changes to `UiBackendAdapter::run_event_loop(...)`;
- no semantic mutation;
- no UI runtime widening;
- no `vello`, `softbuffer`, or `tiny-skia` dependency.

## Verification

Reported local verification:

```text
cargo fmt --all
cargo test -p prom-ui-backend-native --features "winit-backend wgpu-backend"
pwsh -File scripts/local_ci.ps1
```

Result:

```text
Admission Guard / local CI: PASS
```

## Out of scope

The next gate should be a separate boundary PR:

```text
R12-UI-FRAME-PRESENTATION-BOUNDARY-PR
```

That PR should define the rules for surface/swapchain/frame presentation before any visible rendering is implemented.