### PR TITLE
test(sm-vm): add local opcode profiling harness

### DIFF
--- a/crates/sm-vm/Cargo.toml
+++ b/crates/sm-vm/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 [features]
 default = ["std"]
 std = ["sm-runtime-core/std", "sm-verify/std", "prom-abi/std", "prom-cap/std"]
-vm-profile = ["disasm"]
+vm-profile = []
 disasm = []
 
 [dependencies]

--- a/crates/sm-vm/Cargo.toml
+++ b/crates/sm-vm/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 [features]
 default = ["std"]
 std = ["sm-runtime-core/std", "sm-verify/std", "prom-abi/std", "prom-cap/std"]
+vm-profile = ["disasm"]
 disasm = []
 
 [dependencies]

--- a/crates/sm-vm/src/lib.rs
+++ b/crates/sm-vm/src/lib.rs
@@ -30,6 +30,7 @@ mod tests {
     use super::*;
     use sm_emit::compile_program_to_semcode;
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn sm_vm_smoke_run() {
         let src = "fn main() { return; }";

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -95,6 +95,257 @@ pub struct VM {
     pub prng_state: u64,
 }
 
+trait OpcodeProfileSink {
+    fn record_opcode(&mut self, opcode: Opcode);
+}
+
+struct NoopOpcodeProfile;
+
+impl OpcodeProfileSink for NoopOpcodeProfile {
+    #[inline(always)]
+    fn record_opcode(&mut self, _opcode: Opcode) {}
+}
+
+#[cfg(feature = "vm-profile")]
+const OPCODE_PROFILE_SLOT_COUNT: usize = 69;
+
+#[cfg(feature = "vm-profile")]
+const OPCODE_PROFILE_OPCODES: [Opcode; OPCODE_PROFILE_SLOT_COUNT] = [
+    Opcode::LoadQ,
+    Opcode::LoadBool,
+    Opcode::LoadI32,
+    Opcode::AddI32,
+    Opcode::SubI32,
+    Opcode::MulI32,
+    Opcode::DivI32,
+    Opcode::ModI32,
+    Opcode::ConcatText,
+    Opcode::LoadU32,
+    Opcode::LoadVar,
+    Opcode::StoreVar,
+    Opcode::QAnd,
+    Opcode::QOr,
+    Opcode::QNot,
+    Opcode::QImpl,
+    Opcode::BoolAnd,
+    Opcode::BoolOr,
+    Opcode::BoolNot,
+    Opcode::CmpEq,
+    Opcode::CmpNe,
+    Opcode::CmpI32Lt,
+    Opcode::CmpI32Le,
+    Opcode::Jmp,
+    Opcode::JmpIf,
+    Opcode::Call,
+    Opcode::Ret,
+    Opcode::Assert,
+    Opcode::MakeTuple,
+    Opcode::TupleGet,
+    Opcode::MakeRecord,
+    Opcode::RecordGet,
+    Opcode::MakeAdt,
+    Opcode::AdtTag,
+    Opcode::AdtGet,
+    Opcode::LoadF64,
+    Opcode::AddF64,
+    Opcode::SubF64,
+    Opcode::MulF64,
+    Opcode::DivF64,
+    Opcode::LoadFx,
+    Opcode::AddFx,
+    Opcode::SubFx,
+    Opcode::MulFx,
+    Opcode::DivFx,
+    Opcode::LoadText,
+    Opcode::MakeSequence,
+    Opcode::SequenceGet,
+    Opcode::MakeClosure,
+    Opcode::ClosureCall,
+    Opcode::SequenceLen,
+    Opcode::SequenceIsEmpty,
+    Opcode::SequenceContains,
+    Opcode::SequencePush,
+    Opcode::SequencePrepend,
+    Opcode::SequencePop,
+    Opcode::MapEmpty,
+    Opcode::MapContains,
+    Opcode::MapGet,
+    Opcode::MapSet,
+    Opcode::RngSeed,
+    Opcode::RngNextI32,
+    Opcode::GateRead,
+    Opcode::GateWrite,
+    Opcode::PulseEmit,
+    Opcode::StateQuery,
+    Opcode::StateUpdate,
+    Opcode::EventPost,
+    Opcode::ClockRead,
+];
+
+#[cfg(feature = "vm-profile")]
+fn opcode_profile_index(opcode: Opcode) -> usize {
+    match opcode {
+        Opcode::LoadQ => 0,
+        Opcode::LoadBool => 1,
+        Opcode::LoadI32 => 2,
+        Opcode::AddI32 => 3,
+        Opcode::SubI32 => 4,
+        Opcode::MulI32 => 5,
+        Opcode::DivI32 => 6,
+        Opcode::ModI32 => 7,
+        Opcode::ConcatText => 8,
+        Opcode::LoadU32 => 9,
+        Opcode::LoadVar => 10,
+        Opcode::StoreVar => 11,
+        Opcode::QAnd => 12,
+        Opcode::QOr => 13,
+        Opcode::QNot => 14,
+        Opcode::QImpl => 15,
+        Opcode::BoolAnd => 16,
+        Opcode::BoolOr => 17,
+        Opcode::BoolNot => 18,
+        Opcode::CmpEq => 19,
+        Opcode::CmpNe => 20,
+        Opcode::CmpI32Lt => 21,
+        Opcode::CmpI32Le => 22,
+        Opcode::Jmp => 23,
+        Opcode::JmpIf => 24,
+        Opcode::Call => 25,
+        Opcode::Ret => 26,
+        Opcode::Assert => 27,
+        Opcode::MakeTuple => 28,
+        Opcode::TupleGet => 29,
+        Opcode::MakeRecord => 30,
+        Opcode::RecordGet => 31,
+        Opcode::MakeAdt => 32,
+        Opcode::AdtTag => 33,
+        Opcode::AdtGet => 34,
+        Opcode::LoadF64 => 35,
+        Opcode::AddF64 => 36,
+        Opcode::SubF64 => 37,
+        Opcode::MulF64 => 38,
+        Opcode::DivF64 => 39,
+        Opcode::LoadFx => 40,
+        Opcode::AddFx => 41,
+        Opcode::SubFx => 42,
+        Opcode::MulFx => 43,
+        Opcode::DivFx => 44,
+        Opcode::LoadText => 45,
+        Opcode::MakeSequence => 46,
+        Opcode::SequenceGet => 47,
+        Opcode::MakeClosure => 48,
+        Opcode::ClosureCall => 49,
+        Opcode::SequenceLen => 50,
+        Opcode::SequenceIsEmpty => 51,
+        Opcode::SequenceContains => 52,
+        Opcode::SequencePush => 53,
+        Opcode::SequencePrepend => 54,
+        Opcode::SequencePop => 55,
+        Opcode::MapEmpty => 56,
+        Opcode::MapContains => 57,
+        Opcode::MapGet => 58,
+        Opcode::MapSet => 59,
+        Opcode::RngSeed => 60,
+        Opcode::RngNextI32 => 61,
+        Opcode::GateRead => 62,
+        Opcode::GateWrite => 63,
+        Opcode::PulseEmit => 64,
+        Opcode::StateQuery => 65,
+        Opcode::StateUpdate => 66,
+        Opcode::EventPost => 67,
+        Opcode::ClockRead => 68,
+    }
+}
+
+#[cfg(feature = "vm-profile")]
+#[allow(dead_code)]
+fn opcode_from_profile_index(index: usize) -> Option<Opcode> {
+    OPCODE_PROFILE_OPCODES.get(index).copied()
+}
+
+#[cfg(feature = "vm-profile")]
+#[derive(Debug, Clone)]
+pub struct VmOpcodeProfile {
+    total_instructions: u64,
+    opcode_counts: [u64; OPCODE_PROFILE_SLOT_COUNT],
+}
+
+#[cfg(feature = "vm-profile")]
+impl Default for VmOpcodeProfile {
+    fn default() -> Self {
+        Self {
+            total_instructions: 0,
+            opcode_counts: [0; OPCODE_PROFILE_SLOT_COUNT],
+        }
+    }
+}
+
+#[cfg(feature = "vm-profile")]
+impl VmOpcodeProfile {
+    pub fn total_instructions(&self) -> u64 {
+        self.total_instructions
+    }
+
+    pub fn count(&self, opcode: Opcode) -> u64 {
+        self.opcode_counts[opcode_profile_index(opcode)]
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_instructions == 0
+    }
+
+    pub fn top_n(&self, n: usize) -> Vec<(Opcode, u64)> {
+        if n == 0 {
+            return Vec::new();
+        }
+        let mut entries: Vec<(usize, Opcode, u64)> = OPCODE_PROFILE_OPCODES
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &opcode)| {
+                let count = self.opcode_counts[index];
+                (count > 0).then_some((index, opcode, count))
+            })
+            .collect();
+        entries.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0)));
+        entries
+            .into_iter()
+            .take(n)
+            .map(|(_, opcode, count)| (opcode, count))
+            .collect()
+    }
+
+    pub fn summary_top_n(&self, n: usize) -> String {
+        use std::fmt::Write as _;
+
+        let top = self.top_n(n);
+        let mut out = String::new();
+        let _ = write!(
+            &mut out,
+            "sm-vm opcode profile: total_instructions={} top={}",
+            self.total_instructions,
+            top.len()
+        );
+        for (opcode, count) in top {
+            let _ = write!(&mut out, "\n  {:?}: {}", opcode, count);
+        }
+        out
+    }
+
+    fn record_opcode_slot(&mut self, opcode: Opcode) {
+        self.total_instructions = self.total_instructions.saturating_add(1);
+        let index = opcode_profile_index(opcode);
+        self.opcode_counts[index] = self.opcode_counts[index].saturating_add(1);
+    }
+}
+
+#[cfg(feature = "vm-profile")]
+impl OpcodeProfileSink for VmOpcodeProfile {
+    #[inline(always)]
+    fn record_opcode(&mut self, opcode: Opcode) {
+        self.record_opcode_slot(opcode);
+    }
+}
+
 enum HelloObservationMode<'a> {
     Discard,
     Collect(&'a mut Vec<HelloObservationEvent>),
@@ -434,6 +685,33 @@ pub fn run_verified_entry_semcode_with_config(
         HelloObservationRuntime::discard(),
     )
     .map(|_| ())
+}
+
+/// Local opcode profiling path for verified token execution.
+///
+/// This is a feature-gated, local measurement harness that collects opcode
+/// execution counts for verified VM execution. It does not change VM semantics
+/// and it is not production telemetry.
+#[cfg(feature = "vm-profile")]
+pub fn run_verified_entry_semcode_with_profile(
+    token: &VerifiedEntrySemCode<'_, '_>,
+    config: ExecutionConfig,
+) -> Result<VmOpcodeProfile, RuntimeError> {
+    let program = prepare_verified_execution(token)?;
+    let mut vm = VM {
+        functions: program.functions,
+        callstack: Vec::new(),
+        config,
+        effect_calls: 0,
+        symbols: program.runtime_symbols,
+        prng_state: 0,
+    };
+    push_frame(&mut vm, token.entry(), Vec::new(), None)?;
+    let mut bridge = LegacyVmHost;
+    let mut observation = HelloObservationRuntime::discard();
+    let mut profile = VmOpcodeProfile::default();
+    exec_loop_with_profile(&mut vm, &mut bridge, &mut observation, &mut profile)?;
+    Ok(profile)
 }
 
 /// Raw execution path.
