### PR TITLE
chore(repo): ignore local assistant scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 !tests/golden/*.smc
 Cargo.lock
 /.semantic-cache/
+/.codebase-memory/
+/.claude/
+/scratch/
+/patch.txt


### PR DESCRIPTION
This PR reduces recurring worktree noise from local assistant/scratch artifacts.\n\nIt updates .gitignore for confirmed local/generated paths and does not delete, move, or commit any untracked artifact contents.\n\nxamples/baseline/ was inspected and left unignored because it contains source-like Semantic material rather than obvious scratch output.\n\nNo source code, no tests, no docs, no UI work, and no public contract changes.