### PR TITLE
docs(roadmap): register Pulsar implementation roadmap

### DIFF
--- a/docs/roadmap/language_maturity/core_trust_freeze/index.md
+++ b/docs/roadmap/language_maturity/core_trust_freeze/index.md
@@ -25,6 +25,7 @@ CTF is not a final phase after PCC. It runs across PCC.
 - Waypoint review: `docs/roadmap/language_maturity/core_trust_freeze/ctf_waypoint_review_after_wp1_wp4.md`
 - Evidence backlog: `docs/roadmap/language_maturity/core_trust_freeze/ctf_evidence_backlog.md`
 - Promotion rules: `docs/roadmap/language_maturity/core_trust_freeze/freeze_candidate_promotion_rules.md`
+- Pulsar roadmap: `docs/roadmap/roadmap_pulsar.md`
 - Evidence backlog / promotion waypoint: `CTF-WP5 — define CTF evidence backlog and freeze-candidate promotion rules`
 - Project-root trust policy: `docs/roadmap/language_maturity/core_trust_freeze/project_root_trust_policy.md`
 - Project-root trust waypoint: `CTF-WP6 — docs(core-trust-freeze): define project-root trust policy before PCC-9I`

--- a/docs/roadmap/pcc/core_trust_freeze_active_declaration.md
+++ b/docs/roadmap/pcc/core_trust_freeze_active_declaration.md
@@ -134,4 +134,10 @@ Recommended next PR:
 
 after this declaration PR is reviewed and merged.
 
+## Related Roadmap
+
+Pulsar is the internal packed-state acceleration roadmap and remains subordinate to this active contour:
+
+- [docs/roadmap/roadmap_pulsar.md](../roadmap_pulsar.md)
+
 Do not strengthen claims beyond this.

