### PR TITLE
test(sm-vm): add scalar movement source-shape comparison fixtures

### DIFF
--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_branch_counters_local.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_branch_counters_local.sm
@@ -1,0 +1,48 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+
+    for i in 0..32 {
+        let state: quad = state_from_index(i);
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_branch_counters_return_value.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_branch_counters_return_value.sm
@@ -1,0 +1,59 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn classify_state(state: quad) -> i32 {
+    let code: i32 = match state {
+        N => { 0 }
+        F => { 1 }
+        T => { 2 }
+        _ => { 3 }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+
+    for i in 0..32 {
+        let state: quad = state_from_index(i);
+        let code: i32 = classify_state(state);
+
+        if code == 0 {
+            n_count += 1;
+        } else {
+            if code == 1 {
+                f_count += 1;
+            } else {
+                if code == 2 {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_dispatch_if_chain.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_dispatch_if_chain.sm
@@ -1,0 +1,69 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn classify_if_chain(state: quad) -> i32 {
+    let code: i32 = if state == N {
+        0
+    } else {
+        if state == F {
+            1
+        } else {
+            if state == T {
+                2
+            } else {
+                3
+            }
+        }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..48 {
+        let state: quad = state_from_index(i);
+        let code: i32 = classify_if_chain(state);
+        code_sum += code;
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    assert(code_sum > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_dispatch_match.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_dispatch_match.sm
@@ -1,0 +1,62 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn classify_match(state: quad) -> i32 {
+    let code: i32 = match state {
+        N => { 0 }
+        F => { 1 }
+        T => { 2 }
+        _ => { 3 }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..48 {
+        let state: quad = state_from_index(i);
+        let code: i32 = classify_match(state);
+        code_sum += code;
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    assert(code_sum > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_helper.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_helper.sm
@@ -1,0 +1,53 @@
+fn helper_transform(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut score: i32 = 0;
+    let mut merged_count: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let state: quad = helper_transform(i);
+        let next: quad = helper_transform(i + 1);
+
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if (state || next) == S {
+            merged_count += 1;
+        }
+    }
+
+    assert(score > 0);
+    assert(merged_count > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_inline.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_inline.sm
@@ -1,0 +1,61 @@
+fn main() {
+    let mut score: i32 = 0;
+    let mut merged_count: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let slot: i32 = i % 4;
+        let state: quad = if slot == 0 {
+            N
+        } else {
+            if slot == 1 {
+                F
+            } else {
+                if slot == 2 {
+                    T
+                } else {
+                    S
+                }
+            }
+        };
+        let next_slot: i32 = (i + 1) % 4;
+        let next: quad = if next_slot == 0 {
+            N
+        } else {
+            if next_slot == 1 {
+                F
+            } else {
+                if next_slot == 2 {
+                    T
+                } else {
+                    S
+                }
+            }
+        };
+
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if (state || next) == S {
+            merged_count += 1;
+        }
+    }
+
+    assert(score > 0);
+    assert(merged_count > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_loop_accumulator_explicit.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_loop_accumulator_explicit.sm
@@ -1,0 +1,32 @@
+fn main() {
+    let mut total: i32 = 0;
+    let mut count: i32 = 0;
+
+    total += 0;
+    count += 1;
+
+    total += 1;
+    count += 2;
+
+    total += 2;
+    count += 1;
+
+    total += 3;
+    count += 2;
+
+    total += 4;
+    count += 1;
+
+    total += 5;
+    count += 2;
+
+    total += 6;
+    count += 1;
+
+    total += 7;
+    count += 2;
+
+    assert(total == 28);
+    assert(count == 12);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_loop_accumulator_looped.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_loop_accumulator_looped.sm
@@ -1,0 +1,17 @@
+fn main() {
+    let mut total: i32 = 0;
+    let mut count: i32 = 0;
+
+    for i in 0..8 {
+        total += i;
+        if i % 2 == 0 {
+            count += 1;
+        } else {
+            count += 2;
+        }
+    }
+
+    assert(total == 28);
+    assert(count == 12);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_temp_staging_direct.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_temp_staging_direct.sm
@@ -1,0 +1,89 @@
+fn wave_state(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn wave_pair(index: i32) -> quad {
+    let slot: i32 = index % 8;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                if slot == 3 {
+                    S
+                } else {
+                    if slot == 4 {
+                        S
+                    } else {
+                        if slot == 5 {
+                            T
+                        } else {
+                            if slot == 6 {
+                                F
+                            } else {
+                                N
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_conflicts: i32 = 0;
+    let mut consensus_score: i32 = 0;
+    let mut invert_score: i32 = 0;
+
+    for i in 0..32 {
+        let observed: quad = wave_state(i);
+        let inferred: quad = wave_pair(i);
+
+        if (observed || inferred) == S {
+            merged_conflicts += 1;
+        }
+
+        if (observed && inferred) == T {
+            consensus_score += 1;
+        } else {
+            if (observed && inferred) == F {
+                consensus_score += 2;
+            } else {
+                if (observed && inferred) == N {
+                    consensus_score += 3;
+                } else {
+                    consensus_score += 4;
+                }
+            }
+        }
+
+        if !observed != observed {
+            invert_score += 1;
+        }
+    }
+
+    assert(merged_conflicts > 0);
+    assert(consensus_score > 0);
+    assert(invert_score > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_temp_staging_named.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_temp_staging_named.sm
@@ -1,0 +1,92 @@
+fn wave_state(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn wave_pair(index: i32) -> quad {
+    let slot: i32 = index % 8;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                if slot == 3 {
+                    S
+                } else {
+                    if slot == 4 {
+                        S
+                    } else {
+                        if slot == 5 {
+                            T
+                        } else {
+                            if slot == 6 {
+                                F
+                            } else {
+                                N
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_conflicts: i32 = 0;
+    let mut consensus_score: i32 = 0;
+    let mut invert_score: i32 = 0;
+
+    for i in 0..32 {
+        let observed: quad = wave_state(i);
+        let inferred: quad = wave_pair(i);
+        let merged: quad = observed || inferred;
+        let consensus: quad = observed && inferred;
+        let inverted: quad = !observed;
+
+        if merged == S {
+            merged_conflicts += 1;
+        }
+
+        if consensus == T {
+            consensus_score += 1;
+        } else {
+            if consensus == F {
+                consensus_score += 2;
+            } else {
+                if consensus == N {
+                    consensus_score += 3;
+                } else {
+                    consensus_score += 4;
+                }
+            }
+        }
+
+        if inverted != observed {
+            invert_score += 1;
+        }
+    }
+
+    assert(merged_conflicts > 0);
+    assert(consensus_score > 0);
+    assert(invert_score > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_transition_old_new_packed_code.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_transition_old_new_packed_code.sm
@@ -1,0 +1,242 @@
+fn old_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        N
+                    } else {
+                        if index == 5 {
+                            N
+                        } else {
+                            if index == 6 {
+                                N
+                            } else {
+                                if index == 7 {
+                                    S
+                                } else {
+                                    if index == 8 {
+                                        S
+                                    } else {
+                                        if index == 9 {
+                                            S
+                                        } else {
+                                            if index == 10 {
+                                                T
+                                            } else {
+                                                if index == 11 {
+                                                    F
+                                                } else {
+                                                    if index == 12 {
+                                                        T
+                                                    } else {
+                                                        F
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn new_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        T
+                    } else {
+                        if index == 5 {
+                            F
+                        } else {
+                            if index == 6 {
+                                S
+                            } else {
+                                if index == 7 {
+                                    T
+                                } else {
+                                    if index == 8 {
+                                        F
+                                    } else {
+                                        if index == 9 {
+                                            N
+                                        } else {
+                                            if index == 10 {
+                                                S
+                                            } else {
+                                                if index == 11 {
+                                                    S
+                                                } else {
+                                                    if index == 12 {
+                                                        F
+                                                    } else {
+                                                        T
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn transition_code(old_state: quad, new_state: quad) -> i32 {
+    let code: i32 = if old_state == N && new_state == N {
+        0
+    } else {
+        if old_state == F && new_state == F {
+            1
+        } else {
+            if old_state == T && new_state == T {
+                2
+            } else {
+                if old_state == S && new_state == S {
+                    3
+                } else {
+                    if old_state == N && new_state == T {
+                        4
+                    } else {
+                        if old_state == N && new_state == F {
+                            5
+                        } else {
+                            if old_state == N && new_state == S {
+                                6
+                            } else {
+                                if old_state == S && new_state == T {
+                                    7
+                                } else {
+                                    if old_state == S && new_state == F {
+                                        8
+                                    } else {
+                                        if old_state == S && new_state == N {
+                                            9
+                                        } else {
+                                            if old_state == T && new_state == S {
+                                                10
+                                            } else {
+                                                if old_state == F && new_state == S {
+                                                    11
+                                                } else {
+                                                    if old_state == T && new_state == F {
+                                                        12
+                                                    } else {
+                                                        13
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return code;
+}
+
+fn main() {
+    let mut entered_true: i32 = 0;
+    let mut left_true: i32 = 0;
+    let mut entered_false: i32 = 0;
+    let mut left_false: i32 = 0;
+    let mut entered_super: i32 = 0;
+    let mut left_super: i32 = 0;
+
+    for i in 0..14 {
+        let old_state: quad = old_state_for(i);
+        let new_state: quad = new_state_for(i);
+        let code: i32 = transition_code(old_state, new_state);
+
+        if code == 4 {
+            entered_true += 1;
+        }
+        if code == 7 {
+            entered_true += 1;
+        }
+        if code == 13 {
+            entered_true += 1;
+        }
+        if code == 10 {
+            left_true += 1;
+        }
+        if code == 12 {
+            left_true += 1;
+        }
+        if code == 5 {
+            entered_false += 1;
+        }
+        if code == 8 {
+            entered_false += 1;
+        }
+        if code == 12 {
+            entered_false += 1;
+        }
+        if code == 11 {
+            left_false += 1;
+        }
+        if code == 13 {
+            left_false += 1;
+        }
+        if code == 6 {
+            entered_super += 1;
+        }
+        if code == 10 {
+            entered_super += 1;
+        }
+        if code == 11 {
+            entered_super += 1;
+        }
+        if code == 7 {
+            left_super += 1;
+        }
+        if code == 8 {
+            left_super += 1;
+        }
+        if code == 9 {
+            left_super += 1;
+        }
+    }
+
+    assert(entered_true == 3);
+    assert(left_true == 2);
+    assert(entered_false == 3);
+    assert(left_false == 2);
+    assert(entered_super == 3);
+    assert(left_super == 3);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_transition_old_new_repeated.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/scalar_transition_old_new_repeated.sm
@@ -1,0 +1,154 @@
+fn old_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        N
+                    } else {
+                        if index == 5 {
+                            N
+                        } else {
+                            if index == 6 {
+                                N
+                            } else {
+                                if index == 7 {
+                                    S
+                                } else {
+                                    if index == 8 {
+                                        S
+                                    } else {
+                                        if index == 9 {
+                                            S
+                                        } else {
+                                            if index == 10 {
+                                                T
+                                            } else {
+                                                if index == 11 {
+                                                    F
+                                                } else {
+                                                    if index == 12 {
+                                                        T
+                                                    } else {
+                                                        F
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn new_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        T
+                    } else {
+                        if index == 5 {
+                            F
+                        } else {
+                            if index == 6 {
+                                S
+                            } else {
+                                if index == 7 {
+                                    T
+                                } else {
+                                    if index == 8 {
+                                        F
+                                    } else {
+                                        if index == 9 {
+                                            N
+                                        } else {
+                                            if index == 10 {
+                                                S
+                                            } else {
+                                                if index == 11 {
+                                                    S
+                                                } else {
+                                                    if index == 12 {
+                                                        F
+                                                    } else {
+                                                        T
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut entered_true: i32 = 0;
+    let mut left_true: i32 = 0;
+    let mut entered_false: i32 = 0;
+    let mut left_false: i32 = 0;
+    let mut entered_super: i32 = 0;
+    let mut left_super: i32 = 0;
+
+    for i in 0..14 {
+        let old_state: quad = old_state_for(i);
+        let new_state: quad = new_state_for(i);
+
+        if old_state != T && new_state == T {
+            entered_true += 1;
+        }
+        if old_state == T && new_state != T {
+            left_true += 1;
+        }
+        if old_state != F && new_state == F {
+            entered_false += 1;
+        }
+        if old_state == F && new_state != F {
+            left_false += 1;
+        }
+        if old_state != S && new_state == S {
+            entered_super += 1;
+        }
+        if old_state == S && new_state != S {
+            left_super += 1;
+        }
+    }
+
+    assert(entered_true == 3);
+    assert(left_true == 2);
+    assert(entered_false == 3);
+    assert(left_false == 2);
+    assert(entered_super == 3);
+    assert(left_super == 3);
+    return;
+}

--- a/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
+++ b/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
@@ -143,6 +143,33 @@ fn print_profile_report(name: &str, profile: &VmOpcodeProfile) {
     println!("{}", format_family_summary(&family_summary(profile)));
 }
 
+fn print_pair_report(
+    pair_name: &str,
+    fixture_a: &str,
+    summary_a: &OpcodeFamilySummary,
+    fixture_b: &str,
+    summary_b: &OpcodeFamilySummary,
+) {
+    let delta_count =
+        summary_a.scalar_movement.count as i64 - summary_b.scalar_movement.count as i64;
+    let delta_ratio = summary_a.scalar_movement.ratio - summary_b.scalar_movement.ratio;
+
+    println!("pair={pair_name}");
+    println!(
+        "  {fixture_a}: {} / {} = {:.2}%",
+        summary_a.scalar_movement.count,
+        summary_a.total_instructions,
+        summary_a.scalar_movement.ratio
+    );
+    println!(
+        "  {fixture_b}: {} / {} = {:.2}%",
+        summary_b.scalar_movement.count,
+        summary_b.total_instructions,
+        summary_b.scalar_movement.ratio
+    );
+    println!("  delta: count={delta_count} ratio={delta_ratio:.2}%");
+}
+
 fn fixture_path(name: &str) -> String {
     format!("{FIXTURE_DIR}/{name}")
 }
@@ -154,6 +181,30 @@ const FACT_INTERSECT_KERNEL: &str = include_str!("fixtures/profiling/fact_inters
 const DELTA_LIKE_KERNEL: &str = include_str!("fixtures/profiling/delta_like_kernel.sm");
 const ANDROMEDA_FACT_WAVE_64: &str = include_str!("fixtures/profiling/andromeda_fact_wave_64.sm");
 const ANDROMEDA_FACT_WAVE_256: &str = include_str!("fixtures/profiling/andromeda_fact_wave_256.sm");
+const SCALAR_HELPER_BOUNDARY_HELPER: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_helper_boundary_helper.sm");
+const SCALAR_HELPER_BOUNDARY_INLINE: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_helper_boundary_inline.sm");
+const SCALAR_TEMP_STAGING_NAMED: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_temp_staging_named.sm");
+const SCALAR_TEMP_STAGING_DIRECT: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_temp_staging_direct.sm");
+const SCALAR_DISPATCH_MATCH: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_dispatch_match.sm");
+const SCALAR_DISPATCH_IF_CHAIN: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_dispatch_if_chain.sm");
+const SCALAR_LOOP_ACCUMULATOR_LOOPED: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_loop_accumulator_looped.sm");
+const SCALAR_LOOP_ACCUMULATOR_EXPLICIT: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_loop_accumulator_explicit.sm");
+const SCALAR_BRANCH_COUNTERS_LOCAL: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_branch_counters_local.sm");
+const SCALAR_BRANCH_COUNTERS_RETURN_VALUE: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_branch_counters_return_value.sm");
+const SCALAR_TRANSITION_OLD_NEW_REPEATED: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_transition_old_new_repeated.sm");
+const SCALAR_TRANSITION_OLD_NEW_PACKED_CODE: &str =
+    include_str!("fixtures/profiling/scalar_movement/scalar_transition_old_new_packed_code.sm");
 
 #[test]
 fn family_summary_empty_profile_is_zero() {
@@ -270,4 +321,220 @@ fn profile_andromeda_fact_wave_256_local() {
     assert!(summary.quad_family.count > 0);
     assert!(summary.control_flow.count > 0);
     assert!(summary.scalar_movement.count > 0);
+}
+
+#[test]
+fn profile_scalar_helper_boundary_pair() {
+    let helper_profile = profile_source_fixture(
+        "scalar_helper_boundary_helper",
+        SCALAR_HELPER_BOUNDARY_HELPER,
+    );
+    let inline_profile = profile_source_fixture(
+        "scalar_helper_boundary_inline",
+        SCALAR_HELPER_BOUNDARY_INLINE,
+    );
+
+    let helper_summary = family_summary(&helper_profile);
+    let inline_summary = family_summary(&inline_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_helper_boundary_helper.sm"),
+        &helper_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_helper_boundary_inline.sm"),
+        &inline_profile,
+    );
+    print_pair_report(
+        "helper-boundary",
+        "scalar_helper_boundary_helper.sm",
+        &helper_summary,
+        "scalar_helper_boundary_inline.sm",
+        &inline_summary,
+    );
+
+    assert!(helper_summary.total_instructions > 0);
+    assert!(inline_summary.total_instructions > 0);
+    assert!(helper_summary.scalar_movement.count > 0);
+    assert!(inline_summary.scalar_movement.count > 0);
+    assert!(helper_summary.calls.count > 0);
+}
+
+#[test]
+fn profile_scalar_temp_staging_pair() {
+    let named_profile =
+        profile_source_fixture("scalar_temp_staging_named", SCALAR_TEMP_STAGING_NAMED);
+    let direct_profile =
+        profile_source_fixture("scalar_temp_staging_direct", SCALAR_TEMP_STAGING_DIRECT);
+
+    let named_summary = family_summary(&named_profile);
+    let direct_summary = family_summary(&direct_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_temp_staging_named.sm"),
+        &named_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_temp_staging_direct.sm"),
+        &direct_profile,
+    );
+    print_pair_report(
+        "temporary-staging",
+        "scalar_temp_staging_named.sm",
+        &named_summary,
+        "scalar_temp_staging_direct.sm",
+        &direct_summary,
+    );
+
+    assert!(named_summary.total_instructions > 0);
+    assert!(direct_summary.total_instructions > 0);
+    assert!(named_summary.scalar_movement.count > 0);
+    assert!(direct_summary.scalar_movement.count > 0);
+    assert!(named_summary.quad_family.count > 0);
+    assert!(direct_summary.quad_family.count > 0);
+}
+
+#[test]
+fn profile_scalar_dispatch_pair() {
+    let match_profile = profile_source_fixture("scalar_dispatch_match", SCALAR_DISPATCH_MATCH);
+    let if_chain_profile =
+        profile_source_fixture("scalar_dispatch_if_chain", SCALAR_DISPATCH_IF_CHAIN);
+
+    let match_summary = family_summary(&match_profile);
+    let if_chain_summary = family_summary(&if_chain_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_dispatch_match.sm"),
+        &match_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_dispatch_if_chain.sm"),
+        &if_chain_profile,
+    );
+    print_pair_report(
+        "dispatch",
+        "scalar_dispatch_match.sm",
+        &match_summary,
+        "scalar_dispatch_if_chain.sm",
+        &if_chain_summary,
+    );
+
+    assert!(match_summary.total_instructions > 0);
+    assert!(if_chain_summary.total_instructions > 0);
+    assert!(match_summary.scalar_movement.count > 0);
+    assert!(if_chain_summary.scalar_movement.count > 0);
+    assert!(match_summary.control_flow.count > 0);
+    assert!(if_chain_summary.control_flow.count > 0);
+}
+
+#[test]
+fn profile_scalar_loop_accumulator_pair() {
+    let looped_profile = profile_source_fixture(
+        "scalar_loop_accumulator_looped",
+        SCALAR_LOOP_ACCUMULATOR_LOOPED,
+    );
+    let explicit_profile = profile_source_fixture(
+        "scalar_loop_accumulator_explicit",
+        SCALAR_LOOP_ACCUMULATOR_EXPLICIT,
+    );
+
+    let looped_summary = family_summary(&looped_profile);
+    let explicit_summary = family_summary(&explicit_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_loop_accumulator_looped.sm"),
+        &looped_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_loop_accumulator_explicit.sm"),
+        &explicit_profile,
+    );
+    print_pair_report(
+        "looped-accumulator",
+        "scalar_loop_accumulator_looped.sm",
+        &looped_summary,
+        "scalar_loop_accumulator_explicit.sm",
+        &explicit_summary,
+    );
+
+    assert!(looped_summary.total_instructions > 0);
+    assert!(explicit_summary.total_instructions > 0);
+    assert!(looped_summary.scalar_movement.count > 0);
+    assert!(explicit_summary.scalar_movement.count > 0);
+    assert!(looped_summary.integer_ops.count > 0);
+    assert!(explicit_summary.integer_ops.count > 0);
+}
+
+#[test]
+fn profile_scalar_branch_counter_pair() {
+    let local_profile =
+        profile_source_fixture("scalar_branch_counters_local", SCALAR_BRANCH_COUNTERS_LOCAL);
+    let return_value_profile = profile_source_fixture(
+        "scalar_branch_counters_return_value",
+        SCALAR_BRANCH_COUNTERS_RETURN_VALUE,
+    );
+
+    let local_summary = family_summary(&local_profile);
+    let return_value_summary = family_summary(&return_value_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_branch_counters_local.sm"),
+        &local_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_branch_counters_return_value.sm"),
+        &return_value_profile,
+    );
+    print_pair_report(
+        "branch-counters",
+        "scalar_branch_counters_local.sm",
+        &local_summary,
+        "scalar_branch_counters_return_value.sm",
+        &return_value_summary,
+    );
+
+    assert!(local_summary.total_instructions > 0);
+    assert!(return_value_summary.total_instructions > 0);
+    assert!(local_summary.scalar_movement.count > 0);
+    assert!(return_value_summary.scalar_movement.count > 0);
+    assert!(local_summary.control_flow.count > 0);
+    assert!(return_value_summary.control_flow.count > 0);
+}
+
+#[test]
+fn profile_scalar_transition_reload_pair() {
+    let repeated_profile = profile_source_fixture(
+        "scalar_transition_old_new_repeated",
+        SCALAR_TRANSITION_OLD_NEW_REPEATED,
+    );
+    let packed_profile = profile_source_fixture(
+        "scalar_transition_old_new_packed_code",
+        SCALAR_TRANSITION_OLD_NEW_PACKED_CODE,
+    );
+
+    let repeated_summary = family_summary(&repeated_profile);
+    let packed_summary = family_summary(&packed_profile);
+
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_transition_old_new_repeated.sm"),
+        &repeated_profile,
+    );
+    print_profile_report(
+        &fixture_path("scalar_movement/scalar_transition_old_new_packed_code.sm"),
+        &packed_profile,
+    );
+    print_pair_report(
+        "transition-reload",
+        "scalar_transition_old_new_repeated.sm",
+        &repeated_summary,
+        "scalar_transition_old_new_packed_code.sm",
+        &packed_summary,
+    );
+
+    assert!(repeated_summary.total_instructions > 0);
+    assert!(packed_summary.total_instructions > 0);
+    assert!(repeated_summary.scalar_movement.count > 0);
+    assert!(packed_summary.scalar_movement.count > 0);
+    assert!(repeated_summary.integer_ops.count > 0);
+    assert!(packed_summary.integer_ops.count > 0);
 }


### PR DESCRIPTION
## Summary
Adds the VM-M8 scalar-movement source-shape comparison fixtures and wires them into the existing vm-profile workload tests.

## Boundary
No runtime, verifier, SemCode, parser, lowering, or Pulsar changes.

## Validation
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads --no-run
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --nocapture
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --ignored
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --ignored --nocapture
- cargo clippy -p sm-vm --all-targets --all-features -- -D warnings
- cargo check -p sm-vm --no-default-features
