### PR TITLE
docs(spec): clarify quad equality and evidence algebra boundary

### DIFF
--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -609,6 +609,36 @@ Current `if` expression semantics:
 `quad` is intentionally not treated as an implicit condition type. Users must
 write explicit comparisons.
 
+### Quad values and control flow
+
+`quad` values do not implicitly control execution flow.
+
+`if` conditions must evaluate to `bool`.
+
+A `quad` value may enter control flow only through an explicit predicate, such
+as:
+
+```sm
+if signal == T {
+    ...
+}
+```
+
+or through explicit `match` handling:
+
+```sm
+match signal {
+    T => { ... }
+    F => { ... }
+    N => { ... }
+    S => { ... }
+    _ => { ... }
+}
+```
+
+This prevents semantic uncertainty or conflict from silently selecting a
+control-flow branch.
+
 Current v0 limit:
 
 - `else if` sugar is not yet supported for value-producing `if`; users must

--- a/docs/spec/types.md
+++ b/docs/spec/types.md
@@ -143,6 +143,50 @@ Current rules:
   standard-form `Option(T)` / `Result(T, E)` families
 - `quad` is not accepted directly as an `if` condition
 
+### Quad equality
+
+`quad == quad` is a structural identity predicate.
+
+It returns `bool`, not `quad`.
+
+Examples:
+
+- `N == N` -> `true`
+- `F == F` -> `true`
+- `T == T` -> `true`
+- `S == S` -> `true`
+- `N == S` -> `false`
+- `T == S` -> `false`
+- `T == F` -> `false`
+
+This operator does not perform semantic inference, evidence merging,
+consensus detection, or conflict resolution.
+
+`==` and `!=` are identity predicates.
+They always return `bool`.
+They never return `quad`.
+They never drive control flow through implicit `quad` coercion.
+
+Identity predicates answer whether two values have the same source/runtime
+state.
+
+Evidence operators operate on T/F evidence planes and return `quad`.
+
+Therefore:
+
+- `S == S` -> `true : bool`
+- `S && S` -> `S : quad`
+- `S || T` -> `S : quad`
+- `if S` -> rejected
+- `if signal == S` -> admitted because the condition is `bool`
+
+| Family | Example | Result type | Meaning |
+| --- | --- | --- | --- |
+| Identity predicate | `a == b` | `bool` | same value state |
+| Evidence algebra | `a && b`, `a || b`, `!a`, `a -> b` | `quad` | T/F evidence-plane operation |
+| Control-flow predicate | `a == T`, `a == S` | `bool` | explicit boolean condition |
+| Future semantic helper | `quad_consensus(a, b)` | explicit API-defined type | policy-defined analysis |
+
 ## Standard Forms
 
 Current first-wave standard forms:


### PR DESCRIPTION
## Summary

Clarifies the source-level boundary between `quad` evidence algebra, structural equality, and `bool` control flow.

This documents that `quad == quad` is a structural identity predicate returning `bool`, not `quad`.

## Scope

- Documents `quad` equality behavior.
- Clarifies that `==` / `!=` are identity predicates.
- Clarifies that evidence algebra returns `quad`.
- Clarifies that `if` remains `bool`-only.
- Adds examples such as `S == S -> true : bool` and `S && S -> S : quad`.

## Boundary

No changes to:

- Rust code
- parser
- typechecker
- IR
- SemCode
- verifier
- VM
- Pulsar / `ton618-core`
- PROMETHEUS
- CTF contour
- CI workflows

## Validation

- `cargo fmt --check`
- `git diff --check`

## Risk

Low. Docs-only clarification of existing language/type semantics.
