### PR TITLE
docs(post-ui): link ProjectionBundle basis in closeout

### DIFF
--- a/docs/roadmap/post_ui/intent_driven_projection_closeout.md
+++ b/docs/roadmap/post_ui/intent_driven_projection_closeout.md
@@ -85,8 +85,10 @@ Required reading order:
 9. `docs/spec/ui/task_projection_model.md`
 10. `docs/spec/ui/multi_client_freshness_model.md`
 11. `docs/spec/ui/projection_bundle_delivery.md`
-12. `docs/roadmap/post_ui/ui_shell_kit_projection_alignment.md`
-13. `docs/roadmap/post_ui/intent_driven_projection_closeout.md`
+12. `docs/roadmap/post_ui/projection_bundle_fixture_inventory.md`
+13. `docs/spec/ui/projection_bundle_basis.md`
+14. `docs/roadmap/post_ui/ui_shell_kit_projection_alignment.md`
+15. `docs/roadmap/post_ui/intent_driven_projection_closeout.md`
 
 ```text
 Read the doctrine before the mechanism.
@@ -245,6 +247,9 @@ No loader.
 No runtime.
 No shell player.
 No production wiring.
+
+`ProjectionBundle Basis v0` is the claim boundary for the current fixture evidence contour.
+It records that the current achieved level is Level 3 only and that reader/parser, loader, runtime, and production UI behavior are not claimed.
 
 Do not create that fixture in this PR.
 


### PR DESCRIPTION
## Summary

Adds `docs/spec/ui/projection_bundle_basis.md` to the POST-UI closeout reading order.

This makes `ProjectionBundle Basis v0` an explicit claim-boundary document for future ProjectionBundle work.

## What changed

- Updates `docs/roadmap/post_ui/intent_driven_projection_closeout.md`.
- Adds `docs/spec/ui/projection_bundle_basis.md` to the reading order.
- Records that the current ProjectionBundle evidence contour stops at Level 3 only.
- Preserves that reader/parser, loader, runtime, and production UI behavior are not claimed.

## Boundary

Docs-only closeout/index update.

No code changes.  
No fixture changes.  
No guard changes.  
No Rust draft type changes.  
No new fixtures.  
No parser.  
No loader.  
No runtime.  
No schema.  
No final serialization choice.  
No Rust crate.  
No Cargo changes.  
No CI wiring.  
No 7hell wiring.  
No pre-commit wiring.  
No ProjectionBundle implementation.  
No bundle verification implementation.  
No UI IR / Action IR implementation.  
No Binding Graph implementation.  
No patch stream implementation.  
No shell player.  
No runtime patch pipeline.  
No production UI wiring.  
No Workbench dependency.  
No `ui-shell-kit` changes.  
No `prom-ui` changes.  
No verifier / VM / SemCode changes.  
No runtime capability widening.  
No capability / audit authority widening.  
No Level 4+ claim.

## Validation

`git diff --check`

Optional sanity check:

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`
