### PR TITLE
test-fixtures(post-ui): guard manifest draft drift

### DIFF
--- a/tools/post_ui/check_post_ui_fixtures.ps1
+++ b/tools/post_ui/check_post_ui_fixtures.ps1
@@ -46,6 +46,10 @@ $guards = @(
     @{
         Name = "ProjectionBundle manifest draft type guard"
         Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_manifest_draft.ps1"
+    },
+    @{
+        Name = "ProjectionBundle manifest sketch/draft drift guard"
+        Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_manifest_drift.ps1"
     }
 )
 

--- a/tools/post_ui/check_projection_bundle_manifest_drift.ps1
+++ b/tools/post_ui/check_projection_bundle_manifest_drift.ps1
@@ -1,0 +1,90 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$sketchPath = Join-Path $repoRoot "tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md"
+$draftPath = Join-Path $repoRoot "tools/post_ui/projection_bundle_manifest_draft.rs"
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Assert-FileExists {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "FAIL: Missing $($Label): $Path"
+    }
+}
+
+function Assert-AnchorInBoth {
+    param(
+        [string]$Name,
+        [string]$Text,
+        [string]$SketchContent,
+        [string]$DraftContent
+    )
+
+    if (-not $SketchContent.Contains($Text)) {
+        Fail "FAIL: Missing anchor '$Name' in $($sketchPath): $Text"
+    }
+
+    if (-not $DraftContent.Contains($Text)) {
+        Fail "FAIL: Missing anchor '$Name' in $($draftPath): $Text"
+    }
+}
+
+Assert-FileExists -Path $sketchPath -Label "manifest sketch"
+Assert-FileExists -Path $draftPath -Label "manifest draft"
+
+$sketch = Get-Content -Raw -LiteralPath $sketchPath
+$draft = Get-Content -Raw -LiteralPath $draftPath
+
+$sharedAnchors = @(
+    @{ Name = "bundle id"; Text = "bundle.example.minimal" },
+    @{ Name = "bundle version"; Text = "0-sketch" },
+    @{ Name = "projection id"; Text = "ExampleMinimalProjection" },
+    @{ Name = "semantic source ref"; Text = "semantic.source.example" },
+    @{ Name = "projection source ref"; Text = "projection.source.example" },
+    @{ Name = "ui ir ref"; Text = "ui_ir.example.minimal" },
+    @{ Name = "binding graph ref"; Text = "binding_graph.example.minimal" },
+    @{ Name = "action ir ref"; Text = "action_ir.example.minimal" },
+    @{ Name = "role dictionary version"; Text = "ui-roles.0-sketch" },
+    @{ Name = "renderer profile"; Text = "semantic-shell.reference-sketch" },
+    @{ Name = "safety class"; Text = "VerifiedDynamic" },
+    @{ Name = "criticality"; Text = "NonCritical" },
+    @{ Name = "freshness policy"; Text = "FreshForControl" },
+    @{ Name = "placeholder hash"; Text = "sha256:SKETCH-NOT-A-REAL-HASH" },
+    @{ Name = "placeholder signature"; Text = "signature:SKETCH-NOT-A-REAL-SIGNATURE" },
+    @{ Name = "placeholder creator"; Text = "semantic-projection-compiler.SKETCH" },
+    @{ Name = "placeholder timestamp"; Text = "not-a-real-timestamp" },
+    @{ Name = "compiler identity"; Text = "semantic-projection-compiler.0-sketch" },
+    @{ Name = "runtime tree streaming policy key"; Text = "allow_runtime_tree_streaming" },
+    @{ Name = "production activation policy key"; Text = "allow_production_activation" },
+    @{ Name = "pending unknown policy key"; Text = "allow_critical_update_during_pending_unknown" },
+    @{ Name = "quarantine policy key"; Text = "allow_critical_update_during_quarantine" }
+)
+
+foreach ($anchor in $sharedAnchors) {
+    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draft
+}
+
+$policyAnchors = @(
+    @{ Name = "runtime tree streaming disabled"; Text = "allow_runtime_tree_streaming: false" },
+    @{ Name = "production activation disabled"; Text = "allow_production_activation: false" },
+    @{ Name = "pending unknown updates disabled"; Text = "allow_critical_update_during_pending_unknown: false" },
+    @{ Name = "quarantine updates disabled"; Text = "allow_critical_update_during_quarantine: false" },
+    @{ Name = "verification required"; Text = "require_verification: true" },
+    @{ Name = "safe update boundary required"; Text = "require_safe_update_boundary: true" }
+)
+
+foreach ($anchor in $policyAnchors) {
+    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draft
+}
+
+Write-Host "PASS: ProjectionBundle manifest sketch/draft anchors match"

