### PR TITLE
experiment(post-ui): probe trust signature shape classification

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-TRUST-HASH-SHAPE-REJECTION
-  title: Probe trust hash shape rejection
+  id: POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-CLASSIFICATION
+  title: Probe trust signature shape classification
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): probe trust hash shape rejection
+  summary: experiment(post-ui): probe trust signature shape classification
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-TRUST-HASH-SHAPE-REJECTION.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-CLASSIFICATION.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -38,6 +38,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
 primary_error: duplicate_field: allow_runtime_tree_streaming
@@ -86,6 +87,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
 primary_error: missing required anchor semantic source ref: semantic.source.example
@@ -129,6 +131,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: none
 validation_result: accepted
 ---
@@ -171,6 +174,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L33)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: none
 validation_result: accepted
 ---
@@ -198,7 +202,7 @@ scalars: 22 total
   [projection_bundle/safety] criticality = NonCritical (L24)
   [projection_bundle/safety] freshness_policy = FreshForControl (L26)
   [projection_bundle/trust] hash = just-a-string-without-prefix (L30)
-  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
+  [projection_bundle/trust] signature = invalid-signature-shape (L31)
   [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
   [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
   [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
@@ -213,6 +217,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: malformed
+signature_shape: malformed
 unknown_items: none
 validation_result: rejected
 primary_error: malformed_hash_shape
@@ -256,6 +261,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: sha256_like
+signature_shape: signature_like
 unknown_items: none
 validation_result: rejected
 primary_error: field hash mismatch: expected "sha256:SKETCH-NOT-A-REAL-HASH", got "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -301,6 +307,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L28)
   [projection_bundle/diagnostics] expected = [] (L53)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: both
 validation_result: rejected
 primary_error: unknown_section: projection_bundle/safety/unknown_nested_section
@@ -345,6 +352,7 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L26)
   [projection_bundle/diagnostics] expected = [] (L51)
 hash_shape: placeholder
+signature_shape: placeholder
 unknown_items: found_unknown_fields
 validation_result: rejected
 primary_error: unknown_field: unknown_scalar

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -202,7 +202,7 @@ scalars: 22 total
   [projection_bundle/safety] criticality = NonCritical (L24)
   [projection_bundle/safety] freshness_policy = FreshForControl (L26)
   [projection_bundle/trust] hash = just-a-string-without-prefix (L30)
-  [projection_bundle/trust] signature = invalid-signature-shape (L31)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
   [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
   [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
   [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
@@ -217,10 +217,54 @@ arrays: 3 total
   [projection_bundle/safety] required_capabilities = [] (L25)
   [projection_bundle/diagnostics] expected = [] (L50)
 hash_shape: malformed
-signature_shape: malformed
+signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
 primary_error: malformed_hash_shape
+---
+fixture: probe_trust_invalid_signature_shape.sketch.md
+text_block: found
+sections: 8 total
+  projection_bundle (L1 - L52)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/activation_policy (L37 - L41)
+  projection_bundle/update_policy (L43 - L47)
+  projection_bundle/diagnostics (L49 - L51)
+scalars: 22 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] signature = invalid-signature-shape (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/activation_policy] require_verification = true (L38)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L39)
+  [projection_bundle/activation_policy] allow_production_activation = false (L40)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L45)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L46)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L50)
+hash_shape: placeholder
+signature_shape: malformed
+unknown_items: none
+validation_result: rejected
+primary_error: field signature mismatch: expected "signature:SKETCH-NOT-A-REAL-SIGNATURE", got "invalid-signature-shape"
 ---
 fixture: probe_trust_wrong_fixture_identity.sketch.md
 text_block: found

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_invalid_shape.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_invalid_shape.sketch.md
@@ -44,7 +44,7 @@ projection_bundle {
 
   trust {
     hash: "just-a-string-without-prefix"
-    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    signature: "invalid-signature-shape"
     created_by: "semantic-projection-compiler.SKETCH"
     created_at: "not-a-real-timestamp"
     compiler_identity: "semantic-projection-compiler.0-sketch"

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_invalid_signature_shape.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_invalid_signature_shape.sketch.md
@@ -43,8 +43,8 @@ projection_bundle {
   }
 
   trust {
-    hash: "just-a-string-without-prefix"
-    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "invalid-signature-shape"
     created_by: "semantic-projection-compiler.SKETCH"
     created_at: "not-a-real-timestamp"
     compiler_identity: "semantic-projection-compiler.0-sketch"

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -2536,6 +2536,7 @@ fn run_probe(path: &str) -> Result<String, String> {
 
     if let Ok(core) = parse_sketch_core(&content) {
         let mut hash_shape = "unknown";
+        let mut signature_shape = "unknown";
         let mut has_unknown_sections = false;
         let mut has_unknown_fields = false;
 
@@ -2585,13 +2586,23 @@ fn run_probe(path: &str) -> Result<String, String> {
         }
 
         for scalar in &core.scalars {
-            if scalar.section == "projection_bundle/trust" && scalar.key == "hash" {
-                if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
-                    hash_shape = "placeholder";
-                } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 && scalar.value[7..].chars().all(|c| c.is_ascii_hexdigit()) {
-                    hash_shape = "sha256_like";
-                } else {
-                    hash_shape = "malformed";
+            if scalar.section == "projection_bundle/trust" {
+                if scalar.key == "hash" {
+                    if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
+                        hash_shape = "placeholder";
+                    } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 && scalar.value[7..].chars().all(|c| c.is_ascii_hexdigit()) {
+                        hash_shape = "sha256_like";
+                    } else {
+                        hash_shape = "malformed";
+                    }
+                } else if scalar.key == "signature" {
+                    if scalar.value == "signature:SKETCH-NOT-A-REAL-SIGNATURE" {
+                        signature_shape = "placeholder";
+                    } else if scalar.value.starts_with("signature:") && scalar.value.len() == 74 && scalar.value[10..].chars().all(|c| c.is_ascii_hexdigit()) {
+                        signature_shape = "signature_like";
+                    } else {
+                        signature_shape = "malformed";
+                    }
                 }
             }
             if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {
@@ -2613,6 +2624,7 @@ fn run_probe(path: &str) -> Result<String, String> {
         };
 
         push_line(&mut out, &format!("hash_shape: {}", hash_shape));
+        push_line(&mut out, &format!("signature_shape: {}", signature_shape));
         push_line(&mut out, &format!("unknown_items: {}", unknown_items));
     }
 


### PR DESCRIPTION
- Adds experimental trust signature shape classification.
- Classifies signature as placeholder, signature_like, or malformed.
- Allows malformed signature to be observed separately from fixture identity mismatch.
- Does not add cryptographic verification or rejection rules for signature shape.