### PR TITLE
docs(skill): record Semantic language principles

### DIFF
--- a/.agents/skills/semantic/SKILL.md
+++ b/.agents/skills/semantic/SKILL.md
@@ -268,6 +268,24 @@ Rules:
 - Display order may vary in UI/infographics.
 - Encoding order and semantic meaning must not vary.
 
+SEMANTIC_LANGUAGE_PRINCIPLES_FOR_ASSISTANTS:
+- Preserve the `bool` / `quad` boundary: `bool` decides, `quad` means.
+- Never imply an implicit `quad -> bool` collapse.
+- Frame determinism as what makes expressive programs trustworthy, not as a
+  constraint that narrows meaning.
+- Frame verifier-first admission as protection for meaning and execution
+  boundaries, not as a cage.
+- Keep uncertainty and conflict visible instead of smoothing them away.
+- Keep every surface syntax form tied to canonical deterministic lowering.
+- Preserve verifier and SemCode authority boundaries when describing the
+  language or its execution model.
+- Treat local profiling, evidence, and roadmap notes as diagnostic surfaces, not
+  production telemetry.
+- Avoid overclaiming runtime acceleration, P5-A status, GPU/Vulkan plans, or
+  production performance from local evidence.
+- When in doubt, prefer wording that preserves admitted scope over wording that
+  implies broader capability.
+
 PROMETHEUS_RULES:
 - Semantic core remains deterministic and effect-controlled.
 - PROMETHEUS boundary owns external interaction.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ source
 - New to the project: read `docs/roadmap/public_maturity_snapshot.md`.
 - Want to try the pipeline: run the zero-effect verifier smoke path in `Quickstart`.
 - Want the contract: start with `docs/spec/index.md`, `docs/spec/semcode.md`, `docs/spec/verifier.md`, and `docs/spec/vm.md`.
+- Want the language principles: read `docs/language/semantic_language_principles.md`.
 - Want the active development track: read `docs/language/semantic_hello_*`.
 - [Semantic VM Verified Execution Core](docs/architecture/svm_verified_execution_core.md) — current scalar `sm-vm` verified execution path, admission gate, local evidence/profiling paths, and current Pulsar/P5-A status.
 

--- a/docs/language/semantic_language_principles.md
+++ b/docs/language/semantic_language_principles.md
@@ -1,0 +1,61 @@
+# Semantic Language Principles
+
+Status: docs-only principles record for Semantic language framing
+
+## Purpose
+
+This document records the core principles that should remain visible when
+describing Semantic, its verified execution model, and its public surface.
+
+It is a documentation record, not a grammar change, not a verifier change, and
+not a runtime change.
+
+## Principles
+
+- `bool` decides.
+- `quad` means.
+- Semantic keeps native quad semantics, including uncertainty and conflict.
+- Deterministic execution protects meaning; it does not replace expressive
+  freedom.
+- Verifier-first admission protects meaning by checking what is allowed before
+  execution.
+- Uncertainty and conflict stay visible instead of being silently collapsed.
+- Every surface syntax form must lower to canonical deterministic semantics.
+- Future syntax should remain tied to canonical lowering, verifier admission,
+  and SemCode authority boundaries.
+- Local profiling and evidence paths are diagnostic surfaces, not production
+  telemetry.
+- Public claims about acceleration, P5-A, GPU/Vulkan, or performance should
+  stay narrow and evidence-based.
+
+## Assistant Framing
+
+When writing about Semantic, keep these statements clear:
+
+- `bool` is branch control; `quad` is semantic state.
+- There is no implicit `quad -> bool` collapse.
+- Determinism is the condition that makes expressive programs trustworthy.
+- Verifier-first is a protection boundary for meaning, not a cage around it.
+- Canonical lowering owns the deterministic meaning of accepted surface forms.
+- Uncertainty and conflict must remain visible through the toolchain.
+- Do not overstate runtime readiness or promotion status from local evidence.
+
+## Non-Claims
+
+This document does not claim:
+
+- new runtime behavior;
+- new verifier behavior;
+- new SemCode behavior;
+- any public API widening;
+- any performance improvement;
+- any P5-A reopening;
+- any GPU/Vulkan backend;
+- any production telemetry change;
+- any replacement of the verifier-first route.
+
+## Validation
+
+- `git diff --check`
+- `cargo fmt --check`
+- `git status --short`


### PR DESCRIPTION
## Summary

Records Semantic language principles in docs and makes them discoverable from the README and canonical `semantic` skill.

## Scope

- Adds `docs/language/semantic_language_principles.md`.
- Updates `.agents/skills/semantic/SKILL.md` with assistant-facing principles.
- Adds a short README link to the new principles document.

## Boundary

No changes to:

- Rust code
- tests
- VM runtime behavior
- verifier behavior
- SemCode format
- parser/typechecker/lowering
- public Semantic API
- PROMETHEUS / CTF boundaries
- production telemetry
- runtime integration
- P5 implementation
- CI workflows
- Cargo.toml / Cargo.lock

## Validation

- `git diff --check`
- `cargo fmt --check`

## Risk

Low.

Docs-only principles and navigation update.