### PR TITLE
test(toolchain): qualify local module import surface

### DIFF
--- a/examples/qualification/import_surface/negative_duplicate_import_symbol/src/left.sm
+++ b/examples/qualification/import_surface/negative_duplicate_import_symbol/src/left.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/import_surface/negative_duplicate_import_symbol/src/main.sm
+++ b/examples/qualification/import_surface/negative_duplicate_import_symbol/src/main.sm
@@ -1,0 +1,6 @@
+Import "left.sm"
+Import "right.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/import_surface/negative_duplicate_import_symbol/src/right.sm
+++ b/examples/qualification/import_surface/negative_duplicate_import_symbol/src/right.sm
@@ -1,0 +1,3 @@
+fn score(value: i32) -> i32 {
+    return value;
+}

--- a/examples/qualification/import_surface/negative_import_cycle/src/a.sm
+++ b/examples/qualification/import_surface/negative_import_cycle/src/a.sm
@@ -1,0 +1,1 @@
+Import "b.sm"

--- a/examples/qualification/import_surface/negative_import_cycle/src/b.sm
+++ b/examples/qualification/import_surface/negative_import_cycle/src/b.sm
@@ -1,0 +1,1 @@
+Import "a.sm"

--- a/examples/qualification/import_surface/negative_import_cycle/src/main.sm
+++ b/examples/qualification/import_surface/negative_import_cycle/src/main.sm
@@ -1,0 +1,5 @@
+Import "a.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/import_surface/negative_missing_import_file/src/main.sm
+++ b/examples/qualification/import_surface/negative_missing_import_file/src/main.sm
@@ -1,0 +1,5 @@
+Import "missing.sm"
+
+fn main() {
+    return;
+}

--- a/examples/qualification/import_surface/positive_nested_relative_import/src/helpers/checks.sm
+++ b/examples/qualification/import_surface/positive_nested_relative_import/src/helpers/checks.sm
@@ -1,0 +1,3 @@
+fn is_positive(value: i32) -> bool {
+    return value > 0;
+}

--- a/examples/qualification/import_surface/positive_nested_relative_import/src/helpers/math.sm
+++ b/examples/qualification/import_surface/positive_nested_relative_import/src/helpers/math.sm
@@ -1,0 +1,3 @@
+fn add_one(value: i32) -> i32 {
+    return value + 1;
+}

--- a/examples/qualification/import_surface/positive_nested_relative_import/src/main.sm
+++ b/examples/qualification/import_surface/positive_nested_relative_import/src/main.sm
@@ -1,0 +1,8 @@
+Import "helpers/math.sm" { add_one }
+Import "helpers/checks.sm" { is_positive }
+
+fn main() {
+    let value: i32 = add_one(1);
+    assert(is_positive(value));
+    return;
+}

--- a/examples/qualification/import_surface/positive_single_import/src/main.sm
+++ b/examples/qualification/import_surface/positive_single_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "math.sm" { add_one }
+
+fn main() {
+    let value: i32 = add_one(1);
+    assert(value == 2);
+    return;
+}

--- a/examples/qualification/import_surface/positive_single_import/src/math.sm
+++ b/examples/qualification/import_surface/positive_single_import/src/math.sm
@@ -1,0 +1,3 @@
+fn add_one(value: i32) -> i32 {
+    return value + 1;
+}

--- a/examples/qualification/import_surface/positive_transitive_import/src/core.sm
+++ b/examples/qualification/import_surface/positive_transitive_import/src/core.sm
@@ -1,0 +1,3 @@
+fn seed() -> i32 {
+    return 2;
+}

--- a/examples/qualification/import_surface/positive_transitive_import/src/domain.sm
+++ b/examples/qualification/import_surface/positive_transitive_import/src/domain.sm
@@ -1,0 +1,5 @@
+Import "core.sm" { seed }
+
+fn domain_value() -> i32 {
+    return seed() + 1;
+}

--- a/examples/qualification/import_surface/positive_transitive_import/src/main.sm
+++ b/examples/qualification/import_surface/positive_transitive_import/src/main.sm
@@ -1,0 +1,7 @@
+Import "domain.sm" { domain_value }
+
+fn main() {
+    let value: i32 = domain_value();
+    assert(value == 3);
+    return;
+}

--- a/tests/import_surface_qualification.rs
+++ b/tests/import_surface_qualification.rs
@@ -1,0 +1,160 @@
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Depth {
+    CheckOnly,
+    CompileOk,
+    VerifyOk,
+    RunOk,
+}
+
+impl Depth {
+    fn label(self) -> &'static str {
+        match self {
+            Self::CheckOnly => "CheckOnly",
+            Self::CompileOk => "CompileOk",
+            Self::VerifyOk => "VerifyOk",
+            Self::RunOk => "RunOk",
+        }
+    }
+}
+
+fn run_depth(rel: &str, depth: Depth) {
+    let path = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+    if matches!(depth, Depth::CheckOnly) {
+        return;
+    }
+
+    let temp_dir = mk_temp_dir("import_surface");
+    let out = temp_dir.join(
+        Path::new(rel)
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("output.smc")),
+    );
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            path.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {path}"),
+    );
+    if matches!(depth, Depth::CompileOk) {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        return;
+    }
+
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    if matches!(depth, Depth::VerifyOk) {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        return;
+    }
+
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn import_surface_qualification_pack_is_depth_classified() {
+    let depth_ladder = [
+        Depth::CheckOnly,
+        Depth::CompileOk,
+        Depth::VerifyOk,
+        Depth::RunOk,
+    ];
+    assert_eq!(depth_ladder[3].label(), "RunOk");
+
+    let positive_cases = [
+        (
+            "examples/qualification/import_surface/positive_single_import/src/main.sm",
+            Depth::RunOk,
+        ),
+        (
+            "examples/qualification/import_surface/positive_nested_relative_import/src/main.sm",
+            Depth::RunOk,
+        ),
+        (
+            "examples/qualification/import_surface/positive_transitive_import/src/main.sm",
+            Depth::RunOk,
+        ),
+    ];
+
+    for (rel, depth) in positive_cases {
+        assert_eq!(depth.label(), "RunOk", "unexpected depth for {rel}");
+        run_depth(rel, depth);
+    }
+
+    let negative_cases = [
+        (
+            "examples/qualification/import_surface/negative_missing_import_file/src/main.sm",
+            "failed to resolve entry module",
+        ),
+        (
+            "examples/qualification/import_surface/negative_duplicate_import_symbol/src/main.sm",
+            "duplicate function 'score'",
+        ),
+        (
+            "examples/qualification/import_surface/negative_import_cycle/src/main.sm",
+            "cyclic executable helper import detected",
+        ),
+    ];
+
+    for (rel, needle) in negative_cases {
+        let err = cli_err(
+            vec!["check".to_string(), repo_path(rel)],
+            &format!("smc check for {rel}"),
+        );
+        assert!(
+            err.contains(needle),
+            "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
This PR adds focused qualification coverage for local module import behavior in Semantic.

It covers already-supported local import composition patterns through examples and focused tests, including positive executable cases and deterministic negative authoring cases.

No new syntax, no VM/verifier/runtime/ABI changes, no UI work, no docs, and no public contract widening.
