### PR TITLE
experiment(post-ui): separate fixture identity checks from reader shape checks

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-PROBE-CLASSIFICATION
-  title: Classify ProjectionBundle reader probe observations
+  id: POST-UI-PROJECTION-BUNDLE-READER-SHAPE-CHECKS
+  title: Separate fixture identity checks from reader shape checks
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): classify first ProjectionBundle reader probe observations
+  summary: experiment(post-ui): separate fixture identity checks from reader shape checks
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-PROBE-CLASSIFICATION.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SHAPE-CHECKS.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -37,6 +37,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L51)
+trust_shape: placeholder
 validation_result: rejected
 primary_error: duplicate_field: allow_runtime_tree_streaming
 ---
@@ -83,6 +84,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [source1, source2, source3] (L6)
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
+trust_shape: placeholder
 validation_result: rejected
 primary_error: missing required anchor semantic source ref: semantic.source.example
 ---
@@ -124,6 +126,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
+trust_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_section_order_accepted.sketch.md
@@ -164,6 +167,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L33)
   [projection_bundle/diagnostics] expected = [] (L50)
+trust_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_trust_invalid_shape.sketch.md
@@ -204,6 +208,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
+trust_shape: malformed
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "just-a-string-without-prefix"
 ---
@@ -245,6 +250,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
+trust_shape: sha256_like
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 ---
@@ -288,6 +294,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L28)
   [projection_bundle/diagnostics] expected = [] (L53)
+trust_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_unknown_scalar.sketch.md
@@ -329,6 +336,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
+trust_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_unterminated_text_block.sketch.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -37,7 +37,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L51)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: rejected
 primary_error: duplicate_field: allow_runtime_tree_streaming
 ---
@@ -84,7 +84,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [source1, source2, source3] (L6)
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: rejected
 primary_error: missing required anchor semantic source ref: semantic.source.example
 ---
@@ -126,7 +126,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_section_order_accepted.sketch.md
@@ -167,7 +167,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L33)
   [projection_bundle/diagnostics] expected = [] (L50)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_trust_invalid_shape.sketch.md
@@ -208,7 +208,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
-trust_shape: malformed
+hash_shape: malformed
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "just-a-string-without-prefix"
 ---
@@ -250,7 +250,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
-trust_shape: sha256_like
+hash_shape: sha256_like
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 ---
@@ -294,7 +294,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L28)
   [projection_bundle/diagnostics] expected = [] (L53)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_unknown_scalar.sketch.md
@@ -336,7 +336,7 @@ arrays: 3 total
   [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
-trust_shape: placeholder
+hash_shape: placeholder
 validation_result: accepted
 ---
 fixture: probe_unterminated_text_block.sketch.md

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2458,19 +2458,19 @@ fn run_probe(path: &str) -> Result<String, String> {
     }
 
     if let Ok(core) = parse_sketch_core(&content) {
-        let mut trust_shape = "unknown";
+        let mut hash_shape = "unknown";
         for scalar in &core.scalars {
             if scalar.section == "projection_bundle/trust" && scalar.key == "hash" {
                 if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
-                    trust_shape = "placeholder";
+                    hash_shape = "placeholder";
                 } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 {
-                    trust_shape = "sha256_like";
+                    hash_shape = "sha256_like";
                 } else {
-                    trust_shape = "malformed";
+                    hash_shape = "malformed";
                 }
             }
         }
-        push_line(&mut out, &format!("trust_shape: {}", trust_shape));
+        push_line(&mut out, &format!("hash_shape: {}", hash_shape));
     }
 
     match validate_sketch(&content) {

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2457,6 +2457,22 @@ fn run_probe(path: &str) -> Result<String, String> {
         }
     }
 
+    if let Ok(core) = parse_sketch_core(&content) {
+        let mut trust_shape = "unknown";
+        for scalar in &core.scalars {
+            if scalar.section == "projection_bundle/trust" && scalar.key == "hash" {
+                if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
+                    trust_shape = "placeholder";
+                } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 {
+                    trust_shape = "sha256_like";
+                } else {
+                    trust_shape = "malformed";
+                }
+            }
+        }
+        push_line(&mut out, &format!("trust_shape: {}", trust_shape));
+    }
+
     match validate_sketch(&content) {
         Ok(_) => {
             push_line(&mut out, "validation_result: accepted");

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2463,7 +2463,7 @@ fn run_probe(path: &str) -> Result<String, String> {
             if scalar.section == "projection_bundle/trust" && scalar.key == "hash" {
                 if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
                     hash_shape = "placeholder";
-                } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 {
+                } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 && scalar.value[7..].chars().all(|c| c.is_ascii_hexdigit()) {
                     hash_shape = "sha256_like";
                 } else {
                     hash_shape = "malformed";


### PR DESCRIPTION
## Goal

Separate the fixture identity check from the shape check of the trust fields by emitting a specific trust_shape diagnostic.

This ensures the identity snapshot rejection does not obscure the reader's shape extraction abilities.