### PR TITLE
docs(trust): map final Core Trust Freeze readiness

### DIFF
--- a/docs/roadmap/pcc/core_trust_freeze_final_readiness_map.md
+++ b/docs/roadmap/pcc/core_trust_freeze_final_readiness_map.md
@@ -1,0 +1,101 @@
+# CTF-5 — Core Trust Freeze Final Readiness Map
+
+## Status
+
+Status: READINESS MAP / NOT A FREEZE DECLARATION
+
+Core Trust Freeze: NOT DECLARED COMPLETE
+
+This document consolidates the current PCC / CTF evidence after PR #1185 and POST-MERGE-1.
+
+## Baseline
+
+- PR #1185 merge commit: `37a5c8e pcc: sequence ownership conservative contour`
+- post-merge closeout commit: `9fce024 docs(pcc): record sequence ownership post-merge closeout`
+- current work starts from synced `main`
+- old `pcc/sequence-ownership-contract` branch is not the base for future work
+
+## Readiness Classification
+
+- READY FOR FREEZE CONTOUR
+- BLOCKS FREEZE
+- DEFERRED / NON-BLOCKING
+- OUT OF SCOPE
+
+## Freeze-Candidate Contour
+
+| Area | Current evidence | Status | Blocks CTF? | Notes |
+|---|---|---:|---|---|
+| Verifier-first canonical execution route | Canonical route remains `emit SemCode -> verify_semcode -> run_verified_semcode* -> capability-gated boundary`. | READY FOR FREEZE CONTOUR | No | Public execution still goes through verifier-first admission. |
+| `VerifiedSemCode` / `VerifiedEntrySemCode` token route | Verified token route remains the public execution entry. | READY FOR FREEZE CONTOUR | No | This is part of the conservative execution contour, not a freeze declaration. |
+| `sm-format` as SemCode format/decode authority | `sm-format` continues to own SemCode format/decode authority. | READY FOR FREEZE CONTOUR | No | Format ownership remains explicit and narrow. |
+| `sm-vm` trust dependency boundary | VM consumes verified SemCode and does not own format or admission. | READY FOR FREEZE CONTOUR | No | VM semantics remain deterministic and bounded. |
+| `sm-verify` admission boundary | Verifier remains the admission gate, not the executor. | READY FOR FREEZE CONTOUR | No | Admission and execution remain separated. |
+| `prom-cap` dependency boundary | Capability policy remains at the PROMETHEUS boundary. | READY FOR FREEZE CONTOUR | No | No capability-policy widening is implied here. |
+| Raw execution compatibility classification | Raw execution helpers remain compatibility / lower-level surfaces where applicable. | READY FOR FREEZE CONTOUR | No | Compatibility inventory is explicit, not a release claim. |
+| Runtime ownership conservative contour | Conservative runtime ownership contour is closed. | READY FOR FREEZE CONTOUR | No | This closes the narrow runtime contour without claiming symbolic precision. |
+| Record field ownership | Record-field ownership is qualified within the conservative contour. | READY FOR FREEZE CONTOUR | No | Matches the existing runtime ownership closeout. |
+| Tuple index ownership | Tuple index ownership is qualified within the conservative contour. | READY FOR FREEZE CONTOUR | No | Kept aligned with the conservative ownership slice. |
+| ADT payload ownership vocabulary / contour | ADT payload ownership vocabulary remains conservative and qualified. | READY FOR FREEZE CONTOUR | No | No claim of full symbolic precision is made. |
+| Static sequence index ownership | Static sequence ownership is closed and precise. | READY FOR FREEZE CONTOUR | No | Covered by the sequence ownership closeout. |
+| Dynamic sequence fallback `seq[i] -> seq` | Dynamic sequence ownership falls back conservatively to the parent sequence path. | READY FOR FREEZE CONTOUR | No | This is the intended narrow dynamic behavior. |
+| Public claim wording hardening | Public wording has been hardened to avoid claim widening. | READY FOR FREEZE CONTOUR | No | The map preserves that wording discipline. |
+| no_std qualification audit | Full workspace no_std qualification remains separately audited and not claimed. | DEFERRED / NON-BLOCKING | No | The separate no_std lane is not part of the current freeze-candidate contour. |
+
+## Blockers
+
+Within the conservative freeze-candidate contour, no additional hard blocker is identified by this map.
+
+A freeze declaration still requires a separate explicit declaration PR.
+
+## Deferred / Non-Blocking Areas
+
+These are not blockers unless they are explicitly added to the freeze scope:
+
+- full no_std qualification
+- `SequenceIndexDynamic`
+- symbolic dynamic sequence ownership
+- range ownership
+- iterator ownership
+- advanced alias reasoning
+- runtime dynamic-index equality
+- full contract/schema runtime semantics
+- broad Logos/System/Entity/Law qualification
+- UI/Workbench expansion
+- full language completion
+
+## Out of Scope
+
+These remain out of scope for the current conservative contour unless explicitly pulled into the freeze scope:
+
+- release readiness
+- production stability guarantee
+- full embedded/no_std platform support
+- UI product readiness
+- symbolic ownership precision
+- general-purpose alias analysis
+
+## Claim Boundary
+
+Allowed wording:
+
+- conservative freeze-candidate contour
+- verifier-first route qualified
+- runtime ownership conservative contour qualified
+- Core Trust Freeze preparation is advanced
+- Core Trust Freeze is not declared complete
+
+Forbidden wording:
+
+- Core Trust Freeze complete
+- frozen trusted core
+- stable release-ready
+- full no_std qualification
+- full dynamic sequence precision
+- symbolic/range/iterator ownership implemented
+
+## Recommended Next PR
+
+Recommended next slice: `CTF-6 — Core Trust Freeze Declaration Draft`
+
+This recommendation only applies because this map does not identify a hard blocker inside the conservative contour.

