### PR TITLE
test(sm-vm): add second-generation scalar movement fixtures

### DIFF
--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_if_chain.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_if_chain.sm
@@ -1,0 +1,69 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn classify_if_chain(state: quad) -> i32 {
+    let code: i32 = if state == N {
+        0
+    } else {
+        if state == F {
+            1
+        } else {
+            if state == T {
+                2
+            } else {
+                3
+            }
+        }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..32 {
+        let state: quad = state_from_index(i);
+        let code: i32 = classify_if_chain(state);
+        code_sum += code;
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count == 8);
+    assert(f_count == 8);
+    assert(t_count == 8);
+    assert(s_count == 8);
+    assert(code_sum == 48);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_match.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_match.sm
@@ -1,0 +1,62 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn classify_match(state: quad) -> i32 {
+    let code: i32 = match state {
+        N => { 0 }
+        F => { 1 }
+        T => { 2 }
+        _ => { 3 }
+    };
+    return code;
+}
+
+fn main() {
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..32 {
+        let state: quad = state_from_index(i);
+        let code: i32 = classify_match(state);
+        code_sum += code;
+
+        if state == N {
+            n_count += 1;
+        } else {
+            if state == F {
+                f_count += 1;
+            } else {
+                if state == T {
+                    t_count += 1;
+                } else {
+                    s_count += 1;
+                }
+            }
+        }
+    }
+
+    assert(n_count == 8);
+    assert(f_count == 8);
+    assert(t_count == 8);
+    assert(s_count == 8);
+    assert(code_sum == 48);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_helper.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_helper.sm
@@ -1,0 +1,59 @@
+fn classify_slot(index: i32) -> i32 {
+    let class: i32 = index % 4;
+    return class;
+}
+
+fn state_from_class(class: i32) -> quad {
+    let state: quad = if class == 0 {
+        N
+    } else {
+        if class == 1 {
+            F
+        } else {
+            if class == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut score: i32 = 0;
+    let mut chain_hits: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let class: i32 = classify_slot(i);
+        let state: quad = state_from_class(class);
+        let next_class: i32 = classify_slot(i + 1);
+        let next_state: quad = state_from_class(next_class);
+
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if (state || next_state) == S {
+            chain_hits += 1;
+        }
+    }
+
+    assert(score == 40);
+    assert(chain_hits > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_inline.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_inline.sm
@@ -1,0 +1,61 @@
+fn main() {
+    let mut score: i32 = 0;
+    let mut chain_hits: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let class: i32 = i % 4;
+        let state: quad = if class == 0 {
+            N
+        } else {
+            if class == 1 {
+                F
+            } else {
+                if class == 2 {
+                    T
+                } else {
+                    S
+                }
+            }
+        };
+        let next_class: i32 = (i + 1) % 4;
+        let next_state: quad = if next_class == 0 {
+            N
+        } else {
+            if next_class == 1 {
+                F
+            } else {
+                if next_class == 2 {
+                    T
+                } else {
+                    S
+                }
+            }
+        };
+
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if (state || next_state) == S {
+            chain_hits += 1;
+        }
+    }
+
+    assert(score == 40);
+    assert(chain_hits > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_helper.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_helper.sm
@@ -1,0 +1,51 @@
+fn helper_transform(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut score: i32 = 0;
+    let mut hit_count: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..8 {
+        let state: quad = helper_transform(i);
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if state == S {
+            hit_count += 1;
+        }
+    }
+
+    assert(score == 20);
+    assert(hit_count == 2);
+    assert(checksum == 28);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_inline.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_inline.sm
@@ -1,0 +1,47 @@
+fn main() {
+    let mut score: i32 = 0;
+    let mut hit_count: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..8 {
+        let slot: i32 = i % 4;
+        let state: quad = if slot == 0 {
+            N
+        } else {
+            if slot == 1 {
+                F
+            } else {
+                if slot == 2 {
+                    T
+                } else {
+                    S
+                }
+            }
+        };
+
+        checksum += i;
+
+        if state == N {
+            score += 1;
+        } else {
+            if state == F {
+                score += 2;
+            } else {
+                if state == T {
+                    score += 3;
+                } else {
+                    score += 4;
+                }
+            }
+        }
+
+        if state == S {
+            hit_count += 1;
+        }
+    }
+
+    assert(score == 20);
+    assert(hit_count == 2);
+    assert(checksum == 28);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_explicit.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_explicit.sm
@@ -1,0 +1,170 @@
+fn state_from_slot(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut total: i32 = 0;
+    let mut count: i32 = 0;
+
+    let state0: quad = state_from_slot(0);
+    if state0 == N {
+        total += 1;
+    } else {
+        if state0 == F {
+            total += 2;
+        } else {
+            if state0 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state0 == T {
+        count += 1;
+    }
+
+    let state1: quad = state_from_slot(1);
+    if state1 == N {
+        total += 1;
+    } else {
+        if state1 == F {
+            total += 2;
+        } else {
+            if state1 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state1 == T {
+        count += 1;
+    }
+
+    let state2: quad = state_from_slot(2);
+    if state2 == N {
+        total += 1;
+    } else {
+        if state2 == F {
+            total += 2;
+        } else {
+            if state2 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state2 == T {
+        count += 1;
+    }
+
+    let state3: quad = state_from_slot(3);
+    if state3 == N {
+        total += 1;
+    } else {
+        if state3 == F {
+            total += 2;
+        } else {
+            if state3 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state3 == T {
+        count += 1;
+    }
+
+    let state4: quad = state_from_slot(4);
+    if state4 == N {
+        total += 1;
+    } else {
+        if state4 == F {
+            total += 2;
+        } else {
+            if state4 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state4 == T {
+        count += 1;
+    }
+
+    let state5: quad = state_from_slot(5);
+    if state5 == N {
+        total += 1;
+    } else {
+        if state5 == F {
+            total += 2;
+        } else {
+            if state5 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state5 == T {
+        count += 1;
+    }
+
+    let state6: quad = state_from_slot(6);
+    if state6 == N {
+        total += 1;
+    } else {
+        if state6 == F {
+            total += 2;
+        } else {
+            if state6 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state6 == T {
+        count += 1;
+    }
+
+    let state7: quad = state_from_slot(7);
+    if state7 == N {
+        total += 1;
+    } else {
+        if state7 == F {
+            total += 2;
+        } else {
+            if state7 == T {
+                total += 3;
+            } else {
+                total += 4;
+            }
+        }
+    }
+    if state7 == T {
+        count += 1;
+    }
+
+    assert(total == 20);
+    assert(count == 2);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_looped.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_looped.sm
@@ -1,0 +1,48 @@
+fn state_from_slot(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut total: i32 = 0;
+    let mut count: i32 = 0;
+
+    for i in 0..8 {
+        let state: quad = state_from_slot(i);
+
+        if state == N {
+            total += 1;
+        } else {
+            if state == F {
+                total += 2;
+            } else {
+                if state == T {
+                    total += 3;
+                } else {
+                    total += 4;
+                }
+            }
+        }
+
+        if state == T {
+            count += 1;
+        }
+    }
+
+    assert(total == 20);
+    assert(count == 2);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_direct.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_direct.sm
@@ -1,0 +1,40 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_score: i32 = 0;
+    let mut recheck_score: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        checksum += i;
+
+        if (state_from_index(i) || state_from_index(i + 1)) == S {
+            merged_score += 1;
+        }
+
+        if (state_from_index(i) || state_from_index(i + 1)) != N {
+            recheck_score += 1;
+        }
+    }
+
+    assert(merged_score > 0);
+    assert(recheck_score > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_named.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_named.sm
@@ -1,0 +1,44 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut merged_score: i32 = 0;
+    let mut recheck_score: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let observed: quad = state_from_index(i);
+        let inferred: quad = state_from_index(i + 1);
+        let merged: quad = observed || inferred;
+
+        checksum += i;
+
+        if merged == S {
+            merged_score += 1;
+        }
+
+        if merged != N {
+            recheck_score += 1;
+        }
+    }
+
+    assert(merged_score > 0);
+    assert(recheck_score > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_direct.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_direct.sm
@@ -1,0 +1,34 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut score: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        checksum += i;
+
+        if (state_from_index(i) || state_from_index(i + 1)) == S {
+            score += 1;
+        }
+    }
+
+    assert(score > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_named.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_named.sm
@@ -1,0 +1,38 @@
+fn state_from_index(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut score: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..16 {
+        let observed: quad = state_from_index(i);
+        let inferred: quad = state_from_index(i + 1);
+        let merged: quad = observed || inferred;
+
+        checksum += i;
+
+        if merged == S {
+            score += 1;
+        }
+    }
+
+    assert(score > 0);
+    assert(checksum == 120);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_classified.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_classified.sm
@@ -1,0 +1,119 @@
+fn old_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    T
+                } else {
+                    if index == 4 {
+                        N
+                    } else {
+                        if index == 5 {
+                            S
+                        } else {
+                            if index == 6 {
+                                F
+                            } else {
+                                F
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn new_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        T
+    } else {
+        if index == 1 {
+            T
+        } else {
+            if index == 2 {
+                N
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        F
+                    } else {
+                        if index == 5 {
+                            F
+                        } else {
+                            if index == 6 {
+                                N
+                            } else {
+                                S
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn transition_code(old_state: quad, new_state: quad) -> i32 {
+    let code: i32 = if old_state != T && new_state == T {
+        0
+    } else {
+        if old_state == T && new_state != T {
+            1
+        } else {
+            if old_state != F && new_state == F {
+                2
+            } else {
+                3
+            }
+        }
+    };
+    return code;
+}
+
+fn main() {
+    let mut entered_true: i32 = 0;
+    let mut left_true: i32 = 0;
+    let mut entered_false: i32 = 0;
+    let mut left_false: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..8 {
+        let old_state: quad = old_state_for(i);
+        let new_state: quad = new_state_for(i);
+        let code: i32 = transition_code(old_state, new_state);
+
+        if code == 0 {
+            entered_true += 1;
+        } else {
+            if code == 1 {
+                left_true += 1;
+            } else {
+                if code == 2 {
+                    entered_false += 1;
+                } else {
+                    left_false += 1;
+                }
+            }
+        }
+
+        code_sum += code;
+    }
+
+    assert(entered_true > 0);
+    assert(left_true > 0);
+    assert(entered_false > 0);
+    assert(left_false > 0);
+    assert(code_sum > 0);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_repeated.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_repeated.sm
@@ -1,0 +1,112 @@
+fn old_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        N
+    } else {
+        if index == 1 {
+            F
+        } else {
+            if index == 2 {
+                T
+            } else {
+                if index == 3 {
+                    T
+                } else {
+                    if index == 4 {
+                        N
+                    } else {
+                        if index == 5 {
+                            S
+                        } else {
+                            if index == 6 {
+                                F
+                            } else {
+                                F
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn new_state_for(index: i32) -> quad {
+    let state: quad = if index == 0 {
+        T
+    } else {
+        if index == 1 {
+            T
+        } else {
+            if index == 2 {
+                N
+            } else {
+                if index == 3 {
+                    S
+                } else {
+                    if index == 4 {
+                        F
+                    } else {
+                        if index == 5 {
+                            F
+                        } else {
+                            if index == 6 {
+                                N
+                            } else {
+                                S
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut entered_true: i32 = 0;
+    let mut left_true: i32 = 0;
+    let mut entered_false: i32 = 0;
+    let mut left_false: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for i in 0..8 {
+        let old_state: quad = old_state_for(i);
+        let new_state: quad = new_state_for(i);
+
+        if old_state != T && new_state == T {
+            entered_true += 1;
+        }
+        if old_state == T && new_state != T {
+            left_true += 1;
+        }
+        if old_state != F && new_state == F {
+            entered_false += 1;
+        }
+        if old_state == F && new_state != F {
+            left_false += 1;
+        }
+
+        if old_state != T && new_state == T {
+            code_sum += 0;
+        } else {
+            if old_state == T && new_state != T {
+                code_sum += 1;
+            } else {
+                if old_state != F && new_state == F {
+                    code_sum += 2;
+                } else {
+                    code_sum += 3;
+                }
+            }
+        }
+    }
+
+    assert(entered_true > 0);
+    assert(left_true > 0);
+    assert(entered_false > 0);
+    assert(left_false > 0);
+    assert(code_sum > 0);
+    return;
+}

--- a/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
+++ b/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
@@ -170,6 +170,26 @@ fn print_pair_report(
     println!("  delta: count={delta_count} ratio={delta_ratio:.2}%");
 }
 
+fn profile_scalar_pair(
+    pair_name: &str,
+    fixture_a: &str,
+    source_a: &str,
+    fixture_b: &str,
+    source_b: &str,
+) -> (OpcodeFamilySummary, OpcodeFamilySummary) {
+    let profile_a = profile_source_fixture(fixture_a, source_a);
+    let profile_b = profile_source_fixture(fixture_b, source_b);
+
+    let summary_a = family_summary(&profile_a);
+    let summary_b = family_summary(&profile_b);
+
+    print_profile_report(&fixture_path(fixture_a), &profile_a);
+    print_profile_report(&fixture_path(fixture_b), &profile_b);
+    print_pair_report(pair_name, fixture_a, &summary_a, fixture_b, &summary_b);
+
+    (summary_a, summary_b)
+}
+
 fn fixture_path(name: &str) -> String {
     format!("{FIXTURE_DIR}/{name}")
 }
@@ -205,6 +225,40 @@ const SCALAR_TRANSITION_OLD_NEW_REPEATED: &str =
     include_str!("fixtures/profiling/scalar_movement/scalar_transition_old_new_repeated.sm");
 const SCALAR_TRANSITION_OLD_NEW_PACKED_CODE: &str =
     include_str!("fixtures/profiling/scalar_movement/scalar_transition_old_new_packed_code.sm");
+const SCALAR_G2_HELPER_SINGLE_CALL_HELPER: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_helper.sm"
+);
+const SCALAR_G2_HELPER_SINGLE_CALL_INLINE: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_inline.sm"
+);
+const SCALAR_G2_HELPER_CALL_CHAIN_HELPER: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_helper.sm"
+);
+const SCALAR_G2_HELPER_CALL_CHAIN_INLINE: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_inline.sm"
+);
+const SCALAR_G2_TEMP_SINGLE_USE_NAMED: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_named.sm");
+const SCALAR_G2_TEMP_SINGLE_USE_DIRECT: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_temp_staging_single_use_direct.sm");
+const SCALAR_G2_TEMP_MULTI_USE_NAMED: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_named.sm");
+const SCALAR_G2_TEMP_MULTI_USE_DIRECT: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_temp_staging_multi_use_direct.sm");
+const SCALAR_G2_DISPATCH_EQUALIZED_MATCH: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_match.sm");
+const SCALAR_G2_DISPATCH_EQUALIZED_IF_CHAIN: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_dispatch_equalized_if_chain.sm");
+const SCALAR_G2_LOOP_ACCUMULATOR_EQUALIZED_LOOPED: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_looped.sm"
+);
+const SCALAR_G2_LOOP_ACCUMULATOR_EQUALIZED_EXPLICIT: &str = include_str!(
+    "fixtures/profiling/scalar_movement/g2/scalar_loop_accumulator_equalized_explicit.sm"
+);
+const SCALAR_G2_TRANSITION_EQUALIZED_REPEATED: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_repeated.sm");
+const SCALAR_G2_TRANSITION_EQUALIZED_CLASSIFIED: &str =
+    include_str!("fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_classified.sm");
 
 #[test]
 fn family_summary_empty_profile_is_zero() {
@@ -537,4 +591,128 @@ fn profile_scalar_transition_reload_pair() {
     assert!(packed_summary.scalar_movement.count > 0);
     assert!(repeated_summary.integer_ops.count > 0);
     assert!(packed_summary.integer_ops.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_helper_single_call_pair() {
+    let (helper_summary, inline_summary) = profile_scalar_pair(
+        "helper-single-call",
+        "scalar_movement/g2/scalar_helper_boundary_single_call_helper.sm",
+        SCALAR_G2_HELPER_SINGLE_CALL_HELPER,
+        "scalar_movement/g2/scalar_helper_boundary_single_call_inline.sm",
+        SCALAR_G2_HELPER_SINGLE_CALL_INLINE,
+    );
+
+    assert!(helper_summary.total_instructions > 0);
+    assert!(inline_summary.total_instructions > 0);
+    assert!(helper_summary.scalar_movement.count > 0);
+    assert!(inline_summary.scalar_movement.count > 0);
+    assert!(helper_summary.calls.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_helper_call_chain_pair() {
+    let (helper_summary, inline_summary) = profile_scalar_pair(
+        "helper-call-chain",
+        "scalar_movement/g2/scalar_helper_boundary_call_chain_helper.sm",
+        SCALAR_G2_HELPER_CALL_CHAIN_HELPER,
+        "scalar_movement/g2/scalar_helper_boundary_call_chain_inline.sm",
+        SCALAR_G2_HELPER_CALL_CHAIN_INLINE,
+    );
+
+    assert!(helper_summary.total_instructions > 0);
+    assert!(inline_summary.total_instructions > 0);
+    assert!(helper_summary.scalar_movement.count > 0);
+    assert!(inline_summary.scalar_movement.count > 0);
+    assert!(helper_summary.calls.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_temp_single_use_pair() {
+    let (named_summary, direct_summary) = profile_scalar_pair(
+        "temp-single-use",
+        "scalar_movement/g2/scalar_temp_staging_single_use_named.sm",
+        SCALAR_G2_TEMP_SINGLE_USE_NAMED,
+        "scalar_movement/g2/scalar_temp_staging_single_use_direct.sm",
+        SCALAR_G2_TEMP_SINGLE_USE_DIRECT,
+    );
+
+    assert!(named_summary.total_instructions > 0);
+    assert!(direct_summary.total_instructions > 0);
+    assert!(named_summary.scalar_movement.count > 0);
+    assert!(direct_summary.scalar_movement.count > 0);
+    assert!(named_summary.quad_family.count > 0);
+    assert!(direct_summary.quad_family.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_temp_multi_use_pair() {
+    let (named_summary, direct_summary) = profile_scalar_pair(
+        "temp-multi-use",
+        "scalar_movement/g2/scalar_temp_staging_multi_use_named.sm",
+        SCALAR_G2_TEMP_MULTI_USE_NAMED,
+        "scalar_movement/g2/scalar_temp_staging_multi_use_direct.sm",
+        SCALAR_G2_TEMP_MULTI_USE_DIRECT,
+    );
+
+    assert!(named_summary.total_instructions > 0);
+    assert!(direct_summary.total_instructions > 0);
+    assert!(named_summary.scalar_movement.count > 0);
+    assert!(direct_summary.scalar_movement.count > 0);
+    assert!(named_summary.quad_family.count > 0);
+    assert!(direct_summary.quad_family.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_dispatch_equalized_pair() {
+    let (match_summary, if_chain_summary) = profile_scalar_pair(
+        "dispatch-equalized",
+        "scalar_movement/g2/scalar_dispatch_equalized_match.sm",
+        SCALAR_G2_DISPATCH_EQUALIZED_MATCH,
+        "scalar_movement/g2/scalar_dispatch_equalized_if_chain.sm",
+        SCALAR_G2_DISPATCH_EQUALIZED_IF_CHAIN,
+    );
+
+    assert!(match_summary.total_instructions > 0);
+    assert!(if_chain_summary.total_instructions > 0);
+    assert!(match_summary.scalar_movement.count > 0);
+    assert!(if_chain_summary.scalar_movement.count > 0);
+    assert!(match_summary.control_flow.count > 0);
+    assert!(if_chain_summary.control_flow.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_loop_accumulator_equalized_pair() {
+    let (looped_summary, explicit_summary) = profile_scalar_pair(
+        "loop-accumulator-equalized",
+        "scalar_movement/g2/scalar_loop_accumulator_equalized_looped.sm",
+        SCALAR_G2_LOOP_ACCUMULATOR_EQUALIZED_LOOPED,
+        "scalar_movement/g2/scalar_loop_accumulator_equalized_explicit.sm",
+        SCALAR_G2_LOOP_ACCUMULATOR_EQUALIZED_EXPLICIT,
+    );
+
+    assert!(looped_summary.total_instructions > 0);
+    assert!(explicit_summary.total_instructions > 0);
+    assert!(looped_summary.scalar_movement.count > 0);
+    assert!(explicit_summary.scalar_movement.count > 0);
+    assert!(looped_summary.integer_ops.count > 0);
+    assert!(explicit_summary.integer_ops.count > 0);
+}
+
+#[test]
+fn profile_scalar_g2_transition_equalized_pair() {
+    let (repeated_summary, classified_summary) = profile_scalar_pair(
+        "transition-equalized",
+        "scalar_movement/g2/scalar_transition_equalized_repeated.sm",
+        SCALAR_G2_TRANSITION_EQUALIZED_REPEATED,
+        "scalar_movement/g2/scalar_transition_equalized_classified.sm",
+        SCALAR_G2_TRANSITION_EQUALIZED_CLASSIFIED,
+    );
+
+    assert!(repeated_summary.total_instructions > 0);
+    assert!(classified_summary.total_instructions > 0);
+    assert!(repeated_summary.scalar_movement.count > 0);
+    assert!(classified_summary.scalar_movement.count > 0);
+    assert!(repeated_summary.integer_ops.count > 0);
+    assert!(classified_summary.integer_ops.count > 0);
 }


### PR DESCRIPTION
## Summary
Adds second-generation scalar movement fixtures to sharpen the helper-boundary and temporary-staging signals and to reduce ambiguity in the mixed VM-M8 comparisons.

## Scope
- Adds G2 helper-boundary fixtures.
- Adds G2 temporary-staging fixtures.
- Adds G2 equalized dispatch, loop accumulator, and transition fixtures.
- Wires the fixtures into the existing `vm-profile` workload tests.
- Uses the existing runtime `VmOpcodeProfile` path.

## Boundary
No changes to runtime behavior, verifier behavior, SemCode, parser, lowering, or Pulsar integration.

## Validation
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads --no-run
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --nocapture
- cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --ignored --nocapture
- cargo clippy -p sm-vm --all-targets --all-features -- -D warnings
- cargo check -p sm-vm --no-default-features
- git diff --check
- cargo fmt --check failed due to pre-existing unrelated drift in crates/prom-ui-backend-native/src/lib.rs