### PR TITLE
test(pulsar): add P5-A evidence probe workloads

### DIFF
--- a/crates/sm-vm/tests/fixtures/profiling/p5a_probe/p5a_quad_batch_wave.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/p5a_probe/p5a_quad_batch_wave.sm
@@ -1,0 +1,50 @@
+fn quad_wave(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn main() {
+    let mut batch_hits: i32 = 0;
+    let mut logic_hits: i32 = 0;
+    let mut compare_hits: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..128 {
+        let left: quad = quad_wave(i);
+        let right: quad = quad_wave(i + 1);
+        let merged: quad = left || right;
+        let consensus: quad = left && right;
+        let flipped: quad = !left;
+
+        checksum += i;
+
+        if merged == S {
+            batch_hits += 1;
+        }
+        if consensus != N {
+            logic_hits += 1;
+        }
+        if flipped != left {
+            compare_hits += 1;
+        }
+    }
+
+    assert(batch_hits > 0);
+    assert(logic_hits > 0);
+    assert(compare_hits > 0);
+    assert(checksum == 8128);
+    return;
+}

--- a/crates/sm-vm/tests/fixtures/profiling/p5a_probe/p5a_quad_helper_mix.sm
+++ b/crates/sm-vm/tests/fixtures/profiling/p5a_probe/p5a_quad_helper_mix.sm
@@ -1,0 +1,62 @@
+fn quad_wave(index: i32) -> quad {
+    let slot: i32 = index % 4;
+    let state: quad = if slot == 0 {
+        N
+    } else {
+        if slot == 1 {
+            F
+        } else {
+            if slot == 2 {
+                T
+            } else {
+                S
+            }
+        }
+    };
+    return state;
+}
+
+fn quad_probe_step(left: quad, right: quad) -> quad {
+    let merged: quad = left || right;
+    let consensus: quad = left && right;
+    let inverted: quad = !left;
+    let result: quad = if merged == S {
+        consensus
+    } else {
+        if consensus == N {
+            inverted
+        } else {
+            merged
+        }
+    };
+    return result;
+}
+
+fn main() {
+    let mut hot_path_hits: i32 = 0;
+    let mut batch_hits: i32 = 0;
+    let mut control_hits: i32 = 0;
+    let mut checksum: i32 = 0;
+
+    for i in 0..128 {
+        let left: quad = quad_wave(i);
+        let right: quad = quad_wave(i + 1);
+        let probe: quad = quad_probe_step(left, right);
+        let merged: quad = left || right;
+
+        checksum += i;
+
+        if probe == S {
+            hot_path_hits += 1;
+        }
+        if merged == S {
+            batch_hits += 1;
+        }
+        if probe != left {
+            control_hits += 1;
+        }
+    }
+
+    assert(checksum == 8128);
+    return;
+}

--- a/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
+++ b/crates/sm-vm/tests/vm_opcode_profile_workloads.rs
@@ -259,6 +259,10 @@ const SCALAR_G2_TRANSITION_EQUALIZED_REPEATED: &str =
     include_str!("fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_repeated.sm");
 const SCALAR_G2_TRANSITION_EQUALIZED_CLASSIFIED: &str =
     include_str!("fixtures/profiling/scalar_movement/g2/scalar_transition_equalized_classified.sm");
+const P5A_QUAD_BATCH_WAVE: &str =
+    include_str!("fixtures/profiling/p5a_probe/p5a_quad_batch_wave.sm");
+const P5A_QUAD_HELPER_MIX: &str =
+    include_str!("fixtures/profiling/p5a_probe/p5a_quad_helper_mix.sm");
 
 #[test]
 fn family_summary_empty_profile_is_zero() {
@@ -715,4 +719,37 @@ fn profile_scalar_g2_transition_equalized_pair() {
     assert!(classified_summary.scalar_movement.count > 0);
     assert!(repeated_summary.integer_ops.count > 0);
     assert!(classified_summary.integer_ops.count > 0);
+}
+
+#[test]
+fn profile_pulsar_p5a_evidence_probe_pair() {
+    let batch_wave_profile = profile_source_fixture("p5a_quad_batch_wave", P5A_QUAD_BATCH_WAVE);
+    let helper_mix_profile = profile_source_fixture("p5a_quad_helper_mix", P5A_QUAD_HELPER_MIX);
+
+    let batch_wave_summary = family_summary(&batch_wave_profile);
+    let helper_mix_summary = family_summary(&helper_mix_profile);
+
+    print_profile_report(
+        &fixture_path("p5a_probe/p5a_quad_batch_wave.sm"),
+        &batch_wave_profile,
+    );
+    print_profile_report(
+        &fixture_path("p5a_probe/p5a_quad_helper_mix.sm"),
+        &helper_mix_profile,
+    );
+    print_pair_report(
+        "p5a-evidence-probe",
+        "p5a_quad_batch_wave.sm",
+        &batch_wave_summary,
+        "p5a_quad_helper_mix.sm",
+        &helper_mix_summary,
+    );
+
+    assert!(batch_wave_summary.total_instructions > 0);
+    assert!(helper_mix_summary.total_instructions > 0);
+    assert!(batch_wave_summary.quad_logic.count > 0);
+    assert!(helper_mix_summary.quad_logic.count > 0);
+    assert!(batch_wave_summary.quad_family.count > 0);
+    assert!(helper_mix_summary.quad_family.count > 0);
+    assert!(helper_mix_summary.calls.count > 0);
 }

--- a/docs/roadmap/pulsar_p5a_evidence_probe.md
+++ b/docs/roadmap/pulsar_p5a_evidence_probe.md
@@ -1,0 +1,148 @@
+# Pulsar P5-A Evidence Probe
+
+## Status
+
+This probe does not reopen P5-A.
+This probe only adds local profiling evidence.
+P5-A remains blocked unless the measured results show one narrow,
+meaningful, batchable quad-state hot path and a future promotion review approves it.
+
+- P4 shadow equivalence is closed and evidence-repaired.
+- `#1237` completed CPU/features diagnostics and `QuadroBank` batch-path coverage.
+- Current profiling evidence blocks P5-A.
+- Fresh measured runtime evidence is required before candidate selection.
+
+## Goal
+
+This probe asks one narrow question:
+
+Can current Semantic workloads produce a meaningful, batchable quad-state hot path
+that could justify reopening Pulsar P5-A later?
+
+The answer is based on local profiling evidence only.
+
+## Workloads inspected
+
+Existing profiling corpus context:
+
+- `quad_logic_storm.sm`
+- `quad_match_dispatch.sm`
+- `fact_merge_kernel.sm`
+- `fact_intersect_kernel.sm`
+- `delta_like_kernel.sm`
+- `andromeda_fact_wave_64.sm`
+- `andromeda_fact_wave_256.sm`
+
+New probe workloads:
+
+- `p5a_probe/p5a_quad_batch_wave.sm`
+- `p5a_probe/p5a_quad_helper_mix.sm`
+
+## New probe workloads
+
+### `p5a_quad_batch_wave.sm`
+
+This workload exists to stress repeated quad logical operations in a direct,
+batch-like loop shape without relying on a helper chain.
+
+It uses:
+
+- repeated `quad` state generation;
+- `||`, `&&`, and `!` over a loop of 128 iterations;
+- only enough scalar bookkeeping to keep the workload realistic.
+
+This is the closest probe shape to a future batchable quad-state hot path.
+It still must be treated as evidence, not as an approval.
+
+### `p5a_quad_helper_mix.sm`
+
+This workload exists to stress the same quad-state operations while adding helper
+boundary pressure.
+
+It uses:
+
+- the same `quad` state generation shape;
+- a helper function around repeated quad operations;
+- the same 128-iteration loop scale;
+- a checksum guard to keep execution honest.
+
+This workload helps distinguish direct quad pressure from helper-induced
+scalar/call overhead.
+
+## Measurement method
+
+Measured with the existing local `vm-profile` workload path:
+
+```text
+compile .sm source
+  -> verify SemCode
+  -> run verified entry with profile
+  -> collect VmOpcodeProfile
+  -> summarize opcode families
+```
+
+Relevant commands:
+
+- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads profile_pulsar_p5a_evidence_probe_pair -- --nocapture`
+- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads --no-run`
+- `cargo test -p sm-vm`
+- `cargo test -p sm-vm --all-features`
+
+The probe reuses the existing `run_verified_entry_semcode_with_profile` and
+`VmOpcodeProfile` path.
+
+## Results
+
+| Workload | Total | Quad logic | Quad family | Control flow | Scalar movement | Calls | Interpretation |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `p5a_probe/p5a_quad_batch_wave.sm` | 14248 | 384 / 2.70% | 1985 / 13.93% | 3140 / 22.04% | 6346 / 44.54% | 513 / 3.60% | Direct batch-like quad pressure exists, but scalar movement still dominates. |
+| `p5a_probe/p5a_quad_helper_mix.sm` | 17084 | 512 / 3.00% | 2433 / 14.24% | 3524 / 20.63% | 8167 / 47.80% | 769 / 4.50% | Helper boundary pressure increases call/scalar cost instead of producing a cleaner batch signal. |
+
+Observed shape:
+
+- both probe workloads produce real quad-state activity;
+- both probe workloads are still dominated by scalar movement;
+- helper pressure increases call count and scalar movement;
+- the direct batch-like workload is the cleaner of the two, but it still does
+  not show a clearly batchable hot path by itself.
+
+## Interpretation
+
+The probe shows that current Semantic workloads can generate quad-state pressure,
+but the measured shape still looks structurally expensive in scalar movement.
+
+The best direct batch-like workload is not yet strong enough to serve as a future
+P5-A reopening signal on its own.
+
+This is evidence for continued profiling and candidate narrowing, not for
+runtime integration.
+
+## P5-A gate decision
+
+P5-A remains BLOCKED.
+
+The probe did not show a narrow, meaningful, batchable quad-state hot path with
+enough authority to reopen candidate review.
+
+## Non-claims
+
+This document does not claim:
+
+- P5-A is open;
+- P5-B is approved;
+- Pulsar is runtime-integrated;
+- Pulsar replaces `sm-vm`;
+- VM performance improved;
+- public VM API changed;
+- SemCode format changed;
+- verifier admission changed;
+- production telemetry was added;
+- PROMETHEUS or CTF boundaries widened.
+
+## Validation
+
+- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads profile_pulsar_p5a_evidence_probe_pair -- --nocapture` passed
+- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads --no-run` passed
+- `cargo test -p sm-vm` passed
+- `cargo test -p sm-vm --all-features` passed
+

--- a/docs/roadmap/roadmap_pulsar.md
+++ b/docs/roadmap/roadmap_pulsar.md
@@ -601,6 +601,7 @@ The canonical P5-A rule remains:
 P5-A must select exactly one narrow acceleration candidate based on measured VM/runtime evidence.
 
 See also: [Pulsar P5-A Expected Candidate Path](pulsar_p5a_expected_candidate_path.md).
+See also: [Pulsar P5-A Evidence Probe](pulsar_p5a_evidence_probe.md).
 
 A candidate must not be selected because it is architecturally attractive or theoretically fast.
 It must be selected because profiling shows it is a meaningful hot path.


### PR DESCRIPTION
## Summary

Adds local profiling evidence probe workloads for future Pulsar P5-A evaluation.

This PR checks whether current Semantic workloads can produce a meaningful, batchable quad-state hot path that could justify reopening P5-A later.

## Scope

- Extends the existing local `sm-vm` profiling workload pattern.
- Adds quad-state pressure probe workloads.
- Records measured evidence and interpretation in a roadmap report.

## Boundary

No changes to:

- VM runtime behavior
- verifier behavior
- SemCode format
- parser/typechecker/lowering
- public Semantic API
- PROMETHEUS / CTF boundaries
- production telemetry
- runtime integration
- P5 implementation
- SIMD
- GPU/Vulkan backend
- CI workflows
- Cargo.toml / Cargo.lock

This PR does not reopen P5-A and does not approve P5-B.

## Validation

- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads profile_pulsar_p5a_evidence_probe_pair -- --nocapture`
- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --nocapture`
- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads -- --ignored --nocapture`
- `cargo test -p sm-vm --features vm-profile --test vm_opcode_profile_workloads --no-run`
- `cargo test -p sm-vm`
- `cargo test -p sm-vm --all-features`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low to moderate.

The PR is evidence-only, but it may clarify whether Pulsar has a measurable future acceleration candidate.
