### PR TITLE
docs(language): prepare canonical .sm samples

### DIFF
--- a/examples/canonical/README.md
+++ b/examples/canonical/README.md
@@ -16,6 +16,19 @@ This pack is intentionally split into:
 - five positive examples inside the current `qualified limited release` contour
 - one boundary example that shows a still-real limit honestly
 
+This pack is also the canonical `.sm` sample surface intended for future GitHub
+Linguist review. The five positive examples are small, readable, and stable
+enough to serve as representative language samples:
+
+- `cli_batch_core`
+- `rule_state_decision`
+- `data_audit_record_iterable`
+- `wave2_local_helper_import`
+- `positive_selected_import`
+
+The boundary example remains included as an honest exclusion marker and should
+not be treated as a positive sample for Linguist detection.
+
 ## Canonical Examples
 
 1. `cli_batch_core`


### PR DESCRIPTION
This documents the existing canonical `.sm` sample pack as the representative surface for future GitHub Linguist review.

Scope:
- keep the sample set small and readable;
- point to the five positive canonical samples already covered by tests;
- keep the boundary example as an honest exclusion marker.

No syntax, parser, or compiler behavior changes.

Closes #358
