### PR TITLE
feat(pulsar): export Quadro substrate at ton618-core root

### DIFF
--- a/crates/ton618-core/src/lib.rs
+++ b/crates/ton618-core/src/lib.rs
@@ -23,6 +23,12 @@ pub mod source;
 pub use arena::{Arena, ArenaId};
 pub use diagnostics::{DiagLevel, Diagnostic};
 pub use ids::{ExprId, StmtId, SymbolId};
+pub use quadro::{
+    iter_mask_indices, QuadMasks, QuadState, QuadroError, QuadroReg, StateDelta, LSB_MASK,
+    MSB_MASK, QUADIT_COUNT, QUADIT_WIDTH,
+};
+#[cfg(feature = "alloc")]
+pub use quadro::{DeltaSoA, MaskIndexIter, QuadroBank};
 #[cfg(feature = "alloc")]
 pub use sigtable::SigTable;
 pub use source::{FileId, SourceMark, Span};


### PR DESCRIPTION
## Summary

Exports the existing Quadro substrate API from `ton618-core` crate root.

This is a narrow public substrate API patch only. It does not change VM execution, verifier admission, SemCode format, CTF policy, capability behavior, or PROMETHEUS boundaries.

## Changes

Re-exported from `crates/ton618-core/src/lib.rs`:

- `QuadState`
- `QuadroError`
- `QuadroReg`
- `QuadMasks`
- `StateDelta`
- `iter_mask_indices`
- `LSB_MASK`
- `MSB_MASK`
- `QUADIT_COUNT`
- `QUADIT_WIDTH`

Alloc-gated re-exports:

- `DeltaSoA`
- `MaskIndexIter`
- `QuadroBank`

## Validation

- `cargo fmt --check`
- `cargo clippy -p ton618-core --all-targets --all-features -- -D warnings`
- `cargo check -p ton618-core --no-default-features`
- `cargo check -p ton618-core --no-default-features --features alloc`
- `cargo test -p ton618-core --all-features`
- `cargo test --workspace --all-features`
- `powershell -ExecutionPolicy Bypass -File .\tools\7hell\run.ps1`
- `git diff --check`

## Boundary

No changes to:

- VM
- verifier
- SemCode format
- CTF
- PROMETHEUS integration
- capability policy
- docs contracts

## Risk

Low. This PR only exposes already-existing substrate items at the crate root.
