### PR TITLE
test-fixtures(post-ui): add manifest draft types

### DIFF
--- a/tools/post_ui/check_post_ui_fixtures.ps1
+++ b/tools/post_ui/check_post_ui_fixtures.ps1
@@ -42,6 +42,10 @@ $guards = @(
     @{
         Name = "ProjectionBundle fixture anchor guard"
         Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_fixtures.ps1"
+    },
+    @{
+        Name = "ProjectionBundle manifest draft type guard"
+        Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_manifest_draft.ps1"
     }
 )
 

--- a/tools/post_ui/check_projection_bundle_manifest_draft.ps1
+++ b/tools/post_ui/check_projection_bundle_manifest_draft.ps1
@@ -1,0 +1,93 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$draftPath = Join-Path $repoRoot "tools/post_ui/projection_bundle_manifest_draft.rs"
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Assert-FileExists {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "FAIL: Missing draft file: $Path"
+    }
+}
+
+function Assert-NotContainsText {
+    param(
+        [string]$Path,
+        [string]$Content,
+        [string]$Forbidden
+    )
+
+    if ($Content.Contains($Forbidden)) {
+        Fail "FAIL: Forbidden text found in $($Path): $Forbidden"
+    }
+}
+
+Assert-FileExists -Path $draftPath
+
+$rustc = Get-Command rustc -ErrorAction SilentlyContinue
+if ($null -eq $rustc) {
+    Fail "FAIL: rustc not found"
+}
+
+$draft = Get-Content -Raw -LiteralPath $draftPath
+$scanDraft = $draft -replace [regex]::Escape('#![forbid(unsafe_code)]'), ''
+
+$forbiddenStrings = @(
+    "serde",
+    "Serialize",
+    "Deserialize",
+    "FromStr",
+    "TryFrom",
+    "TryInto",
+    "std::fs",
+    "std::io",
+    "std::path",
+    "File",
+    "read_to_string",
+    "include_str!",
+    "include_bytes!",
+    "Command",
+    "process",
+    "unsafe",
+    "fn main",
+    "#[test]",
+    "mod tests"
+)
+
+foreach ($forbidden in $forbiddenStrings) {
+    Assert-NotContainsText -Path $draftPath -Content $scanDraft -Forbidden $forbidden
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("post_ui_projection_bundle_manifest_draft_" + [guid]::NewGuid().ToString("N"))
+$null = New-Item -ItemType Directory -Path $tempRoot -Force
+
+try {
+    $outputPath = Join-Path $tempRoot "projection_bundle_manifest_draft.rmeta"
+    $rustcExe = $rustc.Path
+    if ([string]::IsNullOrWhiteSpace($rustcExe)) {
+        $rustcExe = $rustc.Source
+    }
+    & $rustcExe --edition=2021 --crate-type lib --emit=metadata -o $outputPath $draftPath
+    $exitCode = 0
+    if (Get-Variable -Name LASTEXITCODE -Scope 0 -ErrorAction SilentlyContinue) {
+        $exitCode = [int]$global:LASTEXITCODE
+    }
+    if ($exitCode -ne 0) {
+        Fail "FAIL: rustc metadata compilation failed for $draftPath"
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}
+
+Write-Host "PASS: ProjectionBundle manifest draft types compile"

--- a/tools/post_ui/projection_bundle_manifest_draft.rs
+++ b/tools/post_ui/projection_bundle_manifest_draft.rs
@@ -1,0 +1,138 @@
+// Fixture-facing ProjectionBundle manifest draft types.
+// This file is compile-checked as test/fixture evidence only.
+// It is not a parser.
+// It is not a loader.
+// It is not final serialization.
+// It is not runtime activation code.
+// It does not verify bundles.
+// It does not authorize production UI wiring.
+#![forbid(unsafe_code)]
+#![allow(dead_code)]
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProjectionBundleManifestDraft<'a> {
+    pub bundle_id: &'a str,
+    pub bundle_version: &'a str,
+    pub projection_id: &'a str,
+    pub source_refs: &'a [&'a str],
+    pub artifacts: ManifestArtifactsDraft<'a>,
+    pub compatibility: ManifestCompatibilityDraft<'a>,
+    pub safety: ManifestSafetyDraft<'a>,
+    pub trust: ManifestTrustDraft<'a>,
+    pub activation_policy: ManifestActivationPolicyDraft,
+    pub update_policy: ManifestUpdatePolicyDraft,
+    pub diagnostics: ManifestDiagnosticsDraft<'a>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestArtifactsDraft<'a> {
+    pub ui_ir_ref: &'a str,
+    pub binding_graph_ref: &'a str,
+    pub action_ir_ref: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestCompatibilityDraft<'a> {
+    pub role_dictionary_version: &'a str,
+    pub renderer_profile: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestSafetyDraft<'a> {
+    pub safety_class: ManifestSafetyClassDraft,
+    pub criticality: ManifestCriticalityDraft,
+    pub required_capabilities: &'a [&'a str],
+    pub freshness_policy: ManifestFreshnessPolicyDraft,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestTrustDraft<'a> {
+    pub hash: &'a str,
+    pub signature: &'a str,
+    pub created_by: &'a str,
+    pub created_at: &'a str,
+    pub compiler_identity: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestActivationPolicyDraft {
+    pub require_verification: bool,
+    pub allow_runtime_tree_streaming: bool,
+    pub allow_production_activation: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestUpdatePolicyDraft {
+    pub require_safe_update_boundary: bool,
+    pub allow_critical_update_during_pending_unknown: bool,
+    pub allow_critical_update_during_quarantine: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ManifestDiagnosticsDraft<'a> {
+    pub expected: &'a [&'a str],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManifestSafetyClassDraft {
+    CriticalPinned,
+    VerifiedDynamic,
+    DiagnosticOnly,
+    WorkbenchExperimental,
+    ReadOnlyDashboard,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManifestCriticalityDraft {
+    NonCritical,
+    Guarded,
+    Critical,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManifestFreshnessPolicyDraft {
+    FreshForControl,
+    ReadOnlyWhenStale,
+    ObservationOnly,
+}
+
+pub const MINIMAL_SKETCH_MANIFEST_DRAFT: ProjectionBundleManifestDraft<'static> =
+    ProjectionBundleManifestDraft {
+        bundle_id: "bundle.example.minimal",
+        bundle_version: "0-sketch",
+        projection_id: "ExampleMinimalProjection",
+        source_refs: &["semantic.source.example", "projection.source.example"],
+        artifacts: ManifestArtifactsDraft {
+            ui_ir_ref: "ui_ir.example.minimal",
+            binding_graph_ref: "binding_graph.example.minimal",
+            action_ir_ref: "action_ir.example.minimal",
+        },
+        compatibility: ManifestCompatibilityDraft {
+            role_dictionary_version: "ui-roles.0-sketch",
+            renderer_profile: "semantic-shell.reference-sketch",
+        },
+        safety: ManifestSafetyDraft {
+            safety_class: ManifestSafetyClassDraft::VerifiedDynamic,
+            criticality: ManifestCriticalityDraft::NonCritical,
+            required_capabilities: &[],
+            freshness_policy: ManifestFreshnessPolicyDraft::FreshForControl,
+        },
+        trust: ManifestTrustDraft {
+            hash: "sha256:SKETCH-NOT-A-REAL-HASH",
+            signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE",
+            created_by: "semantic-projection-compiler.SKETCH",
+            created_at: "not-a-real-timestamp",
+            compiler_identity: "semantic-projection-compiler.0-sketch",
+        },
+        activation_policy: ManifestActivationPolicyDraft {
+            require_verification: true,
+            allow_runtime_tree_streaming: false,
+            allow_production_activation: false,
+        },
+        update_policy: ManifestUpdatePolicyDraft {
+            require_safe_update_boundary: true,
+            allow_critical_update_during_pending_unknown: false,
+            allow_critical_update_during_quarantine: false,
+        },
+        diagnostics: ManifestDiagnosticsDraft { expected: &[] },
+    };


### PR DESCRIPTION
## Summary

Adds the first fixture-facing Rust draft types for POST-UI ProjectionBundle manifest evidence.

The Rust source is standalone and compile-checked only through a PowerShell guard. It is not a crate, not a Cargo package, not parser input, not loader input, not final serialization, not verification, and not runtime activation code.

## What changed

- Adds `tools/post_ui/projection_bundle_manifest_draft.rs`.
- Adds `tools/post_ui/check_projection_bundle_manifest_draft.ps1`.
- Updates `tools/post_ui/check_post_ui_fixtures.ps1` to run the new compile-only guard.
- Defines fixture-facing manifest draft structs/enums.
- Defines `MINIMAL_SKETCH_MANIFEST_DRAFT` mirroring the existing inert manifest sketch conceptually.

## Boundary

Test-only / fixture-facing compile evidence.

No fixture changes.  
No new fixtures.  
No JSON/YAML/TOML schema.  
No parser.  
No loader.  
No runtime reader.  
No Rust crate.  
No Cargo changes.  
No CI wiring.  
No 7hell wiring.  
No pre-commit wiring.  
No ProjectionBundle implementation.  
No bundle verification implementation.  
No UI IR / Action IR implementation.  
No Binding Graph implementation.  
No patch stream implementation.  
No shell player.  
No runtime patch pipeline.  
No production UI wiring.  
No Workbench dependency.  
No `ui-shell-kit` changes.  
No `prom-ui` changes.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No capability / audit authority widening.

## Validation

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_manifest_draft.ps1`  
`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`  
`git diff --check`
