### PR TITLE
docs(post-ui): close sketch reader evidence contour

### DIFF
--- a/docs/roadmap/post_ui/intent_driven_projection_closeout.md
+++ b/docs/roadmap/post_ui/intent_driven_projection_closeout.md
@@ -88,8 +88,9 @@ Required reading order:
 12. `docs/roadmap/post_ui/projection_bundle_fixture_inventory.md`
 13. `docs/spec/ui/projection_bundle_basis.md`
 14. `docs/spec/ui/projection_bundle_reader_parser_entry_gate.md`
-15. `docs/roadmap/post_ui/ui_shell_kit_projection_alignment.md`
-16. `docs/roadmap/post_ui/intent_driven_projection_closeout.md`
+15. `docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md`
+16. `docs/roadmap/post_ui/ui_shell_kit_projection_alignment.md`
+17. `docs/roadmap/post_ui/intent_driven_projection_closeout.md`
 
 ```text
 Read the doctrine before the mechanism.
@@ -98,6 +99,8 @@ Read the closeout before opening new work.
 ```
 
 The closeout comes last so future tasks do not treat the docs stack as an implementation license.
+
+`ProjectionBundle Reader Evidence Closeout` records the current fixture-facing reader evidence contour after the golden output pack. It does not claim general Level 4 behavior, loader behavior, runtime behavior, or production UI behavior.
 
 ## 4. Authority Map
 

--- a/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
+++ b/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
@@ -1,0 +1,78 @@
+# ProjectionBundle Reader Evidence Closeout
+
+Status: evidence closeout
+Track: POST-UI / Intent-Driven Projection
+Scope type: claim-boundary closeout
+Current achieved level: Level 3 baseline
+Reader evidence status: narrow reader-facing fixture evidence only
+General Level 4 status: not claimed
+Loader status: not claimed
+Runtime status: not claimed
+Production UI status: not claimed
+Level 5+ is not claimed
+
+## 1. What Landed
+
+- inert positive sketch fixture;
+- fixture boundary guard;
+- manifest draft type;
+- manifest sketch/draft drift guard;
+- sketch reader draft;
+- production activation negative fixture;
+- negative fixture pack;
+- positive normalized reader output golden fixture;
+- negative rejection report golden fixture;
+- exact golden comparison guard.
+
+## 2. What This Proves
+
+- the positive inert sketch is accepted by the fixture-facing sketch reader draft;
+- the positive inert sketch emits deterministic normalized text output;
+- the negative fixture pack is rejected;
+- each negative fixture is rejected for the intended single reason;
+- the negative rejection report is deterministic;
+- the guard compares emitted output exactly against committed golden text fixtures.
+
+## 3. What This Does Not Prove
+
+- does not prove general parser correctness;
+- does not prove general reader/parser behavior;
+- does not prove final serialization;
+- does not prove loader behavior;
+- does not prove runtime behavior;
+- does not prove verification behavior;
+- does not prove trust/security correctness;
+- does not prove production UI behavior;
+- does not authorize activation;
+- does not claim Level 5+.
+
+## 4. Claim Boundary
+
+Current achieved level remains: Level 3 baseline.
+
+The current evidence may be described only as:
+
+`narrow reader-facing fixture evidence`
+
+Do not describe it as:
+
+`Level 4 achieved`
+`Level 4 implemented`
+`reader/parser implemented`
+`parser implemented`
+`loader-ready`
+`runtime-ready`
+`production-ready`
+
+## 5. Next Allowed Transition
+
+Next allowed transition is not loader/runtime.
+
+The next allowed transition must be one of:
+
+- reader/parser basis update;
+- stricter placeholder trust rejection evidence;
+- deterministic output shape review;
+- claim-boundary guard improvement.
+
+Any transition toward loader/runtime/production requires a separate task and explicit gate.

--- a/docs/spec/ui/projection_bundle_basis.md
+++ b/docs/spec/ui/projection_bundle_basis.md
@@ -61,15 +61,23 @@ This basis exists to prevent overclaiming and to define the current evidence bou
 - is not: parser verification, Rust AST analysis, loader verification, or runtime verification
 
 `tools/post_ui/projection_bundle_sketch_reader_draft.rs`
-- is: fixture-facing executable reader draft for one inert sketch, plus a deterministic negative fixture check
+- is: fixture-facing executable reader draft for one inert sketch, plus deterministic negative fixture and golden output checks
 - is not: general reader/parser behavior, loader behavior, runtime behavior, or production UI wiring