--- a/tools/post_ui/check_projection_bundle_manifest_drift.ps1
+++ b/tools/post_ui/check_projection_bundle_manifest_drift.ps1
@@ -45,6 +45,14 @@ Assert-FileExists -Path $draftPath -Label "manifest draft"
 $sketch = Get-Content -Raw -LiteralPath $sketchPath
 $draft = Get-Content -Raw -LiteralPath $draftPath
 
+$draftConstantMarker = "pub const MINIMAL_SKETCH_MANIFEST_DRAFT"
+$draftConstantStart = $draft.IndexOf($draftConstantMarker)
+if ($draftConstantStart -lt 0) {
+    Fail "FAIL: Missing Rust manifest draft constant marker: $draftConstantMarker"
+}
+
+$draftEvidence = $draft.Substring($draftConstantStart)
+
 $sharedAnchors = @(
     @{ Name = "bundle id"; Text = "bundle.example.minimal" },
     @{ Name = "bundle version"; Text = "0-sketch" },
@@ -71,7 +79,7 @@ $sharedAnchors = @(
 )
 
 foreach ($anchor in $sharedAnchors) {
-    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draft
+    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draftEvidence
 }
 
 $policyAnchors = @(
@@ -84,7 +92,7 @@ $policyAnchors = @(
 )
 
 foreach ($anchor in $policyAnchors) {
-    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draft
+    Assert-AnchorInBoth -Name $anchor.Name -Text $anchor.Text -SketchContent $sketch -DraftContent $draftEvidence
 }
 
 Write-Host "PASS: ProjectionBundle manifest sketch/draft anchors match"


### PR DESCRIPTION
## Summary

Adds a text-only drift guard between the inert ProjectionBundle manifest sketch and the fixture-facing Rust manifest draft constant.

The guard checks that required shared literal anchors remain present in both files before any parser, loader, schema, reader, verifier, or runtime path exists.

## What changed

- Adds `tools/post_ui/check_projection_bundle_manifest_drift.ps1`.
- Updates `tools/post_ui/check_post_ui_fixtures.ps1` to run the new drift guard.
- Checks shared manifest anchors across:
  - `tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md`
  - `tools/post_ui/projection_bundle_manifest_draft.rs`

## Boundary

Test-only / fixture-facing text evidence.

No fixture changes.  
No Rust draft type changes.  
No new fixtures.  
No JSON/YAML/TOML schema.  
No parser.  
No loader.  
No runtime reader.  
No Rust crate.  
No Cargo changes.  
No CI wiring.  
No 7hell wiring.  
No pre-commit wiring.  
No ProjectionBundle implementation.  
No bundle verification implementation.  
No UI IR / Action IR implementation.  
No Binding Graph implementation.  
No patch stream implementation.  
No shell player.  
No runtime patch pipeline.  
No production UI wiring.  
No Workbench dependency.  
No `ui-shell-kit` changes.  
No `prom-ui` changes.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No capability / audit authority widening.

## Validation

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_manifest_drift.ps1`  
`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`  
`git diff --check`
