### PR TITLE
R12-UI-NATIVE-PIPELINE-SESSION-HOOK-SOURCE-PR

### DIFF
--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -22,6 +22,7 @@ use prom_ui_runtime::{
 pub mod action_translation;
 pub mod frame_sink;
 pub mod interaction;
+pub mod session_hook;
 
 pub use action_translation::{DefaultNativeActionTranslator, NativeActionTranslator};
 pub use frame_sink::{UiBackendFrame, UiBackendFrameEntry, UiFrameSink};
@@ -761,7 +762,7 @@ pub mod winit_placeholder {
     /// Return the current controlled integration plan.
     pub const fn current_native_backend_winit_run_loop_plan(
     ) -> NativeBackendWinitRunLoopIntegrationPlan {
-        NativeBackendWinitRunLoopIntegrationPlan::current_integrated_plan()
+        NativeBackendWinitRunLoopIntegrationPlan::current_manual_app_state_plan()
     }
 
     /// Preflight the staged NativeBackend state for the current manual app-state run path.

--- a/crates/prom-ui-backend-native/src/session_hook.rs
+++ b/crates/prom-ui-backend-native/src/session_hook.rs
@@ -1,0 +1,24 @@
+use crate::RawBackendEvent;
+use prom_ui::layout::geometry::UiLayoutGeometryModel;
+use prom_ui::UiActionDispatcher;
+use prom_ui_runtime::action_mapping::UiActionMapper;
+use prom_ui_runtime::interaction::UiHitTester;
+use prom_ui_runtime::interaction_pipeline::{InteractionPipeline, InteractionPipelineReport};
+
+/// Ticks the generic interaction pipeline with a batch of native events.
+///
+/// This demonstrates the transport boundary: the native backend only transports
+/// physical evidence (`RawBackendEvent`). The actual interpretation, routing, admission, and semantic
+/// dispatch is entirely coordinated by the `InteractionPipeline` from the runtime.
+pub fn tick_native_interaction_pipeline<H, M, D>(
+    events: &[RawBackendEvent],
+    layout: &UiLayoutGeometryModel,
+    pipeline: &InteractionPipeline<H, M, D>,
+) -> InteractionPipelineReport
+where
+    H: UiHitTester,
+    M: UiActionMapper<RawBackendEvent>,
+    D: UiActionDispatcher,
+{
+    pipeline.process_batch_report(events, layout)
+}

--- a/crates/prom-ui-backend-native/tests/interaction_pipeline_native_hook_smoke.rs
+++ b/crates/prom-ui-backend-native/tests/interaction_pipeline_native_hook_smoke.rs
@@ -1,5 +1,12 @@
 use prom_ui::{
-    action_binding::InteractionActionBindingId, model::UiIrNodeId, projection::UiProjectedNodeId,
+    action_binding::InteractionActionBindingId,
+    layout::{build_layout_geometry, layout_render_model},
+    model::UiIrNodeId,
+    projection::{
+        UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+        UiProjectionArtifactId,
+    },
+    renderer::render_projection_to_model,
     InteractionAdmittedSemanticAction, SemanticIntent, UiActionDispatcher,
 };
 use prom_ui_backend_native::{RawBackendEvent, RawButtonState, RawKeyCode};
@@ -54,6 +61,18 @@ impl UiActionDispatcher for TestDispatcher {
     }
 }
 
+fn test_layout_geometry() -> prom_ui::layout::geometry::UiLayoutGeometryModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(1),
+        UiProjectedNodeKind::Root,
+    ));
+
+    let render_model = render_projection_to_model(&artifact).expect("render model");
+    let layout_model = layout_render_model(&render_model);
+    build_layout_geometry(&layout_model)
+}
+
 #[test]
 fn native_event_pipeline_hook_smoke() {
     let pipeline = InteractionPipeline::new(
@@ -63,9 +82,7 @@ fn native_event_pipeline_hook_smoke() {
         TestDispatcher,
     );
 
-    let dummy_layout =
-        std::mem::MaybeUninit::<prom_ui::layout::geometry::UiLayoutGeometryModel>::uninit();
-    let layout = unsafe { &*dummy_layout.as_ptr() };
+    let layout = test_layout_geometry();
 
     let events = vec![
         RawBackendEvent::KeyboardInput {
@@ -76,7 +93,7 @@ fn native_event_pipeline_hook_smoke() {
         RawBackendEvent::PointerMoved { x: 10.0, y: 10.0 },
     ];
 
-    let report = pipeline.process_batch_report(&events, layout);
+    let report = pipeline.process_batch_report(&events, &layout);
 
     assert_eq!(report.received, 3);
     assert_eq!(report.skipped_no_coordinates, 1); // KeyboardInput has no coordinates

--- a/crates/prom-ui-backend-native/tests/native_pipeline_session_hook.rs
+++ b/crates/prom-ui-backend-native/tests/native_pipeline_session_hook.rs
@@ -1,7 +1,14 @@
 use prom_ui::{
-    action_binding::InteractionActionBindingId, layout::geometry::UiLayoutGeometryModel,
-    model::UiIrNodeId, projection::UiProjectedNodeId, InteractionAdmittedSemanticAction,
-    SemanticIntent, UiActionDispatcher,
+    action_binding::InteractionActionBindingId,
+    layout::geometry::UiLayoutGeometryModel,
+    layout::{build_layout_geometry, layout_render_model},
+    model::UiIrNodeId,
+    projection::{
+        UiProjectedNode, UiProjectedNodeId, UiProjectedNodeKind, UiProjectionArtifact,
+        UiProjectionArtifactId,
+    },
+    renderer::render_projection_to_model,
+    InteractionAdmittedSemanticAction, SemanticIntent, UiActionDispatcher,
 };
 use prom_ui_backend_native::session_hook::tick_native_interaction_pipeline;
 use prom_ui_backend_native::{RawBackendEvent, RawButtonState, RawKeyCode};
@@ -60,6 +67,18 @@ impl UiActionDispatcher for MockDispatcher {
     }
 }
 
+fn test_layout_geometry() -> UiLayoutGeometryModel {
+    let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(1));
+    artifact.push_node(UiProjectedNode::new(
+        UiProjectedNodeId::new(42),
+        UiProjectedNodeKind::Root,
+    ));
+
+    let render_model = render_projection_to_model(&artifact).expect("render model");
+    let layout_model = layout_render_model(&render_model);
+    build_layout_geometry(&layout_model)
+}
+
 #[test]
 fn native_pipeline_session_hook_contract() {
     let hit_tester = MockHitTester;
@@ -70,9 +89,7 @@ fn native_pipeline_session_hook_contract() {
     let pipeline =
         InteractionPipeline::new(hit_tester, action_mapper, admission, dispatcher.clone());
 
-    // Create a dummy layout model since MockHitTester ignores it.
-    let dummy_layout = std::mem::MaybeUninit::<UiLayoutGeometryModel>::uninit();
-    let layout = unsafe { &*dummy_layout.as_ptr() };
+    let layout = test_layout_geometry();
 
     // Mixed events batch
     let events = vec![
@@ -84,7 +101,7 @@ fn native_pipeline_session_hook_contract() {
         RawBackendEvent::CloseRequested,                      // No coordinates mapped, skipped
     ];
 
-    let report = tick_native_interaction_pipeline(&events, layout, &pipeline);
+    let report = tick_native_interaction_pipeline(&events, &layout, &pipeline);
 
     // Verify correct processing counts
     assert_eq!(report.received, 3);

--- a/crates/prom-ui-backend-native/tests/native_pipeline_session_hook.rs
+++ b/crates/prom-ui-backend-native/tests/native_pipeline_session_hook.rs
@@ -1,0 +1,106 @@
+use prom_ui::{
+    action_binding::InteractionActionBindingId, layout::geometry::UiLayoutGeometryModel,
+    model::UiIrNodeId, projection::UiProjectedNodeId, InteractionAdmittedSemanticAction,
+    SemanticIntent, UiActionDispatcher,
+};
+use prom_ui_backend_native::session_hook::tick_native_interaction_pipeline;
+use prom_ui_backend_native::{RawBackendEvent, RawButtonState, RawKeyCode};
+use prom_ui_runtime::action_mapping::UiActionMapper;
+use prom_ui_runtime::intent_admission::RuntimeIntentAdmission;
+use prom_ui_runtime::interaction::{RoutedInteraction, UiHitTester};
+use prom_ui_runtime::interaction_pipeline::InteractionPipeline;
+
+// Mocks for pipeline components
+
+#[derive(Clone)]
+struct MockHitTester;
+
+impl UiHitTester for MockHitTester {
+    fn find_target_at(
+        &self,
+        _layout: &UiLayoutGeometryModel,
+        _x: f64,
+        _y: f64,
+    ) -> Option<UiIrNodeId> {
+        Some(UiIrNodeId::new(42))
+    }
+}
+
+#[derive(Clone)]
+struct MockActionMapper;
+
+impl UiActionMapper<RawBackendEvent> for MockActionMapper {
+    fn map_interaction(
+        &self,
+        interaction: RoutedInteraction<RawBackendEvent>,
+    ) -> Option<SemanticIntent> {
+        match interaction.event {
+            RawBackendEvent::PointerMoved { .. } => Some(SemanticIntent::new(
+                UiProjectedNodeId::new(interaction.target.raw()),
+                InteractionActionBindingId(100),
+            )),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct MockDispatcher {
+    dispatched_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl UiActionDispatcher for MockDispatcher {
+    fn dispatch_action(
+        &self,
+        _action: InteractionAdmittedSemanticAction,
+    ) -> Result<(), prom_ui::IntentDispatchError> {
+        self.dispatched_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[test]
+fn native_pipeline_session_hook_contract() {
+    let hit_tester = MockHitTester;
+    let action_mapper = MockActionMapper;
+    let admission = RuntimeIntentAdmission::new();
+    let dispatcher = MockDispatcher::default();
+
+    let pipeline =
+        InteractionPipeline::new(hit_tester, action_mapper, admission, dispatcher.clone());
+
+    // Create a dummy layout model since MockHitTester ignores it.
+    let dummy_layout = std::mem::MaybeUninit::<UiLayoutGeometryModel>::uninit();
+    let layout = unsafe { &*dummy_layout.as_ptr() };
+
+    // Mixed events batch
+    let events = vec![
+        RawBackendEvent::PointerMoved { x: 100.0, y: 150.0 }, // Has coordinates, will be hit-tested and admitted (UserSubmit)
+        RawBackendEvent::KeyboardInput {
+            key: RawKeyCode::Enter,
+            state: RawButtonState::Pressed,
+        }, // No coordinates mapped yet, skipped by routing in this wave
+        RawBackendEvent::CloseRequested,                      // No coordinates mapped, skipped
+    ];
+
+    let report = tick_native_interaction_pipeline(&events, layout, &pipeline);
+
+    // Verify correct processing counts
+    assert_eq!(report.received, 3);
+    assert_eq!(report.skipped_no_coordinates, 2); // Keyboard and CloseRequested
+    assert_eq!(report.routed, 1); // PointerMoved
+    assert_eq!(report.mapped, 1); // PointerMoved mapped
+                                  // InertCapabilityEvaluator denies all semantic intents by default
+    assert_eq!(report.admitted, 0);
+    assert_eq!(report.denied, 1);
+    assert_eq!(report.dispatched, 0);
+
+    // Ensure dispatcher received 0
+    assert_eq!(
+        dispatcher
+            .dispatched_count
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+}


### PR DESCRIPTION
This PR adds a source/test hook proving native RawBackendEvent batches can be processed through the existing InteractionPipeline report path.

It does not change NativeBackend::run_event_loop, add docs, introduce new runtime authority, or expand rendering behavior.