### PR TITLE
docs(pulsar): specify shadow adapter evidence contract

### DIFF
--- a/docs/roadmap/roadmap_pulsar.md
+++ b/docs/roadmap/roadmap_pulsar.md
@@ -432,6 +432,62 @@ Feature name example:
 
 - `pulsar-shadow`
 
+### P4-A - Shadow Adapter Evidence Contract
+
+Type: docs / evidence contract
+Depends on: P4
+
+Goal:
+
+- define how the baseline path and the Pulsar path are compared before any implementation slice expands beyond shadow-only evidence.
+
+Evidence contract:
+
+```text
+baseline path A
+Pulsar path B
+A == B bit-for-bit for the selected target
+if A != B -> build a local diagnostic report, then fail the test or fuzz case
+```
+
+Required mismatch evidence:
+
+- operation name;
+- input case id or fuzz seed, when available;
+- register index;
+- first differing quadit index, when applicable;
+- baseline raw register / mask / delta;
+- Pulsar raw register / mask / delta;
+- old and new state for delta comparisons;
+- CPU feature path, such as scalar, SIMD, AVX2, NEON, or fallback;
+- enabled Cargo features;
+- compact human-readable summary.
+
+This is local diagnostic evidence only.
+It must not introduce telemetry, remote reporting, runtime behavior changes, VM authority changes, verifier changes, SemCode changes, CTF widening, or PROMETHEUS boundary changes.
+
+P4-A first shadow targets:
+
+| Target | Reason |
+| --- | --- |
+| conflict mask calculation | direct mask projection with no behavior widening |
+| known mask calculation | stable structural comparison target |
+| state delta comparison | already modeled by scalar delta outputs |
+| batch merge equivalence | pure OR-style structural check |
+| batch intersect equivalence | pure AND-style structural check |
+
+P4-A non-goals:
+
+- runtime acceleration;
+- SemCode vocabulary changes;
+- verifier logic changes;
+- VM dispatch changes;
+- symbolic ownership;
+- range ownership;
+- iterator ownership;
+- new public Semantic API claims;
+- release readiness wording.
+
 ### P5 - Runtime Acceleration Candidate
 
 Type: controlled implementation


### PR DESCRIPTION
## Summary

Specifies the P4-A shadow adapter evidence contract for Pulsar.

This docs-only PR defines how baseline path A and Pulsar path B are compared, what local diagnostic evidence is required on mismatch, and which shadow targets are allowed first.

## Scope

- Adds a P4-A evidence contract section to `docs/roadmap/roadmap_pulsar.md`.
- Keeps the shadow path test-only / shadow-only and feature-gated by roadmap policy.
- Clarifies first shadow targets and mismatch diagnostics.
- Keeps P5 blocked until P4 evidence exists.

## Claims

- Pulsar does not widen the active Core Trust Freeze contour.
- No VM, verifier, SemCode, runtime, or PROMETHEUS authority boundaries change.
- This PR does not introduce runtime acceleration or implementation code.
- This PR does not claim release readiness, production stability, or full no_std qualification.

## Validation

- `cargo fmt --check`
- `git diff --check`
