### PR TITLE
test-fixtures(post-ui): add fixture guard aggregator

### DIFF
--- a/tools/post_ui/check_post_ui_fixtures.ps1
+++ b/tools/post_ui/check_post_ui_fixtures.ps1
@@ -1,0 +1,53 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Assert-FileExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "FAIL: Missing guard: $($Path)"
+    }
+}
+
+function Invoke-Guard {
+    param(
+        [string]$Name,
+        [string]$Path
+    )
+
+    Write-Host "RUN: $Name"
+    & $Path
+    $exitCode = 0
+    $lastExitCode = Get-Variable -Name LASTEXITCODE -Scope 0 -ErrorAction SilentlyContinue
+    if ($null -ne $lastExitCode) {
+        $exitCode = [int]$lastExitCode.Value
+    }
+    if ($exitCode -ne 0) {
+        Fail "FAIL: $Name failed"
+    }
+}
+
+$guards = @(
+    @{
+        Name = "ProjectionBundle fixture anchor guard"
+        Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_fixtures.ps1"
+    }
+)
+
+foreach ($guard in $guards) {
+    Assert-FileExists -Path $guard.Path -Label "guard"
+    Invoke-Guard -Name $guard.Name -Path $guard.Path
+}
+
+Write-Host "PASS: POST-UI fixture guards passed"


### PR DESCRIPTION
## Summary

Adds a POST-UI fixture guard aggregator.

The aggregator provides one local test-only command for POST-UI fixture guard checks and currently runs the existing ProjectionBundle fixture anchor guard.

## What changed

- Adds `tools/post_ui/check_post_ui_fixtures.ps1`.
- Runs `tools/post_ui/check_projection_bundle_fixtures.ps1`.
- Fails if the child guard is missing or fails.
- Prints deterministic run/pass output.
- Establishes a stable local command shape for future POST-UI fixture guards.

## Boundary

Test-only / validation-only.

No fixture changes.  
No new fixtures.  
No code generation.  
No Rust types.  
No parser.  
No loader.  
No runtime reader.  
No schema.  
No final serialization choice.  
No CI wiring.  
No 7hell wiring.  
No pre-commit wiring.  
No ProjectionBundle implementation.  
No bundle verification implementation.  
No UI IR / Action IR implementation.  
No Binding Graph implementation.  
No patch stream implementation.  
No shell player.  
No runtime patch pipeline.  
No production UI wiring.  
No Workbench dependency.  
No `ui-shell-kit` changes.  
No `prom-ui` changes.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No capability / audit authority widening.

## Validation

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`  
`git diff --check`
