### PR TITLE
docs(language): sync quad surface contract

### DIFF
--- a/docs/language/quad_language_design.md
+++ b/docs/language/quad_language_design.md
@@ -39,7 +39,7 @@ QLD covers:
 
 The verifier sees canonical core semantics, not aesthetic syntax.
 
-Future surface forms lower to the following core forms:
+Current surface forms lower to the following core forms:
 
 | Surface | Canonical lowering |
 | --- | --- |

--- a/docs/language/quad_predicate_vocabulary.md
+++ b/docs/language/quad_predicate_vocabulary.md
@@ -62,6 +62,13 @@ That means:
 - conditions remain `bool`;
 - quad values do not become branch control by implication.
 
+The current vocabulary is:
+
+- `x is S` -> `x == S`
+- `known(x)` -> `x != N`
+- `unknown(x)` -> `x == N`
+- `conflict(x)` -> `x == S`
+
 ## Non-Goals
 
 This document does not approve:

--- a/docs/language/quad_surface_syntax_migration.md
+++ b/docs/language/quad_surface_syntax_migration.md
@@ -236,9 +236,8 @@ type boundary.
 
 ## Status Notes
 
-- `== S` and the other current core forms are implemented today.
-- `is`, `when`, `else if`, `match`, and expression-bodied functions are part of
-  the QLD surface-syntax track.
+- `== S`, `is`, `when`, `else if`, `match`, and expression-bodied functions
+  are part of the current QLD surface-syntax track.
 - conservative local `let` inference is implemented today for obvious local
   values.
 - This guide documents the migration path; it does not widen release claims.

--- a/docs/language/semantic_language_experience.md
+++ b/docs/language/semantic_language_experience.md
@@ -156,3 +156,8 @@ This document does not:
 - change parser admission
 - define a release promise
 
+## Related Docs
+
+- [`docs/language/semantic_sugar_track.md`](semantic_sugar_track.md)
+- [`docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md`](../roadmap/language_maturity/semantic_sugar_track_roadmap.md)
+

--- a/docs/language/semantic_quad_surface.md
+++ b/docs/language/semantic_quad_surface.md
@@ -49,10 +49,14 @@ The current admitted branch vocabulary is explicit:
 
 - `if q == T { ... }`
 - `if q == F { ... }`
+- `if q is S { ... }`
+- `known(q)`
+- `unknown(q)`
+- `conflict(q)`
 - `match q { N => ... F => ... T => ... S => ... _ => ... }`
 
-Roadmap vocabulary candidates such as `when` and `is` should be treated as
-design candidates, not as current admitted grammar.
+`when` is the compact expression-selection form used in quad-heavy code, and
+`is` is the readable surface alias for explicit quad comparison.
 
 ## Surface Syntax
 
@@ -86,7 +90,9 @@ Canonical lowering stays deterministic:
 
 - `if q == T { ... }` lowers through the `bool` result of the comparison
 - `if q == F { ... }` lowers the same way
+- `if q is S { ... }` lowers through the same `bool` comparison path
 - `else if` lowers as nested `if` in source order
+- `when` lowers as nested expression `if`
 - `match q` lowers as ordered dispatch over the quad literals
 - `_` remains the explicit default arm
 
@@ -151,7 +157,6 @@ if boot==T { observe "ready"; }
 
 This document does not:
 
-- claim `when` or `is` are currently admitted parser forms
 - collapse `quad` into boolean truthiness
 - widen runtime behavior
 - change verifier policy

