### PR TITLE
feat(ui): add calculator app shell primitives

### DIFF
--- a/crates/prom-ui-demo/src/calculator_shell.rs
+++ b/crates/prom-ui-demo/src/calculator_shell.rs
@@ -1,14 +1,23 @@
 //! PromUI-only calculator shell.
 //!
-//! This module renders an inert calculator interface and captures UI-local
-//! button intent preview. It does not implement calculator semantics, does not
-//! execute Semantic code, and does not call `smc`.
+//! This module renders a local calculator UI prototype and implements
+//! UI-local calculator behavior for native interaction testing.
+//! It does not execute Semantic code, does not call `smc`, and does not
+//! claim to be the authoritative Semantic calculator logic.
 //!
 //! Calculator truth belongs to a future Semantic `.sm` logic slice.
 
-use prom_ui::layout::UiLayoutGeometryRect;
-use prom_ui_runtime::{Color, DrawFrame, Rect};
+#[path = "ui_shell.rs"]
+pub(crate) mod ui_shell;
 
+use self::ui_shell::{UiButtonState, UiButtonTone};
+use prom_ui::layout::UiLayoutGeometryRect;
+use prom_ui_runtime::DrawFrame;
+
+#[cfg(test)]
+use prom_ui_runtime::Color;
+
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CalculatorButton {
     Digit(u8),
@@ -21,7 +30,6 @@ pub enum CalculatorButton {
 }
 
 impl CalculatorButton {
-    #[cfg(test)]
     pub const fn label(self) -> &'static str {
         match self {
             Self::Digit(0) => "0",
@@ -65,18 +73,36 @@ pub struct CalculatorShellState {
     focused_button: Option<CalculatorButton>,
     last_button: Option<CalculatorButton>,
     press_count: u32,
+    display_value: String,
+    accumulator: Option<i64>,
+    pending_operator: Option<CalculatorButton>,
+    replace_display_on_next_digit: bool,
+    error_state: bool,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CalculatorShell {
     state: CalculatorShellState,
+}
+
+impl Default for CalculatorShell {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CalculatorShell {
     pub fn new() -> Self {
         Self {
-            state: CalculatorShellState::default(),
+            state: CalculatorShellState {
+                display_value: "0".to_string(),
+                ..CalculatorShellState::default()
+            },
         }
+    }
+
+    pub fn display_text(&self) -> &str {
+        &self.state.display_value
     }
 
     pub fn handle_pointer_moved(&mut self, x: f64, y: f64, scene_bounds: UiLayoutGeometryRect) {
@@ -89,142 +115,199 @@ impl CalculatorShell {
         self.state.focused_button = pressed;
 
         if let Some(button) = pressed {
-            self.state.last_button = Some(button);
-            self.state.press_count += 1;
+            self.handle_button_press(button);
         }
     }
 
-    pub fn handle_pointer_up(&mut self) {}
+    pub fn handle_pointer_up(&mut self) {
+        self.state.selected_button = None;
+    }
+
+    pub fn handle_button_press(&mut self, button: CalculatorButton) {
+        self.state.last_button = Some(button);
+        self.state.press_count = self.state.press_count.saturating_add(1);
+
+        match button {
+            CalculatorButton::Digit(digit) => self.push_digit(digit),
+            CalculatorButton::Clear => self.clear(),
+            CalculatorButton::Equals => self.evaluate(),
+            CalculatorButton::Add
+            | CalculatorButton::Subtract
+            | CalculatorButton::Multiply
+            | CalculatorButton::Divide => self.queue_operator(button),
+        }
+    }
+
+    fn pending_operator_text(&self) -> Option<&'static str> {
+        self.state.pending_operator.map(|operator| operator.label())
+    }
+
+    fn clear(&mut self) {
+        self.state.display_value = "0".to_string();
+        self.state.accumulator = None;
+        self.state.pending_operator = None;
+        self.state.replace_display_on_next_digit = false;
+        self.state.error_state = false;
+    }
+
+    fn push_digit(&mut self, digit: u8) {
+        if digit > 9 {
+            return;
+        }
+
+        if self.state.error_state {
+            self.clear();
+        }
+
+        if self.state.replace_display_on_next_digit || self.state.display_value == "0" {
+            self.state.display_value = digit.to_string();
+        } else {
+            self.state.display_value.push(char::from(b'0' + digit));
+        }
+
+        self.state.replace_display_on_next_digit = false;
+    }
+
+    fn queue_operator(&mut self, operator: CalculatorButton) {
+        if self.state.error_state {
+            return;
+        }
+
+        if let Some(lhs) = self.state.accumulator {
+            if let Some(previous_operator) = self.state.pending_operator {
+                let Some(rhs) = self.current_display_value() else {
+                    self.show_error();
+                    return;
+                };
+                match apply_pending_operation(lhs, rhs, previous_operator) {
+                    Some(result) => {
+                        self.set_display_from_value(result);
+                        self.state.accumulator = Some(result);
+                    }
+                    None => {
+                        self.show_error();
+                        return;
+                    }
+                }
+            }
+        } else if let Some(current) = self.current_display_value() {
+            self.state.accumulator = Some(current);
+        }
+
+        self.state.pending_operator = Some(operator);
+        self.state.replace_display_on_next_digit = true;
+    }
+
+    fn evaluate(&mut self) {
+        if self.state.error_state {
+            return;
+        }
+
+        let Some(lhs) = self.state.accumulator else {
+            return;
+        };
+        let Some(operator) = self.state.pending_operator else {
+            return;
+        };
+        let Some(rhs) = self.current_display_value() else {
+            self.show_error();
+            return;
+        };
+
+        match apply_pending_operation(lhs, rhs, operator) {
+            Some(result) => {
+                self.set_display_from_value(result);
+                self.state.accumulator = Some(result);
+                self.state.pending_operator = None;
+                self.state.replace_display_on_next_digit = true;
+            }
+            None => self.show_error(),
+        }
+    }
+
+    fn set_display_from_value(&mut self, value: i64) {
+        self.state.display_value = value.to_string();
+        self.state.error_state = false;
+    }
+
+    fn show_error(&mut self) {
+        self.state.display_value = "ERR".to_string();
+        self.state.accumulator = None;
+        self.state.pending_operator = None;
+        self.state.replace_display_on_next_digit = true;
+        self.state.error_state = true;
+    }
+
+    fn current_display_value(&self) -> Option<i64> {
+        if self.state.error_state {
+            return None;
+        }
+
+        self.state.display_value.parse::<i64>().ok()
+    }
 
     pub fn render(&self, out_frame: &mut DrawFrame, scene_bounds: UiLayoutGeometryRect) {
-        let panel = calculator_bounds(scene_bounds);
+        self.render_scene(out_frame, scene_bounds);
+    }
 
-        out_frame.fill_rect(
-            Rect::new(panel.x(), panel.y(), panel.width(), panel.height()),
-            Color::rgb(18, 22, 30),
-        );
-        draw_outline(out_frame, panel, Color::rgb(108, 118, 148), 2);
-        out_frame.fill_rect(
-            Rect::new(panel.x(), panel.y(), panel.width(), 28),
-            Color::rgb(28, 34, 48),
-        );
-        out_frame.draw_text("Calculator", panel.x() + 14, panel.y() + 18, Color::WHITE);
-        out_frame.draw_text(
-            "Semantic bridge: not connected",
-            panel.x() + 122,
-            panel.y() + 18,
-            Color::rgb(194, 206, 223),
-        );
+    pub fn render_scene(&self, out_frame: &mut DrawFrame, scene_bounds: UiLayoutGeometryRect) {
+        let theme = ui_shell::default_theme();
+        ui_shell::draw_app_background(out_frame, scene_bounds, theme);
+        self.render_panel(out_frame, scene_bounds, theme);
+    }
+
+    pub(crate) fn render_panel(
+        &self,
+        out_frame: &mut DrawFrame,
+        scene_bounds: UiLayoutGeometryRect,
+        theme: ui_shell::UiShellTheme,
+    ) {
+        let panel = ui_shell::centered_rect(scene_bounds, 420, 420);
+        ui_shell::draw_panel(out_frame, panel, theme);
 
         let display =
-            UiLayoutGeometryRect::new(panel.x() + 14, panel.y() + 40, panel.width() - 28, 34);
-        out_frame.fill_rect(
-            Rect::new(display.x(), display.y(), display.width(), display.height()),
-            Color::rgb(26, 31, 44),
-        );
-        draw_outline(out_frame, display, Color::rgb(72, 140, 255), 1);
-        out_frame.draw_text(
-            "Display",
-            display.x() + 10,
-            display.y() + 12,
-            Color::rgb(194, 206, 223),
-        );
-        draw_digit_glyph(
+            UiLayoutGeometryRect::new(panel.x() + 24, panel.y() + 44, panel.width() - 48, 74);
+        ui_shell::draw_display(
             out_frame,
-            UiLayoutGeometryRect::new(display.x() + 10, display.y() + 10, 20, 16),
-            0,
-            Color::WHITE,
+            display,
+            self.display_text(),
+            self.pending_operator_text(),
+            theme,
         );
+
         let buttons = calculator_button_layout(panel);
         for (row, row_buttons) in buttons.iter().enumerate() {
             for (col, button) in row_buttons.iter().enumerate() {
                 let rect = button_rect(panel, row, col);
-                let is_hovered = self.state.hovered_button == Some(*button);
-                let is_selected = self.state.selected_button == Some(*button);
-                let is_focused = self.state.focused_button == Some(*button);
-
-                let fill = if is_selected {
-                    Color::rgb(255, 214, 96)
-                } else if is_hovered {
-                    Color::rgb(44, 84, 120)
-                } else {
-                    Color::rgb(38, 42, 56)
+                let state = UiButtonState {
+                    hovered: self.state.hovered_button == Some(*button),
+                    pressed: self.state.selected_button == Some(*button),
+                    focused: self.state.focused_button == Some(*button),
                 };
-                let label_panel = button_label_panel_color(*button, is_hovered, is_selected);
-                let outline = if is_selected {
-                    Color::rgb(255, 250, 210)
-                } else if is_hovered {
-                    Color::rgb(102, 222, 255)
-                } else {
-                    Color::rgb(84, 96, 126)
-                };
-                let glyph_color = button_glyph_color(*button, is_selected);
-
-                out_frame.fill_rect(
-                    Rect::new(rect.x(), rect.y(), rect.width(), rect.height()),
-                    fill,
-                );
-                let inset = UiLayoutGeometryRect::new(
-                    rect.x() + 6,
-                    rect.y() + 3,
-                    rect.width().saturating_sub(12),
-                    rect.height().saturating_sub(6),
-                );
-                out_frame.fill_rect(
-                    Rect::new(inset.x(), inset.y(), inset.width(), inset.height()),
-                    label_panel,
-                );
-                draw_outline(
+                ui_shell::draw_button(
                     out_frame,
                     rect,
-                    outline,
-                    if is_selected {
-                        3
-                    } else if is_focused {
-                        2
-                    } else {
-                        1
-                    },
+                    button.label(),
+                    button_tone(*button),
+                    state,
+                    theme,
                 );
-                draw_button_glyph(out_frame, inset, *button, glyph_color);
-                if is_selected {
-                    draw_selection_spark(out_frame, rect, Color::rgb(255, 255, 235));
-                }
             }
         }
 
-        out_frame.draw_text(
-            format!("Press count: {}", self.state.press_count),
-            panel.x() + 14,
-            panel.y() + panel.height() as i32 - 18,
-            Color::rgb(194, 206, 223),
+        ui_shell::draw_text_line(
+            out_frame,
+            panel.x() + 24,
+            panel.y() + 8,
+            "Semantic bridge: not connected",
+            2,
+            theme.muted_text,
         );
-        out_frame.draw_text(
-            "Calculation: inert",
-            panel.x() + 160,
-            panel.y() + panel.height() as i32 - 18,
-            Color::rgb(225, 232, 242),
-        );
-
-        if let Some(button) = self.state.last_button {
-            let badge = UiLayoutGeometryRect::new(display.x() + 154, display.y() + 1, 154, 30);
-            out_frame.fill_rect(
-                Rect::new(badge.x(), badge.y(), badge.width(), badge.height()),
-                button_label_panel_color(button, false, true),
-            );
-            draw_outline(out_frame, badge, Color::rgb(255, 250, 210), 3);
-            draw_button_glyph(
-                out_frame,
-                UiLayoutGeometryRect::new(badge.x() + 40, badge.y() + 6, 72, 20),
-                button,
-                button_glyph_color(button, true),
-            );
-        }
     }
 }
 
 fn calculator_bounds(scene_bounds: UiLayoutGeometryRect) -> UiLayoutGeometryRect {
-    UiLayoutGeometryRect::new(scene_bounds.x() + 16, scene_bounds.y() + 404, 344, 188)
+    ui_shell::centered_rect(scene_bounds, 420, 420)
 }
 
 fn calculator_button_layout(_panel: UiLayoutGeometryRect) -> [[CalculatorButton; 4]; 4] {
@@ -257,19 +340,51 @@ fn calculator_button_layout(_panel: UiLayoutGeometryRect) -> [[CalculatorButton;
 }
 
 fn button_rect(panel: UiLayoutGeometryRect, row: usize, col: usize) -> UiLayoutGeometryRect {
-    let button_width = 74;
-    let button_height = 20;
-    let gap_x = 6;
-    let gap_y = 4;
-    let start_x = panel.x() + 12;
-    let start_y = panel.y() + 76;
+    let button_width = 84;
+    let button_height = 58;
+    let gap_x = 12;
+    let gap_y = 12;
+    let start_x = panel.x() + 24;
+    let start_y = panel.y() + 150;
 
-    UiLayoutGeometryRect::new(
-        start_x + (col as i32 * (button_width + gap_x)),
-        start_y + (row as i32 * (button_height + gap_y)),
+    ui_shell::grid_cell(
+        start_x,
+        start_y,
         button_width as u32,
         button_height as u32,
+        gap_x,
+        gap_y,
+        row,
+        col,
     )
+}
+
+fn button_tone(button: CalculatorButton) -> UiButtonTone {
+    match button {
+        CalculatorButton::Digit(_) => UiButtonTone::Digit,
+        CalculatorButton::Divide
+        | CalculatorButton::Multiply
+        | CalculatorButton::Subtract
+        | CalculatorButton::Add => UiButtonTone::Operator,
+        CalculatorButton::Clear => UiButtonTone::Action,
+        CalculatorButton::Equals => UiButtonTone::Equals,
+    }
+}
+
+fn apply_pending_operation(lhs: i64, rhs: i64, operator: CalculatorButton) -> Option<i64> {
+    match operator {
+        CalculatorButton::Add => lhs.checked_add(rhs),
+        CalculatorButton::Subtract => lhs.checked_sub(rhs),
+        CalculatorButton::Multiply => lhs.checked_mul(rhs),
+        CalculatorButton::Divide => {
+            if rhs == 0 {
+                None
+            } else {
+                lhs.checked_div(rhs)
+            }
+        }
+        _ => None,
+    }
 }
 
 fn hit_test_button(scene_bounds: UiLayoutGeometryRect, x: f64, y: f64) -> Option<CalculatorButton> {
@@ -294,207 +409,6 @@ fn hit_test_button(scene_bounds: UiLayoutGeometryRect, x: f64, y: f64) -> Option
     None
 }
 
-fn draw_outline(
-    out_frame: &mut DrawFrame,
-    rect: UiLayoutGeometryRect,
-    color: Color,
-    thickness: u32,
-) {
-    let x = rect.x();
-    let y = rect.y();
-    let w = rect.width();
-    let h = rect.height();
-    let thickness_i32 = thickness as i32;
-
-    out_frame.fill_rect(Rect::new(x, y, w, thickness), color);
-    out_frame.fill_rect(
-        Rect::new(x, y + (h as i32) - thickness_i32, w, thickness),
-        color,
-    );
-    out_frame.fill_rect(Rect::new(x, y, thickness, h), color);
-    out_frame.fill_rect(
-        Rect::new(x + (w as i32) - thickness_i32, y, thickness, h),
-        color,
-    );
-}
-
-fn draw_selection_spark(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let x = rect.x() + rect.width() as i32 - 12;
-    let y = rect.y() + 4;
-    out_frame.fill_rect(Rect::new(x, y, 6, 2), color);
-    out_frame.fill_rect(Rect::new(x + 2, y - 2, 2, 6), color);
-}
-
-fn draw_button_glyph(
-    out_frame: &mut DrawFrame,
-    rect: UiLayoutGeometryRect,
-    button: CalculatorButton,
-    color: Color,
-) {
-    match button {
-        CalculatorButton::Digit(digit) => draw_digit_glyph(out_frame, rect, digit, color),
-        CalculatorButton::Divide => draw_divide_glyph(out_frame, rect, color),
-        CalculatorButton::Multiply => draw_multiply_glyph(out_frame, rect, color),
-        CalculatorButton::Subtract => draw_subtract_glyph(out_frame, rect, color),
-        CalculatorButton::Add => draw_add_glyph(out_frame, rect, color),
-        CalculatorButton::Clear => draw_clear_glyph(out_frame, rect, color),
-        CalculatorButton::Equals => draw_equals_glyph(out_frame, rect, color),
-    }
-}
-
-fn button_label_panel_color(
-    button: CalculatorButton,
-    is_hovered: bool,
-    is_selected: bool,
-) -> Color {
-    match (button, is_selected, is_hovered) {
-        (CalculatorButton::Digit(_), true, _) => Color::rgb(175, 208, 255),
-        (CalculatorButton::Digit(_), false, true) => Color::rgb(98, 140, 210),
-        (CalculatorButton::Digit(_), false, false) => Color::rgb(72, 104, 160),
-
-        (CalculatorButton::Divide, true, _) => Color::rgb(176, 241, 255),
-        (CalculatorButton::Divide, false, true) => Color::rgb(98, 188, 204),
-        (CalculatorButton::Divide, false, false) => Color::rgb(60, 128, 144),
-
-        (CalculatorButton::Multiply, true, _) => Color::rgb(236, 206, 255),
-        (CalculatorButton::Multiply, false, true) => Color::rgb(164, 122, 210),
-        (CalculatorButton::Multiply, false, false) => Color::rgb(108, 78, 150),
-
-        (CalculatorButton::Subtract, true, _) => Color::rgb(255, 224, 192),
-        (CalculatorButton::Subtract, false, true) => Color::rgb(192, 142, 94),
-        (CalculatorButton::Subtract, false, false) => Color::rgb(132, 92, 56),
-
-        (CalculatorButton::Add, true, _) => Color::rgb(220, 255, 192),
-        (CalculatorButton::Add, false, true) => Color::rgb(142, 196, 88),
-        (CalculatorButton::Add, false, false) => Color::rgb(88, 132, 52),
-
-        (CalculatorButton::Clear, true, _) => Color::rgb(255, 206, 214),
-        (CalculatorButton::Clear, false, true) => Color::rgb(206, 92, 112),
-        (CalculatorButton::Clear, false, false) => Color::rgb(140, 60, 76),
-
-        (CalculatorButton::Equals, true, _) => Color::rgb(226, 220, 255),
-        (CalculatorButton::Equals, false, true) => Color::rgb(146, 132, 210),
-        (CalculatorButton::Equals, false, false) => Color::rgb(92, 86, 146),
-    }
-}
-
-fn button_glyph_color(button: CalculatorButton, is_selected: bool) -> Color {
-    if is_selected {
-        match button {
-            CalculatorButton::Digit(_) => Color::rgb(18, 22, 30),
-            CalculatorButton::Divide
-            | CalculatorButton::Multiply
-            | CalculatorButton::Subtract
-            | CalculatorButton::Add
-            | CalculatorButton::Clear
-            | CalculatorButton::Equals => Color::rgb(18, 22, 30),
-        }
-    } else {
-        Color::WHITE
-    }
-}
-
-fn draw_digit_glyph(
-    out_frame: &mut DrawFrame,
-    rect: UiLayoutGeometryRect,
-    digit: u8,
-    color: Color,
-) {
-    let segments = match digit {
-        0 => [true, true, true, true, true, true, false],
-        1 => [false, true, true, false, false, false, false],
-        2 => [true, true, false, true, true, false, true],
-        3 => [true, true, true, true, false, false, true],
-        4 => [false, true, true, false, false, true, true],
-        5 => [true, false, true, true, false, true, true],
-        6 => [true, false, true, true, true, true, true],
-        7 => [true, true, true, false, false, false, false],
-        8 => [true, true, true, true, true, true, true],
-        9 => [true, true, true, true, false, true, true],
-        _ => [true, true, true, true, true, true, true],
-    };
-
-    let x = rect.x();
-    let y = rect.y();
-    let w = rect.width() as i32;
-    let h = rect.height() as i32;
-    let t_i32 = 2;
-    let t_u32 = 2;
-    let inner_w = (w - 4).max(0) as u32;
-    let half_h = (h / 2 - 2).max(0) as u32;
-
-    if segments[0] {
-        out_frame.fill_rect(Rect::new(x + 2, y, inner_w, t_u32), color);
-    }
-    if segments[1] {
-        out_frame.fill_rect(Rect::new(x + w - t_i32, y + 2, t_u32, half_h), color);
-    }
-    if segments[2] {
-        out_frame.fill_rect(Rect::new(x + w - t_i32, y + (h / 2), t_u32, half_h), color);
-    }
-    if segments[3] {
-        out_frame.fill_rect(Rect::new(x + 2, y + h - t_i32, inner_w, t_u32), color);
-    }
-    if segments[4] {
-        out_frame.fill_rect(Rect::new(x, y + (h / 2), t_u32, half_h), color);
-    }
-    if segments[5] {
-        out_frame.fill_rect(Rect::new(x, y + 2, t_u32, half_h), color);
-    }
-    if segments[6] {
-        out_frame.fill_rect(Rect::new(x + 2, y + (h / 2) - 1, inner_w, t_u32), color);
-    }
-}
-
-fn draw_add_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let cx = rect.x() + rect.width() as i32 / 2;
-    let cy = rect.y() + rect.height() as i32 / 2;
-    out_frame.fill_rect(Rect::new(cx - 7, cy - 1, 14, 2), color);
-    out_frame.fill_rect(Rect::new(cx - 1, cy - 6, 2, 12), color);
-}
-
-fn draw_subtract_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let cy = rect.y() + rect.height() as i32 / 2;
-    let width = rect.width().saturating_sub(8);
-    out_frame.fill_rect(Rect::new(rect.x() + 4, cy - 1, width, 2), color);
-}
-
-fn draw_equals_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let cx = rect.x() + rect.width() as i32 / 2;
-    out_frame.fill_rect(Rect::new(cx - 7, rect.y() + 5, 14, 2), color);
-    out_frame.fill_rect(Rect::new(cx - 7, rect.y() + 10, 14, 2), color);
-}
-
-fn draw_divide_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let x = rect.x() + 18;
-    let y = rect.y() + 3;
-    for step in 0..7 {
-        out_frame.fill_rect(Rect::new(x + step * 2, y + step * 2, 2, 2), color);
-    }
-    out_frame.fill_rect(Rect::new(rect.x() + 8, rect.y() + 2, 3, 3), color);
-    out_frame.fill_rect(Rect::new(rect.x() + 20, rect.y() + 13, 3, 3), color);
-}
-
-fn draw_multiply_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let x = rect.x() + 10;
-    let y = rect.y() + 4;
-    for step in 0..6 {
-        out_frame.fill_rect(Rect::new(x + step * 2, y + step * 2, 2, 2), color);
-        out_frame.fill_rect(Rect::new(x + 10 - step * 2, y + step * 2, 2, 2), color);
-    }
-}
-
-fn draw_clear_glyph(out_frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color) {
-    let x = rect.x() + 4;
-    let y = rect.y() + 3;
-    let w = rect.width() - 8;
-    let h = rect.height() - 6;
-    out_frame.fill_rect(Rect::new(x, y, w, 2), color);
-    out_frame.fill_rect(Rect::new(x, y + h as i32 - 2, w, 2), color);
-    out_frame.fill_rect(Rect::new(x, y, 2, h), color);
-    out_frame.fill_rect(Rect::new(x, y + 2, 2, h - 4), color);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,10 +426,10 @@ mod tests {
         let mut shell = CalculatorShell::new();
         let scene_bounds = UiLayoutGeometryRect::new(0, 0, 760, 420);
 
-        shell.handle_pointer_moved(40.0, 490.0, scene_bounds);
+        shell.handle_pointer_moved(210.0, 170.0, scene_bounds);
         assert_eq!(shell.state.hovered_button, Some(CalculatorButton::Digit(7)));
 
-        shell.handle_pointer_down(40.0, 490.0, scene_bounds);
+        shell.handle_pointer_down(210.0, 170.0, scene_bounds);
         assert_eq!(
             shell.state.selected_button,
             Some(CalculatorButton::Digit(7))
@@ -523,6 +437,7 @@ mod tests {
         assert_eq!(shell.state.focused_button, Some(CalculatorButton::Digit(7)));
         assert_eq!(shell.state.last_button, Some(CalculatorButton::Digit(7)));
         assert_eq!(shell.state.press_count, 1);
+        assert_eq!(shell.display_text(), "7");
     }
 
     #[test]
@@ -530,39 +445,70 @@ mod tests {
         let shell = CalculatorShell::new();
         let mut frame = DrawFrame::new();
         let scene_bounds = UiLayoutGeometryRect::new(0, 0, 760, 420);
+        let panel = calculator_bounds(scene_bounds);
+        let seven_button = button_rect(panel, 0, 0);
+        let add_button = button_rect(panel, 3, 3);
 
-        shell.render(&mut frame, scene_bounds);
+        shell.render_scene(&mut frame, scene_bounds);
 
         assert!(!frame.is_empty());
         assert!(frame.commands().iter().any(|cmd| matches!(
             cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Calculator")
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::WHITE
         )));
         assert!(frame.commands().iter().any(|cmd| matches!(
             cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Semantic bridge: not connected")
+            prom_ui_runtime::DrawCommand::FillRect { rect, color }
+                if *color == Color::WHITE
+                    && rect.x >= seven_button.x()
+                    && rect.x < seven_button.x() + seven_button.width() as i32
+                    && rect.y >= seven_button.y()
+                    && rect.y < seven_button.y() + seven_button.height() as i32
         )));
         assert!(frame.commands().iter().any(|cmd| matches!(
             cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Display")
+            prom_ui_runtime::DrawCommand::FillRect { rect, color }
+                if *color == Color::WHITE
+                    && rect.x >= add_button.x()
+                    && rect.x < add_button.x() + add_button.width() as i32
+                    && rect.y >= add_button.y()
+                    && rect.y < add_button.y() + add_button.height() as i32
         )));
-        let glyph_fill_count = frame
-            .commands()
-            .iter()
-            .filter(|cmd| {
-                matches!(
-                    cmd,
-                    prom_ui_runtime::DrawCommand::FillRect { color, .. }
-                        if *color == Color::WHITE
-                )
-            })
-            .count();
-        assert!(
-            glyph_fill_count >= 8,
-            "expected visible glyph fill rects, got {glyph_fill_count}"
-        );
+        assert!(frame.commands().iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(205, 216, 229)
+        )));
+        assert!(frame.commands().iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(53, 59, 74)
+        )));
+    }
+
+    #[test]
+    fn calculator_button_presses_update_display() {
+        let mut shell = CalculatorShell::new();
+
+        shell.handle_button_press(CalculatorButton::Digit(1));
+        shell.handle_button_press(CalculatorButton::Digit(2));
+        shell.handle_button_press(CalculatorButton::Add);
+        shell.handle_button_press(CalculatorButton::Digit(3));
+        shell.handle_button_press(CalculatorButton::Equals);
+
+        assert_eq!(shell.display_text(), "15");
+    }
+
+    #[test]
+    fn calculator_division_by_zero_sets_error_display() {
+        let mut shell = CalculatorShell::new();
+
+        shell.handle_button_press(CalculatorButton::Digit(8));
+        shell.handle_button_press(CalculatorButton::Divide);
+        shell.handle_button_press(CalculatorButton::Digit(0));
+        shell.handle_button_press(CalculatorButton::Equals);
+
+        assert_eq!(shell.display_text(), "ERR");
     }
 }

--- a/crates/prom-ui-demo/src/demo_interaction.rs
+++ b/crates/prom-ui-demo/src/demo_interaction.rs
@@ -1,4 +1,4 @@
-use crate::calculator_shell::CalculatorShell;
+use crate::calculator_shell::{ui_shell, CalculatorShell};
 use prom_ui::action_binding::InteractionActionBindingId;
 use prom_ui::layout::physical_placement::{hit_test_placement, UiLayoutPhysicalPlacementModel};
 use prom_ui::projection::UiProjectedNodeId;
@@ -32,6 +32,14 @@ pub struct DemoState {
     denied_count: u32,
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DemoSceneMode {
+    #[default]
+    Calculator,
+    Diagnostics,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct DemoActionBindings {
     bindings: HashMap<UiRenderNodeId, (UiProjectedNodeId, InteractionActionBindingId)>,
@@ -63,6 +71,7 @@ pub struct DemoInteraction {
     bindings: DemoActionBindings,
     admission_gate: RuntimeIntentAdmission,
     calculator: CalculatorShell,
+    scene_mode: DemoSceneMode,
 }
 
 impl DemoInteraction {
@@ -72,6 +81,15 @@ impl DemoInteraction {
             bindings: DemoActionBindings::new(),
             admission_gate: RuntimeIntentAdmission::new(),
             calculator: CalculatorShell::new(),
+            scene_mode: DemoSceneMode::Calculator,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_diagnostics() -> Self {
+        Self {
+            scene_mode: DemoSceneMode::Diagnostics,
+            ..Self::new()
         }
     }
 
@@ -98,6 +116,56 @@ impl DemoInteraction {
     }
 
     fn handle_event(
+        &mut self,
+        event: &InputEvent,
+        placement: &UiLayoutPhysicalPlacementModel,
+    ) -> LoopControl {
+        match self.scene_mode {
+            DemoSceneMode::Calculator => self.handle_calculator_event(event, placement),
+            DemoSceneMode::Diagnostics => self.handle_diagnostics_event(event, placement),
+        }
+    }
+
+    fn handle_calculator_event(
+        &mut self,
+        event: &InputEvent,
+        placement: &UiLayoutPhysicalPlacementModel,
+    ) -> LoopControl {
+        match event.kind {
+            InputEventKind::CloseRequested => LoopControl::ExitRequested,
+            InputEventKind::KeyDown { key_code: 27 } => LoopControl::ExitRequested,
+            InputEventKind::PointerMoved { x, y } => {
+                self.state.pointer_x = x as i32;
+                self.state.pointer_y = y as i32;
+                if let Some(bounds) = placement_bounds(placement) {
+                    self.calculator.handle_pointer_moved(x, y, bounds);
+                }
+                LoopControl::Continue
+            }
+            InputEventKind::PointerDown { .. } => {
+                if let Some(bounds) = placement_bounds(placement) {
+                    self.state.pointer_x = self.state.pointer_x.max(0);
+                    self.state.pointer_y = self.state.pointer_y.max(0);
+                    self.calculator.handle_pointer_down(
+                        self.state.pointer_x as f64,
+                        self.state.pointer_y as f64,
+                        bounds,
+                    );
+                }
+                self.state.is_pointer_down = true;
+                LoopControl::Continue
+            }
+            InputEventKind::PointerUp { .. } => {
+                self.state.is_pointer_down = false;
+                self.calculator.handle_pointer_up();
+                LoopControl::Continue
+            }
+            InputEventKind::KeyDown { .. } => LoopControl::Continue,
+            InputEventKind::KeyUp { .. } => LoopControl::Continue,
+        }
+    }
+
+    fn handle_diagnostics_event(
         &mut self,
         event: &InputEvent,
         placement: &UiLayoutPhysicalPlacementModel,
@@ -193,12 +261,17 @@ pub fn render_demo_frame(
     placement: &UiLayoutPhysicalPlacementModel,
     interaction: &DemoInteraction,
 ) -> DrawFrame {
-    let mut out_frame = generate_draw_frame(placement);
+    let mut out_frame = match interaction.scene_mode {
+        DemoSceneMode::Calculator => DrawFrame::new(),
+        DemoSceneMode::Diagnostics => generate_draw_frame(placement),
+    };
+
     render_feedback_overlays(
         &mut out_frame,
         placement,
         interaction.state(),
         interaction.calculator(),
+        interaction.scene_mode,
     );
     out_frame
 }
@@ -208,16 +281,31 @@ fn render_feedback_overlays(
     placement: &UiLayoutPhysicalPlacementModel,
     state: &DemoState,
     calculator: &CalculatorShell,
+    scene_mode: DemoSceneMode,
 ) {
-    if let Some(bounds) = placement_bounds(placement) {
-        draw_scene_backdrop(out_frame, bounds);
-        draw_scene_header(out_frame, bounds);
-        draw_scene_cards(out_frame, placement, state);
-        draw_status_area(out_frame, bounds, state);
-        calculator.render(out_frame, bounds);
+    let bounds = match scene_mode {
+        DemoSceneMode::Calculator => calculator_scene_bounds(placement),
+        DemoSceneMode::Diagnostics => placement_bounds(placement),
+    };
+
+    if let Some(bounds) = bounds {
+        match scene_mode {
+            DemoSceneMode::Calculator => {
+                calculator.render(out_frame, bounds);
+            }
+            DemoSceneMode::Diagnostics => {
+                draw_scene_backdrop(out_frame, bounds);
+                draw_scene_header(out_frame, bounds);
+                draw_scene_cards(out_frame, placement, state);
+                draw_status_area(out_frame, bounds, state);
+                calculator.render_panel(out_frame, bounds, ui_shell::default_theme());
+            }
+        }
     }
 
-    draw_pointer_marker(out_frame, state);
+    if matches!(scene_mode, DemoSceneMode::Diagnostics) {
+        draw_pointer_marker(out_frame, state);
+    }
 }
 
 fn draw_hovered_feedback(out_frame: &mut DrawFrame, rect: prom_ui::layout::UiLayoutGeometryRect) {
@@ -287,6 +375,19 @@ fn placement_bounds(
         (max_x - min_x + 56) as u32,
         (max_y - min_y + 172) as u32,
     ))
+}
+
+fn calculator_scene_bounds(
+    placement: &UiLayoutPhysicalPlacementModel,
+) -> Option<prom_ui::layout::UiLayoutGeometryRect> {
+    placement_bounds(placement).map(|bounds| {
+        prom_ui::layout::UiLayoutGeometryRect::new(
+            bounds.x(),
+            bounds.y(),
+            bounds.width().max(760),
+            bounds.height().max(560),
+        )
+    })
 }
 
 fn draw_scene_backdrop(out_frame: &mut DrawFrame, bounds: prom_ui::layout::UiLayoutGeometryRect) {
@@ -600,6 +701,10 @@ mod tests {
     use prom_ui_runtime::{InputEvent, InputEventKind};
 
     fn test_interaction() -> DemoInteraction {
+        DemoInteraction::new_diagnostics()
+    }
+
+    fn test_calculator_interaction() -> DemoInteraction {
         DemoInteraction::new()
     }
 
@@ -747,22 +852,47 @@ mod tests {
         assert!(commands.iter().any(|cmd| matches!(
             cmd,
             prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Calculator")
-        )));
-        assert!(commands.iter().any(|cmd| matches!(
-            cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
-                if text.contains("Semantic bridge: not connected")
-        )));
-        assert!(commands.iter().any(|cmd| matches!(
-            cmd,
-            prom_ui_runtime::DrawCommand::DrawText { text, .. }
                 if text.contains("Pointer:")
         )));
         assert!(commands.iter().any(|cmd| matches!(
             cmd,
             prom_ui_runtime::DrawCommand::DrawText { text, .. }
                 if text.contains("Denied marker")
+        )));
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(205, 216, 229)
+        )));
+    }
+
+    #[test]
+    fn primary_calculator_scene_omits_demo_status_and_cards() {
+        let placement = test_placement();
+        let interaction = test_calculator_interaction();
+
+        let frame = render_demo_frame(&placement, &interaction);
+        let commands = frame.commands();
+
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::WHITE
+        )));
+        assert!(commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::FillRect { color, .. }
+                if *color == Color::rgb(205, 216, 229)
+        )));
+        assert!(!commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::DrawText { text, .. }
+                if text.contains("Demo status")
+        )));
+        assert!(!commands.iter().any(|cmd| matches!(
+            cmd,
+            prom_ui_runtime::DrawCommand::DrawText { text, .. }
+                if text.contains("Primary region")
         )));
     }
 }

--- a/crates/prom-ui-demo/src/main.rs
+++ b/crates/prom-ui-demo/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
 
     println!("=== Semantic UI Application Boundary - Native Render Demo ===");
 
-    let config = WindowConfig::new("Semantic UI Demo - WGPU Native", 800, 600);
+    let config = WindowConfig::new("Semantic Calculator", 800, 600);
     let backend = NativeBackend::new();
 
     let mut session =

--- a/crates/prom-ui-demo/src/ui_shell.rs
+++ b/crates/prom-ui-demo/src/ui_shell.rs
@@ -1,0 +1,340 @@
+use prom_ui::layout::UiLayoutGeometryRect;
+use prom_ui_runtime::{Color, DrawFrame, Rect};
+
+#[derive(Debug, Clone, Copy)]
+pub struct UiShellTheme {
+    pub app_bg: Color,
+    pub panel_bg: Color,
+    pub panel_outline: Color,
+    pub display_bg: Color,
+    pub display_outline: Color,
+    pub button_bg: Color,
+    pub button_hovered: Color,
+    pub button_pressed: Color,
+    pub button_outline: Color,
+    pub text: Color,
+    pub muted_text: Color,
+    pub accent: Color,
+    pub danger: Color,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum UiButtonTone {
+    Digit,
+    Operator,
+    Action,
+    Equals,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UiButtonState {
+    pub hovered: bool,
+    pub pressed: bool,
+    pub focused: bool,
+}
+
+pub fn default_theme() -> UiShellTheme {
+    UiShellTheme {
+        app_bg: Color::rgb(28, 31, 41),
+        panel_bg: Color::rgb(53, 59, 74),
+        panel_outline: Color::rgb(159, 170, 194),
+        display_bg: Color::rgb(77, 84, 101),
+        display_outline: Color::rgb(140, 182, 255),
+        button_bg: Color::rgb(138, 165, 207),
+        button_hovered: Color::rgb(159, 194, 233),
+        button_pressed: Color::rgb(242, 223, 154),
+        button_outline: Color::rgb(125, 133, 154),
+        text: Color::WHITE,
+        muted_text: Color::rgb(205, 216, 229),
+        accent: Color::rgb(176, 210, 149),
+        danger: Color::rgb(208, 128, 143),
+    }
+}
+
+pub fn centered_rect(
+    parent: UiLayoutGeometryRect,
+    width: u32,
+    height: u32,
+) -> UiLayoutGeometryRect {
+    let width = width.min(parent.width());
+    let height = height.min(parent.height());
+    let x = parent.x() + ((parent.width() as i32 - width as i32) / 2).max(0);
+    let y = parent.y() + ((parent.height() as i32 - height as i32) / 2).max(0);
+    UiLayoutGeometryRect::new(x, y, width, height)
+}
+
+pub fn inset_rect(rect: UiLayoutGeometryRect, inset: i32) -> UiLayoutGeometryRect {
+    let x = rect.x() + inset;
+    let y = rect.y() + inset;
+    let width = rect.width().saturating_sub((inset.max(0) as u32) * 2);
+    let height = rect.height().saturating_sub((inset.max(0) as u32) * 2);
+    UiLayoutGeometryRect::new(x, y, width, height)
+}
+
+pub fn grid_cell(
+    origin_x: i32,
+    origin_y: i32,
+    cell_w: u32,
+    cell_h: u32,
+    gap_x: i32,
+    gap_y: i32,
+    row: usize,
+    col: usize,
+) -> UiLayoutGeometryRect {
+    UiLayoutGeometryRect::new(
+        origin_x + (col as i32 * (cell_w as i32 + gap_x)),
+        origin_y + (row as i32 * (cell_h as i32 + gap_y)),
+        cell_w,
+        cell_h,
+    )
+}
+
+pub fn draw_app_background(
+    frame: &mut DrawFrame,
+    bounds: UiLayoutGeometryRect,
+    theme: UiShellTheme,
+) {
+    frame.fill_rect(
+        Rect::new(bounds.x(), bounds.y(), bounds.width(), bounds.height()),
+        theme.app_bg,
+    );
+    frame.fill_rect(
+        Rect::new(bounds.x(), bounds.y(), bounds.width(), 6),
+        Color::rgb(40, 45, 58),
+    );
+}
+
+pub fn draw_panel(frame: &mut DrawFrame, rect: UiLayoutGeometryRect, theme: UiShellTheme) {
+    frame.fill_rect(
+        Rect::new(rect.x(), rect.y(), rect.width(), rect.height()),
+        theme.panel_bg,
+    );
+    draw_outline(frame, rect, theme.panel_outline, 2);
+    frame.fill_rect(
+        Rect::new(rect.x(), rect.y(), rect.width(), 26),
+        Color::rgb(64, 71, 88),
+    );
+}
+
+pub fn draw_display(
+    frame: &mut DrawFrame,
+    rect: UiLayoutGeometryRect,
+    value: &str,
+    pending: Option<&str>,
+    theme: UiShellTheme,
+) {
+    let inner = inset_rect(rect, 8);
+
+    frame.fill_rect(
+        Rect::new(rect.x(), rect.y(), rect.width(), rect.height()),
+        theme.display_bg,
+    );
+    draw_outline(frame, rect, theme.display_outline, 2);
+
+    let value_scale = display_scale(inner, value, 6);
+    let value_y = inner.y() + ((inner.height() as i32 - (7 * value_scale)) / 2).max(0);
+    let value_width = measure_text_width(value, value_scale);
+    let value_x = (inner.x() + inner.width() as i32 - value_width - 4).max(inner.x() + 4);
+    draw_text_line(frame, value_x, value_y, value, value_scale, theme.text);
+
+    if let Some(pending) = pending {
+        let pending_scale = 2;
+        let pending_width = measure_text_width(pending, pending_scale);
+        let pending_x = inner.x() + inner.width() as i32 - pending_width - 4;
+        let pending_y = inner.y() + 4;
+        draw_text_line(
+            frame,
+            pending_x,
+            pending_y,
+            pending,
+            pending_scale,
+            theme.muted_text,
+        );
+    }
+}
+
+pub fn draw_button(
+    frame: &mut DrawFrame,
+    rect: UiLayoutGeometryRect,
+    label: &str,
+    tone: UiButtonTone,
+    state: UiButtonState,
+    theme: UiShellTheme,
+) {
+    let fill = if state.pressed {
+        theme.button_pressed
+    } else if state.hovered {
+        theme.button_hovered
+    } else {
+        match tone {
+            UiButtonTone::Digit => theme.button_bg,
+            UiButtonTone::Operator => theme.accent,
+            UiButtonTone::Action => theme.danger,
+            UiButtonTone::Equals => theme.button_pressed,
+        }
+    };
+
+    let outline = if state.focused || state.pressed {
+        theme.display_outline
+    } else if state.hovered {
+        theme.text
+    } else {
+        theme.button_outline
+    };
+
+    frame.fill_rect(
+        Rect::new(rect.x(), rect.y(), rect.width(), rect.height()),
+        fill,
+    );
+    draw_outline(frame, rect, outline, if state.focused { 2 } else { 1 });
+
+    let text_scale = if label.len() > 1 { 3 } else { 4 };
+    let text_width = measure_text_width(label, text_scale);
+    let text_x = rect.x() + ((rect.width() as i32 - text_width) / 2).max(0);
+    let text_y = rect.y() + ((rect.height() as i32 - (7 * text_scale)) / 2).max(0);
+    let text_color = if state.pressed {
+        Color::BLACK
+    } else {
+        Color::WHITE
+    };
+    draw_text_line(frame, text_x, text_y, label, text_scale, text_color);
+}
+
+pub(crate) fn draw_text_line(
+    frame: &mut DrawFrame,
+    x: i32,
+    y: i32,
+    text: &str,
+    scale: i32,
+    color: Color,
+) {
+    let mut cursor_x = x;
+    for ch in text.chars() {
+        if ch == ' ' {
+            cursor_x += (4 * scale) / 2 + scale;
+            continue;
+        }
+
+        draw_glyph(frame, cursor_x, y, ch, scale, color);
+        cursor_x += glyph_advance(scale);
+    }
+}
+
+fn draw_outline(frame: &mut DrawFrame, rect: UiLayoutGeometryRect, color: Color, thickness: u32) {
+    let x = rect.x();
+    let y = rect.y();
+    let w = rect.width();
+    let h = rect.height();
+    let thickness_i32 = thickness as i32;
+
+    frame.fill_rect(Rect::new(x, y, w, thickness), color);
+    frame.fill_rect(
+        Rect::new(x, y + (h as i32) - thickness_i32, w, thickness),
+        color,
+    );
+    frame.fill_rect(Rect::new(x, y, thickness, h), color);
+    frame.fill_rect(
+        Rect::new(x + (w as i32) - thickness_i32, y, thickness, h),
+        color,
+    );
+}
+
+fn display_scale(rect: UiLayoutGeometryRect, text: &str, max_scale: i32) -> i32 {
+    let width_scale = if text.is_empty() {
+        max_scale
+    } else {
+        ((rect.width() as i32 - 24) / measure_text_width(text, 1)).max(1)
+    };
+    let height_scale = ((rect.height() as i32 - 12) / 7).max(1);
+    width_scale.min(height_scale).min(max_scale).max(1)
+}
+
+fn measure_text_width(text: &str, scale: i32) -> i32 {
+    if text.is_empty() {
+        return 0;
+    }
+
+    let chars = text.chars().count() as i32;
+    chars * glyph_advance(scale)
+}
+
+fn glyph_advance(scale: i32) -> i32 {
+    6 * scale
+}
+
+fn draw_glyph(frame: &mut DrawFrame, x: i32, y: i32, ch: char, scale: i32, color: Color) {
+    let rows = glyph_rows(ch.to_ascii_uppercase());
+    for (row_index, row_bits) in rows.iter().enumerate() {
+        for col in 0..5 {
+            if row_bits & (1 << (4 - col)) == 0 {
+                continue;
+            }
+
+            let px = x + (col as i32 * scale);
+            let py = y + (row_index as i32 * scale);
+            frame.fill_rect(Rect::new(px, py, scale as u32, scale as u32), color);
+        }
+    }
+}
+
+fn glyph_rows(ch: char) -> [u8; 7] {
+    match ch {
+        '0' => [
+            0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110,
+        ],
+        '1' => [
+            0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110,
+        ],
+        '2' => [
+            0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111,
+        ],
+        '3' => [
+            0b11110, 0b00001, 0b00001, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        '4' => [
+            0b00010, 0b00110, 0b01010, 0b10010, 0b11111, 0b00010, 0b00010,
+        ],
+        '5' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b00001, 0b00001, 0b11110,
+        ],
+        '6' => [
+            0b01110, 0b10000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110,
+        ],
+        '7' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b10000,
+        ],
+        '8' => [
+            0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110,
+        ],
+        '9' => [
+            0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00001, 0b01110,
+        ],
+        '+' => [
+            0b00000, 0b00100, 0b00100, 0b11111, 0b00100, 0b00100, 0b00000,
+        ],
+        '-' => [
+            0b00000, 0b00000, 0b00000, 0b11111, 0b00000, 0b00000, 0b00000,
+        ],
+        '*' => [
+            0b10001, 0b01010, 0b00100, 0b01010, 0b10001, 0b00000, 0b00000,
+        ],
+        '/' => [
+            0b00001, 0b00010, 0b00100, 0b01000, 0b10000, 0b00000, 0b00000,
+        ],
+        '=' => [
+            0b00000, 0b11111, 0b00000, 0b11111, 0b00000, 0b00000, 0b00000,
+        ],
+        'C' => [
+            0b01110, 0b10001, 0b10000, 0b10000, 0b10000, 0b10001, 0b01110,
+        ],
+        'E' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b10000, 0b10000, 0b11111,
+        ],
+        'R' => [
+            0b11110, 0b10001, 0b10001, 0b11110, 0b10100, 0b10010, 0b10001,
+        ],
+        _ => [
+            0b11111, 0b10001, 0b00100, 0b00100, 0b00100, 0b10001, 0b11111,
+        ],
+    }
+}

--- a/crates/prom-ui-demo/src/ui_shell.rs
+++ b/crates/prom-ui-demo/src/ui_shell.rs
@@ -71,6 +71,7 @@ pub fn inset_rect(rect: UiLayoutGeometryRect, inset: i32) -> UiLayoutGeometryRec
     UiLayoutGeometryRect::new(x, y, width, height)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn grid_cell(
     origin_x: i32,
     origin_y: i32,
@@ -265,13 +266,14 @@ fn glyph_advance(scale: i32) -> i32 {
 fn draw_glyph(frame: &mut DrawFrame, x: i32, y: i32, ch: char, scale: i32, color: Color) {
     let rows = glyph_rows(ch.to_ascii_uppercase());
     for (row_index, row_bits) in rows.iter().enumerate() {
+        let row_index = row_index as i32;
         for col in 0..5 {
             if row_bits & (1 << (4 - col)) == 0 {
                 continue;
             }
 
-            let px = x + (col as i32 * scale);
-            let py = y + (row_index as i32 * scale);
+            let px = x + (col * scale);
+            let py = y + (row_index * scale);
             frame.fill_rect(Rect::new(px, py, scale as u32, scale as u32), color);
         }
     }


### PR DESCRIPTION
## Summary

Adds minimal `prom-ui-demo` app shell primitives and makes the Semantic Calculator the default primary scene.

The calculator is now rendered as a standalone primary UI instead of a diagnostics/demo overlay. Diagnostics mode remains available as an alternate/test path.

## Layer

`prom-ui-demo` only.

## Changes

- Added `ui_shell.rs` with minimal shell drawing helpers:
  - theme
  - centered layout
  - panel
  - display
  - button
  - bitmap text rendering
- Reworked `calculator_shell.rs` to use shell primitives.
- Split calculator rendering into primary scene rendering and reusable panel rendering.
- Updated `demo_interaction.rs` so calculator is the default primary scene.
- Preserved diagnostics rendering as an alternate path.
- Updated window title to `Semantic Calculator`.

## Contract impact

No Semantic runtime, verifier, VM, SemCode, backend ownership, PCC, CTF, examples, or `tools/7hell` behavior changed.

Calculator arithmetic remains UI-local demo behavior only and does not claim Semantic `.sm` authority.

## Validation

- `cargo check -p prom-ui-demo`
- `cargo test -p prom-ui-demo`

## Invariants

- UI remains projection/demo shell, not semantic authority.
- No `smc` call is introduced.
- No runtime/verifier/VM/SemCode authority transfer.
- No backend rewrite.
- Diagnostics scene remains available as a separate path.
- Existing untracked local residue was not touched.

## Non-goals

- no Workbench
- no Semantic logic bridge yet
- no backend-native primitive expansion
- no renderer rewrite
- no PCC/CTF changes
- no cleanup of local audit residue