### PR TITLE
experiment(post-ui): probe strict unknown item rejection

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-UNKNOWN-BEHAVIOR
-  title: Observe unknown field rejection behavior
+  id: POST-UI-PROJECTION-BUNDLE-READER-STRICT-UNKNOWN-REJECTION
+  title: Probe strict unknown item rejection
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): observe unknown field rejection behavior
+  summary: experiment(post-ui): probe strict unknown item rejection
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-UNKNOWN-BEHAVIOR.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-STRICT-UNKNOWN-REJECTION.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -302,7 +302,8 @@ arrays: 3 total
   [projection_bundle/diagnostics] expected = [] (L53)
 hash_shape: placeholder
 unknown_items: both
-validation_result: accepted
+validation_result: rejected
+primary_error: unknown_section: projection_bundle/safety/unknown_nested_section
 ---
 fixture: probe_unknown_scalar.sketch.md
 text_block: found
@@ -345,7 +346,8 @@ arrays: 3 total
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
 unknown_items: found_unknown_fields
-validation_result: accepted
+validation_result: rejected
+primary_error: unknown_field: unknown_scalar
 ---
 fixture: probe_unterminated_text_block.sketch.md
 core_parse_error: unterminated text block

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -1068,14 +1068,69 @@ fn require_no_known_unknown_fields_except_core(
     core: &SketchReaderCore,
     allowed_unknown_fields: &[&str],
 ) -> Result<(), String> {
-    for key in ["unknown_future_field", "allow_unreviewed_activation"] {
-        if allowed_unknown_fields.contains(&key) {
-            continue;
-        }
-        if count_scalar_occurrences_core(core, key) > 0 {
-            return Err(format!("unknown_field: {}", key));
+    let known_sections = [
+        "projection_bundle",
+        "projection_bundle/artifacts",
+        "projection_bundle/compatibility",
+        "projection_bundle/safety",
+        "projection_bundle/trust",
+        "projection_bundle/activation_policy",
+        "projection_bundle/update_policy",
+        "projection_bundle/diagnostics",
+    ];
+
+    let known_fields = [
+        ("projection_bundle", "bundle_id"),
+        ("projection_bundle", "bundle_version"),
+        ("projection_bundle", "projection_id"),
+        ("projection_bundle", "source_refs"),
+        ("projection_bundle/artifacts", "ui_ir_ref"),
+        ("projection_bundle/artifacts", "binding_graph_ref"),
+        ("projection_bundle/artifacts", "action_ir_ref"),
+        ("projection_bundle/compatibility", "role_dictionary_version"),
+        ("projection_bundle/compatibility", "renderer_profile"),
+        ("projection_bundle/safety", "safety_class"),
+        ("projection_bundle/safety", "criticality"),
+        ("projection_bundle/safety", "freshness_policy"),
+        ("projection_bundle/safety", "required_capabilities"),
+        ("projection_bundle/trust", "hash"),
+        ("projection_bundle/trust", "signature"),
+        ("projection_bundle/trust", "created_by"),
+        ("projection_bundle/trust", "created_at"),
+        ("projection_bundle/trust", "compiler_identity"),
+        ("projection_bundle/activation_policy", "require_verification"),
+        ("projection_bundle/activation_policy", "allow_runtime_tree_streaming"),
+        ("projection_bundle/activation_policy", "allow_production_activation"),
+        ("projection_bundle/update_policy", "require_safe_update_boundary"),
+        ("projection_bundle/update_policy", "allow_critical_update_during_pending_unknown"),
+        ("projection_bundle/update_policy", "allow_critical_update_during_quarantine"),
+        ("projection_bundle/diagnostics", "expected"),
+    ];
+
+    for section in &core.sections {
+        if !known_sections.contains(&section.path.as_str()) {
+            return Err(format!("unknown_section: {}", section.path));
         }
     }
+
+    for scalar in &core.scalars {
+        if allowed_unknown_fields.contains(&scalar.key.as_str()) {
+            continue;
+        }
+        if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {
+            return Err(format!("unknown_field: {}", scalar.key));
+        }
+    }
+
+    for array in &core.arrays {
+        if allowed_unknown_fields.contains(&array.key.as_str()) {
+            continue;
+        }
+        if !known_fields.contains(&(array.section.as_str(), array.key.as_str())) {
+            return Err(format!("unknown_field: {}", array.key));
+        }
+    }
+
     Ok(())
 }
 
@@ -1298,71 +1353,7 @@ fn require_no_known_unknown_fields_except(
     allowed_unknown_fields: &[&str],
 ) -> Result<(), String> {
     let core = parse_sketch_core(content).map_err(|err| err.message)?;
-
-    let known_sections = [
-        "projection_bundle",
-        "projection_bundle/artifacts",
-        "projection_bundle/compatibility",
-        "projection_bundle/safety",
-        "projection_bundle/trust",
-        "projection_bundle/activation_policy",
-        "projection_bundle/update_policy",
-        "projection_bundle/diagnostics",
-    ];
-
-    let known_fields = [
-        ("projection_bundle", "bundle_id"),
-        ("projection_bundle", "bundle_version"),
-        ("projection_bundle", "projection_id"),
-        ("projection_bundle", "source_refs"),
-        ("projection_bundle/artifacts", "ui_ir_ref"),
-        ("projection_bundle/artifacts", "binding_graph_ref"),
-        ("projection_bundle/artifacts", "action_ir_ref"),
-        ("projection_bundle/compatibility", "role_dictionary_version"),
-        ("projection_bundle/compatibility", "renderer_profile"),
-        ("projection_bundle/safety", "safety_class"),
-        ("projection_bundle/safety", "criticality"),
-        ("projection_bundle/safety", "freshness_policy"),
-        ("projection_bundle/safety", "required_capabilities"),
-        ("projection_bundle/trust", "hash"),
-        ("projection_bundle/trust", "signature"),
-        ("projection_bundle/trust", "created_by"),
-        ("projection_bundle/trust", "created_at"),
-        ("projection_bundle/trust", "compiler_identity"),
-        ("projection_bundle/activation_policy", "require_verification"),
-        ("projection_bundle/activation_policy", "allow_runtime_tree_streaming"),
-        ("projection_bundle/activation_policy", "allow_production_activation"),
-        ("projection_bundle/update_policy", "require_safe_update_boundary"),
-        ("projection_bundle/update_policy", "allow_critical_update_during_pending_unknown"),
-        ("projection_bundle/update_policy", "allow_critical_update_during_quarantine"),
-        ("projection_bundle/diagnostics", "expected"),
-    ];
-
-    for section in &core.sections {
-        if !known_sections.contains(&section.path.as_str()) {
-            return Err(format!("unknown_section: {}", section.path));
-        }
-    }
-
-    for scalar in &core.scalars {
-        if allowed_unknown_fields.contains(&scalar.key.as_str()) {
-            continue;
-        }
-        if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {
-            return Err(format!("unknown_field: {}", scalar.key));
-        }
-    }
-
-    for array in &core.arrays {
-        if allowed_unknown_fields.contains(&array.key.as_str()) {
-            continue;
-        }
-        if !known_fields.contains(&(array.section.as_str(), array.key.as_str())) {
-            return Err(format!("unknown_field: {}", array.key));
-        }
-    }
-
-    Ok(())
+    require_no_known_unknown_fields_except_core(&core, allowed_unknown_fields)
 }
 
 fn require_field_order(

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -1299,13 +1299,66 @@ fn require_no_known_unknown_fields_except(
 ) -> Result<(), String> {
     let core = parse_sketch_core(content).map_err(|err| err.message)?;
 
-    for key in ["unknown_future_field", "allow_unreviewed_activation"] {
-        if allowed_unknown_fields.contains(&key) {
+    let known_sections = [
+        "projection_bundle",
+        "projection_bundle/artifacts",
+        "projection_bundle/compatibility",
+        "projection_bundle/safety",
+        "projection_bundle/trust",
+        "projection_bundle/activation_policy",
+        "projection_bundle/update_policy",
+        "projection_bundle/diagnostics",
+    ];
+
+    let known_fields = [
+        ("projection_bundle", "bundle_id"),
+        ("projection_bundle", "bundle_version"),
+        ("projection_bundle", "projection_id"),
+        ("projection_bundle", "source_refs"),
+        ("projection_bundle/artifacts", "ui_ir_ref"),
+        ("projection_bundle/artifacts", "binding_graph_ref"),
+        ("projection_bundle/artifacts", "action_ir_ref"),
+        ("projection_bundle/compatibility", "role_dictionary_version"),
+        ("projection_bundle/compatibility", "renderer_profile"),
+        ("projection_bundle/safety", "safety_class"),
+        ("projection_bundle/safety", "criticality"),
+        ("projection_bundle/safety", "freshness_policy"),
+        ("projection_bundle/safety", "required_capabilities"),
+        ("projection_bundle/trust", "hash"),
+        ("projection_bundle/trust", "signature"),
+        ("projection_bundle/trust", "created_by"),
+        ("projection_bundle/trust", "created_at"),
+        ("projection_bundle/trust", "compiler_identity"),
+        ("projection_bundle/activation_policy", "require_verification"),
+        ("projection_bundle/activation_policy", "allow_runtime_tree_streaming"),
+        ("projection_bundle/activation_policy", "allow_production_activation"),
+        ("projection_bundle/update_policy", "require_safe_update_boundary"),
+        ("projection_bundle/update_policy", "allow_critical_update_during_pending_unknown"),
+        ("projection_bundle/update_policy", "allow_critical_update_during_quarantine"),
+        ("projection_bundle/diagnostics", "expected"),
+    ];
+
+    for section in &core.sections {
+        if !known_sections.contains(&section.path.as_str()) {
+            return Err(format!("unknown_section: {}", section.path));
+        }
+    }
+
+    for scalar in &core.scalars {
+        if allowed_unknown_fields.contains(&scalar.key.as_str()) {
             continue;
         }
+        if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {
+            return Err(format!("unknown_field: {}", scalar.key));
+        }
+    }
 
-        if count_scalar_occurrences_core(&core, key) > 0 {
-            return Err(format!("unknown_field: {}", key));
+    for array in &core.arrays {
+        if allowed_unknown_fields.contains(&array.key.as_str()) {
+            continue;
+        }
+        if !known_fields.contains(&(array.section.as_str(), array.key.as_str())) {
+            return Err(format!("unknown_field: {}", array.key));
         }
     }
 


### PR DESCRIPTION
## Goal

Convert the diagnostic unknown field check into an active experimental validation rule.

- Updates require_no_known_unknown_fields_except to reject any unknown fields or sections based on the explicit whitelist.
- Modifies probe_unknown_scalar and probe_unknown_nested_section to be strictly rejected.
- No documentation or final policy claims are updated yet.