--- a/docs/language/semantic_sugar_track.md
+++ b/docs/language/semantic_sugar_track.md
@@ -1,0 +1,162 @@
+# Semantic Sugar Track RFC
+
+Status: proposal
+
+## Purpose
+
+This document records a narrow syntactic-sugar track for Semantic.
+
+The goal is to improve readability and reduce ritual without changing the
+deterministic execution model, verifier boundaries, or SemCode lowering
+discipline.
+
+## Design Principles
+
+- Sugar must lower to an obvious canonical core form.
+- Sugar must not add hidden runtime behavior.
+- Sugar must not blur `bool` and `quad`.
+- Sugar must not create a second canonical way to express the same core rule.
+- Sugar must be readable in dense policy-heavy code.
+- Sugar must stay easy to diagnose when malformed.
+
+## Proposed Surface
+
+### Field Punning
+
+Field punning allows record fields to omit the redundant `field: field` form
+when a local binding with the same name is already in scope.
+
+Example:
+
+```sm
+let consensus = S;
+let alert = T;
+let quality = 0.8;
+
+let plan = DecisionPlan { consensus, alert, quality };
+```
+
+Canonical lowering:
+
+```sm
+let plan = DecisionPlan {
+    consensus: consensus,
+    alert: alert,
+    quality: quality,
+};
+```
+
+### Tail Expression Return
+
+Tail expression return allows a value-producing block to omit the final
+`return` when the last expression is already in value position.
+
+Example:
+
+```sm
+fn abs_delta(x: f64, y: f64) -> f64 {
+    let d = x - y;
+    abs(d)
+}
+```
+
+Canonical lowering:
+
+```sm
+fn abs_delta(x: f64, y: f64) -> f64 {
+    let d = x - y;
+    return abs(d);
+}
+```
+
+### Quad Predicate Vocabulary
+
+Readable quad predicates may be surfaced as aliases for explicit comparisons.
+
+Proposed forms:
+
+- `known(x)` lowers to `x != N`
+- `unknown(x)` lowers to `x == N`
+- `conflict(x)` lowers to `x == S`
+
+Optional companion alias:
+
+- `x is S` lowers to `x == S`
+
+Example:
+
+```sm
+if conflict(camera_state) {
+    return S;
+}
+```
+
+Canonical lowering:
+
+```sm
+if camera_state == S {
+    return S;
+}
+```
+
+## Alternatives Considered
+
+- Keep only explicit core syntax and avoid all sugar.
+- Add `unless` as a general negated guard keyword.
+- Add `when let` before the simpler record and tail-expression sugar.
+- Introduce a pipeline operator before pinning down quad predicate vocabulary.
+
+These alternatives were rejected or deferred because they either add more
+surface than they remove, or they complicate the lowering story before the
+lowest-risk improvements land.
+
+## Rollout
+
+Suggested implementation order:
+
+1. field punning
+2. tail expression return
+3. quad predicate vocabulary aliases
+
+Only after those are stable should the repository consider:
+
+- `when let`
+- `unless`
+- pipeline operator `|>`
+
+## Open Questions
+
+- Should field punning be allowed in record update blocks on day one, or added
+  after record literals only?
+- Should tail expressions apply only in explicit value position, or also inside
+  arm bodies where the context is already value-producing?
+- Should `is` remain a short alias for `==` against `S`, or stay deferred until
+  the quad predicate vocabulary settles?
+
+## Deferred Ideas
+
+- `when let`
+- `unless`
+- pipeline operator `|>`
+
+These may remain roadmap candidates, but they are not required for the first
+pass of this sugar track.
+
+## Non-Goals
+
+This document does not:
+
+- change the runtime model
+- introduce dynamic typing
+- introduce reflection
+- relax verifier admission
+- add implicit truthiness
+- widen `quad` into `bool`
+- claim implementation status
+
+## Related Docs
+
+- [`docs/language/semantic_language_experience.md`](semantic_language_experience.md)
+- [`docs/language/semantic_code_style_principles.md`](semantic_code_style_principles.md)
+- [`docs/language/semantic_quad_surface.md`](semantic_quad_surface.md)
+- [`docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md`](../roadmap/language_maturity/semantic_sugar_track_roadmap.md)

--- a/docs/roadmap/language_maturity/semantic_language_experience_roadmap.md
+++ b/docs/roadmap/language_maturity/semantic_language_experience_roadmap.md
@@ -28,7 +28,8 @@ It is a documentation roadmap, not an implementation promise.
 9. [`conflict quarantine UX pattern`](../../language/semantic_conflict_quarantine_ux_pattern.md)
 10. [`non-goals`](../../language/semantic_language_non_goals.md)
 11. [`examples`](../../examples/semantic_language_experience_examples.md)
