### PR TITLE
test(post-ui): add calculator reference snapshot evidence

### DIFF
--- a/experiments/ui-shell-kit/tests/calculator_reference_scenario.rs
+++ b/experiments/ui-shell-kit/tests/calculator_reference_scenario.rs
@@ -47,8 +47,16 @@ fn calculator_reference_scenario_is_executable() {
     assert!(!initial_frame.is_empty(), "initial render should emit draw commands");
     let initial_snapshot = frame_to_snapshot(&initial_frame);
     assert!(
+        !initial_snapshot.is_empty(),
+        "initial snapshot should not be empty"
+    );
+    assert!(
         initial_snapshot.contains("value=\"0\""),
         "initial snapshot should include the zero display"
+    );
+    assert!(
+        initial_snapshot.contains("value=\"Semantic Calculator\""),
+        "initial snapshot should include the calculator title"
     );
 
     for label in ["7", "+", "3", "="] {
@@ -71,7 +79,15 @@ fn calculator_reference_scenario_is_executable() {
 
     let final_snapshot = frame_to_snapshot(&final_frame);
     assert!(
+        !final_snapshot.is_empty(),
+        "final snapshot should not be empty"
+    );
+    assert!(
         final_snapshot.contains("value=\"10\""),
         "final snapshot should include the evaluated result"
+    );
+    assert!(
+        final_snapshot.contains("value=\"Semantic Calculator\""),
+        "final snapshot should include the calculator title"
     );
 }


### PR DESCRIPTION
## Summary

Adds focused snapshot evidence for the canonical ui-shell-kit calculator reference scenario.

The test continues to drive the calculator through the controller/layout/hit-testing path and verifies that the final rendered snapshot contains the expected `7 + 3 = 10` state.

## Boundary

Sandbox-only.

No production UI wiring.
No prom-ui changes.
No Workbench dependency.
No verifier / VM / SemCode changes.
No runtime capability widening.
No workspace wiring changes.

## Validation

cargo test --manifest-path experiments/ui-shell-kit/Cargo.toml
cargo run --manifest-path experiments/ui-shell-kit/Cargo.toml --example calculator_interaction_dump
cargo run --manifest-path experiments/ui-shell-kit/Cargo.toml --example calculator_motion_dump
git diff --check

Final constraint

This PR should add narrow executable evidence.

It must not introduce broad golden infrastructure, production wiring, renderer backend assumptions, or promotion behavior.