### PR TITLE
docs(linguist): add Semantic recognition readiness issue templates

### DIFF
--- a/docs/roadmap/issues/issue_linguist_semantic_grammar_repo.md
+++ b/docs/roadmap/issues/issue_linguist_semantic_grammar_repo.md
@@ -1,0 +1,29 @@
+# Linguist: Semantic Grammar Repository
+
+## Status
+
+Readiness infrastructure.
+
+## Purpose
+
+Prepare the public grammar repository needed for Semantic language recognition.
+
+This is infrastructure for readiness, not an acceptance claim.
+
+## Scope
+
+- confirm the grammar repository exists or is ready to be created;
+- keep `scopeName: source.semantic` documented;
+- keep the grammar license to verify;
+- keep the upstream Linguist submission blocked until the broader evidence is ready.
+
+## Acceptance Criteria
+
+- the document frames the grammar repo as readiness infrastructure;
+- the document does not say GitHub Linguist has accepted Semantic;
+- the document does not say Semantic highlighting is ready upstream;
+- the document keeps the usage-evidence blocker visible.
+
+## Notes
+
+This track can define the grammar-repo surface, but it does not by itself prove readiness for upstream submission.

--- a/docs/roadmap/issues/issue_linguist_semantic_local_validation.md
+++ b/docs/roadmap/issues/issue_linguist_semantic_local_validation.md
@@ -1,0 +1,26 @@
+# Linguist: Semantic Local Validation
+
+## Status
+
+Local validation pending.
+
+## Purpose
+
+Prepare a local validation plan for the Semantic Linguist readiness work.
+
+## Scope
+
+- define local validation steps for the readiness track;
+- keep the environment dependency explicit;
+- avoid claiming validation success unless it is actually run in the target environment.
+
+## Acceptance Criteria
+
+- the document says `local validation pending` or equivalent;
+- the document says `planned` or `environment-dependent`;
+- the document does not claim tests pass without an actual run;
+- the document does not overclaim readiness.
+
+## Notes
+
+Local validation is part of the readiness track, but it is not proof of upstream acceptance.

--- a/docs/roadmap/issues/issue_linguist_semantic_readiness.md
+++ b/docs/roadmap/issues/issue_linguist_semantic_readiness.md
@@ -1,0 +1,32 @@
+# Linguist: Semantic Recognition Readiness
+
+## Status
+
+Not submit-ready.
+
+## Purpose
+
+Track readiness for GitHub Linguist recognition of the Semantic language.
+
+This document is a readiness track, not a submission claim.
+
+## Scope
+
+- document the current recognition readiness surface;
+- keep the upstream PR blocked until usage evidence is strong enough;
+- keep the blocker wording explicit;
+- keep this aligned with the candidate grammar repo and sample plan.
+
+## Acceptance Criteria
+
+- the document says `not submit-ready`;
+- the document says `readiness track`;
+- the document says `blocked by usage evidence`;
+- the document says `no upstream PR yet`;
+- the document does not claim Linguist acceptance.
+
+## Notes
+
+GitHub Linguist should not be treated as already accepting Semantic.
+
+The only honest position at this stage is that the project is collecting readiness evidence.

--- a/docs/roadmap/issues/issue_linguist_semantic_samples.md
+++ b/docs/roadmap/issues/issue_linguist_semantic_samples.md
@@ -1,0 +1,36 @@
+# Linguist: Semantic Canonical Samples
+
+## Status
+
+Readiness samples.
+
+## Purpose
+
+Prepare canonical Semantic samples for future `samples/Semantic/` inclusion.
+
+These samples support readiness, but they do not prove Linguist acceptance.
+
+## Scope
+
+- select small representative `.sm` examples;
+- keep them licensed clearly;
+- keep them stable enough for Linguist samples;
+- keep them representative of actual Semantic usage.
+
+## Suggested Sample Set
+
+- `samples/Semantic/weather_station.sm`
+- `samples/Semantic/deterministic_safe.sm`
+- `samples/Semantic/quad_decision.sm`
+- `samples/Semantic/module_imports.sm`
+
+## Acceptance Criteria
+
+- the samples are marked as readiness or canonical candidates;
+- the document does not say samples alone prove readiness;
+- the document does not overclaim upstream Linguist acceptance;
+- the document does not replace the grammar repo or usage evidence tracks.
+
+## Notes
+
+Samples are useful evidence, but they are not the whole readiness story.

--- a/docs/roadmap/issues/issue_linguist_semantic_usage_evidence.md
+++ b/docs/roadmap/issues/issue_linguist_semantic_usage_evidence.md
@@ -1,0 +1,28 @@
+# Linguist: Semantic `.sm` Usage Evidence
+
+## Status
+
+Blocked by usage evidence.
+
+## Purpose
+
+Collect and document public `.sm` usage evidence for Semantic before any upstream Linguist submission.
+
+## Scope
+
+- record the search URL;
+- record the indexed result count;
+- exclude forks from the evidence;
+- check the distribution across unique `user/repo` combinations;
+- document honestly if the evidence is dominated by `skulmakov-oss/Semantic` or related repos.
+
+## Acceptance Criteria
+
+- the upstream PR remains blocked until public `.sm` usage evidence is strong enough;
+- the document does not overclaim readiness;
+- the document does not treat a search query alone as proof;
+- the document does not claim the `.sm` threshold is met without a count and distribution check.
+
+## Notes
+
+This is an evidence collection track, not a submission track.


### PR DESCRIPTION
## Summary

Add conservative Linguist readiness issue templates for Semantic language recognition.

This is the first small port slice selected from the external PR #1301 reference after bridge, inventory, wording, and port-plan audits.

## Layer

Docs only.

## Contract impact

None.

No runtime, verifier, VM, SemCode, capability, tests, examples, or 7hell behavior changed.

## Files

- `docs/roadmap/issues/issue_linguist_semantic_readiness.md`
- `docs/roadmap/issues/issue_linguist_semantic_grammar_repo.md`
- `docs/roadmap/issues/issue_linguist_semantic_usage_evidence.md`
- `docs/roadmap/issues/issue_linguist_semantic_samples.md`
- `docs/roadmap/issues/issue_linguist_semantic_local_validation.md`

## Readiness wording

The templates remain conservative:

- Semantic is not submit-ready for upstream Linguist.
- `.sm` public usage evidence remains a blocker.
- Grammar/sample/local validation tracks are readiness infrastructure only.
- No upstream PR should be opened yet.

## Validation

Commit gate passed locally.

Staged diff was limited to exactly the five Linguist readiness template files.

## Non-goals

- no PCC Practical Core claim
- no CTF sync claim
- no examples/tests/7hell changes
- no upstream Linguist PR