-12. [`closeout record`](semantic_language_experience_closeout.md)
+12. [`sugar track`](../../language/semantic_sugar_track.md)
+13. [`closeout record`](semantic_language_experience_closeout.md)
 
 ## Guardrails
 

--- a/docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md
+++ b/docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md
@@ -1,0 +1,54 @@
+# Semantic Sugar Track Roadmap
+
+Status: active documentation roadmap
+Scope type: documentation only
+
+## Purpose
+
+This roadmap groups the sugar-track proposals that improve readability while
+keeping the Semantic core deterministic and verifier-friendly.
+
+It is a documentation roadmap, not an implementation promise.
+
+## Design Goals
+
+- keep canonical lowering obvious
+- reduce repetition in record-heavy code
+- reduce return noise in value-producing blocks
+- make quad predicates read like domain language
+- keep diagnostics and parsing simple
+
+## Included Topics
+
+- field punning
+- tail expression return
+- quad predicate vocabulary aliases
+
+## Deferred Topics
+
+- `when let`
+- `unless`
+- pipeline operator `|>`
+
+## Related Docs
+
+- [`docs/language/semantic_sugar_track.md`](../../language/semantic_sugar_track.md)
+- [`docs/language/semantic_language_experience.md`](../../language/semantic_language_experience.md)
+- [`docs/language/semantic_code_style_principles.md`](../../language/semantic_code_style_principles.md)
+- [`docs/language/semantic_quad_surface.md`](../../language/semantic_quad_surface.md)
+
+## Sequence
+
+1. field punning
+2. tail expression return
+3. quad predicate vocabulary aliases
+4. examples
+5. closeout record
+
+## Guardrails
+
+- do not claim grammar support before parser work lands
+- do not add hidden semantics
+- do not widen runtime behavior
+- do not introduce a second canonical spelling for the same core meaning
+- keep examples explicitly labeled as proposed until implementation exists

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -607,6 +607,8 @@ Current `if` semantics:
 Current `if` expression semantics:
 
 - `if condition { ... } else { ... }` may appear in value position
+- `if condition { ... } else if condition { ... } else { ... }` is also
+  admitted and lowers through the same nested `if` structure
 - both branches are evaluated through value-producing block semantics
 - both branches must produce the same type
 - `else` is required for value-producing `if`
@@ -646,8 +648,8 @@ control-flow branch.
 
 Current v0 limit:
 
-- `else if` sugar is not yet supported for value-producing `if`; users must
-  write `else { if ... }`
+- `if` still requires `bool` conditions; `quad` is not an implicit condition
+  type
 
 ### Expression-Bodied Functions
 
@@ -667,11 +669,11 @@ Current quad selection remains explicit and deterministic:
   forms for quad values
 - `match q { ... }` remains the compact selection form when all four quad
   states must be handled together
+- `when` is the compact expression-selection form used in quad-heavy code; it
+  lowers to the canonical nested expression-`if` shape
+- `is` is a readable alias for explicit quad comparison and lowers to `==`
 - `else if` remains nested `if` sugar in source order and does not add a new
   quad predicate family
-- `when` and `is` are discussed in roadmap/design documents as vocabulary
-  candidates for future quad-heavy syntax, but they are not part of the current
-  source contract
 
 ## Tuples
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -159,6 +159,8 @@ Current v0 record limits:
 - `RecordName { field: expr, ... }` is the current stage-1 record construction form
 - `record_value.field_name` is the current stage-1 read-only field access form
 - `record_value with { field: expr, ... }` is the current stage-2 immutable record update form
+- record literals and record updates may use field punning shorthand when the
+  field name and the in-scope binding name are the same
 - record literal fields must appear exactly once by name
 - lowering preserves declaration-slot order rather than source-field order
 - record types may now appear in executable local bindings, parameters, and returns
