### PR TITLE
docs(dna): cross-link Semantic UI DNA v2

### DIFF
--- a/docs/dna/SEMANTIC_UI_DNA.md
+++ b/docs/dna/SEMANTIC_UI_DNA.md
@@ -4,6 +4,14 @@ Status: architecture doctrine
 Track: POST-UI / Semantic UI Application Boundary
 Scope type: documentation only
 
+## Doctrine Extension
+
+This document is extended by:
+
+- [`SEMANTIC_UI_DNA_v2.md`](SEMANTIC_UI_DNA_v2.md) - Intent-Driven Projection, zero-glue authoring, UI IR, Action IR, ProjectionBundle delivery, freshness, denial/recovery projection, and multi-client projection.
+
+The v2 doctrine extends this document. It does not replace the original Semantic UI ownership, renderer boundary, authority non-transfer, Quad-state, evidence/trace, and UI state separation principles.
+
 ## Core Principle
 
 Semantic UI is a Semantic-native UI architecture.


### PR DESCRIPTION
## Summary

Adds a minimal cross-link from the original Semantic UI DNA document to Semantic UI DNA v2.

This makes the Intent-Driven Projection / zero-glue authoring doctrine discoverable from the original UI DNA entrypoint.

## What changed

- Adds a short doctrine extension pointer to `docs/dna/SEMANTIC_UI_DNA.md`.
- Clarifies that `SEMANTIC_UI_DNA_v2.md` extends the original UI DNA and does not replace it.

## Boundary

Docs-only.

No code changes.  
No production UI wiring.  
No `prom-ui` integration.  
No Workbench dependency.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No renderer backend decision.  
No promotion of `ui-shell-kit`.

## Validation

`git diff --check`