-- evidence: the inert positive manifest sketch is accepted; the invalid manifest sketch with `allow_production_activation: true` is rejected
-- evidence type: narrow reader-facing fixture evidence for the sketch reader draft only
+- evidence: the inert positive manifest sketch is accepted; the invalid manifest sketch with `allow_production_activation: true` is rejected; the positive normalized reader output golden fixture matches; the negative rejection report golden fixture matches; the exact golden comparison guard passes
+- evidence type: narrow reader-facing fixture evidence
 
 `tools/post_ui/check_projection_bundle_sketch_reader_draft.ps1`
-- is: compile-and-run guard for the fixture-facing sketch reader draft
+- is: compile-and-run guard for the fixture-facing sketch reader draft and exact golden comparison
 - is not: runtime activation, loader validation, verification, or proof of general reader/parser behavior
-- evidence: the reader draft guard exits successfully on the accepted positive sketch and the rejected negative sketch
+- evidence: the reader draft guard exits successfully on the accepted positive sketch, the rejected negative sketch, and the emitted golden output pack
+
+`tests/fixtures/post_ui/projection_bundle/expected/manifest_minimal.reader.out.txt`
+- is: golden normalized reader output for the accepted positive sketch
+- is not: final serialization, parser input, loader input, runtime input, or production UI wiring
+
+`tests/fixtures/post_ui/projection_bundle/expected/negative_pack.reader.out.txt`
+- is: golden rejection report for the rejected negative pack
+- is not: final serialization, parser input, loader input, runtime input, or production UI wiring
 
 ## 3. Claim Levels
 
@@ -103,13 +111,16 @@ Levels 4–7 are not claimed.
 
 ## 4. Narrow Reader Evidence Note
 
-After the sketch reader draft guard, the evidence contour includes a narrow reader-facing check:
+After the sketch reader draft and golden output pack, the evidence contour includes a narrow reader-facing fixture evidence:
 
+- positive normalized reader output golden fixture;
+- negative rejection report golden fixture;
+- exact golden comparison guard;
 - the inert positive manifest sketch is accepted;
 - the invalid manifest sketch with `allow_production_activation: true` is rejected;
 - the check is fixture-facing and test-only.
 
-This is narrow reader-facing fixture evidence for the current sketch reader draft only.
+Current achieved level remains: Level 3 baseline.
 
 Level 4 is not generally achieved.
 
@@ -235,4 +246,4 @@ If a PR increases the claim level, it must add evidence for that level.
 
 If no new evidence is added, the PR must not increase the claim level.
 
-Do not use words like implemented, verified, secure, runtime-ready, or production-ready unless the corresponding basis level and evidence exist.
+Do not use words like implemented, verified, secure, runtime-prepared, or production-prepared unless the corresponding basis level and evidence exist.

--- a/docs/spec/ui/projection_bundle_reader_parser_entry_gate.md
+++ b/docs/spec/ui/projection_bundle_reader_parser_entry_gate.md
@@ -55,6 +55,12 @@ Current evidence:
 
 This evidence is sufficient for Level 3 only.
 
+The current sketch reader evidence contour strengthens fixture-facing evidence, but it does not satisfy this gate.
+
+General Level 4 remains not claimed.
+
+A separate reader/parser basis is still required before any general Level 4 reader/parser claim.
+
 ## 3. What Level 4 Would Mean
 
 Level 4 means a separately approved reader or parser can consume an approved ProjectionBundle evidence format and produce a deterministic, testable representation without loader, runtime, verification, or production UI authority.

--- a/tools/post_ui/check_post_ui_fixtures.ps1
+++ b/tools/post_ui/check_post_ui_fixtures.ps1
@@ -54,6 +54,10 @@ $guards = @(
     @{
         Name = "ProjectionBundle sketch reader draft guard"
         Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_sketch_reader_draft.ps1"
+    },
+    @{
+        Name = "ProjectionBundle claim boundary guard"
+        Path = Join-Path $repoRoot "tools/post_ui/check_projection_bundle_claim_boundaries.ps1"
     }
 )
 

