### PR TITLE
test(sm-vm): close helper-boundary equivalence cycle

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -113,7 +113,7 @@ struct VmTestObservation {
 #[cfg(test)]
 thread_local! {
     static VM_TEST_TERMINAL_OBSERVATION: std::cell::RefCell<Option<VmTestObservation>> =
-        std::cell::RefCell::new(None);
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(test)]

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -3342,6 +3342,31 @@ mod tests {
             }
         }
 
+        fn canonicalize_terminal_observable(observable: &str, semantic_locals: &[&str]) -> String {
+            let (ret_part, locals_part) = observable
+                .split_once("; locals=")
+                .expect("terminal observable return/locals split");
+            let locals_part = locals_part
+                .strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'))
+                .expect("terminal observable locals list");
+
+            let locals = locals_part
+                .split(", ")
+                .filter_map(|entry| entry.split_once('='))
+                .map(|(name, value)| (name.trim(), value.trim()))
+                .collect::<Vec<_>>();
+
+            let mut selected = Vec::new();
+            for wanted in semantic_locals {
+                if let Some((_, value)) = locals.iter().find(|(name, _)| name == wanted) {
+                    selected.push(format!("{wanted}={value}"));
+                }
+            }
+
+            format!("{ret_part}; locals=[{}]", selected.join(", "))
+        }
+
         #[test]
         fn private_vm_observation_helper_captures_terminal_state() {
             let observation = observe_verified_entry_semcode("empty_main", "fn main() { return; }");
@@ -3354,6 +3379,102 @@ mod tests {
                 .expect("terminal observable");
             assert!(observable.contains("return=Unit"));
             assert!(observable.contains("locals=[]"));
+        }
+
+        struct HelperBoundaryPair {
+            name: &'static str,
+            helper_fixture: &'static str,
+            inline_fixture: &'static str,
+            helper_source: &'static str,
+            inline_source: &'static str,
+            semantic_locals: &'static [&'static str],
+        }
+
+        const HELPER_BOUNDARY_PAIRS: &[HelperBoundaryPair] = &[
+            HelperBoundaryPair {
+                name: "vm-m9 helper boundary",
+                helper_fixture: "scalar_helper_boundary_helper.sm",
+                inline_fixture: "scalar_helper_boundary_inline.sm",
+                helper_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_helper.sm"
+                ),
+                inline_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/scalar_helper_boundary_inline.sm"
+                ),
+                semantic_locals: &["checksum", "merged_count", "score"],
+            },
+            HelperBoundaryPair {
+                name: "g2 helper single-call",
+                helper_fixture: "scalar_helper_boundary_single_call_helper.sm",
+                inline_fixture: "scalar_helper_boundary_single_call_inline.sm",
+                helper_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_helper.sm"
+                ),
+                inline_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_single_call_inline.sm"
+                ),
+                semantic_locals: &["checksum", "hit_count", "score"],
+            },
+            HelperBoundaryPair {
+                name: "g2 helper call-chain",
+                helper_fixture: "scalar_helper_boundary_call_chain_helper.sm",
+                inline_fixture: "scalar_helper_boundary_call_chain_inline.sm",
+                helper_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_helper.sm"
+                ),
+                inline_source: include_str!(
+                    "../tests/fixtures/profiling/scalar_movement/g2/scalar_helper_boundary_call_chain_inline.sm"
+                ),
+                semantic_locals: &["checksum", "chain_hits", "score"],
+            },
+        ];
+
+        fn assert_helper_boundary_pair_equivalence(pair: &HelperBoundaryPair) {
+            let helper = observe_verified_entry_semcode(pair.helper_fixture, pair.helper_source);
+            let inline = observe_verified_entry_semcode(pair.inline_fixture, pair.inline_source);
+            let helper_observable = helper.observable.as_deref().map(|observable| {
+                canonicalize_terminal_observable(observable, pair.semantic_locals)
+            });
+            let inline_observable = inline.observable.as_deref().map(|observable| {
+                canonicalize_terminal_observable(observable, pair.semantic_locals)
+            });
+
+            println!("pair: {}", pair.name);
+            println!(
+                "  helper: status={:?} observable={:?}",
+                helper.status, helper.observable
+            );
+            println!(
+                "  inline:  status={:?} observable={:?}",
+                inline.status, inline.observable
+            );
+
+            assert_eq!(
+                helper.status,
+                VmTestStatus::Completed,
+                "{} helper run did not complete",
+                pair.name
+            );
+            assert_eq!(
+                inline.status,
+                VmTestStatus::Completed,
+                "{} inline run did not complete",
+                pair.name
+            );
+            assert!(helper.trap.is_none(), "{} helper run trapped", pair.name);
+            assert!(inline.trap.is_none(), "{} inline run trapped", pair.name);
+            assert_eq!(
+                helper_observable, inline_observable,
+                "{} helper and inline observations diverged",
+                pair.name
+            );
+        }
+
+        #[test]
+        fn helper_boundary_pair_equivalence_harness_matches_terminal_observations() {
+            for pair in HELPER_BOUNDARY_PAIRS {
+                assert_helper_boundary_pair_equivalence(pair);
+            }
         }
     }
 

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -94,6 +94,75 @@ pub struct VM {
     /// PRNG state for random_seed / random_next_i32 (xorshift64; 0 = unseeded).
     pub prng_state: u64,
 }
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VmTestStatus {
+    Completed,
+    Failed,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VmTestObservation {
+    status: VmTestStatus,
+    observable: Option<String>,
+    trap: Option<String>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static VM_TEST_TERMINAL_OBSERVATION: std::cell::RefCell<Option<VmTestObservation>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn vm_test_clear_terminal_observation() {
+    VM_TEST_TERMINAL_OBSERVATION.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+#[cfg(test)]
+fn vm_test_store_terminal_observation(observation: VmTestObservation) {
+    VM_TEST_TERMINAL_OBSERVATION.with(|slot| {
+        *slot.borrow_mut() = Some(observation);
+    });
+}
+
+#[cfg(test)]
+fn vm_test_take_terminal_observation() -> Option<VmTestObservation> {
+    VM_TEST_TERMINAL_OBSERVATION.with(|slot| slot.borrow_mut().take())
+}
+
+#[cfg(test)]
+fn vm_test_format_terminal_observable(
+    ret_val: &Value,
+    frame: &Frame,
+    symbols: &sm_runtime_core::RuntimeSymbolTable,
+) -> String {
+    let mut locals = frame
+        .locals
+        .iter()
+        .map(|(symbol, value)| {
+            let name = symbols.resolve(*symbol).unwrap_or("<unknown>").to_string();
+            let value = format!("{value:?}");
+            (name, value)
+        })
+        .collect::<Vec<_>>();
+    locals.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+    let locals = if locals.is_empty() {
+        "[]".to_string()
+    } else {
+        let joined = locals
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{joined}]")
+    };
+    format!("return={ret_val:?}; locals={locals}")
+}
 trait OpcodeProfileSink {
     fn record_opcode(&mut self, opcode: Opcode);
 }
@@ -2240,6 +2309,16 @@ where
                         write_reg(caller, dst as usize, ret_val, &vm.config.quotas)?;
                     }
                 } else {
+                    #[cfg(test)]
+                    {
+                        let observable =
+                            vm_test_format_terminal_observable(&ret_val, &finished, &vm.symbols);
+                        vm_test_store_terminal_observation(VmTestObservation {
+                            status: VmTestStatus::Completed,
+                            observable: Some(observable),
+                            trap: None,
+                        });
+                    }
                     return Ok(());
                 }
                 continue;
