### PR TITLE
docs(trust): record CTF-6 post-merge closeout

### DIFF
--- a/docs/roadmap/pcc/post_merge_ctf6_declaration_draft_closeout.md
+++ b/docs/roadmap/pcc/post_merge_ctf6_declaration_draft_closeout.md
@@ -1,0 +1,53 @@
+# POST-MERGE-3 - CTF-6 Declaration Draft Closeout
+
+## Status
+
+PR `#1188` was merged successfully via squash merge.
+
+Merge commit:
+
+`4ab4cc1 docs(trust): draft Core Trust Freeze declaration (#1188)`
+
+Status:
+
+`CLOSED`
+
+## Closed Slice
+
+CTF-6 closed the Core Trust Freeze declaration draft slice.
+
+The merged document is a draft declaration for the conservative verified core
+contour.
+
+It is not an active Core Trust Freeze declaration.
+
+## Trust Boundary
+
+Core Trust Freeze is still not declared complete.
+
+This closeout does not widen release, no_std, symbolic ownership, runtime
+precision, UI authority, or stability claims.
+
+## Promotion Boundary
+
+The CTF-6 draft records that promotion to an active declaration requires a
+separate final review / declaration PR.
+
+The next planned slice is:
+
+`CTF-6a - Core Trust Freeze Declaration Final Review`
+
+## Next Work Base
+
+Future work must start from synced `main`.
+
+The old `docs/ctf6-freeze-declaration-draft` branch must not be used as the
+base for new work.
+
+## Branch Cleanup
+
+The remote PR branch was deleted by GitHub during squash merge.
+
+Local branch cleanup is deferred and may be done later after a sanity check.
+
+Do not add stronger claims.


### PR DESCRIPTION
## Summary

Records the post-merge closeout for PR #1188 / CTF-6.

This closeout documents that the Core Trust Freeze declaration draft was merged, but remains a draft and not an active freeze declaration.

## Scope

Docs-only post-merge closeout.

## Claims

- Core Trust Freeze is still not declared complete.
- This PR does not widen release, no_std, symbolic ownership, runtime precision, UI authority, or stability claims.
- CTF-6a remains the next final review step before any active declaration.

## Validation

- `cargo fmt --check`
- `cargo test --workspace --all-features`
- `powershell -ExecutionPolicy Bypass -File .\\tools\\7hell\\run.ps1`
- `git diff --check`