--- a/docs/roadmap/pcc/post_merge_sequence_ownership_closeout.md
+++ b/docs/roadmap/pcc/post_merge_sequence_ownership_closeout.md
@@ -1,0 +1,45 @@
+# POST-MERGE-1 - Sequence Ownership Conservative Contour Closeout
+
+## Status
+
+PR `#1185` was merged successfully via squash merge.
+
+Merge commit:
+
+`37a5c8e pcc: sequence ownership conservative contour`
+
+Status:
+
+`CLOSED`
+
+## Closed Contour
+
+The sequence ownership conservative contour is closed.
+
+Qualified behavior remains:
+
+- static sequence indexes are precise;
+- dynamic sequence indexes fall back conservatively to the parent sequence path;
+- symbolic dynamic sequence ownership remains deferred;
+- range ownership remains deferred;
+- iterator ownership remains deferred.
+
+## Trust Boundary
+
+Core Trust Freeze is still not declared complete.
+
+This closeout does not widen trust, release, no_std, symbolic ownership, or runtime precision claims.
+
+## Next Work Base
+
+Future work must start from the synced `main` worktree:
+
+`C:\Users\said3\Desktop\EXOcode\Semantic_phase1_prom_ui`
+
+The old `pcc/sequence-ownership-contract` branch must not be used as the base for new work.
+
+## Branch Cleanup
+
+Branch deletion is intentionally deferred.
+
+The feature branch may be cleaned up later after an additional sanity check.


### PR DESCRIPTION
## Summary

Adds a Core Trust Freeze final readiness map after PR #1185 and POST-MERGE-1.

This consolidates the current PCC / CTF evidence and classifies areas as:

- ready for the conservative freeze-candidate contour
- blockers
- deferred / non-blocking
- out of scope

## Scope

Docs-only audit / readiness map.

## Claims

- Core Trust Freeze is not declared complete.
- This PR does not widen release, no_std, symbolic ownership, or runtime precision claims.
- Deferred areas remain deferred unless explicitly pulled into a future freeze scope.

## Validation

- `cargo fmt --check`
- `cargo test --workspace --all-features`
- `powershell -ExecutionPolicy Bypass -File .\\tools\\7hell\\run.ps1`
- `git diff --check`
