### PR TITLE
test(post-ui): enforce calculator reference scenario

### DIFF
--- a/experiments/ui-shell-kit/tests/calculator_reference_scenario.rs
+++ b/experiments/ui-shell-kit/tests/calculator_reference_scenario.rs
@@ -1,0 +1,77 @@
+use ui_shell_kit::action::UiAction;
+use ui_shell_kit::calculator_controller::CalculatorController;
+use ui_shell_kit::calculator_scene::{calculator_button_label, calculator_layout};
+use ui_shell_kit::event::{UiEvent, UiEventKind, UiPointerButton};
+use ui_shell_kit::geometry::UiRect;
+use ui_shell_kit::paint::UiFrame;
+use ui_shell_kit::snapshot::frame_to_snapshot;
+use ui_shell_kit::theme::UiShellTheme;
+
+fn button_center(rect: UiRect) -> (i32, i32) {
+    (rect.x + rect.width as i32 / 2, rect.y + rect.height as i32 / 2)
+}
+
+fn press_button(
+    controller: &mut CalculatorController,
+    layout: &ui_shell_kit::calculator_scene::CalculatorLayout,
+    label: &str,
+) -> Vec<UiAction> {
+    let (_, rect) = layout
+        .buttons
+        .iter()
+        .find(|(button, _)| calculator_button_label(*button) == label)
+        .expect("calculator button exists in reference layout");
+
+    let (x, y) = button_center(*rect);
+    let event = UiEvent {
+        kind: UiEventKind::PointerDown {
+            x,
+            y,
+            button: UiPointerButton::Primary,
+        },
+    };
+
+    controller.handle_event(event, layout).drain()
+}
+
+#[test]
+fn calculator_reference_scenario_is_executable() {
+    let mut controller = CalculatorController::new();
+    let scene = UiRect::new(0, 0, 800, 600);
+    let theme = UiShellTheme::default();
+    let layout = calculator_layout(scene);
+
+    let mut initial_frame = UiFrame::new();
+    controller.render(&mut initial_frame, scene, &theme);
+    assert_eq!(controller.state.display, "0");
+    assert!(!initial_frame.is_empty(), "initial render should emit draw commands");
+    let initial_snapshot = frame_to_snapshot(&initial_frame);
+    assert!(
+        initial_snapshot.contains("value=\"0\""),
+        "initial snapshot should include the zero display"
+    );
+
+    for label in ["7", "+", "3", "="] {
+        let actions = press_button(&mut controller, &layout, label);
+        assert!(
+            actions.iter().any(|action| matches!(action, UiAction::CalculatorButtonPressed { .. })),
+            "pressing {label} should emit a calculator button action"
+        );
+        assert!(
+            actions.iter().any(|action| matches!(action, UiAction::ButtonPressed { .. })),
+            "pressing {label} should emit a button press action"
+        );
+    }
+
+    assert_eq!(controller.state.display, "10");
+
+    let mut final_frame = UiFrame::new();
+    controller.render(&mut final_frame, scene, &theme);
+    assert!(!final_frame.is_empty(), "final render should emit draw commands");
+
+    let final_snapshot = frame_to_snapshot(&final_frame);
+    assert!(
+        final_snapshot.contains("value=\"10\""),
+        "final snapshot should include the evaluated result"
+    );
+}


### PR DESCRIPTION
Summary

Adds an executable deterministic test for the canonical "ui-shell-kit" calculator reference scenario.

The test drives the calculator through the real UI shell path:

CalculatorController
  ↓
calculator_layout
  ↓
button hit target lookup
  ↓
UiEvent / hit testing
  ↓
controller state update
  ↓
render / snapshot evidence

It verifies the canonical interaction:

Initial display: 0
7 + 3 =
Final display: 10

Added test

- "experiments/ui-shell-kit/tests/calculator_reference_scenario.rs"

What this establishes

- The documented calculator reference scenario is now executable evidence.
- The test uses the controller/layout/hit-testing path rather than direct state mutation.
- Rendering after the scenario remains non-empty.
- The final snapshot contains the expected display value.
- "calculator_interaction_dump" and "calculator_motion_dump" continue to run successfully.

Boundary

Sandbox-only.

No production UI wiring.
No "prom-ui" changes.
No Workbench dependency.
No verifier / VM / SemCode changes.
No runtime capability widening.
No workspace wiring changes.
No promotion decision.

Validation

cargo test --manifest-path experiments/ui-shell-kit/Cargo.toml
cargo run --manifest-path experiments/ui-shell-kit/Cargo.toml --example calculator_interaction_dump
cargo run --manifest-path experiments/ui-shell-kit/Cargo.toml --example calculator_motion_dump
git diff --check

Result:

- all "ui-shell-kit" tests passed;
- "calculator_interaction_dump" ran successfully;
- "calculator_motion_dump" ran successfully;
- only pre-existing unrelated local residue remains outside this PR scope.

Notes

This follows the calculator reference scenario documentation from #1317.

It does not close #1318, which is reserved for the docs-only surface inventory.