### PR TITLE
docs(architecture): link SVM verified execution map

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ source
 - Want to try the pipeline: run the zero-effect verifier smoke path in `Quickstart`.
 - Want the contract: start with `docs/spec/index.md`, `docs/spec/semcode.md`, `docs/spec/verifier.md`, and `docs/spec/vm.md`.
 - Want the active development track: read `docs/language/semantic_hello_*`.
+- [Semantic VM Verified Execution Core](docs/architecture/svm_verified_execution_core.md) — current scalar `sm-vm` verified execution path, admission gate, local evidence/profiling paths, and current Pulsar/P5-A status.
 
 ## Minimal Smoke Example
 


### PR DESCRIPTION
## Summary

Links the newly added SVM verified execution architecture document from the existing docs / architecture index.

## Scope

- Adds navigation to `docs/architecture/svm_verified_execution_core.md`.
- Preserves the current architecture status: scalar `sm-vm` verified execution, Pulsar P5-A blocked, and local evidence/profiling paths as non-production diagnostics.

## Boundary

No changes to:

- Rust code
- tests
- VM runtime behavior
- verifier behavior
- SemCode format
- parser/typechecker/lowering
- public Semantic API
- PROMETHEUS / CTF boundaries
- Pulsar runtime integration
- P5 implementation
- CI workflows
- Cargo.toml / Cargo.lock

This PR does not approve P5-A, P5-B, runtime acceleration, or GPU/Vulkan backend work.

## Validation

- `git diff --check`
- `cargo fmt --check`

## Risk

Low.

Docs-only discoverability update.
