### PR TITLE
test(post-ui): strengthen ProjectionBundle claim-boundary guard

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,24 +1,24 @@
 task:
-  id: POST-UI-READER-CORE-DOCS-CLOSEOUT
-  title: Close out ProjectionBundle reader-core evidence docs
-  type: docs-closeout
+  id: POST-UI-PROJECTION-BUNDLE-CLAIM-BOUNDARY-GUARD
+  title: Strengthen ProjectionBundle claim-boundary guard
+  type: guard-improvement
   mode: active
 
 intent:
-  summary: Record the already-merged fixture-facing ProjectionBundle sketch reader-core evidence closeout.
+  summary: Extend the ProjectionBundle claim-boundary guard to reject accidental reader/parser, loader, runtime, production UI, Level 4, and Level 5+ overclaims.
 
 layer:
-  name: documentation
+  name: tooling
   owner: post-ui
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md
+    - tools/post_ui/check_projection_bundle_claim_boundaries.ps1
 
   forbidden_paths:
+    - docs/**
     - scripts/**
-    - tools/**
     - tests/**
     - tests/fixtures/**
     - Cargo.toml
@@ -32,23 +32,24 @@ actions:
     - create_pr
 
   forbidden:
-    - modify_tools
+    - modify_docs
     - modify_reader_code
     - modify_fixtures
     - modify_golden_outputs
     - modify_cargo_toml
     - modify_cargo_lock
-    - general_parser_claim
-    - schema_claim
     - loader_claim
     - runtime_claim
     - production_ui_claim
+    - level4_claim
+    - level5_claim
 
 constraints:
-  - docs closeout only
-  - fixture-facing ProjectionBundle sketch reader-core evidence only
-  - no tool/code changes
-  - no fixture changes
+  - guard improvement only
+  - claim-boundary enforcement only
+  - no docs changes
+  - no reader code changes
+  - no fixtures changes
   - no golden output changes
   - no Cargo changes
   - no general parser claim
@@ -63,6 +64,8 @@ verification:
   required:
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+    - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+    - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1
 
 report:
-  output: .harness/reports/POST-UI-READER-CORE-DOCS-CLOSEOUT.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-CLAIM-BOUNDARY-GUARD.md

--- a/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+++ b/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
@@ -65,9 +65,13 @@ function Assert-NotContains {
     }
 }
 
+# Keep every ProjectionBundle claim-bearing doc in this canonical scanner.
+# The aggregate POST-UI guard must not drift across separate forbidden lists.
 $paths = @{
     basis = Join-Path $repoRoot "docs/spec/ui/projection_bundle_basis.md"
     gate = Join-Path $repoRoot "docs/spec/ui/projection_bundle_reader_parser_entry_gate.md"
+    readerParserBasis = Join-Path $repoRoot "docs/spec/ui/projection_bundle_reader_parser_basis.md"
+    level4Matrix = Join-Path $repoRoot "docs/roadmap/post_ui/projection_bundle_level4_evidence_matrix.md"
     closeout = Join-Path $repoRoot "docs/roadmap/post_ui/projection_bundle_reader_evidence_closeout.md"
     index = Join-Path $repoRoot "docs/roadmap/post_ui/intent_driven_projection_closeout.md"
 }

--- a/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+++ b/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
@@ -108,19 +108,38 @@ foreach ($anchor in $requiredAnchors) {
     Assert-ContainsAny -Contents $contents -Needle $anchor
 }
 
+# Boundary-safe negative statements such as "not claimed" or
+# "does not claim loader behavior" must remain allowed.
+# This guard rejects affirmative/readiness claims, not vocabulary itself.
 $forbiddenPhrases = @(
     "Level 4 achieved",
     "Level 4 implemented",
+    "Level-4 achieved",
+    "Level-4 implemented",
     "general Level 4 achieved",
     "general Level 4 reader/parser behavior is achieved",
     "reader/parser implemented",
     "parser implemented",
+    "general parser implemented",
+    "ProjectionBundle parser implemented",
+    "ProjectionBundle reader/parser implemented",
     "loader-ready",
     "runtime-ready",
     "production-ready",
+    "loader ready",
+    "runtime ready",
+    "production ready",
+    "activation path ready",
+    "public API ready",
     "activation-ready",
     "verification-ready",
-    "security proven"
+    "security proven",
+    "Level 5 achieved",
+    "Level 5 implemented",
+    "Level-5 achieved",
+    "Level-5 implemented",
+    "Level 5+ achieved",
+    "Level 5+ implemented"
 )
 
 foreach ($phrase in $forbiddenPhrases) {


### PR DESCRIPTION
## Summary

Strengthens the ProjectionBundle claim-boundary guard to reject accidental affirmative overclaims around reader/parser, loader, runtime, production UI, Level 4, and Level 5+ readiness.

## Changed files

- `.harness/current.task.yaml`
- `tools/post_ui/check_projection_bundle_claim_boundaries.ps1`

## Boundary

Guard improvement only.
No docs changes.
No reader code changes.
No fixture changes.
No golden output changes.
No Cargo changes.
No general parser claim.
No schema claim.
No loader/runtime/production claim.
No Level 4 claim.
No Level 5+ claim.

## Notes

The guard rejects affirmative/readiness claims, not legitimate negative boundary statements such as `not claimed` or `does not claim loader behavior`.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_claim_boundaries.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_sketch_reader_draft.ps1`
- `cargo fmt --check`
- `cargo check --tests --quiet`
- `git diff --check`