@@ -1123,6 +1401,20 @@ fn exec_loop<'a, H: VmHostBridge>(
     host: &mut H,
     observation: &mut HelloObservationRuntime<'a>,
 ) -> Result<(), RuntimeError> {
+    let mut profile = NoopOpcodeProfile;
+    exec_loop_with_profile(vm, host, observation, &mut profile)
+}
+
+fn exec_loop_with_profile<'a, H, P>(
+    vm: &mut VM,
+    host: &mut H,
+    observation: &mut HelloObservationRuntime<'a>,
+    profile: &mut P,
+) -> Result<(), RuntimeError>
+where
+    H: VmHostBridge,
+    P: OpcodeProfileSink,
+{
     loop {
         let Some(frame_idx) = vm.callstack.len().checked_sub(1) else {
             return Ok(());
@@ -1144,6 +1436,7 @@ fn exec_loop<'a, H: VmHostBridge>(
         let mut cur = f.instr_start + pc;
         let opcode = Opcode::from_byte(read_u8(&f.code, &mut cur).map_err(map_format_err)?)
             .map_err(map_format_err)?;
+        profile.record_opcode(opcode);
         let next_pc: usize;
 
         match opcode {
@@ -2883,6 +3176,63 @@ mod tests {
     use sm_runtime_core::{
         ExecutionConfig, ExecutionContext, PathComponent, QuotaExceeded, QuotaKind, RuntimeTrap,
     };
+
+    #[cfg(feature = "vm-profile")]
+    mod profile_tests {
+        use super::*;
+        use sm_emit::Opcode;
+
+        #[test]
+        fn opcode_profile_starts_empty_and_records_counts() {
+            let mut profile = VmOpcodeProfile::default();
+            assert!(profile.is_empty());
+            assert_eq!(profile.total_instructions(), 0);
+            assert_eq!(profile.count(Opcode::LoadQ), 0);
+            assert!(profile.top_n(0).is_empty());
+
+            profile.record_opcode_slot(Opcode::LoadQ);
+            profile.record_opcode_slot(Opcode::LoadQ);
+            profile.record_opcode_slot(Opcode::QAnd);
+
+            assert!(!profile.is_empty());
+            assert_eq!(profile.total_instructions(), 3);
+            assert_eq!(profile.count(Opcode::LoadQ), 2);
+            assert_eq!(profile.count(Opcode::QAnd), 1);
+            assert_eq!(profile.count(Opcode::Ret), 0);
+        }
+
+        #[test]
+        fn opcode_profile_ranks_and_summarizes_top_entries() {
+            let mut profile = VmOpcodeProfile::default();
+            profile.record_opcode_slot(Opcode::LoadQ);
+            profile.record_opcode_slot(Opcode::LoadQ);
+            profile.record_opcode_slot(Opcode::QAnd);
+            profile.record_opcode_slot(Opcode::QAnd);
+            profile.record_opcode_slot(Opcode::QAnd);
+            profile.record_opcode_slot(Opcode::CmpEq);
+
+            let top = profile.top_n(3);
+            assert_eq!(top.len(), 3);
+            assert_eq!(top[0], (Opcode::QAnd, 3));
+            assert_eq!(top[1], (Opcode::LoadQ, 2));
+            assert_eq!(top[2], (Opcode::CmpEq, 1));
+
+            let summary = profile.summary_top_n(3);
+            assert!(summary.contains("sm-vm opcode profile: total_instructions=6"));
+            assert!(summary.contains("QAnd"));
+            assert!(summary.contains("LoadQ"));
+            assert!(summary.contains("CmpEq"));
+        }
+
+        #[test]
+        fn opcode_profile_table_round_trips_all_slots() {
+            for (index, opcode) in OPCODE_PROFILE_OPCODES.iter().enumerate() {
+                assert_eq!(opcode_profile_index(*opcode), index);
+                assert_eq!(opcode_from_profile_index(index), Some(*opcode));
+            }
+            assert_eq!(opcode_from_profile_index(OPCODE_PROFILE_SLOT_COUNT), None);
+        }
+    }
 
     #[test]
     fn vm_runs_empty_main() {

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -94,11 +94,9 @@ pub struct VM {
     /// PRNG state for random_seed / random_next_i32 (xorshift64; 0 = unseeded).
     pub prng_state: u64,
 }
-
 trait OpcodeProfileSink {
     fn record_opcode(&mut self, opcode: Opcode);
 }
-
 struct NoopOpcodeProfile;
 
 impl OpcodeProfileSink for NoopOpcodeProfile {
@@ -3482,6 +3480,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_fx_literal_call_and_compare_path() {
         let src = r#"
@@ -3506,6 +3505,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_plain_fx_arithmetic_path() {
         let src = r#"
@@ -3539,6 +3539,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_text_literal_and_equality_path() {
         let src = r#"
@@ -3558,6 +3559,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_sequence_literal_index_and_equality_path() {
         let src = r#"
@@ -3577,6 +3579,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_first_class_closure_direct_invocation_path() {
         let src = r#"
@@ -3614,6 +3617,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_u32_literal_compare_path() {
         let src = r#"
@@ -3630,6 +3634,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_tuple_return_and_equality_path() {
         let src = r#"
@@ -3650,6 +3655,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_tuple_destructuring_bind_path() {
         let src = r#"
@@ -3868,6 +3874,7 @@ mod tests {
         run_semcode(&bytes).expect("sibling record field write must stay allowed");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_stage1_record_literal_path() {
         let src = r#"
@@ -3889,6 +3896,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_stage1_enum_constructor_path() {
         let src = r#"
@@ -3916,6 +3924,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_option_and_result_standard_form_paths() {
         let src = r#"
@@ -3949,6 +3958,7 @@ mod tests {
         run_semcode(&bytes).expect("Option/Result standard-form paths should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_option_and_result_match_ergonomics_paths() {
         let src = r#"
@@ -3986,6 +3996,7 @@ mod tests {
         run_semcode(&bytes).expect("Option/Result match ergonomics paths should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_stage1_adt_match_path() {
         let src = r#"
@@ -4016,6 +4027,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_exhaustive_adt_match_without_default_path() {
         let src = r#"
@@ -4046,6 +4058,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_adt_payload_ownership_positive_e2e_path() {
         let src = r#"
@@ -4100,6 +4113,7 @@ mod tests {
     // Therefore, we rely on the runtime-patched tests added in ADT-3 (like `vm_rejects_adt_payload_write_when_borrowed_same_payload`)
     // to prove the VM borrow-checker correctness, and we will add the negative E2E test once the language surface is ready.
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_stage1_record_field_access_path() {
         let src = r#"
@@ -4121,6 +4135,7 @@ mod tests {
         run_semcode(&bytes).expect("run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_pass_return_and_safe_equality_path() {
         let src = r#"
@@ -4144,6 +4159,7 @@ mod tests {
         run_semcode(&bytes).expect("record pass/return/equality should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_access_policy_scenario() {
         let src = r#"
@@ -4185,6 +4201,7 @@ mod tests {
         run_semcode(&bytes).expect("record access-policy scenario should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_destructuring_bind_path() {
         let src = r#"
@@ -4206,6 +4223,7 @@ mod tests {
         run_semcode(&bytes).expect("record destructuring bind path should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_let_else_path() {
         let src = r#"
@@ -4227,6 +4245,7 @@ mod tests {
         run_semcode(&bytes).expect("record let-else path should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_copy_with_path() {
         let src = r#"
@@ -4250,6 +4269,7 @@ mod tests {
         run_semcode(&bytes).expect("record copy-with path should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_record_stage2_ergonomics_scenario() {
         let src = r#"
@@ -4281,6 +4301,7 @@ mod tests {
         run_semcode(&bytes).expect("record stage-2 ergonomics scenario should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_for_range_inclusive_path() {
         let src = r#"
@@ -4311,6 +4332,7 @@ mod tests {
         run_semcode(&bytes).expect("inclusive for-range should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_for_range_empty_half_open_path() {
         let src = r#"
@@ -4329,6 +4351,7 @@ mod tests {
         run_semcode(&bytes).expect("empty half-open for-range should skip body");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_iterable_for_over_sequence_path() {
         let src = r#"
@@ -4351,6 +4374,7 @@ mod tests {
         run_semcode(&bytes).expect("Sequence(T) iterable loop should run");
     }
 
+    #[cfg(feature = "disasm")]
     #[test]
     fn vm_runs_iterable_for_over_explicit_record_impl_path() {
         let src = r#"

--- a/crates/sm-vm/tests/vm_opcode_profile.rs
+++ b/crates/sm-vm/tests/vm_opcode_profile.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "vm-profile")]
+
+use sm_emit::{compile_program_to_semcode, Opcode};
+use sm_runtime_core::{ExecutionConfig, ExecutionContext};
+use sm_verify::verify_semcode_token;
+use sm_vm::run_verified_entry_semcode_with_profile;
+
+#[test]
+fn vm_opcode_profile_smoke_runs_verified_entry() {
+    let src = r#"
+        fn main() {
+            let a: quad = T;
+            let b: quad = S;
+            let c = a && b;
+            if c == T { return; } else { return; }
+        }
+    "#;
+
+    let bytes = compile_program_to_semcode(src).expect("compile");
+    let token = verify_semcode_token(&bytes).expect("verify");
+    let entry_token = token.require_entry("main").expect("entry");
+    let config = ExecutionConfig::for_context(ExecutionContext::VerifiedLocal);
+    let profile =
+        run_verified_entry_semcode_with_profile(&entry_token, config).expect("profile run");
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(profile.count(Opcode::QAnd) > 0);
+    assert!(profile.count(Opcode::CmpEq) > 0);
+    println!("{}", profile.summary_top_n(12));
+}

--- a/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
+++ b/tests/golden_snapshots/public_api/sm_vm_semcode_vm.txt
@@ -37,6 +37,14 @@ pub config: ExecutionConfig,
 pub effect_calls: usize,
 pub symbols: RuntimeSymbolTable,
 pub prng_state: u64,
+#[cfg(feature = "vm-profile")]
+#[derive(Debug, Clone)]
+pub struct VmOpcodeProfile {
+pub fn total_instructions(&self) -> u64 {
+pub fn count(&self, opcode: Opcode) -> u64 {
+pub fn is_empty(&self) -> bool {
+pub fn top_n(&self, n: usize) -> Vec<(Opcode, u64)> {
+pub fn summary_top_n(&self, n: usize) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeError {
 pub fn run_semcode(bytes: &[u8]) -> Result<(), RuntimeError> {
@@ -52,6 +60,8 @@ pub fn run_verified_semcode_with_host_and_capabilities_and_config< H: Prometheus
 pub fn run_verified_entry_semcode_with_host_and_capabilities_and_config< H: PrometheusHostAbi, C: CapabilityChecker, >( token: &VerifiedEntrySemCode<'_, '_>, host: &mut H, capabilities: &C, config: ExecutionConfig, ) -> Result<(), RuntimeError> {
 pub fn run_verified_entry_semcode( token: &VerifiedEntrySemCode<'_, '_>, ) -> Result<(), RuntimeError> {
 pub fn run_verified_entry_semcode_with_config( token: &VerifiedEntrySemCode<'_, '_>, config: ExecutionConfig, ) -> Result<(), RuntimeError> {
+#[cfg(feature = "vm-profile")]
+pub fn run_verified_entry_semcode_with_profile( token: &VerifiedEntrySemCode<'_, '_>, config: ExecutionConfig, ) -> Result<VmOpcodeProfile, RuntimeError> {
 pub fn run_semcode_with_entry_and_config( bytes: &[u8], entry: &str, config: ExecutionConfig, ) -> Result<(), RuntimeError> {
 #[cfg(feature = "disasm")]
 pub fn disasm_semcode(bytes: &[u8]) -> Result<String, RuntimeError> {


### PR DESCRIPTION
## Summary

Adds a feature-gated local opcode profiling harness for `sm-vm`.

The harness records opcode execution counts during verified VM execution and returns a local `VmOpcodeProfile` for tests and developer diagnostics.

## Scope

- Adds `vm-profile` feature.
- Adds array-backed opcode counters.
- Adds local profile sink abstraction.
- Refactors `exec_loop` through an internal profiled loop with a no-op normal sink.
- Adds `run_verified_entry_semcode_with_profile(...)`.
- Adds profile data structure tests and a runner smoke test.

## Boundary

No changes to:

- normal runtime behavior
- VM authority
- verifier admission
- SemCode format
- PROMETHEUS boundary
- CTF contour
- Pulsar integration
- SIMD
- benchmarks
- CI workflows

This is local profiling, not production telemetry.

## Validation

- `cargo fmt --check`
- `cargo check -p sm-vm --all-features`
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`
- `cargo test -p sm-vm --all-features`
- `cargo test -p sm-vm --features vm-profile`
- `cargo test --workspace --all-features`
- `git diff --check`
