### PR TITLE
feat(ui): add raw backend event capture from winit

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -22,6 +22,51 @@ pub mod frame_sink;
 
 pub use frame_sink::{UiBackendFrame, UiBackendFrameEntry, UiFrameSink};
 
+/// Raw button state representing physical input evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawButtonState {
+    Pressed,
+    Released,
+}
+
+/// Raw keyboard key code representing physical input evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RawKeyCode {
+    KeyA,
+    KeyB,
+    KeyC,
+    KeyD,
+    KeyW,
+    KeyS,
+    Digit0,
+    Digit1,
+    Digit2,
+    Enter,
+    Escape,
+    Space,
+    Unknown(u32),
+}
+
+/// Inert physical event evidence captured from the host.
+///
+/// This does not infer semantic intent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawBackendEvent {
+    WindowResized {
+        width: u32,
+        height: u32,
+    },
+    KeyboardInput {
+        key: RawKeyCode,
+        state: RawButtonState,
+    },
+    PointerMoved {
+        x: f64,
+        y: f64,
+    },
+    CloseRequested,
+}
+
 #[cfg(feature = "winit-backend")]
 #[derive(Debug)]
 pub enum NativeBackendWinitSmokeError {
@@ -213,6 +258,64 @@ pub mod winit_placeholder {
             WindowEvent::CloseRequested => Some(translate_winit_close_requested()),
             WindowEvent::KeyboardInput { event, .. } => {
                 translate_winit_physical_key(event.state, event.physical_key)
+            }
+            _ => None,
+        }
+    }
+
+    /// Translate a selected winit physical key into `RawKeyCode`.
+    pub const fn translate_winit_to_raw_key_code(key_code: KeyCode) -> super::RawKeyCode {
+        match key_code {
+            KeyCode::KeyA => super::RawKeyCode::KeyA,
+            KeyCode::KeyB => super::RawKeyCode::KeyB,
+            KeyCode::KeyC => super::RawKeyCode::KeyC,
+            KeyCode::KeyD => super::RawKeyCode::KeyD,
+            KeyCode::KeyW => super::RawKeyCode::KeyW,
+            KeyCode::KeyS => super::RawKeyCode::KeyS,
+            KeyCode::Digit0 => super::RawKeyCode::Digit0,
+            KeyCode::Digit1 => super::RawKeyCode::Digit1,
+            KeyCode::Digit2 => super::RawKeyCode::Digit2,
+            KeyCode::Enter => super::RawKeyCode::Enter,
+            KeyCode::Escape => super::RawKeyCode::Escape,
+            KeyCode::Space => super::RawKeyCode::Space,
+            _ => super::RawKeyCode::Unknown(key_code as u32),
+        }
+    }
+
+    /// Translate a winit `ElementState` to `RawButtonState`.
+    pub const fn translate_winit_to_raw_button_state(state: ElementState) -> super::RawButtonState {
+        match state {
+            ElementState::Pressed => super::RawButtonState::Pressed,
+            ElementState::Released => super::RawButtonState::Released,
+        }
+    }
+
+    /// Translate a winit `WindowEvent` into inert `RawBackendEvent` evidence.
+    pub fn translate_winit_to_raw_backend_event(
+        event: &WindowEvent,
+    ) -> Option<super::RawBackendEvent> {
+        match event {
+            WindowEvent::CloseRequested => Some(super::RawBackendEvent::CloseRequested),
+            WindowEvent::Resized(physical_size) => Some(super::RawBackendEvent::WindowResized {
+                width: physical_size.width,
+                height: physical_size.height,
+            }),
+            WindowEvent::KeyboardInput { event, .. } => {
+                let key_code = match event.physical_key {
+                    PhysicalKey::Code(code) => translate_winit_to_raw_key_code(code),
+                    PhysicalKey::Unidentified(_) => return None,
+                };
+                let state = translate_winit_to_raw_button_state(event.state);
+                Some(super::RawBackendEvent::KeyboardInput {
+                    key: key_code,
+                    state,
+                })
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                Some(super::RawBackendEvent::PointerMoved {
+                    x: position.x,
+                    y: position.y,
+                })
             }
             _ => None,
         }

--- a/crates/prom-ui-backend-native/tests/native_backend_raw_event_capture_contract.rs
+++ b/crates/prom-ui-backend-native/tests/native_backend_raw_event_capture_contract.rs
@@ -1,0 +1,136 @@
+#![cfg(feature = "winit-backend")]
+
+use prom_ui_backend_native::winit_placeholder::translate_winit_to_raw_backend_event;
+use prom_ui_backend_native::{RawBackendEvent, RawButtonState, RawKeyCode};
+use winit::{
+    dpi::{PhysicalPosition, PhysicalSize},
+    event::{ElementState, KeyEvent, WindowEvent},
+    keyboard::{KeyCode, PhysicalKey},
+};
+
+#[test]
+fn close_requested_translates_to_raw_close_requested() {
+    let event = translate_winit_to_raw_backend_event(&WindowEvent::CloseRequested)
+        .expect("CloseRequested must translate");
+
+    assert_eq!(event, RawBackendEvent::CloseRequested);
+}
+
+#[test]
+fn resized_translates_to_raw_window_resized() {
+    let size = PhysicalSize::new(800, 600);
+    let event = translate_winit_to_raw_backend_event(&WindowEvent::Resized(size))
+        .expect("Resized must translate");
+
+    assert_eq!(
+        event,
+        RawBackendEvent::WindowResized {
+            width: 800,
+            height: 600
+        }
+    );
+}
+
+#[test]
+fn pressed_physical_key_translates_to_raw_keyboard_input_pressed() {
+    let winit_event = WindowEvent::KeyboardInput {
+        device_id: unsafe { winit::event::DeviceId::dummy() },
+        event: KeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::KeyA),
+            logical_key: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+            text: None,
+            location: winit::keyboard::KeyLocation::Standard,
+            state: ElementState::Pressed,
+            repeat: false,
+            text_with_all_modifiers: None,
+            without_modifiers: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+        },
+        is_synthetic: false,
+    };
+
+    let event = translate_winit_to_raw_backend_event(&winit_event).expect("KeyA must translate");
+
+    assert_eq!(
+        event,
+        RawBackendEvent::KeyboardInput {
+            key: RawKeyCode::KeyA,
+            state: RawButtonState::Pressed,
+        }
+    );
+}
+
+#[test]
+fn released_physical_key_translates_to_raw_keyboard_input_released() {
+    let winit_event = WindowEvent::KeyboardInput {
+        device_id: unsafe { winit::event::DeviceId::dummy() },
+        event: KeyEvent {
+            physical_key: PhysicalKey::Code(KeyCode::Space),
+            logical_key: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+            text: None,
+            location: winit::keyboard::KeyLocation::Standard,
+            state: ElementState::Released,
+            repeat: false,
+            text_with_all_modifiers: None,
+            without_modifiers: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+        },
+        is_synthetic: false,
+    };
+
+    let event = translate_winit_to_raw_backend_event(&winit_event).expect("Space must translate");
+
+    assert_eq!(
+        event,
+        RawBackendEvent::KeyboardInput {
+            key: RawKeyCode::Space,
+            state: RawButtonState::Released,
+        }
+    );
+}
+
+#[test]
+fn cursor_moved_translates_to_raw_pointer_moved() {
+    let position = PhysicalPosition::new(100.0, 200.0);
+    let winit_event = WindowEvent::CursorMoved {
+        device_id: unsafe { winit::event::DeviceId::dummy() },
+        position,
+    };
+
+    let event =
+        translate_winit_to_raw_backend_event(&winit_event).expect("CursorMoved must translate");
+
+    assert_eq!(event, RawBackendEvent::PointerMoved { x: 100.0, y: 200.0 });
+}
+
+#[test]
+fn unidentified_physical_key_returns_none() {
+    let winit_event = WindowEvent::KeyboardInput {
+        device_id: unsafe { winit::event::DeviceId::dummy() },
+        event: KeyEvent {
+            physical_key: PhysicalKey::Unidentified(winit::keyboard::NativeKeyCode::Unidentified),
+            logical_key: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+            text: None,
+            location: winit::keyboard::KeyLocation::Standard,
+            state: ElementState::Pressed,
+            repeat: false,
+            text_with_all_modifiers: None,
+            without_modifiers: winit::keyboard::Key::Unidentified(
+                winit::keyboard::NativeKey::Unidentified,
+            ),
+        },
+        is_synthetic: false,
+    };
+
+    let event = translate_winit_to_raw_backend_event(&winit_event);
+
+    assert!(event.is_none());
+}


