### PR TITLE
test(toolchain): qualify CLI command shape diagnostics

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -65,6 +65,14 @@ fn cli_profile() -> ParserProfile {
     ParserProfile::foundation_default()
 }
 
+fn reject_leading_unknown_flag(input: &str) -> Result<(), String> {
+    if input.starts_with('-') {
+        Err(format!("unknown flag '{}'", input))
+    } else {
+        Ok(())
+    }
+}
+
 pub fn main_entry() -> ExitCode {
     match run(env::args().skip(1).collect()) {
         Ok(()) => ExitCode::SUCCESS,
@@ -105,13 +113,20 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
 }
 
 fn cmd_compile(args: &[String]) -> Result<(), String> {
-    if args.len() < 3 {
+    if args.is_empty() {
         return Err(
             "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
                 .to_string(),
         );
     }
     let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
+    if args.len() < 3 {
+        return Err(
+            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
+                .to_string(),
+        );
+    }
     let mut out: Option<&str> = None;
     let mut metrics = false;
     let mut profile = CompileProfile::Auto;
@@ -273,6 +288,7 @@ fn cmd_check(args: &[String]) -> Result<(), String> {
         );
     }
     let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
     let input_path = Path::new(input);
     let root = if input_path.is_dir() {
         resolve_project_root_check_entry(input_path)?
@@ -2422,6 +2438,7 @@ fn cmd_run(args: &[String]) -> Result<(), String> {
         return Err("usage: smc run <input.sm|project-root>".to_string());
     }
     let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
     let input_path = Path::new(input);
     let root = if input_path.is_dir() {
         resolve_project_root_check_entry(input_path)?
@@ -2442,6 +2459,7 @@ fn cmd_verify(args: &[String]) -> Result<(), String> {
         return Err("usage: smc verify <input.smc>".to_string());
     }
     let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
     let bytes = std::fs::read(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
     let verified = verify_semcode(&bytes).map_err(|report| report.to_string())?;
     println!(
@@ -2460,6 +2478,7 @@ fn cmd_run_smc(args: &[String]) -> Result<(), String> {
         return Err("usage: smc run-smc <input.smc>".to_string());
     }
     let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
     let bytes = std::fs::read(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
     let envelope = render_controlled_observation_envelope(&bytes)?;
     for line in envelope.rendered_lines {

--- a/tests/cli_command_shape_diagnostics.rs
+++ b/tests/cli_command_shape_diagnostics.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+
+fn run_err(args: &[&str]) -> String {
+    smc_cli::run(args.iter().map(|s| s.to_string()).collect())
+        .expect_err("expected command-shape failure")
+}
+
+fn assert_usage_error(args: &[&str], expected_usage_fragment: &str) {
+    let err = run_err(args);
+    assert!(
+        err.contains(expected_usage_fragment),
+        "expected usage fragment '{expected_usage_fragment}' in error:\n{err}"
+    );
+}
+
+fn assert_unknown_flag_error(args: &[&str]) {
+    let err = run_err(args);
+    assert!(
+        err.contains("unknown flag '--bogus'"),
+        "expected unknown-flag error in:\n{err}"
+    );
+}
+
+#[test]
+fn smc_commands_reject_missing_arguments_with_usage() {
+    assert_usage_error(&["check"], "usage: smc check");
+    assert_usage_error(&["compile"], "usage: smc compile");
+    assert_usage_error(&["run"], "usage: smc run");
+    assert_usage_error(&["verify"], "usage: smc verify");
+    assert_usage_error(&["run-smc"], "usage: smc run-smc");
+}
+
+#[test]
+fn smc_commands_reject_leading_unknown_flags() {
+    assert_unknown_flag_error(&["check", "--bogus"]);
+    assert_unknown_flag_error(&["compile", "--bogus"]);
+    assert_unknown_flag_error(&["run", "--bogus"]);
+    assert_unknown_flag_error(&["verify", "--bogus"]);
+    assert_unknown_flag_error(&["run-smc", "--bogus"]);
+}
+
+#[test]
+fn smc_check_keeps_real_missing_path_behavior_distinct() {
+    let missing = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("cli_command_shape_diagnostics")
+        .join("definitely_missing_source.sm");
+
+    if let Some(parent) = missing.parent() {
+        assert!(
+            !parent.exists(),
+            "test path unexpectedly exists: {}",
+            parent.display()
+        );
+    }
+
+    let err = run_err(&["check", &missing.to_string_lossy()]);
+    assert!(
+        err.contains("failed to resolve")
+            || err.contains("failed to read")
+            || err.contains("package module admission error"),
+        "expected a path/admission error, got:\n{err}"
+    );
+    assert!(
+        !err.contains("unknown flag"),
+        "missing path should not be mistaken for a CLI flag:\n{err}"
+    );
+}


### PR DESCRIPTION
This PR qualifies user-facing CLI command-shape diagnostics for the main smc commands.\n\nIt adds focused tests for missing arguments, leading unknown flags, and a real path/admission sanity case. A tiny smc-cli guard is included so leading bogus flags no longer fall through as package/source paths.\n\nNo language semantics changes, no artifact format changes, no VM/runtime/ABI changes, no UI work, no docs, and no broad CLI redesign.