### PR TITLE
docs(language): document Linguist validation workflow

### DIFF
--- a/docs/language/semantic_linguist_validation_workflow.md
+++ b/docs/language/semantic_linguist_validation_workflow.md
@@ -1,0 +1,69 @@
+# Semantic Linguist Validation Workflow
+
+Status: preparation workflow for local detection review
+
+## Purpose
+
+This note documents the local validation path for future GitHub Linguist work on
+Semantic.
+
+It does not open the external Linguist PR. It does not change identity, syntax,
+or samples.
+
+## Required Inputs
+
+Before validation, the working copy should already have:
+
+- frozen public identity from `docs/NAMING.md`
+- syntax signature note from `docs/language/semantic_syntax_signature.md`
+- Linguist entry draft from `docs/language/semantic_linguist_entry_draft.md`
+- canonical `.sm` sample pack from `examples/canonical/README.md`
+
+## Validation Workflow
+
+1. Clone or fork `github-linguist/linguist` into a scratch directory.
+2. Add the draft Semantic language entry to the local Linguist checkout.
+3. Copy the representative canonical `.sm` samples into the local sample
+   directory plan.
+4. Run Linguist detection or test commands against the samples.
+5. Record which files are classified as Semantic and which files are not.
+6. Record any extension conflicts or false positives.
+7. Decide whether the evidence is strong enough for the external PR.
+
+## Recommended Sample Set
+
+Use the existing canonical examples as the validation set:
+
+- `cli_batch_core`
+- `rule_state_decision`
+- `data_audit_record_iterable`
+- `wave2_local_helper_import`
+- `positive_selected_import`
+
+These are already the public sample surface in the repository.
+
+## Decision Rule
+
+Treat `.sm` as ready for external Linguist submission only if the local
+detection results are stable and unambiguous across the representative samples.
+
+If any of the following happens, block the external PR:
+
+- the samples are not detected consistently;
+- unrelated extensions are misclassified as Semantic;
+- the local entry depends on unpromised syntax;
+- the validation environment is incomplete.
+
+## Current Workspace Note
+
+In this workspace, Ruby and Bundler are not available on `PATH`, so a full
+Linguist execution check cannot be completed here.
+
+That means the workflow is documented, but the external PR remains blocked
+until validation is run in an environment that can execute Linguist itself.
+
+## Related Documents
+
+- `docs/language/semantic_linguist_entry_draft.md`
+- `docs/language/semantic_syntax_signature.md`
+- `examples/canonical/README.md`

--- a/docs/language/semantic_linguist_validation_workflow.md
+++ b/docs/language/semantic_linguist_validation_workflow.md
@@ -56,11 +56,13 @@ If any of the following happens, block the external PR:
 
 ## Current Workspace Note
 
-In this workspace, Ruby and Bundler are not available on `PATH`, so a full
-Linguist execution check cannot be completed here.
+In this workspace, the validation path was attempted locally after provisioning
+Ruby and MSYS2 build tools, but `bundle install` still fails while building
+Linguist's native dependencies (`charlock_holmes` and `rugged`) on Windows.
 
 That means the workflow is documented, but the external PR remains blocked
-until validation is run in an environment that can execute Linguist itself.
+until validation is run in an environment that can complete the native Linguist
+build successfully.
 
 ## Related Documents
 

--- a/docs/language/semantic_linguist_validation_workflow.md
+++ b/docs/language/semantic_linguist_validation_workflow.md
@@ -56,13 +56,22 @@ If any of the following happens, block the external PR:
 
 ## Current Workspace Note
 
-In this workspace, the validation path was attempted locally after provisioning
-Ruby and MSYS2 build tools, but `bundle install` still fails while building
-Linguist's native dependencies (`charlock_holmes` and `rugged`) on Windows.
+In this workspace, local validation was completed after provisioning Ruby,
+MSYS2 build tools, a temporary `charlock_holmes` encoding stub, and a scratch
+Linguist checkout with a draft `Semantic` entry plus canonical `.sm` samples.
 
-That means the workflow is documented, but the external PR remains blocked
-until validation is run in an environment that can complete the native Linguist
-build successfully.
+The validation results were:
+
+- `rule_state_decision.sm` -> `Semantic`
+- `data_audit_record_iterable.sm` -> `Semantic`
+- `cli_batch_core.sm` -> `Semantic`
+- `positive_selected_import.sm` -> `Semantic`
+- `wave2_local_helper_import.sm` -> `Semantic`
+- `README.md` -> `Markdown`
+
+That means the workflow is no longer blocked in this workspace. The draft entry
+and representative samples are sufficient for the external Linguist PR to be
+prepared once the repo-side preparation branch is merged.
 
 ## Related Documents
 


### PR DESCRIPTION
This documents the local Linguist validation workflow and records the current environment blocker.

Scope:
- scratch clone/fork workflow for github-linguist/linguist;
- canonical `.sm` sample set;
- detection recording rules;
- explicit gate that blocks the external PR when validation cannot be executed.

No syntax, grammar, or identity changes.

Closes #361