### PR DESCRIPTION
# R12-UI-RAW-EVENT-CAPTURE-SOURCE-PR Walkthrough

## Summary of Changes
We have successfully implemented the raw physical event capture pipeline in the backend native crate, completing the `R12-UI-RAW-EVENT-CAPTURE-SOURCE-PR` gate.

### 1. New Evidence Types
- Added `RawBackendEvent`, `RawKeyCode`, and `RawButtonState` to `crates/prom-ui-backend-native/src/lib.rs`.
- These enumerations represent inert physical facts (e.g. `KeyboardInput`, `WindowResized`, `PointerMoved`, `CloseRequested`).
- They intentionally lack semantic meaning (e.g., they don't know what "Submit" or "Cancel" is).

### 2. Winit Translator
- Added `translate_winit_to_raw_backend_event` within the `winit_placeholder` module.
- Maps `winit`'s complex nested event system down to our flat, platform-neutral `RawBackendEvent` representation.
- Unsupported keys or unidentified inputs are gracefully mapped to `Unknown(code)` or ignored without crashing.

### 3. Verification Contracts
- Added `native_backend_raw_event_capture_contract.rs` to prove the translation rules.
- Contains 6 specific tests guaranteeing that `CloseRequested`, `Resized`, `KeyboardInput`, and `CursorMoved` translate predictably.
- The `winit` pipeline continues working seamlessly without breaking the existing `InputEvent` pipeline that relies on the runtime's types.

## Verification
- Local Admission Guard parity script (`pwsh -File scripts\local_ci.ps1`) passes completely.
- Formatter checks and cargo checks run cleanly with no warnings or errors.

## Next Steps
The PR is pushed and merged. The physical event evidence capture boundary is secure!