--- a/docs/roadmap/roadmap_pulsar.md
+++ b/docs/roadmap/roadmap_pulsar.md
@@ -1,0 +1,585 @@
+# Pulsar Roadmap
+
+Status: draft roadmap
+Owner: runtime acceleration / packed-state substrate
+Scope type: documentation only
+
+## Purpose
+
+Pulsar is the code name for the fast Semantic compute core for packed quad-state operations.
+
+Main goal:
+
+- give Semantic a fast low-level substrate for mass processing of N/F/T/S states;
+- do so without violating the active Core Trust Freeze contour.
+
+Pulsar does not replace the current `sm-*` crate owners.
+
+Current authority boundaries remain:
+
+| Area | Owner |
+| --- | --- |
+| SemCode format / decode | `sm-format` |
+| verifier admission | `sm-verify` |
+| VM execution mechanics | `sm-vm` |
+| runtime vocabulary | `sm-runtime-core` |
+| CLI orchestration | `smc-cli` |
+| fast packed-state substrate | `ton618-core` / future `pulsar-*` |
+
+## Architecture Role
+
+Pulsar is not a new language, verifier, or VM.
+
+Pulsar is an internal kernel substrate:
+
+```text
+Semantic / SemCode / VM
+        -> runtime operation
+        -> Pulsar adapter
+        -> packed quad-state kernels
+```
+
+Main tasks:
+
+- packed quadit storage;
+- fast mask extraction;
+- conflict scan;
+- delta scan;
+- batch merge / intersect / inverse;
+- SoA event output;
+- future acceleration backend for runtime state propagation.
+
+## Must Not Become
+
+Pulsar must not become a second owner of:
+
+- SemCode format;
+- verifier admission;
+- VM execution authority;
+- CLI public contract;
+- source language semantics;
+- ownership precision beyond the current conservative contour.
+
+Forbidden claims:
+
+- Pulsar is the new Semantic VM.
+- Pulsar replaces `sm-vm`.
+- Pulsar owns SemCode.
+- Pulsar proves full symbolic ownership.
+- Pulsar makes Semantic release-ready.
+- Pulsar completes no_std qualification.
+
+Correct wording:
+
+- Pulsar is an internal fast packed-state substrate candidate for Semantic runtime acceleration.
+
+## Core Data Model
+
+### Quadit Encoding
+
+```text
+N = 00
+F = 01
+T = 10
+S = 11
+```
+
+One `u64` stores 32 quadits:
+
+```text
+QuadroReg = 64 bits = 32 x 2-bit states
+```
+
+### Bit-Plane Interpretation
+
+- LSB plane = `F` bit
+- MSB plane = `T` bit
+
+Then:
+
+- `N` = no bits
+- `F` = `F` bit
+- `T` = `T` bit
+- `S` = `F` bit + `T` bit
+
+### Core Operations
+
+| Operation | Meaning | Low-level op |
+| --- | --- | --- |
+| merge | join / accumulate | OR |
+| intersect | meet / filter | AND |
+| inverse | swap T/F | bit-plane swap |
+| mask_n | unknown/null states | `!F & !T` |
+| mask_f | strict false | `F & !T` |
+| mask_t | strict true | `T & !F` |
+| mask_s | conflict/super | `F & T` |
+| delta | state transition events | mask difference |
+
+## Repository Layout
+
+Start without crate sprawl.
+
+### Phase 1 Layout
+
+```text
+crates/
+  ton618-core/
+    src/
+      lib.rs
+      ids.rs
+      source.rs
+      diagnostics.rs
+      arena.rs
+      sigtable.rs
+      quadro.rs        # Pulsar seed module
+    benches/
+      quadro_logic.rs  # optional after Q1
+```
+
+### Future Layout, if Pulsar Grows
+
+```text
+crates/
+  pulsar-core/       # packed quad-state primitives
+  pulsar-kernels/    # batch kernels
+  pulsar-bench/      # benchmark harness
+  pulsar-adapter/    # integration adapters into sm-runtime-core/sm-vm
+```
+
+Do not create separate crates in the first phase unless needed.
+
+## Milestones
+
+### P0 - Kernel Boundary Audit
+
+Type: audit / code inspection
+Scope: no behavior changes
+
+Goal:
+
+- confirm Pulsar develops as a substrate, not a new authority owner.
+
+Check:
+
+- where `ton618-core` lives today;
+- which modules already exist;
+- what counts as primitive substrate;
+- where naming confusion can occur;
+- which crates must not be touched in the first phase.
+
+Acceptance:
+
+- current CTF contour does not change;
+- no claim widening;
+- first code slice is selected.
+
+### P1 - Quadro Engine Safety Hardening
+
+Type: code
+Primary target: `crates/ton618-core/src/quadro.rs`
+
+Goal:
+
+- make the packed quad-state engine safe as a public API;
+- make unsafe / SIMD boundaries explicit and honest.
+
+Changes:
+
+1. Move Quadro logic into a separate module:
+
+   - `crates/ton618-core/src/quadro.rs`
+
+2. Add public exports in `lib.rs`.
+
+3. Split safe and unchecked API:
+
+   - `try_set_by_mask(...)`
+   - `set_by_mask_unchecked(...)`
+   - `try_bulk_calc_delta(...)`
+   - `bulk_calc_delta_unchecked(...)`
+
+4. Remove release-mode safety holes:
+
+   - slice lengths are checked outside `debug_assert`;
+   - invalid state does not silently become `N`;
+   - invalid mask does not pass through public safe API.
+
+5. Feature cleanup:
+
+   - bench requires `std`;
+   - `simd` is optional;
+   - `no_std` without `alloc` still compiles where intended.
+
+6. x86 cfg cleanup:
+
+   - x86_64 uses `core::arch::x86_64`;
+   - x86 is either explicitly supported or removed from cfg.
+
+Acceptance:
+
+```text
+cargo fmt --check
+cargo clippy -p ton618-core --all-targets --all-features -- -D warnings
+cargo test -p ton618-core --all-features
+cargo check -p ton618-core --no-default-features
+cargo check -p ton618-core --no-default-features --features alloc
+```
+
+Non-goals:
+
+- no VM integration;
+- no SemCode changes;
+- no verifier changes;
+- no CTF scope widening.
+
+### P2 - Quadro Microbench Harness
+
+Type: benchmark / measurement
+Depends on: P1
+
+Goal:
+
+- measure real speed of packed quad-state primitives.
+
+Add:
+
+- `crates/ton618-core/benches/quadro_logic.rs`
+
+Benchmark workloads:
+
+| Benchmark | Description |
+| --- | --- |
+| `qreg_merge` | OR over packed quadits |
+| `qreg_intersect` | AND over packed quadits |
+| `qreg_inverse` | T/F plane swap |
+| `qreg_masks_all` | extract N/F/T/S masks |
+| `qreg_calc_delta` | scalar delta |
+| `qbank_merge_inplace` | bank batch merge |
+| `qbank_calc_delta_soa` | batch delta SoA |
+| `vec_u8_baseline_delta` | simple baseline |
+| `enum_baseline_delta` | optional enum baseline |
+
+Metrics:
+
+- ns/op
+- regs/sec
+- quadits/sec
+- approximate bytes/sec
+
+Acceptance:
+
+```text
+cargo bench -p ton618-core
+cargo test -p ton618-core --all-features
+```
+
+Benchmark rule:
+
+- do not claim performance without recorded benchmark output.
+
+### P3 - Correctness Vectors
+
+Type: tests
+Depends on: P1
+
+Goal:
+
+- prove bit-for-bit correctness of quad algebra.
+
+Add tests for:
+
+- all 16 `merge` truth table combinations;
+- all 16 `intersect` combinations;
+- inverse truth table;
+- mask extraction for N/F/T/S;
+- mask alignment;
+- delta transitions;
+- random scalar vs batch equivalence;
+- SIMD vs scalar equivalence when SIMD is enabled.
+
+Acceptance:
+
+```text
+cargo test -p ton618-core --all-features
+cargo test -p ton618-core --no-default-features --features alloc
+```
+
+### P4 - Shadow Adapter Design
+
+Type: code / test, no production behavior change
+Depends on: P1 + P3
+
+Goal:
+
+- connect Pulsar as a shadow calculation path without changing runtime behavior.
+
+Shape:
+
+```text
+existing runtime path -> result A
+Pulsar packed path   -> result B
+assert_eq!(A, B)
+```
+
+First application areas:
+
+- conflict masks;
+- known masks;
+- state delta;
+- simple batch ownership masks.
+
+Acceptance:
+
+- adapter compiled behind a feature flag;
+- default runtime behavior unchanged;
+- tests compare old path and Pulsar path;
+- no public claim widening.
+
+Feature name example:
+
+- `pulsar-shadow`
+
+### P5 - Runtime Acceleration Candidate
+
+Type: controlled implementation
+Depends on: P2 + P4
+
+Goal:
+
+- use Pulsar as an internal acceleration backend only for proven identical operations.
+
+Allowed first candidates:
+
+| Operation | Why |
+| --- | --- |
+| conflict scan | direct `mask_s` |
+| known mask scan | direct `mask_non_null` |
+| state delta | already modeled |
+| batch merge | pure OR |
+| batch intersect | pure AND |
+
+Not allowed yet:
+
+- symbolic ownership;
+- dynamic index precision;
+- range ownership;
+- iterator ownership;
+- new SemCode vocabulary;
+- verifier admission changes.
+
+Acceptance:
+
+- old tests still pass;
+- new accelerated path has scalar fallback;
+- benchmark shows improvement;
+- behavior equivalence is proven by tests;
+- feature-gated rollout.
+
+### P6 - Promotion Review
+
+Type: trust review
+Depends on: P5
+
+Goal:
+
+- decide whether Pulsar can be treated as part of a frozen internal implementation contour without widening public trust claims.
+
+Promotion criteria:
+
+- correctness vectors green;
+- shadow-mode equivalence green;
+- benchmark advantage recorded;
+- unsafe boundaries reviewed;
+- no new authority ownership introduced;
+- public docs do not claim release readiness.
+
+If promoted:
+
+- Pulsar becomes an internal acceleration backend for selected operations.
+
+If not promoted:
+
+- Pulsar remains an experimental substrate.
+
+## Safety Rules
+
+### Public Safe API
+
+Public safe API must not rely only on `debug_assert`.
+
+Bad:
+
+```rust
+pub fn set_by_mask(mask, state) { debug_assert!(valid); ... }
+```
+
+Good:
+
+```rust
+pub fn try_set_by_mask(mask, state) -> Result<Self, Error>
+```
+
+Hot path:
+
+```rust
+unsafe fn set_by_mask_unchecked(...)
+```
+
+### Unsafe Boundary
+
+All unsafe SIMD functions must be internal and called only after:
+
+- length checks;
+- alignment decision;
+- architecture feature check;
+- fallback path exists.
+
+### Alignment
+
+Default SIMD path should remain unaligned-safe.
+
+Aligned path may be added only as:
+
+- `aligned_unchecked`
+
+and only called when alignment is proven.
+
+### Feature Policy
+
+- `std` = runtime detection / benchmarking / timing
+- `alloc` = `Vec` / `String` backed structures
+- `simd` = explicit acceleration backend
+- `bench` = requires `std`
+
+## Benchmark Policy
+
+Do not accept benchmark results without:
+
+- CPU model;
+- target triple;
+- Rust version;
+- build flags;
+- features;
+- debug / release mode;
+- iteration count;
+- input size;
+- baseline comparison.
+
+Recommended command:
+
+```text
+cargo bench -p ton618-core --features "std simd bench"
+```
+
+Optional native CPU run:
+
+```powershell
+$env:RUSTFLAGS="-C target-cpu=native"
+cargo bench -p ton618-core --features "std simd bench"
+```
+
+## Integration Policy with CTF
+
+Current Core Trust Freeze remains active only for the conservative verified core contour.
+
+Pulsar work must not widen:
+
+- SemCode format authority;
+- verifier admission;
+- VM execution authority;
+- runtime ownership semantics;
+- public release claims.
+
+Pulsar integration must go through:
+
+```text
+standalone module
+-> correctness tests
+-> benchmarks
+-> shadow adapter
+-> promotion review
+-> controlled acceleration
+```
+
+## First Three Implementation Slices
+
+### Slice 1 - PULSAR-Q1 Safety Seed
+
+Likely touched files:
+
+- `crates/ton618-core/src/lib.rs`
+- `crates/ton618-core/src/quadro.rs`
+- `crates/ton618-core/Cargo.toml`
+
+Goal:
+
+- introduce Quadro engine safely, with checked API and tests.
+
+Do not touch:
+
+- `sm-vm`
+- `sm-verify`
+- `sm-format`
+- `sm-runtime-core`
+- SemCode
+- CI workflows
+- `README.md`
+
+### Slice 2 - PULSAR-Q2 Correctness Matrix
+
+Likely touched files:
+
+- `crates/ton618-core/src/quadro.rs`
+- `crates/ton618-core/tests/quadro_logic.rs`
+
+Goal:
+
+- truth tables, mask tests, delta tests, scalar / batch equivalence.
+
+### Slice 3 - PULSAR-Q3 Bench Harness
+
+Likely touched files:
+
+- `crates/ton618-core/benches/quadro_logic.rs`
+- `crates/ton618-core/Cargo.toml`
+
+Goal:
+
+- measure packed engine against scalar baseline workloads.
+
+## Definition of Done for Pulsar v0
+
+Pulsar v0 is complete when:
+
+- Quadro engine exists as an isolated module;
+- safe API is checked;
+- unsafe SIMD boundary is narrow;
+- `no_std` / `alloc` posture is preserved;
+- correctness matrix passes;
+- scalar and batch paths match;
+- benchmark harness exists;
+- benchmark output reports quadits/sec;
+- no current CTF authority boundary is widened;
+- no public release / no_std / symbolic precision claim is added.
+
+## Related Docs
+
+- CTF overview: [docs/roadmap/language_maturity/core_trust_freeze/index.md](language_maturity/core_trust_freeze/index.md)
+- CTF readiness map: [docs/roadmap/pcc/core_trust_freeze_final_readiness_map.md](pcc/core_trust_freeze_final_readiness_map.md)
+- CTF active declaration: [docs/roadmap/pcc/core_trust_freeze_active_declaration.md](pcc/core_trust_freeze_active_declaration.md)
+- CTF final review: [docs/roadmap/pcc/core_trust_freeze_declaration_final_review.md](pcc/core_trust_freeze_declaration_final_review.md)
+- CTF draft declaration: [docs/roadmap/pcc/core_trust_freeze_declaration_draft.md](pcc/core_trust_freeze_declaration_draft.md)
+
+## Final Principle
+
+Pulsar should be treated as:
+
+- a fast internal semantic-state engine
+
+not as:
+
+- a new public Semantic authority.
+
+The goal is not to replace the frozen core.
+
+The goal is to make the frozen core faster from underneath.

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -11,6 +11,12 @@ Release-freeze checkpoint after `v0.1`/`v0.2`/`v0.3` close-out:
 
 This document tracks the next four closure tracks to move Semantic from "working" to "production-disciplined".
 
