### PR TITLE
docs(post-ui): close out ProjectionBundle reader-core evidence

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,25 +1,26 @@
 task:
-  id: LOCAL-HARNESS-CURRENT-TASK-ALLOWED-PATHS
-  title: Fix harness-check to read allowed paths
-  type: harness-fix
+  id: POST-UI-READER-CORE-DOCS-CLOSEOUT
+  title: Close out ProjectionBundle reader-core evidence docs
+  type: docs-closeout
   mode: active
 
 intent:
-  summary: Make harness-check dynamic so it reads allowed_paths from the current task
+  summary: Record the already-merged fixture-facing ProjectionBundle sketch reader-core evidence closeout.
 
 layer:
-  name: tooling
-  owner: repo-local
+  name: documentation
+  owner: post-ui
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - scripts/harness-check.ps1
+    - docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
 
   forbidden_paths:
-    - docs/**
+    - scripts/**
     - tools/**
     - tests/**
+    - tests/fixtures/**
     - Cargo.toml
     - Cargo.lock
 
@@ -28,21 +29,35 @@ actions:
     - read
     - edit_allowed_paths
     - push
+    - create_pr
 
   forbidden:
-    - modify_docs
+    - modify_tools
+    - modify_reader_code
     - modify_fixtures
     - modify_golden_outputs
     - modify_cargo_toml
     - modify_cargo_lock
+    - general_parser_claim
+    - schema_claim
+    - loader_claim
+    - runtime_claim
+    - production_ui_claim
 
 constraints:
-  - harness infrastructure fix only
-  - no docs changes
-  - no tool/code reader changes
+  - docs closeout only
+  - fixture-facing ProjectionBundle sketch reader-core evidence only
+  - no tool/code changes
   - no fixture changes
   - no golden output changes
   - no Cargo changes
+  - no general parser claim
+  - no schema claim
+  - no loader claim
+  - no runtime claim
+  - no production UI claim
+  - no general Level 4 claim
+  - no Level 5+ claim
 
 verification:
   required:
@@ -50,4 +65,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
 
 report:
-  output: .harness/reports/LOCAL-HARNESS-CURRENT-TASK-ALLOWED-PATHS.md
+  output: .harness/reports/POST-UI-READER-CORE-DOCS-CLOSEOUT.md

--- a/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
+++ b/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
@@ -87,3 +87,35 @@ It does not claim general Level 4 reader/parser behavior.
 It does not claim loader behavior.
 It does not claim runtime behavior.
 It does not claim production UI behavior.
+
+## Reader-core publication closeout
+
+Merged publication steps:
+
+- #1358 — harness publication gate for the reader-core candidate.
+- #1359 — fixture-facing ProjectionBundle reader-core evidence.
+
+Evidence recorded after publication:
+
+- The reader guard runs Rust unit tests before compiling the standalone reader draft.
+- Positive output generation derives from parsed reader state.
+- Negative report generation derives from parsed reader state.
+- Section scanning, array scanning, and source_refs extraction are represented in the reader core.
+- Scalar and section ordering checks use parsed positions.
+- Positive and negative validation paths use a single-parse flow.
+- Golden outputs remained unchanged.
+- Post-merge validation on main passed:
+  - scripts/harness-check.ps1
+  - 	ools/post_ui/check_projection_bundle_sketch_reader_draft.ps1
+  - 	ools/post_ui/check_post_ui_fixtures.ps1
+  - cargo fmt --check
+  - cargo check --tests --quiet
+  - git diff --check
+
+Boundary:
+
+- This is fixture-facing ProjectionBundle sketch reader-core evidence only.
+- It is not a general parser claim.
+- It is not a schema claim.
+- It is not a loader, runtime reader, verifier, activation path, production UI path, or public API claim.
+- It does not imply general Level 4 or Level 5+ readiness.

--- a/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
+++ b/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
@@ -1,241 +1,122 @@
 # ProjectionBundle Reader Evidence Closeout
 
-
-
 Status: evidence closeout
-
 Track: POST-UI / Intent-Driven Projection
-
 Scope type: claim-boundary closeout
-
 Current achieved level: Level 3 baseline
-
 Reader evidence status: narrow reader-facing fixture evidence only
-
 General Level 4 status: not claimed
-
 Loader status: not claimed
-
 Runtime status: not claimed
-
 Production UI status: not claimed
-
 Level 5+ is not claimed
-
-
 
 ## 1. What Landed
 
-
-
 - inert positive sketch fixture;
-
 - fixture boundary guard;
-
 - manifest draft type;
-
 - manifest sketch/draft drift guard;
-
 - sketch reader draft;
-
 - production activation negative fixture;
-
 - negative fixture pack;
-
 - positive normalized reader output golden fixture;
-
 - negative rejection report golden fixture;
-
 - exact golden comparison guard.
-
-
 
 ## 2. What This Proves
 
-
-
 - the positive inert sketch is accepted by the fixture-facing sketch reader draft;
-
 - the positive inert sketch emits deterministic normalized text output;
-
 - the negative fixture pack is rejected;
-
 - each negative fixture is rejected for the intended single reason;
-
 - the negative rejection report is deterministic;
-
 - the guard compares emitted output exactly against committed golden text fixtures.
-
-
 
 ## 3. What This Does Not Prove
 
-
-
 - does not prove general parser correctness;
-
 - does not prove general reader/parser behavior;
-
 - does not prove final serialization;
-
 - does not prove loader behavior;
-
 - does not prove runtime behavior;
-
 - does not prove verification behavior;
-
 - does not prove trust/security correctness;
-
 - does not prove production UI behavior;
-
 - does not authorize activation;
-
 - does not claim Level 5+.
-
-
 
 ## 4. Claim Boundary
 
-
-
 Current achieved level remains: Level 3 baseline.
-
-
 
 The current evidence may be described only as:
 
-
-
 `narrow reader-facing fixture evidence`
-
-
 
 Do not describe it as:
 
-
-
 `Level 4 achieved`
-
 `Level 4 implemented`
-
 `reader/parser implemented`
-
 `parser implemented`
-
 `loader-ready`
-
 `runtime-ready`
-
 `production-ready`
-
-
 
 ## 5. Next Allowed Transition
 
-
-
 Next allowed transition is not loader/runtime.
-
-
 
 The next allowed transition must be one of:
 
-
-
 - reader/parser basis update;
-
 - stricter placeholder trust rejection evidence;
-
 - deterministic output shape review;
-
 - claim-boundary guard improvement.
-
-
 
 The reader/parser basis is now the next specification boundary before implementation work.
 
-
-
 Any transition toward loader/runtime/production requires a separate task and explicit gate.
-
-
 
 The reader/parser basis and Level-4 evidence matrix define future promotion requirements. They do not change the current achieved level.
 
-
-
 The first Level-4 evidence expansion pack adds fixture-facing malformed-field, unknown-field, duplicate-field, and field-ordering rejection evidence.
-
 This strengthens narrow reader-facing fixture evidence only.
-
 It does not claim general Level 4 reader/parser behavior.
-
 It does not claim loader behavior.
-
 It does not claim runtime behavior.
-
 It does not claim production UI behavior.
-
-
 
 ## Reader-core publication closeout
 
-
-
 Merged publication steps:
 
-
-
 - #1358 - harness publication gate for the reader-core candidate.
-
 - #1359 - fixture-facing ProjectionBundle reader-core evidence.
-
-
+- #1360 - dynamic Harness path-scope fix for allowed_paths and forbidden_paths.
 
 Evidence recorded after publication:
 
-
-
 - The reader guard runs Rust unit tests before compiling the standalone reader draft.
-
 - Positive output generation derives from parsed reader state.
-
 - Negative report generation derives from parsed reader state.
-
 - Section scanning, array scanning, and source_refs extraction are represented in the reader core.
-
 - Scalar and section ordering checks use parsed positions.
-
 - Positive and negative validation paths use a single-parse flow.
-
 - Golden outputs remained unchanged.
-
 - Post-merge validation on main passed:
-
   - scripts/harness-check.ps1
-
-  - ttools/post_ui/check_projection_bundle_sketch_reader_draft.ps1
-
-  - ttools/post_ui/check_post_ui_fixtures.ps1
-
+  - tools/post_ui/check_projection_bundle_sketch_reader_draft.ps1
+  - tools/post_ui/check_post_ui_fixtures.ps1
   - cargo fmt --check
-
   - cargo check --tests --quiet
-
   - git diff --check
-
-
 
 Boundary:
 
-
-
 - This is fixture-facing ProjectionBundle sketch reader-core evidence only.
-
 - It is not a general parser claim.
-
 - It is not a schema claim.
-
 - It is not a loader, runtime reader, verifier, activation path, production UI path, or public API claim.
-
 - It does not imply general Level 4 or Level 5+ readiness.

--- a/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
+++ b/docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
@@ -1,121 +1,241 @@
 # ProjectionBundle Reader Evidence Closeout
 
+
+
 Status: evidence closeout
+
 Track: POST-UI / Intent-Driven Projection
+
 Scope type: claim-boundary closeout
+
 Current achieved level: Level 3 baseline
+
 Reader evidence status: narrow reader-facing fixture evidence only
+
 General Level 4 status: not claimed
+
 Loader status: not claimed
+
 Runtime status: not claimed
+
 Production UI status: not claimed
+
 Level 5+ is not claimed
+
+
 
 ## 1. What Landed
 
+
+
 - inert positive sketch fixture;
+
 - fixture boundary guard;
+
 - manifest draft type;
+
 - manifest sketch/draft drift guard;
+
 - sketch reader draft;
+
 - production activation negative fixture;
+
 - negative fixture pack;
+
 - positive normalized reader output golden fixture;
+
 - negative rejection report golden fixture;
+
 - exact golden comparison guard.
+
+
 
 ## 2. What This Proves
 
+
+
 - the positive inert sketch is accepted by the fixture-facing sketch reader draft;
+
 - the positive inert sketch emits deterministic normalized text output;
+
 - the negative fixture pack is rejected;
+
 - each negative fixture is rejected for the intended single reason;
+
 - the negative rejection report is deterministic;
+
 - the guard compares emitted output exactly against committed golden text fixtures.
+
+
 
 ## 3. What This Does Not Prove
 
+
+
 - does not prove general parser correctness;
+
 - does not prove general reader/parser behavior;
+
 - does not prove final serialization;
+
 - does not prove loader behavior;
+
 - does not prove runtime behavior;
+
 - does not prove verification behavior;
+
 - does not prove trust/security correctness;
+
 - does not prove production UI behavior;
+
 - does not authorize activation;
+
 - does not claim Level 5+.
+
+
 
 ## 4. Claim Boundary
 
+
+
 Current achieved level remains: Level 3 baseline.
+
+
 
 The current evidence may be described only as:
 
+
+
 `narrow reader-facing fixture evidence`
+
+
 
 Do not describe it as:
 
+
+
 `Level 4 achieved`
+
 `Level 4 implemented`
+
 `reader/parser implemented`
+
 `parser implemented`
+
 `loader-ready`
+
 `runtime-ready`
+
 `production-ready`
+
+
 
 ## 5. Next Allowed Transition
 
+
+
 Next allowed transition is not loader/runtime.
+
+
 
 The next allowed transition must be one of:
 
+
+
 - reader/parser basis update;
+
 - stricter placeholder trust rejection evidence;
+
 - deterministic output shape review;
+
 - claim-boundary guard improvement.
+
+
 
 The reader/parser basis is now the next specification boundary before implementation work.
 
+
+
 Any transition toward loader/runtime/production requires a separate task and explicit gate.
+
+
 
 The reader/parser basis and Level-4 evidence matrix define future promotion requirements. They do not change the current achieved level.
 
+
+
 The first Level-4 evidence expansion pack adds fixture-facing malformed-field, unknown-field, duplicate-field, and field-ordering rejection evidence.
+
 This strengthens narrow reader-facing fixture evidence only.
+
 It does not claim general Level 4 reader/parser behavior.
+
 It does not claim loader behavior.
+
 It does not claim runtime behavior.
+
 It does not claim production UI behavior.
+
+
 
 ## Reader-core publication closeout
 
+
+
 Merged publication steps:
 
-- #1358 — harness publication gate for the reader-core candidate.
-- #1359 — fixture-facing ProjectionBundle reader-core evidence.
+
+
+- #1358 - harness publication gate for the reader-core candidate.
+
+- #1359 - fixture-facing ProjectionBundle reader-core evidence.
+
+
 
 Evidence recorded after publication:
 
+
+
 - The reader guard runs Rust unit tests before compiling the standalone reader draft.
+
 - Positive output generation derives from parsed reader state.
+
 - Negative report generation derives from parsed reader state.
+
 - Section scanning, array scanning, and source_refs extraction are represented in the reader core.
+
 - Scalar and section ordering checks use parsed positions.
+
 - Positive and negative validation paths use a single-parse flow.
+
 - Golden outputs remained unchanged.
+
 - Post-merge validation on main passed:
+
   - scripts/harness-check.ps1
-  - 	ools/post_ui/check_projection_bundle_sketch_reader_draft.ps1
-  - 	ools/post_ui/check_post_ui_fixtures.ps1
+
+  - ttools/post_ui/check_projection_bundle_sketch_reader_draft.ps1
+
+  - ttools/post_ui/check_post_ui_fixtures.ps1
+
   - cargo fmt --check
+
   - cargo check --tests --quiet
+
   - git diff --check
+
+
 
 Boundary:
 
+
+
 - This is fixture-facing ProjectionBundle sketch reader-core evidence only.
+
 - It is not a general parser claim.
+
 - It is not a schema claim.
+
 - It is not a loader, runtime reader, verifier, activation path, production UI path, or public API claim.
+
 - It does not imply general Level 4 or Level 5+ readiness.


### PR DESCRIPTION
## Summary

Closes out the already-merged ProjectionBundle reader-core evidence work.

This PR records the publication path and evidence from:

- #1358 harness publication gate
- #1359 fixture-facing ProjectionBundle reader-core evidence
- #1360 dynamic Harness path-scope fix that unblocked this docs closeout

## Changed files

- `.harness/current.task.yaml`
- `docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md`

## Boundary

Docs closeout only.
No tool/code changes.
No fixture changes.
No golden output changes.
No Cargo changes.
No general parser claim.
No schema claim.
No loader/runtime/production claim.
No general Level 4 claim.
No Level 5+ claim.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_sketch_reader_draft.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`
- `cargo fmt --check`
- `cargo check --tests --quiet`
- `git diff --check`