@@ -214,6 +216,7 @@ Current statement forms:
 - `guard condition else return expr;`
 - `assert(condition);`
 - `if condition { ... } else { ... }`
+- `if condition { ... } else if condition { ... } else { ... }`
 - `match quad_expr { T => { ... } ... _ => { ... } }`
 - `match quad_expr { T if ready == true => { ... } ... _ => { ... } }`
 - `match maybe_expr { Maybe::Some(value) => { ... } _ => { ... } }`
@@ -341,6 +344,8 @@ Current expression forms:
 - `match` expressions with value-producing arms:
   - `match state { T => { 1.0 } _ => { 0.0 } }`
   - `match state { T if ready == true => { 1.0 } _ => { 0.0 } }`
+- `when` expressions for quad-oriented rule selection:
+  - `when ready { 1.0 } else { 0.0 }`
 - `loop` expressions with explicit `break value`:
   - `loop { break 1.0; }`
   - `loop { if ready { break 1.0; } else { break 0.0; } }`
@@ -354,6 +359,7 @@ Current expression forms:
   - `+`, `-`
   - `<`, `<=`, `>`, `>=`
   - `==`, `!=`
+  - `is`
   - `&&`, `||`
   - `->`
 
@@ -368,6 +374,66 @@ Current v0 numeric-literal limits:
 - typed literal spelling does not imply new integer arithmetic beyond the
   already documented operator surface
 - tuple literal arity must be at least 2 in the current contract
+
+## Field Punning And Tail Expressions
+
+The current source contract keeps a narrow, deterministic sugar layer for
+readability. These forms are syntax-only conveniences and lower into the same
+canonical core shapes as their explicit counterparts.
+
+### Field Punning
+
+Field punning is accepted in record literals and record updates when a field
+name is spelled exactly the same as an in-scope binding name.
+
+Current forms:
+
+- `RecordName { field }`
+- `record_value with { field }`
+
+Canonical lowering:
+
+- `RecordName { field }` lowers to `RecordName { field: field }`
+- `record_value with { field }` lowers to `record_value with { field: field }`
+
+Current constraints:
+
+- the field name must resolve to a local binding in scope
+- the shorthand does not introduce a new binding
+- the shorthand does not rename or infer a different field name
+- the shorthand is available only where the surrounding record form is already valid
+
+### Tail Expression Return
+
+Value-producing blocks may end with a final expression that becomes the block
+result without an explicit `return`.
+
+Current form:
+
+- `{ let d = x - y; abs(d) }`
+
+Canonical lowering:
+
+- the tail expression lowers as if the block contained `return abs(d);`
+
+Current constraints:
+
+- the shorthand applies only when the block is already in value position
+- intermediate statements still require semicolons
+- a trailing expression without `;` is the only implicit-return form
+- statement-only blocks do not gain an implicit return rule
+- the shorthand does not change control-flow exhaustiveness rules for `if`,
+  `match`, or `loop`
+
+### Related Lowering Rule
+
+Both sugar forms preserve the current canonical lowering discipline:
+
+- the parser accepts the surface form only when the underlying core shape is
+  already well-typed and unambiguous
+- lowering expands the sugar before SemCode generation
+- diagnostics should point back to the canonical explicit form when the sugar
+  is malformed
 
 Current text-literal limits:
 
@@ -608,6 +674,9 @@ Current source restrictions:
 
 - `if quad_expr` is forbidden; users must write an explicit comparison
 - `match` currently accepts only `quad` scrutinees
+- `when` is an expression-level surface form for explicit boolean selection
+- `is` is a readable alias for explicit quad comparison, not a truthiness
+  coercion
 - quad implication uses `->`
 
 ## Builtin Calls


### PR DESCRIPTION
Synchronizes the quad surface docs with the current source syntax and source semantics contract.

Covers:
- is
- when
- lse if
- quad predicate vocabulary
- quad surface migration guidance
- related experience and roadmap docs

Docs-only change. No runtime, parser, or verifier changes included.