### PR TITLE
docs(language): add Semantic sugar track RFC

### DIFF
--- a/docs/language/semantic_sugar_track_rfc.md
+++ b/docs/language/semantic_sugar_track_rfc.md
@@ -1,0 +1,139 @@
+# Semantic Sugar Track RFC
+
+**Status:** proposal
+
+## Purpose
+This document records a narrow syntactic-sugar track for Semantic.
+The goal is to improve readability and reduce ritual without changing the
+deterministic execution model, verifier boundaries, or SemCode lowering
+discipline.
+
+## Design Principles
+- Sugar must lower to an obvious canonical core form.
+- Sugar must not add hidden runtime behavior.
+- Sugar must not blur bool and quad.
+- Sugar must not create a second canonical way to express the same core rule.
+- Sugar must be readable in dense policy-heavy code.
+- Sugar must stay easy to diagnose when malformed.
+
+## Proposed Surface
+
+### Field Punning
+Field punning allows record fields to omit the redundant `field: field` form
+when a local binding with the same name is already in scope.
+
+**Example:**
+```semantic
+let consensus = S;
+let alert = T;
+let quality = 0.8;
+
+let plan = DecisionPlan { consensus, alert, quality };
+```
+
+**Canonical lowering:**
+```semantic
+let plan = DecisionPlan {
+    consensus: consensus,
+    alert: alert,
+    quality: quality,
+};
+```
+
+### Tail Expression Return
+Tail expression return allows a value-producing block to omit the final
+`return` when the last expression is already in value position.
+
+**Example:**
+```semantic
+fn abs_delta(x: f64, y: f64) -> f64 {
+    let d = x - y;
+    abs(d)
+}
+```
+
+**Canonical lowering:**
+```semantic
+fn abs_delta(x: f64, y: f64) -> f64 {
+    let d = x - y;
+    return abs(d);
+}
+```
+
+### Quad Predicate Vocabulary
+Readable quad predicates may be surfaced as aliases for explicit comparisons.
+
+**Proposed forms:**
+- `known(x)` lowers to `x != N`
+- `unknown(x)` lowers to `x == N`
+- `conflict(x)` lowers to `x == S`
+
+**Optional companion alias:**
+- `x is S` lowers to `x == S`
+
+**Example:**
+```semantic
+if conflict(camera_state) {
+    return S;
+}
+```
+
+**Canonical lowering:**
+```semantic
+if camera_state == S {
+    return S;
+}
+```
+
+## Alternatives Considered
+- Keep only explicit core syntax and avoid all sugar.
+- Add `unless` as a general negated guard keyword.
+- Add `when let` before the simpler record and tail-expression sugar.
+- Introduce a pipeline operator before pinning down quad predicate vocabulary.
+
+These alternatives were rejected or deferred because they either add more
+surface than they remove, or they complicate the lowering story before the
+lowest-risk improvements land.
+
+## Rollout
+Suggested implementation order:
+1. field punning
+2. tail expression return
+3. quad predicate vocabulary aliases
+
+Only after those are stable should the repository consider:
+- `when let`
+- `unless`
+- pipeline operator `|>`
+
+## Open Questions
+- Should field punning be allowed in record update blocks on day one, or added
+after record literals only?
+- Should tail expressions apply only in explicit value position, or also inside
+arm bodies where the context is already value-producing?
+- Should `is` remain a short alias for `==` against `S`, or stay deferred until
+the quad predicate vocabulary settles?
+
+## Deferred Ideas
+- `when let`
+- `unless`
+- pipeline operator `|>`
+
+These may remain roadmap candidates, but they are not required for the first
+pass of this sugar track.
+
+## Non-Goals
+This document does not:
+- change the runtime model
+- introduce dynamic typing
+- introduce reflection
+- relax verifier admission
+- add implicit truthiness
+- widen quad into bool
+- claim implementation status
+
+## Related Docs
+- [`docs/language/semantic_language_experience.md`](semantic_language_experience.md)
+- [`docs/language/semantic_code_style_principles.md`](semantic_code_style_principles.md)
+- [`docs/language/semantic_quad_surface.md`](semantic_quad_surface.md)
+- [`docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md`](../roadmap/language_maturity/semantic_sugar_track_roadmap.md)