@@ -3229,6 +3308,52 @@ mod tests {
                 assert_eq!(opcode_from_profile_index(index), Some(*opcode));
             }
             assert_eq!(opcode_from_profile_index(OPCODE_PROFILE_SLOT_COUNT), None);
+        }
+    }
+
+    mod helper_boundary_result_observation_tests {
+        use super::*;
+
+        fn observe_verified_entry_semcode(name: &str, source: &str) -> VmTestObservation {
+            let bytes = compile_program_to_semcode(source)
+                .unwrap_or_else(|err| panic!("{name}: compile failed: {err:?}"));
+            let token = sm_verify::verify_semcode_token(&bytes)
+                .unwrap_or_else(|err| panic!("{name}: verify failed: {err}"));
+            let entry = token
+                .require_entry("main")
+                .unwrap_or_else(|err| panic!("{name}: entry resolution failed: {err:?}"));
+
+            vm_test_clear_terminal_observation();
+            let result = run_verified_entry_semcode_with_config(
+                &entry,
+                ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+            );
+            match result {
+                Ok(()) => vm_test_take_terminal_observation().unwrap_or(VmTestObservation {
+                    status: VmTestStatus::Failed,
+                    observable: None,
+                    trap: Some(format!("{name}: missing terminal observation")),
+                }),
+                Err(err) => VmTestObservation {
+                    status: VmTestStatus::Failed,
+                    observable: None,
+                    trap: Some(format!("{err}")),
+                },
+            }
+        }
+
+        #[test]
+        fn private_vm_observation_helper_captures_terminal_state() {
+            let observation = observe_verified_entry_semcode("empty_main", "fn main() { return; }");
+            assert_eq!(observation.status, VmTestStatus::Completed);
+            assert!(observation.trap.is_none());
+
+            let observable = observation
+                .observable
+                .as_deref()
+                .expect("terminal observable");
+            assert!(observable.contains("return=Unit"));
+            assert!(observable.contains("locals=[]"));
         }
     }
 