--- a/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+++ b/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
@@ -1,0 +1,130 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+
+function Fail {
+    param([string]$Message)
+    Write-Error $Message
+    exit 1
+}
+
+function Assert-FileExists {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "FAIL: Missing required file: $Path"
+    }
+}
+
+function Read-Text {
+    param([string]$Path)
+
+    return Get-Content -LiteralPath $Path -Raw
+}
+
+function Assert-Contains {
+    param(
+        [string]$Content,
+        [string]$Needle,
+        [string]$File
+    )
+
+    if ($Content.IndexOf($Needle, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+        Fail "FAIL: Missing required anchor in ${File}: $Needle"
+    }
+}
+
+function Assert-ContainsAny {
+    param(
+        [hashtable]$Contents,
+        [string]$Needle
+    )
+
+    foreach ($entry in $Contents.GetEnumerator()) {
+        if ($entry.Value.IndexOf($Needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            return
+        }
+    }
+
+    Fail "FAIL: Missing required anchor: $Needle"
+}
+
+function Assert-NotContains {
+    param(
+        [hashtable]$Contents,
+        [string]$Needle
+    )
+
+    foreach ($entry in $Contents.GetEnumerator()) {
+        $sanitized = [regex]::Replace($entry.Value, '(?s)```.*?```', ' ')
+        $sanitized = [regex]::Replace($sanitized, '(?<!`)`[^`]+`(?!`)', ' ')
+        if ($sanitized.IndexOf($Needle, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            Fail "FAIL: Forbidden claim phrase found in $($entry.Key): $Needle"
+        }
+    }
+}
+
+$paths = @{
+    basis = Join-Path $repoRoot "docs/spec/ui/projection_bundle_basis.md"
+    gate = Join-Path $repoRoot "docs/spec/ui/projection_bundle_reader_parser_entry_gate.md"
+    closeout = Join-Path $repoRoot "docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md"
+    index = Join-Path $repoRoot "docs/roadmap/post_ui/intent_driven_projection_closeout.md"
+}
+
+foreach ($path in $paths.Values) {
+    Assert-FileExists -Path $path
+}
+
+$contents = @{}
+foreach ($pair in $paths.GetEnumerator()) {
+    $contents[$pair.Key] = Read-Text -Path $pair.Value
+}
+
+Assert-Contains -Content $contents.basis -Needle "Current achieved level: Level 3 baseline" -File $paths.basis
+Assert-Contains -Content $contents.basis -Needle "narrow reader-facing fixture evidence" -File $paths.basis
+Assert-Contains -Content $contents.basis -Needle "Levels 4–7 are not claimed" -File $paths.basis
+
+Assert-Contains -Content $contents.gate -Needle "General Level 4 remains not claimed" -File $paths.gate
+Assert-Contains -Content $contents.gate -Needle "A separate reader/parser basis is still required before any general Level 4 reader/parser claim." -File $paths.gate
+
+Assert-Contains -Content $contents.closeout -Needle "Current achieved level: Level 3 baseline" -File $paths.closeout
+Assert-Contains -Content $contents.closeout -Needle "Reader evidence status: narrow reader-facing fixture evidence only" -File $paths.closeout
+Assert-Contains -Content $contents.closeout -Needle "General Level 4 status: not claimed" -File $paths.closeout
+Assert-Contains -Content $contents.closeout -Needle "Level 5+ is not claimed" -File $paths.closeout
+
+Assert-Contains -Content $contents.index -Needle "records the current fixture-facing reader evidence contour after the golden output pack." -File $paths.index
+
+$requiredAnchors = @(
+    "loader behavior is not claimed",
+    "runtime behavior is not claimed",
+    "production UI behavior is not claimed",
+    "General Level 4 status: not claimed",
+    "Level 5+ is not claimed",
+    "narrow reader-facing fixture evidence"
+)
+
+foreach ($anchor in $requiredAnchors) {
+    Assert-ContainsAny -Contents $contents -Needle $anchor
+}
+
+$forbiddenPhrases = @(
+    "Level 4 achieved",
+    "Level 4 implemented",
+    "general Level 4 achieved",
+    "general Level 4 reader/parser behavior is achieved",
+    "reader/parser implemented",
+    "parser implemented",
+    "loader-ready",
+    "runtime-ready",
+    "production-ready",
+    "activation-ready",
+    "verification-ready",
+    "security proven"
+)
+
+foreach ($phrase in $forbiddenPhrases) {
+    Assert-NotContains -Contents $contents -Needle $phrase
+}
+
+Write-Host "PASS: ProjectionBundle claim boundaries remain aligned"


### PR DESCRIPTION
## Summary

Closes the current ProjectionBundle sketch reader evidence contour after the golden output pack.

Adds a reader evidence closeout and a claim-boundary guard.

The closeout records:

- positive sketch acceptance;
- deterministic positive normalized reader output;
- negative pack rejection;
- deterministic negative rejection report;
- exact golden comparison guard.

## Boundary

Claim-boundary closeout and guard only.

No reader behavior changes.  
No fixture changes.  
No golden output changes.  
No schema.  
No general parser.  
No loader.  
No runtime.  
No activation path.  
No verification implementation.  
No production UI wiring.  
No Cargo changes.  
No CI wiring.  
No general Level 4 claim.  
No Level 5+ claim.

## Validation

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_claim_boundaries.ps1`

`pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`

`git diff --check`
