### PR TITLE
fix(post-ui): block ProjectionBundle Level 5 readiness overclaims

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-CLAIM-BOUNDARY-GUARD
-  title: Strengthen ProjectionBundle claim-boundary guard
+  id: POST-UI-PROJECTION-BUNDLE-LEVEL5-READINESS-GUARD
+  title: Block ProjectionBundle Level 5 readiness overclaims
   type: guard-improvement
   mode: active
 
 intent:
-  summary: Extend the ProjectionBundle claim-boundary guard to reject accidental reader/parser, loader, runtime, production UI, Level 4, and Level 5+ overclaims.
+  summary: Extend the ProjectionBundle claim-boundary guard to reject affirmative Level 5 and Level 5+ readiness overclaims while preserving legal negative boundary statements.
 
 layer:
   name: tooling
@@ -68,4 +68,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-CLAIM-BOUNDARY-GUARD.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-LEVEL5-READINESS-GUARD.md

--- a/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+++ b/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
@@ -143,7 +143,25 @@ $forbiddenPhrases = @(
     "Level-5 achieved",
     "Level-5 implemented",
     "Level 5+ achieved",
-    "Level 5+ implemented"
+    "Level 5+ implemented",
+    "Level 5 ready",
+    "Level 5 is ready",
+    "Level 5 readiness achieved",
+    "Level 5 readiness established",
+    "Level 5 readiness is established",
+    "Level 5 readiness proven",
+    "Level-5 ready",
+    "Level-5 is ready",
+    "Level-5 readiness achieved",
+    "Level-5 readiness established",
+    "Level-5 readiness is established",
+    "Level-5 readiness proven",
+    "Level 5+ ready",
+    "Level 5+ is ready",
+    "Level 5+ readiness achieved",
+    "Level 5+ readiness established",
+    "Level 5+ readiness is established",
+    "Level 5+ readiness proven"
 )
 
 foreach ($phrase in $forbiddenPhrases) {

--- a/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
+++ b/tools/post_ui/check_projection_bundle_claim_boundaries.ps1
@@ -161,7 +161,15 @@ $forbiddenPhrases = @(
     "Level 5+ readiness achieved",
     "Level 5+ readiness established",
     "Level 5+ readiness is established",
-    "Level 5+ readiness proven"
+    "Level 5+ readiness proven",
+    "Level-5+ achieved",
+    "Level-5+ implemented",
+    "Level-5+ ready",
+    "Level-5+ is ready",
+    "Level-5+ readiness achieved",
+    "Level-5+ readiness established",
+    "Level-5+ readiness is established",
+    "Level-5+ readiness proven"
 )
 
 foreach ($phrase in $forbiddenPhrases) {


### PR DESCRIPTION
## Summary

Blocks affirmative ProjectionBundle Level 5 / Level 5+ readiness overclaims in the canonical claim-boundary guard.

## Background

Follow-up to #1362. Codex identified that the guard rejected `achieved` / `implemented` Level 5+ claims, but did not yet reject readiness wording such as `Level 5+ ready` or `Level 5+ readiness is established`.

## Changed files

- `.harness/current.task.yaml`
- `tools/post_ui/check_projection_bundle_claim_boundaries.ps1`

## Boundary

Guard improvement only.
No docs changes.
No fixtures changes.
No reader/source code changes.
No Cargo changes.
No runtime/loader/production UI claim.
No Level 5 readiness claim.

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_claim_boundaries.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_parser_basis.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_post_ui_fixtures.ps1`
- `cargo fmt --check`
- `cargo check --tests --quiet`
- `git diff --check`

## Mutation proof

- `Level 5+ ready` in reader/parser basis: rejected
- `Level 5+ readiness is established` in Level-4 evidence matrix: rejected
- `Level 5+ readiness is not established`: allowed
