### PR TITLE
docs(language): freeze public language identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This is a zero-effect program. It is useful for checking the core path without c
 
 A Semantic program is compiled into SemCode, admitted by a verifier, and then executed by a deterministic VM under explicit runtime limits and capability boundaries.
 
+The canonical public language name is `Semantic Language`. `Semantic` is the short form used throughout the repository prose and tooling references.
+
 The core execution path is:
 
 ```text
@@ -75,10 +77,10 @@ The public contract is centered in `docs/spec/*`. Historical roadmap notes and l
 
 ## Semantic Language canonical samples
 
-Semantic is the programming language in this repository. In the public surface:
+Semantic Language is the programming language in this repository. In the public surface:
 
-- `.sm` is Semantic source;
-- `.smc` is the compiled SemCode artifact;
+- `.sm` is the primary Semantic Language source extension;
+- `.smc` is the compiled SemCode artifact generated from source;
 - `smc` is the command-line toolchain owner.
 
 These samples are intended as the canonical public sample surface for Semantic Language. They are backed by [`tests/canonical_examples.rs`](tests/canonical_examples.rs) and kept distinct from qualification fixtures, benchmark programs, readiness drafts, and internal or experimental examples.

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -1,7 +1,9 @@
-# Semantic
+# Semantic Language
 
-Semantic is not just a programming language and not just syntax sugar over an existing VM.
+Semantic Language is not just a programming language and not just syntax sugar over an existing VM.
 It is a utilitarian language for describing reasoning processes, inference rules, and semantic state transitions inside the PROMETHEUS system model.
+
+The canonical public language name is `Semantic Language`. `Semantic` is the short form used in repository prose.
 
 Its purpose is to express meaning-oriented logic with the same rigor that ordinary languages apply to computation.
 

--- a/docs/NAMING.md
+++ b/docs/NAMING.md
@@ -11,14 +11,15 @@ This note defines the project's naming rules and the meaning of its short forms.
 
 ## Product Names
 
-- `Semantic Language`: the language and overall project identity.
+- `Semantic Language`: the canonical public language name and overall project identity.
+- `Semantic`: the short form used in prose, headings, and tooling references.
 - `TON618 Core`: the low-level core/engine identity.
 
 ## File Extensions
 
-- `.sm`: source code for Semantic Language.
+- `.sm`: the primary public source code extension for Semantic Language.
 - `.sem`: textual machine/intermediate representation.
-- `.smc`: compiled SemCode bytecode.
+- `.smc`: compiled SemCode bytecode generated from `.sm` source.
 
 ## Tools
 

--- a/docs/roadmap/public_status_model.md
+++ b/docs/roadmap/public_status_model.md
@@ -8,6 +8,11 @@ Primary owners: release discipline, readiness posture, public-facing truth
 This document defines the canonical status vocabulary used by readiness-facing
 and release-facing Semantic documents.
 
+The public identity terms used by the repository are frozen separately in
+`docs/NAMING.md`: `Semantic Language` is the canonical public language name,
+`Semantic` is the short form, `.sm` is the primary public source extension, and
+`.smc` is the generated SemCode artifact.
+
 Its purpose is not to widen scope, reinterpret existing behavior, or change the
 current release verdict.
 


### PR DESCRIPTION
This freezes the public identity surface for Semantic Language.

Scope:
- canonical public language name: `Semantic Language`
- short form in prose: `Semantic`
- primary public source extension: `.sm`
- generated artifact: `.smc`

The change only synchronizes README / naming / status docs. It does not change syntax, grammar, or implementation.

Closes #357
