### PR TITLE
experiment(post-ui): probe trust signature shape rejection

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-CLASSIFICATION
-  title: Probe trust signature shape classification
+  id: POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-REJECTION
+  title: Probe trust signature shape rejection
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): probe trust signature shape classification
+  summary: experiment(post-ui): probe trust signature shape rejection
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-CLASSIFICATION.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-REJECTION.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -264,7 +264,7 @@ hash_shape: placeholder
 signature_shape: malformed
 unknown_items: none
 validation_result: rejected
-primary_error: field signature mismatch: expected "signature:SKETCH-NOT-A-REAL-SIGNATURE", got "invalid-signature-shape"
+primary_error: malformed_signature_shape
 ---
 fixture: probe_trust_wrong_fixture_identity.sketch.md
 text_block: found

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -1157,6 +1157,29 @@ fn require_trust_hash_shape_core(
     Ok(())
 }
 
+fn require_trust_signature_shape_core(
+    core: &SketchReaderCore,
+    skipped_key: Option<&str>,
+) -> Result<(), String> {
+    if skipped_key == Some("signature") {
+        return Ok(());
+    }
+
+    if let Some(sig_scalar) = find_scalar_core(core, "signature") {
+        let val = &sig_scalar.value;
+        let is_placeholder = val == "signature:SKETCH-NOT-A-REAL-SIGNATURE";
+        let is_signature_like = val.starts_with("signature:")
+            && val.len() == 74
+            && val[10..].chars().all(|c| c.is_ascii_hexdigit());
+
+        if !is_placeholder && !is_signature_like {
+            return Err("malformed_signature_shape".to_string());
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_sketch_except_core(
     core: &SketchReaderCore,
     skipped_key: Option<&str>,
@@ -1170,6 +1193,7 @@ fn validate_sketch_except_core(
     }
 
     require_trust_hash_shape_core(core, skipped_key)?;
+    require_trust_signature_shape_core(core, skipped_key)?;
 
     for &(_label, key, expected) in EXPECTED_SCALARS {
         if skipped_key == Some(key) {
@@ -1234,6 +1258,7 @@ fn validate_sketch_without_order_core(
     }
 
     require_trust_hash_shape_core(core, skipped_key)?;
+    require_trust_signature_shape_core(core, skipped_key)?;
 
     for &(_label, key, expected) in EXPECTED_SCALARS {
         if skipped_key == Some(key) {
@@ -1430,6 +1455,7 @@ fn validate_sketch_except(
 
     let core = parse_sketch_core(content).map_err(|err| err.message)?;
     require_trust_hash_shape_core(&core, skipped_key)?;
+    require_trust_signature_shape_core(&core, skipped_key)?;
 
     for &(label, key, expected) in EXPECTED_SCALARS {
         if skipped_key == Some(key) {
@@ -1496,6 +1522,7 @@ fn validate_sketch_without_order(
 
     let core = parse_sketch_core(content).map_err(|err| err.message)?;
     require_trust_hash_shape_core(&core, skipped_key)?;
+    require_trust_signature_shape_core(&core, skipped_key)?;
 
     for &(label, key, expected) in EXPECTED_SCALARS {
         if skipped_key == Some(key) {


### PR DESCRIPTION
- Adds \equire_trust_signature_shape_core\ to validate signature shape.
- Leaves placeholder signatures as accepted for fixture baselines.
- Signature-like values pass the shape check and fall back to fixture identity mismatch if incorrect.
- Malformed signatures receive \primary_error: malformed_signature_shape\.