### PR TITLE
test(sm-vm): add Semantic profiling workload corpus

### DIFF
--- a/crates/sm-vm/tests/fixtures/profiling/andromeda_fact_wave_256.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/andromeda_fact_wave_256.sm
@@ -1,0 +1,95 @@
+fn wave_state(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn wave_pair(index: i32) -> quad {
+    let slot: i32 = index % 8;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                if slot == 3 {
+                    S
+                } else {
+                    if slot == 4 {
+                        S
+                    } else {
+                        if slot == 5 {
+                            T
+                        } else {
+                            if slot == 6 {
+                                F
+                            } else {
+                                N
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_conflicts: i32 = 0;
+    let mut consensus_true: i32 = 0;
+    let mut consensus_false: i32 = 0;
+    let mut consensus_unknown: i32 = 0;
+    let mut consensus_conflict: i32 = 0;
+    let mut total: i32 = 0;
+
+    for i in 0..256 {
+        let observed: quad = wave_state(i);
+        let inferred: quad = wave_pair(i);
+        let merged: quad = observed || inferred;
+        let consensus: quad = observed && inferred;
+
+        total += 1;
+
+        if merged == S {
+            merged_conflicts += 1;
+        }
+
+        if consensus == T {
+            consensus_true += 1;
+        } else {
+            if consensus == F {
+                consensus_false += 1;
+            } else {
+                if consensus == N {
+                    consensus_unknown += 1;
+                } else {
+                    consensus_conflict += 1;
+                }
+            }
+        }
+    }
+
+    assert(total == 256);
+    assert(merged_conflicts > 0);
+    assert(consensus_true > 0);
+    assert(consensus_false > 0);
+    assert(consensus_unknown > 0);
+    assert(consensus_conflict > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/andromeda_fact_wave_64.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/andromeda_fact_wave_64.sm
@@ -1,0 +1,95 @@
+fn wave_state(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn wave_pair(index: i32) -> quad {
+    let slot: i32 = index % 8;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                if slot == 3 {
+                    S
+                } else {
+                    if slot == 4 {
+                        S
+                    } else {
+                        if slot == 5 {
+                            T
+                        } else {
+                            if slot == 6 {
+                                F
+                            } else {
+                                N
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_conflicts: i32 = 0;
+    let mut consensus_true: i32 = 0;
+    let mut consensus_false: i32 = 0;
+    let mut consensus_unknown: i32 = 0;
+    let mut consensus_conflict: i32 = 0;
+    let mut total: i32 = 0;
+
+    for i in 0..64 {
+        let observed: quad = wave_state(i);
+        let inferred: quad = wave_pair(i);
+        let merged: quad = observed || inferred;
+        let consensus: quad = observed && inferred;
+
+        total += 1;
+
+        if merged == S {
+            merged_conflicts += 1;
+        }
+
+        if consensus == T {
+            consensus_true += 1;
+        } else {
+            if consensus == F {
+                consensus_false += 1;
+            } else {
+                if consensus == N {
+                    consensus_unknown += 1;
+                } else {
+                    consensus_conflict += 1;
+                }
+            }
+        }
+    }
+
+    assert(total == 64);
+    assert(merged_conflicts > 0);
+    assert(consensus_true > 0);
+    assert(consensus_false > 0);
+    assert(consensus_unknown > 0);
+    assert(consensus_conflict > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/delta_like_kernel.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/delta_like_kernel.sm
@@ -1,0 +1,154 @@
+fn old_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        N
+                    } else {
+                        if index == 5 {
+                            N
+                        } else {
+                            if index == 6 {
+                                N
+                            } else {
+                                if index == 7 {
+                                    S
+                                } else {
+                                    if index == 8 {
+                                        S
+                                    } else {
+                                        if index == 9 {
+                                            S
+                                        } else {
+                                            if index == 10 {
+                                                T
+                                            } else {
+                                                if index == 11 {
+                                                    F
+                                                } else {
+                                                    if index == 12 {
+                                                        T
+                                                    } else {
+                                                        F
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn new_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        T
+                    } else {
+                        if index == 5 {
+                            F
+                        } else {
+                            if index == 6 {
+                                S
+                            } else {
+                                if index == 7 {
+                                    T
+                                } else {
+                                    if index == 8 {
+                                        F
+                                    } else {
+                                        if index == 9 {
+                                            N
+                                        } else {
+                                            if index == 10 {
+                                                S
+                                            } else {
+                                                if index == 11 {
+                                                    S
+                                                } else {
+                                                    if index == 12 {
+                                                        F
+                                                    } else {
+                                                        T
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut entered_true: i32 = 0;
+    let mut left_true: i32 = 0;
+    let mut entered_false: i32 = 0;
+    let mut left_false: i32 = 0;
+    let mut entered_super: i32 = 0;
+    let mut left_super: i32 = 0;
+
+    for i in 0..14 {
+        let old_state: quad = old_state_for(i);
+        let new_state: quad = new_state_for(i);
+
+        if old_state != T && new_state == T {
+            entered_true += 1;
+        }
+        if old_state == T && new_state != T {
+            left_true += 1;
+        }
+        if old_state != F && new_state == F {
+            entered_false += 1;
+        }
+        if old_state == F && new_state != F {
+            left_false += 1;
+        }
+        if old_state != S && new_state == S {
+            entered_super += 1;
+        }
+        if old_state == S && new_state != S {
+            left_super += 1;
+        }
+    }
+
+    assert(entered_true == 3);
+    assert(left_true == 2);
+    assert(entered_false == 3);
+    assert(left_false == 2);
+    assert(entered_super == 3);
+    assert(left_super == 3);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/fact_intersect_kernel.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/fact_intersect_kernel.sm
@@ -1,0 +1,138 @@
+fn main() {
+    let mut true_count: i32 = 0;
+    let mut false_count: i32 = 0;
+    let mut unknown_count: i32 = 0;
+    let mut conflict_count: i32 = 0;
+
+    let i01: quad = T && S;
+    if i01 == T {
+        true_count += 1;
+    }
+    if i01 == F {
+        false_count += 1;
+    }
+    if i01 == N {
+        unknown_count += 1;
+    }
+    if i01 == S {
+        conflict_count += 1;
+    }
+
+    let i02: quad = F && S;
+    if i02 == T {
+        true_count += 1;
+    }
+    if i02 == F {
+        false_count += 1;
+    }
+    if i02 == N {
+        unknown_count += 1;
+    }
+    if i02 == S {
+        conflict_count += 1;
+    }
+
+    let i03: quad = T && F;
+    if i03 == T {
+        true_count += 1;
+    }
+    if i03 == F {
+        false_count += 1;
+    }
+    if i03 == N {
+        unknown_count += 1;
+    }
+    if i03 == S {
+        conflict_count += 1;
+    }
+
+    let i04: quad = S && S;
+    if i04 == T {
+        true_count += 1;
+    }
+    if i04 == F {
+        false_count += 1;
+    }
+    if i04 == N {
+        unknown_count += 1;
+    }
+    if i04 == S {
+        conflict_count += 1;
+    }
+
+    let i05: quad = N && T;
+    if i05 == T {
+        true_count += 1;
+    }
+    if i05 == F {
+        false_count += 1;
+    }
+    if i05 == N {
+        unknown_count += 1;
+    }
+    if i05 == S {
+        conflict_count += 1;
+    }
+
+    let i06: quad = N && F;
+    if i06 == T {
+        true_count += 1;
+    }
+    if i06 == F {
+        false_count += 1;
+    }
+    if i06 == N {
+        unknown_count += 1;
+    }
+    if i06 == S {
+        conflict_count += 1;
+    }
+
+    let i07: quad = S && N;
+    if i07 == T {
+        true_count += 1;
+    }
+    if i07 == F {
+        false_count += 1;
+    }
+    if i07 == N {
+        unknown_count += 1;
+    }
+    if i07 == S {
+        conflict_count += 1;
+    }
+
+    let i08: quad = T && T;
+    if i08 == T {
+        true_count += 1;
+    }
+    if i08 == F {
+        false_count += 1;
+    }
+    if i08 == N {
+        unknown_count += 1;
+    }
+    if i08 == S {
+        conflict_count += 1;
+    }
+
+    let i09: quad = F && F;
+    if i09 == T {
+        true_count += 1;
+    }
+    if i09 == F {
+        false_count += 1;
+    }
+    if i09 == N {
+        unknown_count += 1;
+    }
+    if i09 == S {
+        conflict_count += 1;
+    }
+
+    assert(true_count == 2);
+    assert(false_count == 2);
+    assert(unknown_count == 4);
+    assert(conflict_count == 1);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/fact_merge_kernel.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/fact_merge_kernel.sm
@@ -1,0 +1,72 @@
+fn main() {
+    let mut conflict_count: i32 = 0;
+    let mut known_count: i32 = 0;
+
+    let m01: quad = N || T;
+    if m01 == S {
+        conflict_count += 1;
+    }
+    if m01 != N {
+        known_count += 1;
+    }
+
+    let m02: quad = N || F;
+    if m02 == S {
+        conflict_count += 1;
+    }
+    if m02 != N {
+        known_count += 1;
+    }
+
+    let m03: quad = T || F;
+    if m03 == S {
+        conflict_count += 1;
+    }
+    if m03 != N {
+        known_count += 1;
+    }
+
+    let m04: quad = F || T;
+    if m04 == S {
+        conflict_count += 1;
+    }
+    if m04 != N {
+        known_count += 1;
+    }
+
+    let m05: quad = S || N;
+    if m05 == S {
+        conflict_count += 1;
+    }
+    if m05 != N {
+        known_count += 1;
+    }
+
+    let m06: quad = S || T;
+    if m06 == S {
+        conflict_count += 1;
+    }
+    if m06 != N {
+        known_count += 1;
+    }
+
+    let m07: quad = S || F;
+    if m07 == S {
+        conflict_count += 1;
+    }
+    if m07 != N {
+        known_count += 1;
+    }
+
+    let m08: quad = N || N;
+    if m08 == S {
+        conflict_count += 1;
+    }
+    if m08 != N {
+        known_count += 1;
+    }
+
+    assert(conflict_count == 5);
+    assert(known_count == 7);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/quad_logic_storm.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/quad_logic_storm.sm
@@ -1,0 +1,51 @@
+fn quad_cycle(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut load_count: i32 = 0;
+    let mut logic_count: i32 = 0;
+    let mut branch_count: i32 = 0;
+    let mut diff_count: i32 = 0;
+
+    for i in 0..64 {
+        let left: quad = quad_cycle(i);
+        let right: quad = quad_cycle(i + 1);
+        let merged: quad = left || right;
+        let consensus: quad = left && right;
+        let inverted: quad = !left;
+
+        if left == N {
+            load_count += 1;
+        }
+        if merged == S {
+            logic_count += 1;
+        }
+        if consensus != N {
+            branch_count += 1;
+        }
+        if inverted != left {
+            diff_count += 1;
+        }
+    }
+
+    assert(load_count > 0);
+    assert(logic_count > 0);
+    assert(branch_count > 0);
+    assert(diff_count > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/quad_match_dispatch.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/quad_match_dispatch.sm
@@ -1,0 +1,62 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn dispatch_code(state: quad) -> i32 {
+    let code: i32 = match state {
+        N => { 0 }
+        F => { 1 }
+        T => { 2 }
+        _ => { 3 }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..48 {
+        let state: quad = state_from_index(i);
+        let code: i32 = dispatch_code(state);
+        code_sum += code;
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    assert(code_sum > 0);
+    return;
+}

--- a/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
+++ b/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
@@ -1,0 +1,133 @@
+#![cfg(feature = "vm-profile")]
+
+use sm_emit::{compile_program_to_semcode, Opcode};
+use sm_runtime_core::{ExecutionConfig, ExecutionContext};
+use sm_verify::verify_semcode_token;
+use sm_vm::{run_verified_entry_semcode_with_profile, VmOpcodeProfile};
+
+const FIXTURE_DIR: &str = "fixtures/profiling";
+
+fn profile_source_fixture(source: &str) -> VmOpcodeProfile {
+    let bytes = compile_program_to_semcode(source).expect("compile fixture");
+    let token = verify_semcode_token(&bytes).expect("verify fixture");
+    let entry = token.require_entry("main").expect("main entry");
+
+    run_verified_entry_semcode_with_profile(
+        &entry,
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+    )
+    .expect("profiled execution")
+}
+
+fn quad_logic_count(profile: &VmOpcodeProfile) -> u64 {
+    profile.count(Opcode::QAnd)
+        + profile.count(Opcode::QOr)
+        + profile.count(Opcode::QNot)
+        + profile.count(Opcode::QImpl)
+}
+
+fn quad_family_count(profile: &VmOpcodeProfile) -> u64 {
+    profile.count(Opcode::LoadQ)
+        + profile.count(Opcode::QAnd)
+        + profile.count(Opcode::QOr)
+        + profile.count(Opcode::QNot)
+        + profile.count(Opcode::QImpl)
+        + profile.count(Opcode::CmpEq)
+        + profile.count(Opcode::CmpNe)
+}
+
+fn control_flow_count(profile: &VmOpcodeProfile) -> u64 {
+    profile.count(Opcode::Jmp) + profile.count(Opcode::JmpIf)
+}
+
+fn print_summary(name: &str, profile: &VmOpcodeProfile) {
+    println!("fixture={name}");
+    println!("{}", profile.summary_top_n(12));
+}
+
+fn fixture_path(name: &str) -> String {
+    format!("{FIXTURE_DIR}/{name}")
+}
+
+#[test]
+fn profile_quad_logic_storm() {
+    let profile = profile_source_fixture(include_str!("fixtures/profiling/quad_logic_storm.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(quad_logic_count(&profile) > 0);
+    assert!(profile.count(Opcode::CmpEq) > 0);
+    assert!(profile.count(Opcode::CmpNe) > 0);
+    print_summary(&fixture_path("quad_logic_storm.sm"), &profile);
+}
+
+#[test]
+fn profile_quad_match_dispatch() {
+    let profile = profile_source_fixture(include_str!("fixtures/profiling/quad_match_dispatch.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(control_flow_count(&profile) > 0 || profile.count(Opcode::CmpEq) > 0);
+    assert!(profile.count(Opcode::Ret) > 0);
+    print_summary(&fixture_path("quad_match_dispatch.sm"), &profile);
+}
+
+#[test]
+fn profile_fact_merge_kernel() {
+    let profile = profile_source_fixture(include_str!("fixtures/profiling/fact_merge_kernel.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(profile.count(Opcode::QOr) > 0);
+    assert!(control_flow_count(&profile) > 0 || profile.count(Opcode::CmpEq) > 0);
+    print_summary(&fixture_path("fact_merge_kernel.sm"), &profile);
+}
+
+#[test]
+fn profile_fact_intersect_kernel() {
+    let profile =
+        profile_source_fixture(include_str!("fixtures/profiling/fact_intersect_kernel.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(profile.count(Opcode::QAnd) > 0);
+    assert!(control_flow_count(&profile) > 0 || profile.count(Opcode::CmpEq) > 0);
+    print_summary(&fixture_path("fact_intersect_kernel.sm"), &profile);
+}
+
+#[test]
+fn profile_delta_like_kernel() {
+    let profile = profile_source_fixture(include_str!("fixtures/profiling/delta_like_kernel.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(quad_family_count(&profile) > 0);
+    assert!(control_flow_count(&profile) > 0 || profile.count(Opcode::CmpEq) > 0);
+    print_summary(&fixture_path("delta_like_kernel.sm"), &profile);
+}
+
+#[test]
+fn profile_andromeda_fact_wave_64() {
+    let profile =
+        profile_source_fixture(include_str!("fixtures/profiling/andromeda_fact_wave_64.sm"));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(quad_family_count(&profile) > 0);
+    assert!(control_flow_count(&profile) > 0);
+    print_summary(&fixture_path("andromeda_fact_wave_64.sm"), &profile);
+}
+
+#[test]
+#[ignore]
+fn profile_andromeda_fact_wave_256_local() {
+    let profile = profile_source_fixture(include_str!(
+        "fixtures/profiling/andromeda_fact_wave_256.sm"
+    ));
+
+    assert!(profile.total_instructions() > 0);
+    assert!(profile.count(Opcode::LoadQ) > 0);
+    assert!(quad_family_count(&profile) > 0);
+    assert!(control_flow_count(&profile) > 0);
+    print_summary(&fixture_path("andromeda_fact_wave_256.sm"), &profile);
+}


### PR DESCRIPTION
## Summary

Adds a source-level Semantic profiling workload corpus for the local `sm-vm` opcode profiling harness.

The workloads are compiled from `.sm`, verified, executed through `sm-vm`, and profiled with `VmOpcodeProfile`.

## Scope

- Adds `.sm` profiling fixtures.
- Adds workload tests using `include_str!`.
- Compiles and verifies fixtures during test setup.
- Profiles verified VM execution.
- Adds micro-op, semantic kernel, and Andromeda-shaped workloads.

## Boundary

No changes to:
- VM runtime semantics
- verifier behavior
- SemCode format
- parser/typechecker/lowering behavior
- Pulsar integration
- production telemetry
- benchmark claims
- CI workflows
- P5 candidate selection

## Validation

- `cargo fmt --check`
- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads`
- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --ignored`
- `cargo test -p sm-vm --features vm-profile`
- `cargo clippy -p sm-vm --all-targets --all-features -- -D warnings`
- `cargo check -p sm-vm --no-default-features`
- `cargo test --workspace --all-features`
- `git diff --check`

## Risk

Low to moderate.

The PR adds test fixtures and profiling workloads only. It does not change VM semantics, runtime behavior, verifier admission, or SemCode format.
