### PR TITLE
chore(repo): ignore local baseline scratch examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 /.claude/
 /scratch/
 /patch.txt
+/examples/baseline/


### PR DESCRIPTION
This PR ignores the remaining local baseline scratch directory after triage.\n\nexamples/baseline/ currently contains source-like material that is not compatible with the admitted smc surface and is not useful as a positive or negative qualification fixture.\n\nNo files are deleted or moved. No source code, tests, docs, UI work, or public contract changes are included.