### PR TITLE
test(toolchain): qualify call-shape diagnostics

### DIFF
--- a/examples/qualification/call_shape_surface/negative_builtin_named_args_rejected/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_builtin_named_args_rejected/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: f64 = sqrt(x = 4.0);
+    return;
+}

--- a/examples/qualification/call_shape_surface/negative_builtin_wrong_type/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_builtin_wrong_type/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let size: i32 = len(1);
+    return;
+}

--- a/examples/qualification/call_shape_surface/negative_unknown_function/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_unknown_function/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    let value: i32 = missing_fn(1);
+    return;
+}

--- a/examples/qualification/call_shape_surface/negative_wrong_argument_type/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_wrong_argument_type/src/main.sm
@@ -1,0 +1,6 @@
+fn inc(value: i32) -> i32 = value + 1;
+
+fn main() {
+    let value: i32 = inc(false);
+    return;
+}

--- a/examples/qualification/call_shape_surface/negative_wrong_arity_too_few/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_wrong_arity_too_few/src/main.sm
@@ -1,0 +1,6 @@
+fn add(a: i32, b: i32) -> i32 = a + b;
+
+fn main() {
+    let value: i32 = add(1);
+    return;
+}

--- a/examples/qualification/call_shape_surface/negative_wrong_arity_too_many/src/main.sm
+++ b/examples/qualification/call_shape_surface/negative_wrong_arity_too_many/src/main.sm
@@ -1,0 +1,6 @@
+fn one(a: i32) -> i32 = a;
+
+fn main() {
+    let value: i32 = one(1, 2);
+    return;
+}

--- a/examples/qualification/call_shape_surface/positive_basic_function_call/src/main.sm
+++ b/examples/qualification/call_shape_surface/positive_basic_function_call/src/main.sm
@@ -1,0 +1,7 @@
+fn add(a: i32, b: i32) -> i32 = a + b;
+
+fn main() {
+    let value: i32 = add(1, 2);
+    assert(value == 3);
+    return;
+}

--- a/examples/qualification/call_shape_surface/positive_builtin_call/src/main.sm
+++ b/examples/qualification/call_shape_surface/positive_builtin_call/src/main.sm
@@ -1,0 +1,6 @@
+fn main() {
+    let values: Sequence(i32) = [1, 2];
+    let grown: Sequence(i32) = prepend(push(values, 3), 0);
+    assert(len(grown) == 4);
+    return;
+}

--- a/examples/qualification/call_shape_surface/positive_named_args_call/src/main.sm
+++ b/examples/qualification/call_shape_surface/positive_named_args_call/src/main.sm
@@ -1,0 +1,7 @@
+fn scale(value: i32, factor: i32) -> i32 = value * factor;
+
+fn main() {
+    let total: i32 = scale(factor = 3, value = 2);
+    assert(total == 6);
+    return;
+}

--- a/examples/qualification/call_shape_surface/positive_nested_function_call/src/main.sm
+++ b/examples/qualification/call_shape_surface/positive_nested_function_call/src/main.sm
@@ -1,0 +1,7 @@
+fn add(a: i32, b: i32) -> i32 = a + b;
+
+fn main() {
+    let value: i32 = add(add(1, 2), 3);
+    assert(value == 6);
+    return;
+}

--- a/tests/call_shape_surface_qualification.rs
+++ b/tests/call_shape_surface_qualification.rs
@@ -1,0 +1,105 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn check_compile_verify_run(rel: &str) {
+    let path = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "call_shape_surface_qualification_{}_{}",
+        std::process::id(),
+        rel.replace(['/', '\\'], "_")
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("mkdir");
+    let out = temp_dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            path.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {path}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn call_shape_surface_qualification_pack_is_covered_by_smoke_and_execution_checks() {
+    let positive_cases = [
+        "examples/qualification/call_shape_surface/positive_basic_function_call/src/main.sm",
+        "examples/qualification/call_shape_surface/positive_nested_function_call/src/main.sm",
+        "examples/qualification/call_shape_surface/positive_builtin_call/src/main.sm",
+        "examples/qualification/call_shape_surface/positive_named_args_call/src/main.sm",
+    ];
+
+    for rel in positive_cases {
+        check_compile_verify_run(rel);
+    }
+
+    let negative_cases = [
+        (
+            "examples/qualification/call_shape_surface/negative_unknown_function/src/main.sm",
+            "unknown function 'missing_fn'",
+        ),
+        (
+            "examples/qualification/call_shape_surface/negative_wrong_arity_too_few/src/main.sm",
+            "function 'add' is missing argument for parameter 'b'",
+        ),
+        (
+            "examples/qualification/call_shape_surface/negative_wrong_arity_too_many/src/main.sm",
+            "function 'one' expects 1 args, got 2",
+        ),
+        (
+            "examples/qualification/call_shape_surface/negative_wrong_argument_type/src/main.sm",
+            "arg 0 for 'inc' has type Bool, expected I32",
+        ),
+        (
+            "examples/qualification/call_shape_surface/negative_builtin_wrong_type/src/main.sm",
+            "builtin 'len' expects a Sequence argument, got I32",
+        ),
+        (
+            "examples/qualification/call_shape_surface/negative_builtin_named_args_rejected/src/main.sm",
+            "named arguments are not supported for builtin 'sqrt'",
+        ),
+    ];
+
+    for (rel, needle) in negative_cases {
+        let err = cli_err(
+            vec!["check".to_string(), repo_path(rel)],
+            &format!("smc check for {rel}"),
+        );
+        assert!(
+            err.contains(needle),
+            "expected diagnostic '{needle}' for {rel}, got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
This PR qualifies function-call and builtin-call authoring diagnostics in Semantic.

It adds focused coverage for supported call shapes, including simple calls, nested calls, builtin calls, and named-argument calls where currently supported.

It also pins deterministic rejection for common call mistakes:

- unknown function;
- too few arguments;
- too many arguments;
- wrong argument type;
- builtin wrong type;
- builtin named-argument rejection.

No new syntax, no broad function-resolution redesign, no VM/runtime/ABI widening, no UI work, no docs, and no public contract widening.

Verification:

- cargo fmt --all
- cargo test --test call_shape_surface_qualification
- cargo test -p sm-front
- cargo test -p sm-sema
- cargo test -p smc-cli
- cargo test --workspace --all-targets
