### PR TITLE
test-fixtures(post-ui): add ProjectionBundle anchor

### DIFF
--- a/tests/fixtures/post_ui/projection_bundle/README.md
+++ b/tests/fixtures/post_ui/projection_bundle/README.md
@@ -1,0 +1,73 @@
+# POST-UI ProjectionBundle Fixtures
+
+Status: inert fixture anchor
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture documentation only
+Execution status: non-executing
+Implementation status: blocked
+
+This directory contains inert planning fixtures for future ProjectionBundle evidence.
+
+These files are not executable.
+They are not final serialization.
+They are not parser input.
+They are not loader input.
+They are not runtime input.
+They are not shell-player input.
+They do not authorize production UI wiring.
+
+## Purpose
+
+This directory exists to anchor future ProjectionBundle fixture work before runtime implementation begins.
+
+```text
+Fixtures before runtime.
+Evidence before authority.
+No loader first.
+```
+
+## Current Contents
+
+- `manifest_minimal.sketch.md` — a non-executing minimal ProjectionBundle manifest sketch
+
+## Hard Boundaries
+
+- No parser.
+- No loader.
+- No runtime.
+- No shell player.
+- No Rust types.
+- No final serialization commitment.
+- No production UI wiring.
+- No Workbench dependency.
+- No ui-shell-kit promotion.
+- No verifier / VM / SemCode changes.
+- No capability / audit authority widening.
+
+## Future Fixture Expansion
+
+Future PRs may add more fixtures only after separate approval.
+
+Allowed future categories may include:
+
+- invalid manifest sketches
+- UI IR skeleton sketches
+- ActionIntent envelope sketches
+- Binding Graph sketches
+- Patch stream sketches
+- Denial/recovery sketches
+- Task projection sketches
+- Multi-client/freshness sketches
+- Evidence/audit trace sketches
+- Accessibility contract sketches
+
+```text
+Each future fixture category must remain inert until a separate parser/reader/test guard task is approved.
+```
+
+## Non-Goals
+
+This directory is not a fixture runner.
+This directory is not a schema authority.
+This directory is not a loader contract.
+This directory is not a production UI entrypoint.

--- a/tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md
@@ -1,0 +1,80 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.


### PR DESCRIPTION
## Summary

Adds the first inert POST-UI ProjectionBundle fixture anchor.

This creates a fixture directory with a README and one non-executing minimal manifest sketch. The sketch is planning evidence only and is not final serialization, parser input, loader input, runtime input, shell-player input, or production UI wiring.

## What changed

- Adds `tests/fixtures/post_ui/projection_bundle/README.md`.
- Adds `tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md`.
- Establishes the first inert fixture anchor for future ProjectionBundle evidence work.

## Boundary

Fixture/docs-only.

No code changes.  
No Rust types.  
No parser.  
No loader.  
No runtime reader.  
No test guard.  
No JSON/YAML/TOML schema.  
No final serialization choice.  
No ProjectionBundle implementation.  
No bundle verification implementation.  
No UI IR / Action IR implementation.  
No Binding Graph implementation.  
No patch stream implementation.  
No shell player.  
No runtime patch pipeline.  
No production UI wiring.  
No Workbench dependency.  
No `ui-shell-kit` changes.  
No `prom-ui` changes.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No capability / audit authority widening.

## Validation

`git diff --check`
