### PR TITLE
feat(ui): add renderer layout inspector demo

### DIFF
--- a/crates/prom-ui-demo/src/main.rs
+++ b/crates/prom-ui-demo/src/main.rs
@@ -1,5 +1,6 @@
 mod calculator_shell;
 mod demo_interaction;
+mod renderer_layout_inspector;
 
 use demo_interaction::{render_demo_frame, DemoInteraction};
 use prom_ui::layout::{
@@ -21,6 +22,8 @@ use prom_ui::projection::{
 use prom_ui::render_projection_to_model;
 use prom_ui_backend_native::NativeBackend;
 use prom_ui_runtime::{DesktopSession, EventBuffer, LoopControl, SessionState, WindowConfig};
+use renderer_layout_inspector::{demo_inspector_tree, render_inspector_text};
+use std::env;
 
 fn build_static_placement() -> UiLayoutPhysicalPlacementModel {
     let mut artifact = UiProjectionArtifact::new(UiProjectionArtifactId::new(100));
@@ -52,6 +55,13 @@ fn build_static_placement() -> UiLayoutPhysicalPlacementModel {
 }
 
 fn main() {
+    if inspector_requested() {
+        let tree = demo_inspector_tree();
+        let output = render_inspector_text(&tree, "root");
+        println!("{output}");
+        return;
+    }
+
     println!("=== Semantic UI Application Boundary - Native Render Demo ===");
 
     let config = WindowConfig::new("Semantic UI Demo - WGPU Native", 800, 600);
@@ -92,4 +102,15 @@ fn main() {
 
     let _ = session.close();
     println!("Session state after close: {:?}", session.state());
+}
+
+fn inspector_requested() -> bool {
+    if env::args().any(|arg| arg == "inspector" || arg == "--inspector") {
+        return true;
+    }
+
+    match env::var("PROM_UI_DEMO") {
+        Ok(value) => value.eq_ignore_ascii_case("inspector"),
+        Err(_) => false,
+    }
 }

--- a/crates/prom-ui-demo/src/renderer_layout_inspector.rs
+++ b/crates/prom-ui-demo/src/renderer_layout_inspector.rs
@@ -1,0 +1,156 @@
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InspectorNode {
+    pub id: &'static str,
+    pub kind: &'static str,
+    pub rect: LayoutRect,
+    pub children: Vec<InspectorNode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayoutRect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+impl LayoutRect {
+    pub const fn new(x: i32, y: i32, width: i32, height: i32) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+}
+
+pub fn demo_inspector_tree() -> InspectorNode {
+    InspectorNode {
+        id: "root",
+        kind: "container",
+        rect: LayoutRect::new(0, 0, 960, 540),
+        children: vec![
+            InspectorNode {
+                id: "header",
+                kind: "bar",
+                rect: LayoutRect::new(0, 0, 960, 64),
+                children: Vec::new(),
+            },
+            InspectorNode {
+                id: "sidebar",
+                kind: "panel",
+                rect: LayoutRect::new(0, 64, 220, 420),
+                children: Vec::new(),
+            },
+            InspectorNode {
+                id: "content",
+                kind: "panel",
+                rect: LayoutRect::new(220, 64, 740, 420),
+                children: vec![
+                    InspectorNode {
+                        id: "card_a",
+                        kind: "card",
+                        rect: LayoutRect::new(244, 88, 320, 160),
+                        children: Vec::new(),
+                    },
+                    InspectorNode {
+                        id: "card_b",
+                        kind: "card",
+                        rect: LayoutRect::new(588, 88, 320, 160),
+                        children: Vec::new(),
+                    },
+                ],
+            },
+            InspectorNode {
+                id: "footer",
+                kind: "bar",
+                rect: LayoutRect::new(0, 484, 960, 56),
+                children: Vec::new(),
+            },
+        ],
+    }
+}
+
+pub fn flatten_nodes(root: &InspectorNode) -> Vec<&InspectorNode> {
+    fn visit<'a>(node: &'a InspectorNode, nodes: &mut Vec<&'a InspectorNode>) {
+        nodes.push(node);
+        for child in &node.children {
+            visit(child, nodes);
+        }
+    }
+
+    let mut nodes = Vec::new();
+    visit(root, &mut nodes);
+    nodes
+}
+
+pub fn find_node<'a>(root: &'a InspectorNode, id: &str) -> Option<&'a InspectorNode> {
+    if root.id == id {
+        return Some(root);
+    }
+
+    for child in &root.children {
+        if let Some(found) = find_node(child, id) {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
+pub fn render_inspector_text(root: &InspectorNode, selected_id: &str) -> String {
+    let nodes = flatten_nodes(root);
+    let selected = find_node(root, selected_id).unwrap_or(root);
+    let id_width = nodes
+        .iter()
+        .map(|node| node.id.len())
+        .max()
+        .unwrap_or(0)
+        .max(9);
+    let kind_width = nodes
+        .iter()
+        .map(|node| node.kind.len())
+        .max()
+        .unwrap_or(0)
+        .max(9);
+
+    let mut output = String::new();
+    writeln!(&mut output, "Renderer/Layout Inspector").unwrap();
+    writeln!(&mut output).unwrap();
+    writeln!(&mut output, "Nodes:").unwrap();
+
+    for node in nodes {
+        let marker = if node.id == selected.id { ">" } else { " " };
+        writeln!(
+            &mut output,
+            "{marker} {:<id_width$} {:<kind_width$} x={} y={} w={} h={} children={}",
+            node.id,
+            node.kind,
+            node.rect.x,
+            node.rect.y,
+            node.rect.width,
+            node.rect.height,
+            node.children.len(),
+            id_width = id_width,
+            kind_width = kind_width,
+        )
+        .unwrap();
+    }
+
+    writeln!(&mut output).unwrap();
+    writeln!(&mut output, "Selected:").unwrap();
+    writeln!(&mut output, "id: {}", selected.id).unwrap();
+    writeln!(&mut output, "kind: {}", selected.kind).unwrap();
+    writeln!(
+        &mut output,
+        "rect: x={} y={} w={} h={}",
+        selected.rect.x, selected.rect.y, selected.rect.width, selected.rect.height
+    )
+    .unwrap();
+    writeln!(&mut output, "children: {}", selected.children.len()).unwrap();
+
+    output
+}

--- a/crates/prom-ui-demo/tests/renderer_layout_inspector.rs
+++ b/crates/prom-ui-demo/tests/renderer_layout_inspector.rs
@@ -1,0 +1,46 @@
+#[path = "../src/renderer_layout_inspector.rs"]
+mod renderer_layout_inspector;
+
+use renderer_layout_inspector::{
+    demo_inspector_tree, find_node, flatten_nodes, render_inspector_text,
+};
+
+#[test]
+fn demo_tree_is_deterministic() {
+    assert_eq!(demo_inspector_tree(), demo_inspector_tree());
+}
+
+#[test]
+fn flatten_nodes_preserves_expected_order() {
+    let tree = demo_inspector_tree();
+    let nodes = flatten_nodes(&tree);
+    let ids: Vec<&str> = nodes.into_iter().map(|node| node.id).collect();
+    assert_eq!(
+        ids,
+        vec!["root", "header", "sidebar", "content", "card_a", "card_b", "footer"]
+    );
+}
+
+#[test]
+fn find_node_returns_card_b() {
+    let tree = demo_inspector_tree();
+    let card_b = find_node(&tree, "card_b").expect("card_b must exist");
+    assert_eq!(card_b.kind, "card");
+    assert_eq!(card_b.rect.x, 588);
+    assert_eq!(card_b.rect.y, 88);
+    assert_eq!(card_b.rect.width, 320);
+    assert_eq!(card_b.rect.height, 160);
+}
+
+#[test]
+fn render_inspector_text_marks_selected_node() {
+    let tree = demo_inspector_tree();
+    let output = render_inspector_text(&tree, "content");
+
+    assert!(output.contains("Renderer/Layout Inspector"));
+    assert!(output.contains("> content"));
+    assert!(output.contains("id: content"));
+    assert!(output.contains("kind: panel"));
+    assert!(output.contains("rect: x=220 y=64 w=740 h=420"));
+    assert!(output.contains("children: 2"));
+}


### PR DESCRIPTION
## Summary

Adds a first visible renderer/layout inspection slice to `prom-ui-demo`.

The demo renders a deterministic layout fixture with node list, geometry, and selected node details.

## Scope

- Adds demo-local renderer/layout inspector model.
- Adds deterministic UI tree fixture.
- Adds text-mode inspector rendering.
- Adds pure-data tests for tree order, lookup, and selected-node output.

## Boundary

No changes to:

- `prom-ui`
- `prom-ui-runtime`
- `prom-ui-backend-native`
- `apps/workbench`
- VM / verifier / SemCode
- Pulsar
- PCC / CTF
- docs / roadmap
- native runtime integration

This is a code-first UI demo slice.

## Validation

- `cargo test -p prom-ui-demo`
- `cargo run -p prom-ui-demo -- inspector`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low.