### PR TITLE
test(toolchain): qualify return and assert diagnostics

### DIFF
--- a/examples/qualification/return_assert_surface/negative_assert_false_runtime_trap/src/main.sm
+++ b/examples/qualification/return_assert_surface/negative_assert_false_runtime_trap/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    assert(false);
+    return;
+}

--- a/examples/qualification/return_assert_surface/negative_assert_non_bool/src/main.sm
+++ b/examples/qualification/return_assert_surface/negative_assert_non_bool/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    assert(1);
+    return;
+}

--- a/examples/qualification/return_assert_surface/negative_branch_return_type_mismatch/src/main.sm
+++ b/examples/qualification/return_assert_surface/negative_branch_return_type_mismatch/src/main.sm
@@ -1,0 +1,11 @@
+fn choose(flag: bool) -> i32 {
+    if flag {
+        return 1;
+    } else {
+        return "bad";
+    }
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/return_assert_surface/negative_missing_return_value/src/main.sm
+++ b/examples/qualification/return_assert_surface/negative_missing_return_value/src/main.sm
@@ -1,0 +1,7 @@
+fn value() -> i32 {
+    return;
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/return_assert_surface/negative_return_type_mismatch/src/main.sm
+++ b/examples/qualification/return_assert_surface/negative_return_type_mismatch/src/main.sm
@@ -1,0 +1,7 @@
+fn value() -> i32 {
+    return "bad";
+}
+
+fn main() {
+    return;
+}

--- a/examples/qualification/return_assert_surface/positive_assert_computed_condition/src/main.sm
+++ b/examples/qualification/return_assert_surface/positive_assert_computed_condition/src/main.sm
@@ -1,0 +1,7 @@
+fn main() {
+    let left: i32 = 2;
+    let right: i32 = 1 + 1;
+    let ok: bool = left == right;
+    assert(ok);
+    return;
+}

--- a/examples/qualification/return_assert_surface/positive_assert_true/src/main.sm
+++ b/examples/qualification/return_assert_surface/positive_assert_true/src/main.sm
@@ -1,0 +1,4 @@
+fn main() {
+    assert(true);
+    return;
+}

--- a/examples/qualification/return_assert_surface/positive_branch_return_value/src/main.sm
+++ b/examples/qualification/return_assert_surface/positive_branch_return_value/src/main.sm
@@ -1,0 +1,7 @@
+fn choose(flag: bool) -> i32 = if flag { 1 } else { 2 };
+
+fn main() {
+    let value: i32 = choose(true);
+    assert(value == 1);
+    return;
+}

--- a/examples/qualification/return_assert_surface/positive_explicit_return_value/src/main.sm
+++ b/examples/qualification/return_assert_surface/positive_explicit_return_value/src/main.sm
@@ -1,0 +1,9 @@
+fn answer() -> i32 {
+    return 42;
+}
+
+fn main() {
+    let value: i32 = answer();
+    assert(value == 42);
+    return;
+}

--- a/tests/return_assert_surface_qualification.rs
+++ b/tests/return_assert_surface_qualification.rs
@@ -1,0 +1,155 @@
+use std::path::PathBuf;
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+fn check_compile_verify_run(rel: &str) {
+    let path = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "return_assert_surface_qualification_{}_{}",
+        std::process::id(),
+        rel.replace(['/', '\\'], "_")
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("mkdir");
+    let out = temp_dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            path.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {path}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+    cli_ok(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+fn assert_check_rejects(rel: &str, needle: &str) {
+    let path = repo_path(rel);
+    let err = cli_err(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+    assert!(
+        err.contains(needle),
+        "expected diagnostic '{needle}' for {rel}, got: {err}"
+    );
+}
+
+fn assert_runtime_trap(rel: &str, needle: &str) {
+    let path = repo_path(rel);
+    cli_ok(
+        vec!["check".to_string(), path.clone()],
+        &format!("smc check for {path}"),
+    );
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "return_assert_surface_trap_{}_{}",
+        std::process::id(),
+        rel.replace(['/', '\\'], "_")
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("mkdir");
+    let out = temp_dir.join("out.smc");
+    let out_arg = out.to_string_lossy().replace('\\', "/");
+
+    cli_ok(
+        vec![
+            "compile".to_string(),
+            path.clone(),
+            "-o".to_string(),
+            out_arg.clone(),
+        ],
+        &format!("smc compile for {path}"),
+    );
+    cli_ok(
+        vec!["verify".to_string(), out_arg.clone()],
+        &format!("smc verify for {out_arg}"),
+    );
+
+    let err = cli_err(
+        vec!["run-smc".to_string(), out_arg.clone()],
+        &format!("smc run-smc for {out_arg}"),
+    );
+    assert!(
+        err.contains(needle),
+        "expected runtime trap containing '{needle}' for {rel}, got: {err}"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn return_assert_surface_positive_cases_run_end_to_end() {
+    let positive_cases = [
+        "examples/qualification/return_assert_surface/positive_explicit_return_value/src/main.sm",
+        "examples/qualification/return_assert_surface/positive_branch_return_value/src/main.sm",
+        "examples/qualification/return_assert_surface/positive_assert_true/src/main.sm",
+        "examples/qualification/return_assert_surface/positive_assert_computed_condition/src/main.sm",
+    ];
+
+    for rel in positive_cases {
+        check_compile_verify_run(rel);
+    }
+}
+
+#[test]
+fn return_assert_surface_static_negative_cases_reject_deterministically() {
+    let negative_cases = [
+        (
+            "examples/qualification/return_assert_surface/negative_return_type_mismatch/src/main.sm",
+            "return type mismatch",
+        ),
+        (
+            "examples/qualification/return_assert_surface/negative_missing_return_value/src/main.sm",
+            "return type mismatch",
+        ),
+        (
+            "examples/qualification/return_assert_surface/negative_assert_non_bool/src/main.sm",
+            "assert builtin requires bool condition",
+        ),
+        (
+            "examples/qualification/return_assert_surface/negative_branch_return_type_mismatch/src/main.sm",
+            "return type mismatch",
+        ),
+    ];
+
+    for (rel, needle) in negative_cases {
+        assert_check_rejects(rel, needle);
+    }
+}
+
+#[test]
+fn return_assert_surface_assert_false_traps_at_runtime() {
+    assert_runtime_trap(
+        "examples/qualification/return_assert_surface/negative_assert_false_runtime_trap/src/main.sm",
+        "assertion failed",
+    );
+}


### PR DESCRIPTION
This PR qualifies return-path and assert/trap behavior in Semantic.

It adds focused examples and tests for supported return/assert cases:

- explicit return value;
- branch return value;
- assert(true);
- computed assert condition.

It also pins deterministic rejection for common static authoring mistakes:

- return type mismatch;
- missing return value;
- non-bool assert condition;
- branch return type mismatch.

Additionally, it adds a runtime trap fixture for "assert(false)" to prove the current toolchain classifies this path through check -> compile -> verify -> run-smc failure.

Note: the branch-return positive fixture is intentionally written as an expression-bodied function because the current statement-branch form is rejected by the checker as potentially exiting without returning "I32".

No VM/runtime/verifier redesign, no new syntax, no UI work, no docs, and no public contract widening.

Verification:

- cargo fmt --all
- cargo test --test return_assert_surface_qualification
- cargo test -p sm-front
- cargo test -p sm-sema
- cargo test -p sm-verify
- cargo test -p sm-vm
- cargo test -p smc-cli
- cargo test --workspace --all-targets