--- a/docs/roadmap/pcc/semantic_sugar_track_rfc_classification_audit.md
+++ b/docs/roadmap/pcc/semantic_sugar_track_rfc_classification_audit.md
@@ -1,0 +1,71 @@
+# Semantic Sugar Track RFC Classification Audit
+
+## Status
+
+Result: TRACK-AS-DOC-CANDIDATE
+
+This is an audit-only classification.
+
+No files were deleted.
+No files were staged.
+No files were committed.
+No RFC content was changed.
+No code/tests/examples/7hell files were changed.
+
+## Source repo state
+
+- branch: `main`
+- HEAD: `a786dcbaf12de030669d85b10790138b5cf15e92`
+- main == origin/main: `yes`
+- dirty tree: untracked files are present
+- target file: `docs/language/semantic_sugar_track_rfc.md`
+
+## Target file
+
+- path: `docs/language/semantic_sugar_track_rfc.md`
+- tracked state: untracked
+- summary: proposal for a narrow Semantic syntactic-sugar track
+- proposed surface: field punning, tail expression return, quad predicate vocabulary aliases
+- implementation status: proposal only, not implemented
+
+## Classification matrix
+
+| Criterion | Result | Evidence |
+|---|---:|---|
+| Proposal-only wording | PASS | File status is `proposal`; purpose says it improves readability without changing the execution model, verifier boundaries, or SemCode lowering discipline. |
+| No implemented-feature claim | PASS | The RFC explicitly says sugar must not add hidden runtime behavior and does not claim implementation status. |
+| No PCC/CTF readiness claim | PASS | The RFC does not mention PCC or CTF readiness or any qualification claim. |
+| No verifier/capability bypass | PASS | The design principles forbid hidden runtime behavior and preserve verifier boundaries. |
+| Correct roadmap placement | PASS | The file is a language-design proposal in `docs/language/`; a companion roadmap already exists in `docs/roadmap/language_maturity/semantic_sugar_track_roadmap.md`. |
+| Safe to track later | PASS | The document is conservative enough to be tracked later as a docs proposal without implying implementation. |
+
+## Findings
+
+- The RFC is clearly proposal-only.
+- It defines a narrow syntactic-sugar track rather than a runtime or verifier change.
+- It includes canonical lowering examples, rollout order, and deferred ideas, which makes it fit a documentation/proposal lane.
+- The surrounding language docs already contain related sugar-track and experience documents, plus a roadmap companion, so the placement in `docs/language/` is consistent rather than suspicious.
+- The file is currently untracked, but the content does not require it to remain untracked on safety grounds.
+
+## Risks
+
+- The title `RFC` can make the file look more formal than the rest of the language notes, so a quick reviewer could confuse proposal language with implementation status.
+- Because there is already a sugar-track roadmap companion, the project could later want to consolidate naming or location.
+- The file should keep an explicit `proposal / not implemented` mental model if tracked later, to avoid accidental implementation drift.
+
+## Recommended action
+
+Choose:
+
+- track later as docs proposal
+
+## Final verdict
+
+This RFC is a legitimate docs proposal candidate.
+It is safe to track later as a documentation artifact, and it does not need to stay untracked for boundary reasons.
+
+Final classification:
+
+```text
+TRACK-AS-DOC-CANDIDATE
+```


### PR DESCRIPTION
## Summary

Add a proposal-only RFC for a narrow Semantic syntactic sugar track.

The RFC covers readability-oriented sugar such as field punning, tail expression return, and quad predicate vocabulary aliases.

## Layer

Docs only.

## Contract impact

None.

No implementation, parser, verifier, VM, SemCode, capability, tests, examples, or 7hell behavior changed.

## Status

This is proposal-only and not implemented.

The included classification audit records the RFC as safe to track as a documentation proposal.

## Non-goals

- no PCC/CTF readiness claim
- no admitted surface claim
- no runtime behavior change
- no verifier/capability boundary change
- no SemCode lowering change