--- a/docs/roadmap/sm_vm_vm_m15_private_test_observation_boundary.md
+++ b/docs/roadmap/sm_vm_vm_m15_private_test_observation_boundary.md
@@ -1,0 +1,93 @@
+# sm-vm VM-M15 Private Test-Only Result Observation Boundary
+
+## Status
+
+VM-M15 specifies the private test-only observation boundary required for helper-vs-inline result equivalence.
+
+This document does not approve runtime changes, lowering changes, fixture changes, SemCode changes, VM optimization, or helper inlining.
+
+## Context
+
+- VM-M9 showed the helper-boundary scalar-movement signal.
+- VM-M11 kept and amplified that signal with G2 helper single-call and call-chain pairs.
+- VM-M12 audited helper-boundary source, lowering, and VM shape and identified argument/result/frame/local-slot staging as plausible mechanisms.
+- VM-M13 defined the evidence boundary for helper-boundary result equivalence.
+- VM-M14 inspected existing VM/test result surfaces and found that no general harness-level result surface is exposed today for ordinary verified execution.
+- VM-M15 now specifies the private test-only observation boundary needed before any helper-vs-inline pair-equivalence harness is selected.
+
+## Problem
+
+Fixture-local assertions show that each fixture reaches its own expected state, but they do not provide a shared harness-level comparison that helper and inline variants return the same observable result.
+
+This does not invalidate VM-M12 evidence.
+
+It only limits how strong the pair-equivalence claim can be until a private test-only observation path exists.
+
+## Approved Observation Boundary
+
+- private test-only observation
+- no public API widening
+- no production VM result API
+- no SemCode change
+- no verifier change
+
+The observation boundary may inspect test-only execution outcomes such as:
+
+- return value snapshot
+- final-state digest
+- trap or runtime failure string
+- deterministic test-only summary
+
+The boundary must remain private to tests and must not become a release-facing execution surface.
+
+## Explicitly Forbidden Boundary
+
+- public VM result APIs
+- production result surfaces
+- fixture-local assertions as the only equivalence claim
+- broad VM runtime changes
+- verifier changes
+- SemCode format changes
+- lowering rewrites
+- helper inlining as a required policy
+
+## Minimal Observable Shape
+
+The minimal acceptable observation shape is a private, deterministic, test-only snapshot that can distinguish:
+
+- successful completion
+- trap or runtime failure
+- the final observable result state for the checked fixture pair
+
+The shape should be as small as possible while still supporting helper-vs-inline pair comparison at the harness level.
+
+## VM-M16 Implementation Constraints
+
+- Keep the helper private or test-only.
+- Do not add a public VM API.
+- Do not widen runtime result contracts.
+- Do not change production VM behavior.
+- Do not require fixture rewrites unless no private observation shape can be derived otherwise.
+- Prefer a final-state or return-value snapshot derived from existing execution state over new runtime plumbing.
+
+## Non-Claims
+
+This document does not claim:
+
+- helper and inline fixtures are already harness-equivalent;
+- VM performance improved;
+- scalar optimization is approved;
+- helper inlining is required;
+- SemCode format should change;
+- VM public APIs should widen;
+- fixture changes are approved;
+- P5-A/P5-B is reopened.
+
+## Validation
+
+- `git diff --check`
+- `cargo fmt --check`
+- `git status --short`
+
+If `cargo fmt --check` fails, the blocker must be recorded honestly and unrelated files must not be modified.
+

