### PR TITLE
fix(ui): make calculator shell readable without text rendering

### DIFF
--- a/crates/prom-ui-demo/src/calculator_shell.rs
+++ b/crates/prom-ui-demo/src/calculator_shell.rs
@@ -21,6 +21,7 @@ pub enum CalculatorButton {
 }
 
 impl CalculatorButton {
+    #[cfg(test)]
     pub const fn label(self) -> &'static str {
         match self {
             Self::Digit(0) => "0",
@@ -43,6 +44,7 @@ impl CalculatorButton {
         }
     }
 
+    #[cfg(test)]
     pub fn intent_text(self) -> String {
         match self {
             Self::Digit(digit) => format!("Digit({digit})"),
@@ -127,20 +129,12 @@ impl CalculatorShell {
             display.y() + 12,
             Color::rgb(194, 206, 223),
         );
-        out_frame.draw_text("0", display.x() + 10, display.y() + 27, Color::WHITE);
-        out_frame.draw_text(
-            format!(
-                "Last calculator intent: {}",
-                self.state
-                    .last_button
-                    .map(CalculatorButton::intent_text)
-                    .unwrap_or_else(|| "none".to_string())
-            ),
-            display.x() + 98,
-            display.y() + 27,
-            Color::rgb(225, 232, 242),
+        draw_digit_glyph(
+            out_frame,
+            UiLayoutGeometryRect::new(display.x() + 10, display.y() + 10, 20, 16),
+            0,
+            Color::WHITE,
         );
-
         let buttons = calculator_button_layout(panel);
         for (row, row_buttons) in buttons.iter().enumerate() {
             for (col, button) in row_buttons.iter().enumerate() {
@@ -150,26 +144,52 @@ impl CalculatorShell {
                 let is_focused = self.state.focused_button == Some(*button);
 
                 let fill = if is_selected {
-                    Color::rgb(96, 74, 34)
+                    Color::rgb(255, 214, 96)
                 } else if is_hovered {
                     Color::rgb(44, 84, 120)
                 } else {
                     Color::rgb(38, 42, 56)
                 };
+                let label_panel = button_label_panel_color(*button, is_hovered, is_selected);
                 let outline = if is_selected {
-                    Color::rgb(255, 196, 77)
+                    Color::rgb(255, 250, 210)
                 } else if is_hovered {
                     Color::rgb(102, 222, 255)
                 } else {
                     Color::rgb(84, 96, 126)
                 };
+                let glyph_color = button_glyph_color(*button, is_selected);
 
                 out_frame.fill_rect(
                     Rect::new(rect.x(), rect.y(), rect.width(), rect.height()),
                     fill,
                 );
-                draw_outline(out_frame, rect, outline, if is_focused { 2 } else { 1 });
-                out_frame.draw_text(button.label(), rect.x() + 20, rect.y() + 14, Color::WHITE);
+                let inset = UiLayoutGeometryRect::new(
+                    rect.x() + 6,
+                    rect.y() + 3,
+                    rect.width().saturating_sub(12),
+                    rect.height().saturating_sub(6),
+                );
+                out_frame.fill_rect(
+                    Rect::new(inset.x(), inset.y(), inset.width(), inset.height()),
+                    label_panel,
+                );
+                draw_outline(
+                    out_frame,
+                    rect,
+                    outline,
+                    if is_selected {
+                        3
+                    } else if is_focused {
+                        2
+                    } else {
+                        1
+                    },
+                );
+                draw_button_glyph(out_frame, inset, *button, glyph_color);
+                if is_selected {
+                    draw_selection_spark(out_frame, rect, Color::rgb(255, 255, 235));
+                }
             }
         }
 
@@ -185,6 +205,21 @@ impl CalculatorShell {
             panel.y() + panel.height() as i32 - 18,
             Color::rgb(225, 232, 242),
         );
+
+        if let Some(button) = self.state.last_button {
+            let badge = UiLayoutGeometryRect::new(display.x() + 154, display.y() + 1, 154, 30);
+            out_frame.fill_rect(
+                Rect::new(badge.x(), badge.y(), badge.width(), badge.height()),
+                button_label_panel_color(button, false, true),
+            );
+            draw_outline(out_frame, badge, Color::rgb(255, 250, 210), 3);
+            draw_button_glyph(
+                out_frame,
+                UiLayoutGeometryRect::new(badge.x() + 40, badge.y() + 6, 72, 20),
+                button,
+                button_glyph_color(button, true),
+            );
+        }
     }
 }
 
@@ -283,6 +318,183 @@ fn draw_outline(
     );
 }
 
+fn draw_selection_spark(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let x = rect.x() + rect.width() as i32 - 12;
+    let y = rect.y() + 4;
+    out_frame.fill_rect(Rect::new(x, y, 6, 2), color);
+    out_frame.fill_rect(Rect::new(x + 2, y - 2, 2, 6), color);
+}
+
+fn draw_button_glyph(
+    out_frame: &mut DrawFrame,
+    rect: UiLayoutGeometryRect,
+    button: CalculatorButton,
+    color: Color,
+) {
+    match button {
+        CalculatorButton::Digit(digit) => draw_digit_glyph(out_frame, rect, digit, color),
+        CalculatorButton::Divide => draw_divide_glyph(out_frame, rect, color),
+        CalculatorButton::Multiply => draw_multiply_glyph(out_frame, rect, color),
+        CalculatorButton::Subtract => draw_subtract_glyph(out_frame, rect, color),
+        CalculatorButton::Add => draw_add_glyph(out_frame, rect, color),
+        CalculatorButton::Clear => draw_clear_glyph(out_frame, rect, color),
+        CalculatorButton::Equals => draw_equals_glyph(out_frame, rect, color),
+    }
+}
+
+fn button_label_panel_color(
+    button: CalculatorButton,
+    is_hovered: bool,
+    is_selected: bool,
+) -> Color {
+    match (button, is_selected, is_hovered) {
+        (CalculatorButton::Digit(_), true, _) => Color::rgb(175, 208, 255),
+        (CalculatorButton::Digit(_), false, true) => Color::rgb(98, 140, 210),
+        (CalculatorButton::Digit(_), false, false) => Color::rgb(72, 104, 160),
+
+        (CalculatorButton::Divide, true, _) => Color::rgb(176, 241, 255),
+        (CalculatorButton::Divide, false, true) => Color::rgb(98, 188, 204),
+        (CalculatorButton::Divide, false, false) => Color::rgb(60, 128, 144),
+
+        (CalculatorButton::Multiply, true, _) => Color::rgb(236, 206, 255),
+        (CalculatorButton::Multiply, false, true) => Color::rgb(164, 122, 210),
+        (CalculatorButton::Multiply, false, false) => Color::rgb(108, 78, 150),
+
+        (CalculatorButton::Subtract, true, _) => Color::rgb(255, 224, 192),
+        (CalculatorButton::Subtract, false, true) => Color::rgb(192, 142, 94),
+        (CalculatorButton::Subtract, false, false) => Color::rgb(132, 92, 56),
+
+        (CalculatorButton::Add, true, _) => Color::rgb(220, 255, 192),
+        (CalculatorButton::Add, false, true) => Color::rgb(142, 196, 88),
+        (CalculatorButton::Add, false, false) => Color::rgb(88, 132, 52),
+
+        (CalculatorButton::Clear, true, _) => Color::rgb(255, 206, 214),
+        (CalculatorButton::Clear, false, true) => Color::rgb(206, 92, 112),
+        (CalculatorButton::Clear, false, false) => Color::rgb(140, 60, 76),
+
+        (CalculatorButton::Equals, true, _) => Color::rgb(226, 220, 255),
+        (CalculatorButton::Equals, false, true) => Color::rgb(146, 132, 210),
+        (CalculatorButton::Equals, false, false) => Color::rgb(92, 86, 146),
+    }
+}
+
+fn button_glyph_color(button: CalculatorButton, is_selected: bool) -> Color {
+    if is_selected {
+        match button {
+            CalculatorButton::Digit(_) => Color::rgb(18, 22, 30),
+            CalculatorButton::Divide
+            | CalculatorButton::Multiply
+            | CalculatorButton::Subtract
+            | CalculatorButton::Add
+            | CalculatorButton::Clear
+            | CalculatorButton::Equals => Color::rgb(18, 22, 30),
+        }
+    } else {
+        Color::WHITE
+    }
+}
+
+fn draw_digit_glyph(
+    out_frame: &mut DrawFrame,
+    rect: UiLayoutGeometryRect,
+    digit: u8,
+    color: Color,
+) {
+    let segments = match digit {
+        0 => [true, true, true, true, true, true, false],
+        1 => [false, true, true, false, false, false, false],
+        2 => [true, true, false, true, true, false, true],
+        3 => [true, true, true, true, false, false, true],
+        4 => [false, true, true, false, false, true, true],
+        5 => [true, false, true, true, false, true, true],
+        6 => [true, false, true, true, true, true, true],
+        7 => [true, true, true, false, false, false, false],
+        8 => [true, true, true, true, true, true, true],
+        9 => [true, true, true, true, false, true, true],
+        _ => [true, true, true, true, true, true, true],
+    };
+
+    let x = rect.x();
+    let y = rect.y();
+    let w = rect.width() as i32;
+    let h = rect.height() as i32;
+    let t_i32 = 2;
+    let t_u32 = 2;
+    let inner_w = (w - 4).max(0) as u32;
+    let half_h = (h / 2 - 2).max(0) as u32;
+
+    if segments[0] {
+        out_frame.fill_rect(Rect::new(x + 2, y, inner_w, t_u32), color);
+    }
+    if segments[1] {
+        out_frame.fill_rect(Rect::new(x + w - t_i32, y + 2, t_u32, half_h), color);
+    }
+    if segments[2] {
+        out_frame.fill_rect(Rect::new(x + w - t_i32, y + (h / 2), t_u32, half_h), color);
+    }
+    if segments[3] {
+        out_frame.fill_rect(Rect::new(x + 2, y + h - t_i32, inner_w, t_u32), color);
+    }
+    if segments[4] {
+        out_frame.fill_rect(Rect::new(x, y + (h / 2), t_u32, half_h), color);
+    }
+    if segments[5] {
+        out_frame.fill_rect(Rect::new(x, y + 2, t_u32, half_h), color);
+    }
+    if segments[6] {
+        out_frame.fill_rect(Rect::new(x + 2, y + (h / 2) - 1, inner_w, t_u32), color);
+    }
+}
+
+fn draw_add_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let cx = rect.x() + rect.width() as i32 / 2;
+    let cy = rect.y() + rect.height() as i32 / 2;
+    out_frame.fill_rect(Rect::new(cx - 7, cy - 1, 14, 2), color);
+    out_frame.fill_rect(Rect::new(cx - 1, cy - 6, 2, 12), color);
+}
+
+fn draw_subtract_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let cy = rect.y() + rect.height() as i32 / 2;
+    let width = rect.width().saturating_sub(8);
+    out_frame.fill_rect(Rect::new(rect.x() + 4, cy - 1, width, 2), color);
+}
+
+fn draw_equals_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let cx = rect.x() + rect.width() as i32 / 2;
+    out_frame.fill_rect(Rect::new(cx - 7, rect.y() + 5, 14, 2), color);
+    out_frame.fill_rect(Rect::new(cx - 7, rect.y() + 10, 14, 2), color);
+}
+
+fn draw_divide_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let x = rect.x() + 18;
+    let y = rect.y() + 3;
+    for step in 0..7 {
+        out_frame.fill_rect(Rect::new(x + step * 2, y + step * 2, 2, 2), color);
+    }
+    out_frame.fill_rect(Rect::new(rect.x() + 8, rect.y() + 2, 3, 3), color);
+    out_frame.fill_rect(Rect::new(rect.x() + 20, rect.y() + 13, 3, 3), color);
+}
+
+fn draw_multiply_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let x = rect.x() + 10;
+    let y = rect.y() + 4;
+    for step in 0..6 {
+        out_frame.fill_rect(Rect::new(x + step * 2, y + step * 2, 2, 2), color);
+        out_frame.fill_rect(Rect::new(x + 10 - step * 2, y + step * 2, 2, 2), color);
+    }
+}
+
+fn draw_clear_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
+    let x = rect.x() + 4;
+    let y = rect.y() + 3;
+    let w = rect.width() - 8;
+    let h = rect.height() - 6;
+    out_frame.fill_rect(Rect::new(x, y, w, 2), color);
+    out_frame.fill_rect(Rect::new(x, y + h as i32 - 2, w, 2), color);
+    out_frame.fill_rect(Rect::new(x, y, 2, h), color);
+    out_frame.fill_rect(Rect::new(x, y + 2, 2, h - 4), color);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,12 +547,22 @@ mod tests {
         assert!(frame.commands().iter().any(|cmd| matches!(
             cmd,
             prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Last calculator intent")
+                if text.contains("Display")
         )));
-        assert!(frame.commands().iter().any(|cmd| matches!(
-            cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text == "7" || text == "+" || text == "C"
-        )));
+        let glyph_fill_count = frame
+            .commands()
+            .iter()
+            .filter(|cmd| {
+                matches!(
+                    cmd,
+                    prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                        if *color == Color::WHITE
+                )
+            })
+            .count();
+        assert!(
+            glyph_fill_count >= 8,
+            "expected visible glyph fill rects, got {glyph_fill_count}"
+        );
     }
 }


### PR DESCRIPTION
This PR makes the PromUI calculator shell manually readable in the native WGPU demo even when `DrawText` is not visibly rendered by the native backend.

It adds shape-based fallback markers for the calculator display and buttons, and strengthens selected-state feedback so button clicks are visible during manual testing.

The calculator remains an inert PromUI-only shell. This PR does not add calculator semantics, does not execute Semantic logic, does not call `smc`, does not add keyboard input, and does not touch VM/verifier/runtime/ABI behavior.