+For the next implementation slice, see the internal packed-state substrate roadmap:
+
+- `docs/roadmap/roadmap_pulsar.md`
+
+Pulsar is a planned internal packed-state substrate roadmap. It does not widen the active Core Trust Freeze contour.
+
 Current status:
 - `NEXT-1..NEXT-4` are completed for the current post-`v1.1.1` closure layer.
 - this document now serves as a close-out record for those tracks, not as an

--- a/tests/legacy_guards.rs
+++ b/tests/legacy_guards.rs
@@ -319,6 +319,7 @@ fn ton618_content_inventory_is_explicit() {
         "./docs/roadmap/language_maturity/root_legacy_cleanup_full_scope.md",
         "./docs/roadmap/language_maturity/ton618_compatibility_perimeter_scope.md",
         "./docs/roadmap/pcc/ctf_no_std_qualification_audit.md",
+        "./docs/roadmap/roadmap_pulsar.md",
         "./docs/roadmap/m_tail_closeout.md",
         "./docs/roadmap/tail_t5_legacy_perimeter_check.md",
         "./src/bin/ton618_core.rs",


### PR DESCRIPTION
## Summary

Registers Pulsar as a planned internal packed-state substrate roadmap.

## Scope

- Adds Pulsar roadmap visibility.
- Adds conservative cross-links from existing roadmap/CTF documents.
- Updates legacy TON618 content inventory so the new roadmap mention remains explicit.

## Claims

- Pulsar does not widen the active Core Trust Freeze contour.
- Pulsar is not a replacement for sm-vm, sm-format, sm-verify, or SemCode authority.
- Pulsar is a planned internal packed-state substrate roadmap for future acceleration work.

## Validation

Local:
- cargo fmt --check
- git diff --check
- cargo test --test legacy_guards ton618_content_inventory_is_explicit -- --nocapture
- cargo test --test legacy_guards ton618_named_path_inventory_is_explicit -- --nocapture
- cargo test --workspace --all-features
- powershell -ExecutionPolicy Bypass -File .\\tools\\7hell\\run.ps1

CI:
- pending after f6125e8