--- a/docs/roadmap/sm_vm_vm_m18_helper_boundary_equivalence_closeout.md
+++ b/docs/roadmap/sm_vm_vm_m18_helper_boundary_equivalence_closeout.md
@@ -1,0 +1,63 @@
+# sm-vm VM-M18 Helper-Boundary Equivalence Closeout
+
+## Status
+
+VM-M18 closes the helper-boundary result-equivalence cycle with a private test-only harness.
+
+This document does not approve runtime changes, verifier changes, SemCode changes, fixture changes, VM optimization, or helper inlining.
+
+## Closed Chain
+
+- VM-M12 → helper-boundary lowering shape audit
+- VM-M13 → result-equivalence evidence boundary
+- VM-M14 → VM/test result surfaces audit
+- VM-M15 → private test-only observation boundary
+- VM-M16 → minimal test-only observation helper
+- VM-M17 → pair-equivalence harness
+- VM-M18 → closeout
+
+## What Is Now Proven
+
+- Helper-boundary fixture pairs are now compared at harness level.
+- The harness uses a private test-only observation path.
+- The observation boundary captures a terminal return-value and final-state snapshot from the verified execution path.
+- The pair comparison normalizes away compiler-generated staging locals and compares the stable semantic locals for each current helper-boundary pair shape.
+- The current helper-boundary shapes checked by the harness are:
+  - VM-M9 helper boundary
+  - VM-M11 G2 helper single-call
+  - VM-M11 G2 helper call-chain
+
+## What Remains Not Claimed
+
+- No public VM API was widened.
+- No production VM behavior changed.
+- No verifier behavior changed.
+- No SemCode format changed.
+- No lowering or parser/typechecker behavior changed.
+- No helper inlining was required.
+- No optimization was approved.
+- No claim is made about raw internal staging locals being identical between helper and inline variants.
+- No claim is made beyond the current helper-boundary fixture pair shapes.
+
+## Files Changed In Implementation
+
+- `docs/roadmap/sm_vm_vm_m15_private_test_observation_boundary.md`
+- `crates/sm-vm/src/semcode_vm.rs`
+- `docs/roadmap/sm_vm_vm_m18_helper_boundary_equivalence_closeout.md`
+
+## Validation
+
+- `cargo test -p sm-vm helper_boundary -- --nocapture`
+- `cargo test -p sm-vm equivalence -- --nocapture`
+- `cargo fmt -- crates/sm-vm/src/semcode_vm.rs`
+
+## Decision
+
+PASS WITH LIMITATION — helper-vs-inline pair equivalence is now checked at harness level for the current helper-boundary fixture pair shapes, using canonicalized terminal semantic locals.
+
+## Follow-Up, If Any
+
+No immediate follow-up is required for the current cycle.
+
+If new helper-boundary fixture shapes are added later, they should reuse the same private observation boundary and extend the pair list explicitly.
+


### PR DESCRIPTION
## Summary

Closes the VM-M15..VM-M18 helper-boundary result-equivalence cycle in one PR.

This follows the already merged VM-M12, VM-M13, and VM-M14 audit chain and adds a private test-only observation path plus a harness-level helper-vs-inline equivalence check.

## Scope

Adds four logical commits:

- `docs(sm-vm): specify private test observation boundary`
- `test(sm-vm): add private VM observation helper`
- `test(sm-vm): add helper-boundary pair equivalence harness`
- `docs(sm-vm): close helper-boundary equivalence cycle`

Includes:

- VM-M15 private test-only observation boundary spec
- VM-M16 minimal private/test-only observation helper
- VM-M17 helper-vs-inline pair-equivalence harness
- VM-M18 closeout audit / decision record

## Boundary

No changes to:

- production VM behavior
- public VM APIs
- verifier behavior
- SemCode format
- lowering
- parser/typechecker
- Cargo.toml / Cargo.lock
- CI workflows
- prom-ui
- PCC docs

Any VM helper code added here is test-only/private and must not become a production observation API.

The pair-equivalence check compares canonicalized terminal semantic locals for the current helper-boundary fixture pair shapes; it does not claim raw staging locals are identical.

## Validation

- `cargo test -p sm-vm`
- `cargo test -p sm-vm helper_boundary -- --nocapture`
- `cargo test -p sm-vm equivalence -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `git status --short`

## Risk

Medium-low.

This is the first code-bearing PR after the VM-M12..M14 docs-only audit chain, but it is intentionally limited to private test-only result observation and harness-level equivalence.