### PR TITLE
feat(examples): add practical surface qualification pack

### DIFF
--- a/examples/qualification/practical_surface/negative_bad_collection_index/src/main.sm
+++ b/examples/qualification/practical_surface/negative_bad_collection_index/src/main.sm
@@ -1,0 +1,5 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2, 3];
+    let value: i32 = values[true];
+    return;
+}

--- a/examples/qualification/practical_surface/negative_bad_match_shape/src/main.sm
+++ b/examples/qualification/practical_surface/negative_bad_match_shape/src/main.sm
@@ -1,0 +1,18 @@
+enum Direction {
+    Left,
+    Right,
+}
+
+enum Signal {
+    High,
+    Low,
+}
+
+fn main() {
+    let dir: Direction = Direction::Left;
+    let value: i32 = match dir {
+        Signal::High => { 1 }
+        Direction::Right => { 2 }
+    };
+    return;
+}

--- a/examples/qualification/practical_surface/negative_bad_numeric_mismatch/src/main.sm
+++ b/examples/qualification/practical_surface/negative_bad_numeric_mismatch/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: i32 = 1.0;
+    return;
+}

--- a/examples/qualification/practical_surface/negative_bad_option_result_use/src/main.sm
+++ b/examples/qualification/practical_surface/negative_bad_option_result_use/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value = Result::Ok(7);
+    return;
+}

--- a/examples/qualification/practical_surface/negative_bad_record_field/src/main.sm
+++ b/examples/qualification/practical_surface/negative_bad_record_field/src/main.sm
@@ -1,0 +1,9 @@
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 1 };
+    return;
+}

--- a/examples/qualification/practical_surface/positive_comments_and_blocks/src/main.sm
+++ b/examples/qualification/practical_surface/positive_comments_and_blocks/src/main.sm
@@ -1,0 +1,13 @@
+// Practical surface check:
+// comments and blank lines should be ignored by the frontend.
+
+fn main() {
+    let mut count: i32 = 0;
+
+    while count < 3 {
+        count = count + 1;
+    }
+
+    assert(count == 3);
+    return;
+}

--- a/examples/qualification/practical_surface/positive_loops_and_sequences/src/main.sm
+++ b/examples/qualification/practical_surface/positive_loops_and_sequences/src/main.sm
@@ -1,0 +1,26 @@
+fn main() {
+    let mut index: i32 = 0;
+    let mut values: Sequence(i32) = [1, 2];
+
+    while index < len(values) {
+        index = index + 1;
+    }
+
+    loop {
+        if len(values) == 2 {
+            values = push(values, 3);
+            continue;
+        }
+        break;
+    }
+
+    values = prepend(values, 0);
+
+    assert(index == 2);
+    assert(len(values) == 4);
+    assert(values[0] == 0);
+    assert(values[1] == 1);
+    assert(values[2] == 2);
+    assert(values[3] == 3);
+    return;
+}

--- a/examples/qualification/practical_surface/positive_module_import_surface/src/helper.sm
+++ b/examples/qualification/practical_surface/positive_module_import_surface/src/helper.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/practical_surface/positive_module_import_surface/src/main.sm
+++ b/examples/qualification/practical_surface/positive_module_import_surface/src/main.sm
@@ -1,0 +1,7 @@
+Import "helper.sm"
+
+fn main() {
+    let value: i32 = score(1);
+    assert(value == 1);
+    return;
+}

--- a/examples/qualification/practical_surface/positive_option_result_flow/src/main.sm
+++ b/examples/qualification/practical_surface/positive_option_result_flow/src/main.sm
@@ -1,0 +1,37 @@
+fn choose_value(flag: bool) -> Option(i32) {
+    if flag {
+        return Option::Some(9);
+    }
+    return Option::None;
+}
+
+fn parse_flag(flag: bool) -> Result(i32, text) {
+    if flag {
+        return Result::Ok(11);
+    }
+    return Result::Err("disabled");
+}
+
+fn unwrap_option(opt: Option(i32)) -> i32 {
+    let value: i32 = match opt {
+        Option::Some(v) => { v }
+        Option::None => { 0 }
+    };
+    return value;
+}
+
+fn unwrap_result(res: Result(i32, text)) -> i32 {
+    let value: i32 = match res {
+        Result::Ok(v) => { v }
+        Result::Err(e) => { 0 }
+    };
+    return value;
+}
+
+fn main() {
+    assert(unwrap_option(choose_value(true)) == 9);
+    assert(unwrap_option(choose_value(false)) == 0);
+    assert(unwrap_result(parse_flag(true)) == 11);
+    assert(unwrap_result(parse_flag(false)) == 0);
+    return;
+}

