### PR TITLE
test(toolchain): qualify match guards and exhaustiveness edges

### DIFF
--- a/examples/qualification/match_surface/negative_guard_non_bool/src/main.sm
+++ b/examples/qualification/match_surface/negative_guard_non_bool/src/main.sm
@@ -1,0 +1,14 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn main() {
+    let out: text = match Direction::Up {
+        Direction::Up if 1 => { "up" }
+        _ => { "other" }
+    };
+    return;
+}

--- a/examples/qualification/match_surface/negative_match_result_type_mismatch/src/main.sm
+++ b/examples/qualification/match_surface/negative_match_result_type_mismatch/src/main.sm
@@ -1,0 +1,16 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn main() {
+    let out: text = match Direction::Up {
+        Direction::Up => { "up" }
+        Direction::Right => { true }
+        Direction::Down => { "down" }
+        Direction::Left => { "left" }
+    };
+    return;
+}

--- a/examples/qualification/match_surface/negative_missing_variant/src/main.sm
+++ b/examples/qualification/match_surface/negative_missing_variant/src/main.sm
@@ -1,0 +1,19 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn label(dir: Direction) -> text {
+    let out: text = match dir {
+        Direction::Up => { "Up" }
+        Direction::Right => { "Right" }
+        Direction::Down => { "Down" }
+    };
+    return out;
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/match_surface/negative_wrong_pattern_family/src/main.sm
+++ b/examples/qualification/match_surface/negative_wrong_pattern_family/src/main.sm
@@ -1,0 +1,12 @@
+fn settle(res: Result(bool, quad)) -> bool {
+    let out: bool = match res {
+        Option::Some(value) => { value }
+        _ => { false }
+    };
+    return out;
+}
+
+fn main() {
+    let out: bool = settle(Result::Err(S));
+    return;
+}

--- a/examples/qualification/match_surface/positive_enum_exhaustive_match/src/main.sm
+++ b/examples/qualification/match_surface/positive_enum_exhaustive_match/src/main.sm
@@ -1,0 +1,21 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn label(dir: Direction) -> text {
+    let out: text = match dir {
+        Direction::Up => { "Up" }
+        Direction::Right => { "Right" }
+        Direction::Down => { "Down" }
+        Direction::Left => { "Left" }
+    };
+    return out;
+}
+
+fn main() {
+    assert(label(Direction::Right) == "Right");
+    return;
+}

--- a/examples/qualification/match_surface/positive_match_guard_bool/src/main.sm
+++ b/examples/qualification/match_surface/positive_match_guard_bool/src/main.sm
@@ -1,0 +1,23 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn classify(dir: Direction, is_primary: bool) -> text {
+    let out: text = match dir {
+        Direction::Up if is_primary => { "primary-up" }
+        Direction::Up => { "up" }
+        Direction::Right => { "right" }
+        Direction::Down => { "down" }
+        Direction::Left => { "left" }
+    };
+    return out;
+}
+
+fn main() {
+    assert(classify(Direction::Up, true) == "primary-up");
+    assert(classify(Direction::Up, false) == "up");
+    return;
+}

--- a/examples/qualification/match_surface/positive_nested_match/src/main.sm
+++ b/examples/qualification/match_surface/positive_nested_match/src/main.sm
@@ -1,0 +1,27 @@
+enum Direction {
+    Up,
+    Right,
+    Down,
+    Left,
+}
+
+fn describe(opt: Option(Direction)) -> text {
+    let out: text = match opt {
+        Option::Some(dir) => {
+            match dir {
+                Direction::Up => { "up" }
+                Direction::Right => { "right" }
+                Direction::Down => { "down" }
+                Direction::Left => { "left" }
+            }
+        }
+        Option::None => { "none" }
+    };
+    return out;
+}
+
+fn main() {
+    assert(describe(Option::Some(Direction::Left)) == "left");
+    assert(describe(Option::None) == "none");
+    return;
+}

--- a/examples/qualification/match_surface/positive_option_result_match/src/main.sm
+++ b/examples/qualification/match_surface/positive_option_result_match/src/main.sm
@@ -1,0 +1,23 @@
+fn unwrap(opt: Option(bool)) -> bool {
+    let out: bool = match opt {
+        Option::Some(value) => { value }
+        Option::None => { false }
+    };
+    return out;
+}
+
+fn settle(res: Result(bool, quad)) -> bool {
+    let out: bool = match res {
+        Result::Ok(value) => { value }
+        Result::Err(code) => { false }
+    };
+    return out;
+}
+
+fn main() {
+    let left: bool = unwrap(Option::Some(true));
+    let right: bool = settle(Result::Err(S));
+    assert(left == true);
+    assert(right == false);
+    return;
+}

--- a/tests/match_surface_qualification.rs
+++ b/tests/match_surface_qualification.rs
@@ -1,0 +1,123 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+fn run_full_pipeline(rel: &str) {
+    let path = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+
+    let temp_dir = mk_temp_dir("match_surface_qualification");
+    let out = temp_dir.join(
+        Path::new(rel)
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("out.smc")),
+    );
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            path.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {path}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+fn assert_check_rejects(rel: &str, needle: &str) {
+    let path = repo_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic containing '{needle}' for {rel}, got: {err}"
+    );
+}
+
+#[test]
+fn match_surface_positive_fixtures_run_end_to_end() {
+    let positive_cases = [
+        "examples/qualification/match_surface/positive_enum_exhaustive_match/src/main.sm",
+        "examples/qualification/match_surface/positive_option_result_match/src/main.sm",
+        "examples/qualification/match_surface/positive_match_guard_bool/src/main.sm",
+        "examples/qualification/match_surface/positive_nested_match/src/main.sm",
+    ];
+
+    for rel in positive_cases {
+        run_full_pipeline(rel);
+    }
+}
+
+#[test]
+fn match_surface_negative_fixtures_reject_deterministically() {
+    let negative_cases = [
+        (
+            "examples/qualification/match_surface/negative_missing_variant/src/main.sm",
+            "non-exhaustive match expression for enum 'Direction'; missing variants: Left",
+        ),
+        (
+            "examples/qualification/match_surface/negative_wrong_pattern_family/src/main.sm",
+            "match arm pattern type 'Option' does not match scrutinee Result(T, E)",
+        ),
+        (
+            "examples/qualification/match_surface/negative_guard_non_bool/src/main.sm",
+            "match guard condition must be bool",
+        ),
+        (
+            "examples/qualification/match_surface/negative_match_result_type_mismatch/src/main.sm",
+            "match expression branch type mismatch",
+        ),
+    ];
+
+    for (rel, needle) in negative_cases {
+        assert_check_rejects(rel, needle);
+    }
+}


### PR DESCRIPTION
This PR adds focused qualification coverage for existing match edge behavior in Semantic.

It covers already-supported match patterns through examples and focused tests, including exhaustive positive cases and deterministic negative authoring cases around missing variants, wrong pattern families, guard type checks where supported, and arm result type mismatches.

No new syntax, no VM/verifier/runtime/ABI changes, no UI work, no docs, and no public contract widening.