### PR TITLE
docs(tooling): update AGENTS policy guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,14 @@ mcp_codebase-memo_get_architecture({ "project": "<display_name>" })
 - `search_code(pattern, project)` — Grep-like text search within indexed files
 - `manage_adr(action)` — CRUD for Architecture Decision Records
 - `ingest_traces(traces)` — Ingest runtime traces to validate HTTP edges
+
+## RuFlo / Codex MCP operating rules
+
+- RuFlo is an orchestration assistant, not the architectural authority.
+- Inspect repository state before changing files.
+- Prefer small, auditable patches.
+- Do not rewrite Semantic core invariants without explicit instruction.
+- Do not add dependencies without justification.
+- Preserve verifier-first design, determinism, and evidence boundaries.
+- After each change, run the smallest relevant check first.
+- Do not push or commit unless explicitly instructed.


### PR DESCRIPTION
## Summary

Update `AGENTS.md` as a separate docs/tooling policy slice.

This change is handled independently because `AGENTS.md` is a repo-level control / agent-guidance file and must not be mixed with UI implementation, post-UI boundary work, PCC/CTF work, tests, examples, or runtime changes.

## Layer

Docs / tooling policy only.

## Contract impact

None.

No implementation, parser, renderer, runtime, verifier, VM, SemCode, capability, tests, examples, or `tools/7hell` behavior changed.

## Scope

Changed file:

- `AGENTS.md`

## Why separate

`AGENTS.md` affects agent workflow and repository guidance. Even when the change is meaningful, it should be reviewed as a standalone policy update.

This avoids mixing control-file changes with:

- UI implementation work;
- post-UI boundary verification;
- PCC / CTF trail work;
- tests or examples;
- runtime / verifier / VM authority.

## Validation

Before merge, verify:

- staged diff is limited to the approved file list;
- no UI implementation files are included;
- no PCC / CTF residue is included;
- no tests, examples, or `tools/7hell` files are included;
- wording is appropriate as repo-level policy/tooling guidance.

## Non-goals

- no UI implementation
- no renderer rewrite
- no native/WGPU backend switch
- no runtime/verifier/VM changes
- no PCC/CTF changes
- no tests/examples/7hell changes
- no cleanup of unrelated local residue
