### PR TITLE
R12-UI-NATIVE-EVENT-PIPELINE-HOOK-SOURCE-PR

### DIFF
--- a/crates/prom-ui-backend-native/tests/interaction_pipeline_native_hook_smoke.rs
+++ b/crates/prom-ui-backend-native/tests/interaction_pipeline_native_hook_smoke.rs
@@ -1,0 +1,88 @@
+use prom_ui::{
+    action_binding::InteractionActionBindingId, model::UiIrNodeId, projection::UiProjectedNodeId,
+    InteractionAdmittedSemanticAction, SemanticIntent, UiActionDispatcher,
+};
+use prom_ui_backend_native::{RawBackendEvent, RawButtonState, RawKeyCode};
+use prom_ui_runtime::action_mapping::UiActionMapper;
+use prom_ui_runtime::intent_admission::RuntimeIntentAdmission;
+use prom_ui_runtime::interaction::{RoutedInteraction, UiHitTester};
+use prom_ui_runtime::interaction_pipeline::InteractionPipeline;
+
+struct TestHitTester;
+
+impl UiHitTester for TestHitTester {
+    fn find_target_at(
+        &self,
+        _layout: &prom_ui::layout::geometry::UiLayoutGeometryModel,
+        x: f64,
+        y: f64,
+    ) -> Option<UiIrNodeId> {
+        if x > 0.0 && y > 0.0 {
+            Some(UiIrNodeId::new(1))
+        } else {
+            None
+        }
+    }
+}
+
+struct TestMapper;
+
+impl UiActionMapper<RawBackendEvent> for TestMapper {
+    fn map_interaction(
+        &self,
+        interaction: RoutedInteraction<RawBackendEvent>,
+    ) -> Option<SemanticIntent> {
+        if interaction.target.raw() == 1 {
+            Some(SemanticIntent::new(
+                UiProjectedNodeId::new(interaction.target.raw()),
+                InteractionActionBindingId(100),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+struct TestDispatcher;
+
+impl UiActionDispatcher for TestDispatcher {
+    fn dispatch_action(
+        &self,
+        _action: InteractionAdmittedSemanticAction,
+    ) -> Result<(), prom_ui::IntentDispatchError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn native_event_pipeline_hook_smoke() {
+    let pipeline = InteractionPipeline::new(
+        TestHitTester,
+        TestMapper,
+        RuntimeIntentAdmission::new(),
+        TestDispatcher,
+    );
+
+    let dummy_layout =
+        std::mem::MaybeUninit::<prom_ui::layout::geometry::UiLayoutGeometryModel>::uninit();
+    let layout = unsafe { &*dummy_layout.as_ptr() };
+
+    let events = vec![
+        RawBackendEvent::KeyboardInput {
+            key: RawKeyCode::KeyA,
+            state: RawButtonState::Pressed,
+        },
+        RawBackendEvent::PointerMoved { x: -10.0, y: -10.0 },
+        RawBackendEvent::PointerMoved { x: 10.0, y: 10.0 },
+    ];
+
+    let report = pipeline.process_batch_report(&events, layout);
+
+    assert_eq!(report.received, 3);
+    assert_eq!(report.skipped_no_coordinates, 1); // KeyboardInput has no coordinates
+    assert_eq!(report.routed, 1); // Only positive coords route to target id 1
+    assert_eq!(report.mapped, 1); // Target 1 gets mapped
+    assert_eq!(report.admitted, 0); // Inert evaluator denies everything
+    assert_eq!(report.denied, 1);
+    assert_eq!(report.dispatched, 0);
+}


### PR DESCRIPTION
# Objective
Prove that the `RawBackendEvent` representation in `prom-ui-backend-native` is fully compatible with the platform-agnostic `InteractionPipeline` from `prom-ui-runtime`.

# Changes
* Added an integration/smoke test `interaction_pipeline_native_hook_smoke.rs` in `prom-ui-backend-native`.
* Instantiates `InteractionPipeline` with mock `HitTester`, `ActionMapper`, `ActionDispatcher`, and a real `RuntimeIntentAdmission`.
* Feeds a batch of `RawBackendEvent`s (with and without coordinates).
* Verifies `InteractionPipelineReport` metrics (`received`, `skipped_no_coordinates`, `routed`, `mapped`, `admitted`, `denied`, `dispatched`).

# Constraints Enforced
* Did NOT change `NativeBackend::run_event_loop`.
* Did NOT connect to a live `winit` loop.
* Did NOT create `wgpu::Surface` or swapchains.
* Did NOT trigger frame presentation.
* Did NOT bypass `RuntimeIntentAdmission`.

This safely prepares the ground for a controlled hook into the event loop in future PRs without prematurely mutating live runtime loops.
