### PR TITLE
experiment(post-ui): observe unknown field rejection behavior

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-SHAPE-CHECKS
-  title: Separate fixture identity checks from reader shape checks
+  id: POST-UI-PROJECTION-BUNDLE-READER-UNKNOWN-BEHAVIOR
+  title: Observe unknown field rejection behavior
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): separate fixture identity checks from reader shape checks
+  summary: experiment(post-ui): observe unknown field rejection behavior
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SHAPE-CHECKS.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-UNKNOWN-BEHAVIOR.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -344,7 +344,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
-unknown_items: found_unknown_scalars
+unknown_items: found_unknown_fields
 validation_result: accepted
 ---
 fixture: probe_unterminated_text_block.sketch.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -38,6 +38,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+unknown_items: none
 validation_result: rejected
 primary_error: duplicate_field: allow_runtime_tree_streaming
 ---
@@ -85,6 +86,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+unknown_items: none
 validation_result: rejected
 primary_error: missing required anchor semantic source ref: semantic.source.example
 ---
@@ -127,6 +129,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: placeholder
+unknown_items: none
 validation_result: accepted
 ---
 fixture: probe_section_order_accepted.sketch.md
@@ -168,6 +171,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L33)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: placeholder
+unknown_items: none
 validation_result: accepted
 ---
 fixture: probe_trust_invalid_shape.sketch.md
@@ -209,6 +213,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: malformed
+unknown_items: none
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "just-a-string-without-prefix"
 ---
@@ -251,6 +256,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: sha256_like
+unknown_items: none
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 ---
@@ -295,6 +301,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L28)
   [projection_bundle/diagnostics] expected = [] (L53)
 hash_shape: placeholder
+unknown_items: both
 validation_result: accepted
 ---
 fixture: probe_unknown_scalar.sketch.md
@@ -337,6 +344,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+unknown_items: found_unknown_scalars
 validation_result: accepted
 ---
 fixture: probe_unterminated_text_block.sketch.md

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2459,6 +2459,54 @@ fn run_probe(path: &str) -> Result<String, String> {
 
     if let Ok(core) = parse_sketch_core(&content) {
         let mut hash_shape = "unknown";
+        let mut has_unknown_sections = false;
+        let mut has_unknown_fields = false;
+
+        let known_sections = [
+            "projection_bundle",
+            "projection_bundle/artifacts",
+            "projection_bundle/compatibility",
+            "projection_bundle/safety",
+            "projection_bundle/trust",
+            "projection_bundle/activation_policy",
+            "projection_bundle/update_policy",
+            "projection_bundle/diagnostics",
+        ];
+
+        let known_fields = [
+            ("projection_bundle", "bundle_id"),
+            ("projection_bundle", "bundle_version"),
+            ("projection_bundle", "projection_id"),
+            ("projection_bundle", "source_refs"),
+            ("projection_bundle/artifacts", "ui_ir_ref"),
+            ("projection_bundle/artifacts", "binding_graph_ref"),
+            ("projection_bundle/artifacts", "action_ir_ref"),
+            ("projection_bundle/compatibility", "role_dictionary_version"),
+            ("projection_bundle/compatibility", "renderer_profile"),
+            ("projection_bundle/safety", "safety_class"),
+            ("projection_bundle/safety", "criticality"),
+            ("projection_bundle/safety", "freshness_policy"),
+            ("projection_bundle/safety", "required_capabilities"),
+            ("projection_bundle/trust", "hash"),
+            ("projection_bundle/trust", "signature"),
+            ("projection_bundle/trust", "created_by"),
+            ("projection_bundle/trust", "created_at"),
+            ("projection_bundle/trust", "compiler_identity"),
+            ("projection_bundle/activation_policy", "require_verification"),
+            ("projection_bundle/activation_policy", "allow_runtime_tree_streaming"),
+            ("projection_bundle/activation_policy", "allow_production_activation"),
+            ("projection_bundle/update_policy", "require_safe_update_boundary"),
+            ("projection_bundle/update_policy", "allow_critical_update_during_pending_unknown"),
+            ("projection_bundle/update_policy", "allow_critical_update_during_quarantine"),
+            ("projection_bundle/diagnostics", "expected"),
+        ];
+
+        for section in &core.sections {
+            if !known_sections.contains(&section.path.as_str()) {
+                has_unknown_sections = true;
+            }
+        }
+
         for scalar in &core.scalars {
             if scalar.section == "projection_bundle/trust" && scalar.key == "hash" {
                 if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
@@ -2469,8 +2517,26 @@ fn run_probe(path: &str) -> Result<String, String> {
                     hash_shape = "malformed";
                 }
             }
+            if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {
+                has_unknown_fields = true;
+            }
         }
+
+        for array in &core.arrays {
+            if !known_fields.contains(&(array.section.as_str(), array.key.as_str())) {
+                has_unknown_fields = true;
+            }
+        }
+
+        let unknown_items = match (has_unknown_sections, has_unknown_fields) {
+            (true, true) => "both",
+            (true, false) => "found_unknown_sections",
+            (false, true) => "found_unknown_scalars",
+            (false, false) => "none",
+        };
+
         push_line(&mut out, &format!("hash_shape: {}", hash_shape));
+        push_line(&mut out, &format!("unknown_items: {}", unknown_items));
     }
 
     match validate_sketch(&content) {

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2531,7 +2531,7 @@ fn run_probe(path: &str) -> Result<String, String> {
         let unknown_items = match (has_unknown_sections, has_unknown_fields) {
             (true, true) => "both",
             (true, false) => "found_unknown_sections",
-            (false, true) => "found_unknown_scalars",
+            (false, true) => "found_unknown_fields",
             (false, false) => "none",
         };
 


### PR DESCRIPTION
## Goal

Add diagnostic classification for unknown scalars and sections to see exactly where the reader needs to be strict.

- Maintains a list of known sections and fields in the probe logic.
- Identifies unknown_items as none, found_unknown_scalars, found_unknown_sections, or both.
- No changes to validation rules yet, strictly diagnostic.