### PR TITLE
feat(workbench): add renderer layout inspector prototype

### DIFF
--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -48,6 +48,7 @@ import {
   type WorkbenchDiagnostic,
 } from './diagnostics'
 import './App.css'
+import { RendererLayoutInspector } from './components/RendererLayoutInspector'
 
 type ScreenSpec = {
   path: string
@@ -999,6 +1000,16 @@ function App() {
               <span className="nav-meta">{route.eyebrow}</span>
             </NavLink>
           ))}
+          <NavLink
+            to="/inspector"
+            end={false}
+            className={({ isActive }) =>
+              isActive ? 'nav-link nav-link-active' : 'nav-link'
+            }
+          >
+            <span className="nav-label">Renderer / Layout Inspector</span>
+            <span className="nav-meta">prototype only</span>
+          </NavLink>
         </nav>
 
         <section className="sidebar-card">
@@ -1114,6 +1125,7 @@ function App() {
               }
             />
           ))}
+          <Route path="/inspector" element={<RendererLayoutInspector />} />
         </Routes>
       </main>
     </div>

--- a/apps/workbench/src/components/RendererLayoutInspector.css
+++ b/apps/workbench/src/components/RendererLayoutInspector.css
@@ -1,0 +1,202 @@
+.renderer-layout-inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--color-background-primary, #1e1e1e);
+  color: var(--color-text-primary, #e0e0e0);
+  font-family: var(--font-family-sans, system-ui, sans-serif);
+  overflow: hidden;
+}
+
+.inspector-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border, #333);
+}
+
+.inspector-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.inspector-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--color-border, #333);
+}
+
+.panel:last-child {
+  border-right: none;
+}
+
+.node-tree-panel {
+  width: 250px;
+  min-width: 200px;
+}
+
+.canvas-panel {
+  flex: 1;
+  min-width: 300px;
+  background-color: var(--color-background-inset, #151515);
+}
+
+.details-panel {
+  width: 250px;
+  min-width: 200px;
+}
+
+.panel-title {
+  margin: 0;
+  padding: 12px 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border, #333);
+  color: var(--color-text-secondary, #aaa);
+}
+
+.node-tree-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.tree-node {
+  padding: 6px 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.15s;
+}
+
+.tree-node:hover {
+  background-color: var(--color-background-hover, rgba(255, 255, 255, 0.05));
+}
+
+.tree-node.selected {
+  background-color: var(--color-background-selected, rgba(64, 156, 255, 0.15));
+  border-left: 3px solid var(--color-accent, #409cff);
+}
+
+.tree-node-id {
+  font-weight: 500;
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.85rem;
+}
+
+.tree-node-kind {
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #888);
+  border: 1px solid var(--color-border, #444);
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.canvas-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow: auto;
+}
+
+.canvas-aspect-ratio {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  max-height: 100%;
+  background-color: #222;
+  border: 1px dashed #555;
+}
+
+.canvas-rect {
+  position: absolute;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.02);
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.canvas-rect:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.canvas-rect.selected {
+  border: 2px solid var(--color-accent, #409cff);
+  background-color: rgba(64, 156, 255, 0.1);
+  z-index: 10;
+}
+
+.canvas-rect-label {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  font-size: 0.7rem;
+  font-family: var(--font-family-mono, monospace);
+  color: rgba(255, 255, 255, 0.6);
+  pointer-events: none;
+}
+
+.canvas-rect.selected > .canvas-rect-label {
+  color: var(--color-accent, #409cff);
+  font-weight: bold;
+}
+
+.details-content {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.node-details {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.detail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-key {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #aaa);
+  text-transform: uppercase;
+}
+
+.detail-value {
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.9rem;
+  background-color: rgba(0, 0, 0, 0.2);
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border, #333);
+}
+
+.no-selection {
+  color: var(--color-text-secondary, #888);
+  font-style: italic;
+  text-align: center;
+  padding-top: 32px;
+}
+
+.inspector-footer {
+  padding: 8px 16px;
+  background-color: var(--color-background-inset, #151515);
+  border-top: 1px solid var(--color-border, #333);
+  font-size: 0.75rem;
+  color: var(--color-text-tertiary, #888);
+  text-align: center;
+}

--- a/apps/workbench/src/components/RendererLayoutInspector.tsx
+++ b/apps/workbench/src/components/RendererLayoutInspector.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { layoutFixture, flattenNodes, type InspectorNode } from '../fixtures/rendererLayoutFixture';
+import './RendererLayoutInspector.css';
+
+export function RendererLayoutInspector() {
+  const [selectedNodeId, setSelectedNodeId] = useState<string>('content');
+  const root = layoutFixture;
+  const flatNodes = flattenNodes(root);
+  const selectedNode = flatNodes.find(n => n.id === selectedNodeId);
+
+  const handleNodeClick = (id: string) => {
+    setSelectedNodeId(id);
+  };
+
+  const renderTree = (node: InspectorNode, depth = 0) => {
+    const isSelected = node.id === selectedNodeId;
+    return (
+      <div key={node.id}>
+        <div 
+          className={`tree-node ${isSelected ? 'selected' : ''}`}
+          style={{ paddingLeft: `${depth * 16 + 8}px` }}
+          onClick={() => handleNodeClick(node.id)}
+        >
+          <span className="tree-node-id">{node.id}</span>
+          <span className="tree-node-kind">{node.kind}</span>
+        </div>
+        {node.children.map(child => renderTree(child, depth + 1))}
+      </div>
+    );
+  };
+
+  const renderRect = (node: InspectorNode) => {
+    const isSelected = node.id === selectedNodeId;
+    
+    // For proper scaling, we can use a container with a specific aspect ratio, 
+    // or just assume a fixed scale. Let's use a percentage-based approach for flexibility.
+    const rootWidth = root.rect.width;
+    const rootHeight = root.rect.height;
+    
+    const left = (node.rect.x / rootWidth) * 100;
+    const top = (node.rect.y / rootHeight) * 100;
+    const width = (node.rect.width / rootWidth) * 100;
+    const height = (node.rect.height / rootHeight) * 100;
+
+    return (
+      <div
+        key={node.id}
+        className={`canvas-rect ${isSelected ? 'selected' : ''}`}
+        style={{
+          left: `${left}%`,
+          top: `${top}%`,
+          width: `${width}%`,
+          height: `${height}%`,
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          handleNodeClick(node.id);
+        }}
+      >
+        <div className="canvas-rect-label">{node.id}</div>
+        {node.children.map(child => renderRect(child))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="renderer-layout-inspector">
+      <div className="inspector-header">
+        <h2>Renderer / Layout Inspector</h2>
+      </div>
+      
+      <div className="inspector-body">
+        <div className="panel node-tree-panel">
+          <h3 className="panel-title">Node Tree</h3>
+          <div className="node-tree-content">
+            {renderTree(root)}
+          </div>
+        </div>
+        
+        <div className="panel canvas-panel">
+          <h3 className="panel-title">Layout Canvas</h3>
+          <div className="canvas-container">
+            <div className="canvas-aspect-ratio" style={{ aspectRatio: `${root.rect.width} / ${root.rect.height}` }}>
+              {renderRect(root)}
+            </div>
+          </div>
+        </div>
+        
+        <div className="panel details-panel">
+          <h3 className="panel-title">Details</h3>
+          <div className="details-content">
+            {selectedNode ? (
+              <div className="node-details">
+                <div className="detail-row"><span className="detail-key">id:</span> <span className="detail-value">{selectedNode.id}</span></div>
+                <div className="detail-row"><span className="detail-key">kind:</span> <span className="detail-value">{selectedNode.kind}</span></div>
+                <div className="detail-row"><span className="detail-key">x:</span> <span className="detail-value">{selectedNode.rect.x}</span></div>
+                <div className="detail-row"><span className="detail-key">y:</span> <span className="detail-value">{selectedNode.rect.y}</span></div>
+                <div className="detail-row"><span className="detail-key">width:</span> <span className="detail-value">{selectedNode.rect.width}</span></div>
+                <div className="detail-row"><span className="detail-key">height:</span> <span className="detail-value">{selectedNode.rect.height}</span></div>
+                <div className="detail-row"><span className="detail-key">children:</span> <span className="detail-value">{selectedNode.children.length}</span></div>
+              </div>
+            ) : (
+              <div className="no-selection">No node selected</div>
+            )}
+          </div>
+        </div>
+      </div>
+      
+      <div className="inspector-footer">
+        Prototype only — fixture data, no backend connection.
+      </div>
+    </div>
+  );
+}

--- a/apps/workbench/src/fixtures/rendererLayoutFixture.ts
+++ b/apps/workbench/src/fixtures/rendererLayoutFixture.ts
@@ -1,0 +1,77 @@
+export type InspectorNode = {
+  id: string;
+  kind: string;
+  rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  children: InspectorNode[];
+};
+
+export const layoutFixture: InspectorNode = {
+  id: 'root',
+  kind: 'canvas',
+  rect: { x: 0, y: 0, width: 960, height: 540 },
+  children: [
+    {
+      id: 'header',
+      kind: 'panel',
+      rect: { x: 0, y: 0, width: 960, height: 64 },
+      children: []
+    },
+    {
+      id: 'sidebar',
+      kind: 'panel',
+      rect: { x: 0, y: 64, width: 220, height: 420 },
+      children: []
+    },
+    {
+      id: 'content',
+      kind: 'panel',
+      rect: { x: 220, y: 64, width: 740, height: 420 },
+      children: [
+        {
+          id: 'card_a',
+          kind: 'card',
+          rect: { x: 244, y: 88, width: 320, height: 160 },
+          children: []
+        },
+        {
+          id: 'card_b',
+          kind: 'card',
+          rect: { x: 588, y: 88, width: 320, height: 160 },
+          children: []
+        }
+      ]
+    },
+    {
+      id: 'footer',
+      kind: 'panel',
+      rect: { x: 0, y: 484, width: 960, height: 56 },
+      children: []
+    }
+  ]
+};
+
+export function flattenNodes(root: InspectorNode): InspectorNode[] {
+  const result: InspectorNode[] = [];
+  function traverse(node: InspectorNode) {
+    result.push(node);
+    for (const child of node.children) {
+      traverse(child);
+    }
+  }
+  traverse(root);
+  return result;
+}
+
+export function findNode(root: InspectorNode, id: string): InspectorNode | undefined {
+  if (root.id === id) return root;
+  for (const child of root.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds a first visible Renderer/Layout Inspector prototype to apps/workbench.

The prototype uses deterministic static fixture data and renders:

- node tree;
- layout rectangles;
- selected node details;
- click-based selection;
- status footer noting that there is no backend connection.

## Scope

- Adds workbench-local fixture data.
- Adds RendererLayoutInspector component.
- Adds inspector styling.
- Wires the inspector into the workbench through /inspector and navigation.

## Boundary

No changes to:

- crates/
- docs / roadmap
- VM / verifier / SemCode
- Pulsar
- PCC / CTF
- native backend / winit / wgpu integration

This is a code-first visual prototype.

## Validation

- npm run build
- git diff --check

## Notes

The fixture is static and deterministic.
This PR does not connect the inspector to live renderer/layout runtime output.