### PR TITLE
docs(trust): record CTF-5 post-merge closeout

### DIFF
--- a/docs/roadmap/pcc/post_merge_ctf5_readiness_map_closeout.md
+++ b/docs/roadmap/pcc/post_merge_ctf5_readiness_map_closeout.md
@@ -1,0 +1,41 @@
+# POST-MERGE-2 - CTF-5 Final Readiness Map Closeout
+
+## Status
+
+PR `#1186` was merged successfully via squash merge.
+
+Merge commit:
+
+`7144bc6 docs(trust): map final Core Trust Freeze readiness (#1186)`
+
+Status:
+
+`CLOSED`
+
+## Closed Slice
+
+CTF-5 closed the final readiness map for the conservative Core Trust Freeze candidate contour.
+
+The map records that, within the conservative freeze-candidate contour, no additional hard blocker is identified.
+
+A Core Trust Freeze declaration still requires a separate explicit declaration PR.
+
+## Trust Boundary
+
+Core Trust Freeze is still not declared complete.
+
+This closeout does not widen release, no_std, symbolic ownership, runtime precision, or stability claims.
+
+## Next Work Base
+
+Future work must start from synced `main`.
+
+The old `docs/ctf-final-readiness-map` branch must not be used as the base for new work.
+
+## Branch Cleanup
+
+The remote PR branch was deleted by GitHub during squash merge.
+
+Local branch cleanup is deferred and may be done later after a sanity check.
+
+Do not add stronger claims.


### PR DESCRIPTION
## Summary

Records the post-merge closeout for PR #1186 / CTF-5.

This closeout documents that the CTF-5 final readiness map was merged and that future work must start from synced main.

## Scope

Docs-only post-merge closeout.

## Claims

- Core Trust Freeze is still not declared complete.
- This PR does not widen release, no_std, symbolic ownership, runtime precision, or stability claims.
- Future work must start from synced main.
- The old docs/ctf-final-readiness-map branch must not be used as the base for new work.

## Validation

- cargo fmt --check
- cargo test --workspace --all-features
- powershell -ExecutionPolicy Bypass -File .\\tools\\7hell\\run.ps1
- git diff --check
