### PR TITLE
feat(ui): improve native demo usability slice

### DIFF
--- a/crates/prom-ui-demo/src/demo_interaction.rs
+++ b/crates/prom-ui-demo/src/demo_interaction.rs
@@ -97,6 +97,7 @@ impl DemoInteraction {
     ) -> LoopControl {
         match event.kind {
             InputEventKind::CloseRequested => LoopControl::ExitRequested,
+            InputEventKind::KeyDown { key_code: 27 } => LoopControl::ExitRequested,
             InputEventKind::PointerMoved { x, y } => {
                 self.handle_pointer_moved(x, y, placement);
                 LoopControl::Continue
@@ -184,38 +185,22 @@ fn render_feedback_overlays(
     placement: &UiLayoutPhysicalPlacementModel,
     state: &DemoState,
 ) {
-    let pointer_color = if state.is_pointer_down {
-        Color::RED
-    } else {
-        Color::GREEN
-    };
-
-    for entry in placement.entries() {
-        let node_id = entry.source_render_node();
-        let rect = entry.final_rect();
-
-        if Some(node_id) == state.selected_node {
-            draw_selected_feedback(out_frame, rect);
-            draw_dispatch_feedback(out_frame, rect, state.dispatch_feedback);
-        } else if Some(node_id) == state.hovered_node {
-            draw_hovered_feedback(out_frame, rect);
-        }
-
-        if Some(node_id) == state.focused_node {
-            draw_focused_feedback(out_frame, rect);
-        }
+    if let Some(bounds) = placement_bounds(placement) {
+        draw_scene_backdrop(out_frame, bounds);
+        draw_scene_header(out_frame, bounds);
+        draw_scene_cards(out_frame, placement, state);
+        draw_status_area(out_frame, bounds, state);
     }
 
-    draw_pointer_status(out_frame, state, pointer_color);
-    draw_key_status(out_frame, state);
+    draw_pointer_marker(out_frame, state);
 }
 
 fn draw_hovered_feedback(out_frame: &mut DrawFrame, rect: prom_ui::layout::UiLayoutGeometryRect) {
-    draw_outline(out_frame, rect, Color::WHITE, 2);
+    draw_outline(out_frame, rect, Color::rgb(102, 222, 255), 2);
 }
 
 fn draw_selected_feedback(out_frame: &mut DrawFrame, rect: prom_ui::layout::UiLayoutGeometryRect) {
-    draw_outline(out_frame, rect, Color::rgb(255, 255, 0), 2);
+    draw_outline(out_frame, rect, Color::rgb(255, 196, 77), 2);
 }
 
 fn draw_focused_feedback(out_frame: &mut DrawFrame, rect: prom_ui::layout::UiLayoutGeometryRect) {
@@ -244,41 +229,319 @@ fn draw_dispatch_feedback(
 
     let color = match feedback {
         DispatchFeedback::None => Color::rgb(128, 128, 128),
-        DispatchFeedback::IntentBuilt => Color::BLUE,
-        DispatchFeedback::Denied => Color::RED,
+        DispatchFeedback::IntentBuilt => Color::rgb(72, 140, 255),
+        DispatchFeedback::Denied => Color::rgb(235, 72, 90),
     };
 
     out_frame.fill_rect(Rect::new(rect.x() + 5, rect.y() - 10, 20, 8), color);
 }
 
-fn draw_pointer_status(out_frame: &mut DrawFrame, state: &DemoState, pointer_color: Color) {
-    out_frame.draw_text(
-        format!(
-            "Pointer: ({}, {}), Keys: {}, Denied: {}",
-            state.pointer_x, state.pointer_y, state.key_press_count, state.denied_count
-        ),
-        10,
-        30,
-        pointer_color,
-    );
+fn placement_bounds(
+    placement: &UiLayoutPhysicalPlacementModel,
+) -> Option<prom_ui::layout::UiLayoutGeometryRect> {
+    let mut min_x = i32::MAX;
+    let mut min_y = i32::MAX;
+    let mut max_x = i32::MIN;
+    let mut max_y = i32::MIN;
 
-    if state.hovered_node.is_none() {
+    for entry in placement.entries() {
+        let rect = entry.final_rect();
+        min_x = min_x.min(rect.x());
+        min_y = min_y.min(rect.y());
+        max_x = max_x.max(rect.x() + rect.width() as i32);
+        max_y = max_y.max(rect.y() + rect.height() as i32);
+    }
+
+    if min_x == i32::MAX {
+        return None;
+    }
+
+    Some(prom_ui::layout::UiLayoutGeometryRect::new(
+        min_x - 28,
+        min_y - 28,
+        (max_x - min_x + 56) as u32,
+        (max_y - min_y + 172) as u32,
+    ))
+}
+
+fn draw_scene_backdrop(out_frame: &mut DrawFrame, bounds: prom_ui::layout::UiLayoutGeometryRect) {
+    let canvas_width = bounds.width().max(760);
+    let canvas_height = bounds.height().max(420);
+
+    out_frame.fill_rect(
+        Rect::new(bounds.x(), bounds.y(), canvas_width, canvas_height),
+        Color::rgb(16, 19, 27),
+    );
+    out_frame.fill_rect(
+        Rect::new(bounds.x(), bounds.y(), canvas_width, 36),
+        Color::rgb(30, 36, 50),
+    );
+}
+
+fn draw_scene_header(out_frame: &mut DrawFrame, bounds: prom_ui::layout::UiLayoutGeometryRect) {
+    out_frame.draw_text(
+        "Semantic UI demo slice",
+        bounds.x() + 16,
+        bounds.y() + 22,
+        Color::WHITE,
+    );
+    out_frame.draw_text(
+        "Hover, click, focus, and type to update the status bar below.",
+        bounds.x() + 16,
+        bounds.y() + 46,
+        Color::rgb(205, 214, 230),
+    );
+}
+
+fn draw_scene_cards(
+    out_frame: &mut DrawFrame,
+    placement: &UiLayoutPhysicalPlacementModel,
+    state: &DemoState,
+) {
+    let Some(bounds) = placement_bounds(placement) else {
+        return;
+    };
+
+    let left_card =
+        prom_ui::layout::UiLayoutGeometryRect::new(bounds.x() + 16, bounds.y() + 64, 300, 176);
+    let right_card =
+        prom_ui::layout::UiLayoutGeometryRect::new(bounds.x() + 336, bounds.y() + 64, 300, 176);
+
+    for (index, entry) in placement.entries().iter().enumerate() {
+        let node_id = entry.source_render_node();
+        let rect = entry.final_rect();
+        let card = if index == 0 { left_card } else { right_card };
+        let is_hovered = Some(node_id) == state.hovered_node;
+        let is_selected = Some(node_id) == state.selected_node;
+        let is_focused = Some(node_id) == state.focused_node;
+
+        let fill = card_fill(node_id, is_hovered, is_selected);
+        let outline = card_outline(node_id, is_hovered, is_selected);
+
         out_frame.fill_rect(
-            Rect::new(state.pointer_x - 5, state.pointer_y - 5, 10, 10),
-            pointer_color,
+            Rect::new(card.x(), card.y(), card.width(), card.height()),
+            fill,
         );
+        draw_outline(out_frame, card, outline, 2);
+        out_frame.fill_rect(
+            Rect::new(card.x() + 14, card.y() + 12, card.width() - 28, 22),
+            Color::rgb(24, 28, 38),
+        );
+
+        if is_focused {
+            draw_focused_feedback(out_frame, card);
+        }
+
+        draw_scene_card_text(out_frame, card, node_id, state);
+        draw_layout_preview(out_frame, card, rect);
+
+        if is_selected {
+            draw_selected_feedback(out_frame, card);
+            draw_dispatch_feedback(out_frame, card, state.dispatch_feedback);
+        } else if is_hovered {
+            draw_hovered_feedback(out_frame, card);
+        }
     }
 }
 
-fn draw_key_status(out_frame: &mut DrawFrame, state: &DemoState) {
-    let key_feedback_text = match state.last_key {
-        Some(key) => format!("Keys pressed: {} (Last: {})", state.key_press_count, key),
-        None => format!("Keys pressed: {}", state.key_press_count),
+fn draw_scene_card_text(
+    out_frame: &mut DrawFrame,
+    card: prom_ui::layout::UiLayoutGeometryRect,
+    node_id: UiRenderNodeId,
+    state: &DemoState,
+) {
+    let label = node_label(node_id);
+    let state_label = if Some(node_id) == state.selected_node {
+        "selected"
+    } else if Some(node_id) == state.hovered_node {
+        "hovered"
+    } else if Some(node_id) == state.focused_node {
+        "focused"
+    } else {
+        "idle"
     };
 
-    let key_width = 20 + (state.key_press_count.min(20) * 8);
-    out_frame.fill_rect(Rect::new(10, 100, key_width, 12), Color::BLUE);
-    out_frame.draw_text(key_feedback_text, 10, 100, Color::WHITE);
+    out_frame.draw_text(label, card.x() + 14, card.y() + 28, Color::WHITE);
+    out_frame.draw_text(
+        format!("State: {}", state_label),
+        card.x() + 14,
+        card.y() + 52,
+        Color::rgb(225, 232, 242),
+    );
+    out_frame.draw_text(
+        format!("Render node {:?}", node_id),
+        card.x() + 14,
+        card.y() + 74,
+        Color::rgb(190, 201, 219),
+    );
+}
+
+fn draw_layout_preview(
+    out_frame: &mut DrawFrame,
+    card: prom_ui::layout::UiLayoutGeometryRect,
+    rect: prom_ui::layout::UiLayoutGeometryRect,
+) {
+    let preview_width = rect.width().clamp(48, 180);
+    let preview_height = rect.height().clamp(14, 28);
+
+    out_frame.fill_rect(
+        Rect::new(card.x() + 14, card.y() + 112, preview_width, preview_height),
+        Color::rgb(70, 130, 180),
+    );
+    out_frame.draw_text(
+        format!("Placement {}x{}", rect.width(), rect.height()),
+        card.x() + 18,
+        card.y() + 110,
+        Color::WHITE,
+    );
+    out_frame.fill_rect(
+        Rect::new(card.x() + 14, card.y() + 148, 64, 10),
+        Color::rgb(92, 102, 122),
+    );
+}
+
+fn draw_status_area(
+    out_frame: &mut DrawFrame,
+    bounds: prom_ui::layout::UiLayoutGeometryRect,
+    state: &DemoState,
+) {
+    let canvas_width = bounds.width().max(760);
+    let status =
+        prom_ui::layout::UiLayoutGeometryRect::new(bounds.x(), bounds.y() + 264, canvas_width, 128);
+
+    out_frame.fill_rect(
+        Rect::new(status.x(), status.y(), status.width(), status.height()),
+        Color::rgb(22, 26, 36),
+    );
+    draw_outline(out_frame, status, Color::rgb(84, 96, 126), 2);
+    out_frame.fill_rect(
+        Rect::new(status.x() + 14, status.y() + 12, status.width() - 28, 22),
+        Color::rgb(31, 36, 48),
+    );
+
+    out_frame.draw_text(
+        "Demo status",
+        status.x() + 16,
+        status.y() + 28,
+        Color::WHITE,
+    );
+
+    out_frame.draw_text(
+        format!(
+            "Pointer: ({}, {})   Hover: {}   Selected: {}   Focused: {}",
+            state.pointer_x,
+            state.pointer_y,
+            render_node_label(state.hovered_node),
+            render_node_label(state.selected_node),
+            render_node_label(state.focused_node)
+        ),
+        status.x() + 16,
+        status.y() + 54,
+        Color::rgb(228, 233, 241),
+    );
+
+    out_frame.draw_text(
+        format!(
+            "Keys pressed: {}   Last key: {}   Denied count: {}",
+            state.key_press_count,
+            state
+                .last_key
+                .map(|key| key.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            state.denied_count
+        ),
+        status.x() + 16,
+        status.y() + 76,
+        Color::rgb(196, 207, 223),
+    );
+
+    let key_bar_width = 48 + state.key_press_count.min(20) * 12;
+    out_frame.fill_rect(
+        Rect::new(status.x() + 16, status.y() + 100, key_bar_width, 10),
+        Color::rgb(72, 140, 255),
+    );
+    out_frame.draw_text(
+        "Key counter",
+        status.x() + 18,
+        status.y() + 98,
+        Color::WHITE,
+    );
+
+    let denied_color = if state.denied_count > 0 {
+        Color::rgb(235, 72, 90)
+    } else {
+        Color::rgb(92, 102, 122)
+    };
+    let denied_width = 24 + state.denied_count.min(8) * 14;
+    out_frame.fill_rect(
+        Rect::new(status.x() + 250, status.y() + 100, denied_width, 10),
+        denied_color,
+    );
+    out_frame.draw_text(
+        "Denied marker",
+        status.x() + 252,
+        status.y() + 98,
+        Color::WHITE,
+    );
+
+    if matches!(state.dispatch_feedback, DispatchFeedback::Denied) {
+        out_frame.fill_rect(
+            Rect::new(status.x() + 420, status.y() + 94, 22, 18),
+            Color::rgb(235, 72, 90),
+        );
+        out_frame.draw_text("!", status.x() + 426, status.y() + 107, Color::WHITE);
+    }
+}
+
+fn draw_pointer_marker(out_frame: &mut DrawFrame, state: &DemoState) {
+    let pointer_color = if state.is_pointer_down {
+        Color::rgb(235, 72, 90)
+    } else {
+        Color::rgb(76, 201, 130)
+    };
+
+    out_frame.fill_rect(
+        Rect::new(state.pointer_x - 4, state.pointer_y - 4, 8, 8),
+        pointer_color,
+    );
+}
+
+fn card_fill(node_id: UiRenderNodeId, is_hovered: bool, is_selected: bool) -> Color {
+    if is_selected {
+        Color::rgb(96, 74, 34)
+    } else if is_hovered {
+        Color::rgb(44, 84, 120)
+    } else if node_id == UiRenderNodeId::new(1) {
+        Color::rgb(38, 58, 94)
+    } else {
+        Color::rgb(38, 82, 64)
+    }
+}
+
+fn card_outline(node_id: UiRenderNodeId, is_hovered: bool, is_selected: bool) -> Color {
+    if is_selected {
+        Color::rgb(255, 196, 77)
+    } else if is_hovered {
+        Color::rgb(102, 222, 255)
+    } else if node_id == UiRenderNodeId::new(1) {
+        Color::rgb(112, 146, 255)
+    } else {
+        Color::rgb(116, 210, 156)
+    }
+}
+
+fn node_label(node_id: UiRenderNodeId) -> &'static str {
+    if node_id == UiRenderNodeId::new(1) {
+        "Primary region"
+    } else if node_id == UiRenderNodeId::new(2) {
+        "Action region"
+    } else {
+        "Demo region"
+    }
+}
+
+fn render_node_label(node: Option<UiRenderNodeId>) -> String {
+    node.map(node_label).unwrap_or("none").to_string()
 }
 
 fn draw_outline(
@@ -376,6 +639,20 @@ mod tests {
     }
 
     #[test]
+    fn escape_key_requests_exit_without_updating_state() {
+        let mut interaction = test_interaction();
+        let placement = test_placement();
+
+        let events = vec![InputEvent::new(InputEventKind::KeyDown { key_code: 27 })];
+        let control = interaction.apply_events(&events, &placement);
+
+        assert_eq!(control, LoopControl::ExitRequested);
+        assert_eq!(interaction.state.key_press_count, 0);
+        assert_eq!(interaction.state.last_key, None);
+        assert_eq!(interaction.state.dispatch_feedback, DispatchFeedback::None);
+    }
+
+    #[test]
     fn enter_or_space_on_focused_node_triggers_denied_feedback() {
         let mut interaction = test_interaction();
         let placement = test_placement();
@@ -425,19 +702,32 @@ mod tests {
         assert!(commands.iter().any(|cmd| matches!(
             cmd,
             prom_ui_runtime::DrawCommand::FillRect { color, .. }
-                if *color == Color::rgb(255, 255, 0)
+                if *color == Color::rgb(16, 19, 27)
         )));
         assert!(commands.iter().any(|cmd| matches!(
             cmd,
-            prom_ui_runtime::DrawCommand::FillRect { color, .. } if *color == Color::RED
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(235, 72, 90)
         )));
         assert!(commands.iter().any(|cmd| matches!(
             cmd,
-            prom_ui_runtime::DrawCommand::FillRect { rect, color } if *color == Color::WHITE
-                && rect.x == 6
-                && rect.y == 16
-                && rect.width == 113
-                && rect.height == 2
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(255, 196, 77)
+        )));
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::DrawText { text, .. }
+                if text.contains("Demo status")
+        )));
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::DrawText { text, .. }
+                if text.contains("Pointer:")
+        )));
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::DrawText { text, .. }
+                if text.contains("Denied marker")
         )));
     }
 }


### PR DESCRIPTION
This PR improves the native WGPU UI demo into a clearer interactive usability slice.\n\nChanges:\n\n- adds Escape handling for clean demo exit;\n- improves the visible demo scene with a larger backdrop, fixed demo cards, placement preview strip, and stronger hover/select/focus feedback;\n- adds a clearer status panel for pointer state, selected/focused node, key count, denied count, and denied feedback;\n- updates demo interaction tests for Escape exit and richer render output.\n\nSafety:\n\n- UI remains an operator/application surface;\n- no VM, ABI, verifier, SemCode, capability, audit, or runtime semantics changed;\n- no new renderer framework;\n- no public contract widening;\n- no roadmap, boundary, closeout, or audit documents.\n\nVerification:\n\n- cargo fmt --all\n- cargo test -p prom-ui-demo\n- cargo test -p prom-ui-backend-native\n- cargo test --workspace --all-targets