### PR TITLE
ci: split fast 7hell gate from full runner

### DIFF
--- a/.github/workflows/7hell-full.yml
+++ b/.github/workflows/7hell-full.yml
@@ -1,0 +1,20 @@
+name: 7hell Full Qualification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  full-qualification:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: 7hell PCC Full Runner
+        shell: powershell
+        run: .\tools\7hell\run.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: 7hell PCC Qualification Mini-Runner
+      - name: 7hell PCC Qualification Fast Gate
         shell: powershell
-        run: .\tools\7hell\run.ps1
+        run: .\tools\7hell\run_ci.ps1
 
   test-std:
     runs-on: ubuntu-latest

--- a/tools/7hell/README.md
+++ b/tools/7hell/README.md
@@ -8,7 +8,7 @@ This is **not** the full release qualification runner.
 - The `sm-verify` and `sm-vm` test gates currently explicitly enable `sm-ir/profile-rust` because verifier fixtures depend on Rust-like profile paths to successfully compile.
 
 ## Execution
-To run all 7 gates, use the script for your OS:
+To run all 7 gates locally, use the full runner for your OS:
 
 **Windows:**
 ```powershell
@@ -21,7 +21,7 @@ To run all 7 gates, use the script for your OS:
 ```
 
 ## CI Usage
-The `7hell` runner is integrated into the CI pipeline (via `.github/workflows/ci.yml`). The Linux runner (`run.sh`) is executed on every push and PR to protect the PCC qualification boundaries.
+The CI pipeline uses the fast gate (`tools/7hell/run_ci.ps1`) to keep PR checks short. The full runner remains available locally via `run.ps1` / `run.sh` for the complete qualification pack.
 
 ## The 7 Gates
 The script will fail fast if any gate is broken.

--- a/tools/7hell/README.md
+++ b/tools/7hell/README.md
@@ -22,6 +22,7 @@ To run all 7 gates locally, use the full runner for your OS:
 
 ## CI Usage
 The CI pipeline uses the fast gate (`tools/7hell/run_ci.ps1`) to keep PR checks short. The full runner remains available locally via `run.ps1` / `run.sh` for the complete qualification pack.
+The full runner also has a separate manual/nightly GitHub workflow for cases where the complete pack needs to run in CI without blocking PR checks.
 
 ## The 7 Gates
 The script will fail fast if any gate is broken.

--- a/tools/7hell/run_ci.ps1
+++ b/tools/7hell/run_ci.ps1
@@ -1,0 +1,84 @@
+$ErrorActionPreference = "Stop"
+
+function Assert-Success {
+    param([string]$message)
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "FAIL: $message" -ForegroundColor Red
+        exit 1
+    }
+}
+
+Write-Host "========================================="
+Write-Host "  7hell PCC Qualification Fast Gate      "
+Write-Host "========================================="
+Write-Host ""
+
+# -----------------------------------------------------------------------------
+# Hell 1
+Write-Host "[ Hell 1 ] Workspace Health..." -ForegroundColor Cyan
+cargo fmt --check
+Assert-Success "cargo fmt failed"
+cargo check --workspace --all-features
+Assert-Success "cargo check failed"
+Write-Host "PASS: Hell 1" -ForegroundColor Green
+
+# -----------------------------------------------------------------------------
+# Hell 2
+Write-Host "`n[ Hell 2 ] Trust Boundary Guards..." -ForegroundColor Cyan
+cargo test -p semantic_language --test trust_boundary_guards
+Assert-Success "Trust boundary guards test failed"
+
+$vm_tree = (cargo tree --edges normal -p sm-vm 2>&1) -join "`n"
+if ($vm_tree -match "sm-ir" -or $vm_tree -match "sm-emit" -or $vm_tree -match "prom-ui") {
+    Write-Host "FAIL: sm-vm depends on higher level crates (sm-ir, sm-emit, or prom-ui)" -ForegroundColor Red
+    exit 1
+}
+
+$verify_tree = (cargo tree --edges normal -p sm-verify 2>&1) -join "`n"
+if ($verify_tree -match "sm-ir" -or $verify_tree -match "sm-emit") {
+    Write-Host "FAIL: sm-verify depends on higher level crates (sm-ir or sm-emit)" -ForegroundColor Red
+    exit 1
+}
+
+$format_tree = (cargo tree --edges normal -p sm-format 2>&1) -join "`n"
+if ($format_tree -match "sm-ir") {
+    Write-Host "FAIL: sm-format depends on sm-ir" -ForegroundColor Red
+    exit 1
+}
+Write-Host "PASS: Hell 2" -ForegroundColor Green
+
+# -----------------------------------------------------------------------------
+# Hell 3
+Write-Host "`n[ Hell 3 ] SemCode Format Authority..." -ForegroundColor Cyan
+cargo test -p sm-format --all-features
+Assert-Success "sm-format tests failed"
+
+$leak1 = Get-ChildItem -Path crates -Recurse -Filter *.rs | Select-String -Pattern "sm_ir::semcode_decode|sm_ir::semcode_format"
+if ($leak1) {
+    Write-Host "FAIL: Leakage of sm_ir decoding/formatting found in crates!" -ForegroundColor Red
+    exit 1
+}
+$leak2 = Get-ChildItem -Path crates -Recurse -Filter *.rs | Select-String -Pattern "sm_emit::semcode_format"
+if ($leak2) {
+    Write-Host "FAIL: Leakage of sm_emit formatting found in crates!" -ForegroundColor Red
+    exit 1
+}
+Write-Host "PASS: Hell 3" -ForegroundColor Green
+
+# -----------------------------------------------------------------------------
+# Hell 4
+Write-Host "`n[ Hell 4 ] Verifier Negative Corpus..." -ForegroundColor Cyan
+cargo test -p sm-verify --all-features --features sm-ir/profile-rust
+Assert-Success "sm-verify tests failed"
+Write-Host "PASS: Hell 4" -ForegroundColor Green
+
+# -----------------------------------------------------------------------------
+# Hell 5
+Write-Host "`n[ Hell 5 ] VM Ownership Semantics..." -ForegroundColor Cyan
+cargo test -p sm-vm --all-features
+Assert-Success "sm-vm tests failed"
+Write-Host "PASS: Hell 5" -ForegroundColor Green
+
+Write-Host "`n========================================="
+Write-Host "  FAST 7HELL GATE PASSED!               " -ForegroundColor Green
+Write-Host "========================================="


### PR DESCRIPTION
Summary

Splits the 7hell qualification path into a fast CI gate and a separate full local runner.

The CI job now uses `tools/7hell/run_ci.ps1`, while `tools/7hell/run.ps1` / `tools/7hell/run.sh` remain the full qualification pack for local use.

What changed

- Adds `tools/7hell/run_ci.ps1`.
- Updates `.github/workflows/ci.yml` to run the fast gate.
- Updates `tools/7hell/README.md` to distinguish fast CI usage from the full runner.

Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/7hell/run_ci.ps1`
- `git diff --check`
- local pre-commit gate passed during commit