--- a/examples/qualification/practical_surface/positive_records_and_match/src/main.sm
+++ b/examples/qualification/practical_surface/positive_records_and_match/src/main.sm
@@ -1,0 +1,28 @@
+record Pair {
+    left: i32,
+    right: i32,
+}
+
+enum Mode {
+    Idle,
+    Run,
+}
+
+fn pair_sum(pair: Pair) -> i32 {
+    return pair.left + pair.right;
+}
+
+fn mode_label(mode: Mode) -> text {
+    let label: text = match mode {
+        Mode::Idle => { "idle" }
+        Mode::Run => { "run" }
+    };
+    return label;
+}
+
+fn main() {
+    let pair: Pair = Pair { left: 2, right: 5 };
+    assert(pair_sum(pair) == 7);
+    assert(mode_label(Mode::Run) == "run");
+    return;
+}

--- a/examples/qualification/practical_surface/positive_text_and_numbers/src/main.sm
+++ b/examples/qualification/practical_surface/positive_text_and_numbers/src/main.sm
@@ -1,0 +1,13 @@
+fn main() {
+    let title: text = "practical surface";
+    let left: i32 = 2;
+    let count: u32 = 3u32;
+    let weight: fx = 2.5fx;
+    let total: fx = weight + 1.5fx;
+
+    assert(title == "practical surface");
+    assert(left + 1 == 3);
+    assert(count == 3u32);
+    assert(total == 4.0fx);
+    return;
+}

--- a/tests/practical_surface_qualification.rs
+++ b/tests/practical_surface_qualification.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(rel: &str) {
+    let path = repo_path(rel);
+    smc_cli::run(vec!["check".to_string(), path.clone()])
+        .unwrap_or_else(|err| panic!("smc check unexpectedly failed for {path}: {err}"));
+}
+
+fn cli_err(rel: &str) -> String {
+    let path = repo_path(rel);
+    smc_cli::run(vec!["check".to_string(), path.clone()])
+        .expect_err(&format!("smc check unexpectedly passed for {path}"))
+}
+
+#[test]
+fn practical_surface_qualification_pack_is_covered_by_smoke_checks() {
+    let positive_cases = [
+        "examples/qualification/practical_surface/positive_comments_and_blocks/src/main.sm",
+        "examples/qualification/practical_surface/positive_records_and_match/src/main.sm",
+        "examples/qualification/practical_surface/positive_option_result_flow/src/main.sm",
+        "examples/qualification/practical_surface/positive_loops_and_sequences/src/main.sm",
+        "examples/qualification/practical_surface/positive_text_and_numbers/src/main.sm",
+        "examples/qualification/practical_surface/positive_module_import_surface/src/main.sm",
+    ];
+
+    for rel in positive_cases {
+        cli_ok(rel);
+    }
+
+    let negative_cases = [
+        (
+            "examples/qualification/practical_surface/negative_bad_record_field/src/main.sm",
+            "record literal 'Pair' is missing field 'right'",
+        ),
+        (
+            "examples/qualification/practical_surface/negative_bad_match_shape/src/main.sm",
+            "match arm pattern type 'Signal' does not match scrutinee enum 'Direction'",
+        ),
+        (
+            "examples/qualification/practical_surface/negative_bad_collection_index/src/main.sm",
+            "sequence indexing currently requires i32 index",
+        ),
+        (
+            "examples/qualification/practical_surface/negative_bad_option_result_use/src/main.sm",
+            "Result::Ok currently requires contextual Result(T, E) type in v0",
+        ),
+        (
+            "examples/qualification/practical_surface/negative_bad_numeric_mismatch/src/main.sm",
+            "type mismatch in let",
+        ),
+    ];
+
+    for (rel, needle) in negative_cases {
+        let err = cli_err(rel);
+        assert!(
+            err.contains(needle),
+            "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a practical Semantic surface qualification pack.

It consolidates already-supported authoring patterns into runnable fixtures and focused tests, covering realistic combinations of comments, blocks, control flow, records, ADT/match, Option/Result-style flow, sequences, text/numeric cases, and common negative authoring mistakes where currently supported.

No new syntax, no VM/verifier/runtime/ABI changes, no UI work, and no public contract widening.

Verification:
- cargo fmt --all
- cargo test -p sm-front
- cargo test -p sm-sema
- cargo test -p smc-cli
- cargo test --workspace --all-targets
