### PR TITLE
refactor(post-ui): share trust shape classification helpers in sketch reader probe

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-REJECTION
-  title: Probe trust signature shape rejection
-  type: experiment
+  id: POST-UI-PROJECTION-BUNDLE-READER-SHARE-TRUST-SHAPE-HELPERS
+  title: Share trust shape classification helpers
+  type: refactor
   mode: active
 
 intent:
-  summary: experiment(post-ui): probe trust signature shape rejection
+  summary: refactor(post-ui): share trust shape classification helpers in sketch reader probe
 
 layer:
   name: tooling
@@ -57,4 +57,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SIGNATURE-SHAPE-REJECTION.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SHARE-TRUST-SHAPE-HELPERS.md

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -42,7 +42,9 @@ actions:
     - level4_claim
 
 constraints:
-  - experiment only
+  - refactor only
+  - no behavior changes
+  - no snapshot changes
   - no docs changes
   - no Cargo changes
   - no loader claim

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -1134,6 +1134,32 @@ fn require_no_known_unknown_fields_except_core(
     Ok(())
 }
 
+fn classify_hash_shape(val: &str) -> &'static str {
+    if val == "sha256:SKETCH-NOT-A-REAL-HASH" {
+        "placeholder"
+    } else if val.starts_with("sha256:")
+        && val.len() == 71
+        && val[7..].chars().all(|c| c.is_ascii_hexdigit())
+    {
+        "sha256_like"
+    } else {
+        "malformed"
+    }
+}
+
+fn classify_signature_shape(val: &str) -> &'static str {
+    if val == "signature:SKETCH-NOT-A-REAL-SIGNATURE" {
+        "placeholder"
+    } else if val.starts_with("signature:")
+        && val.len() == 74
+        && val[10..].chars().all(|c| c.is_ascii_hexdigit())
+    {
+        "signature_like"
+    } else {
+        "malformed"
+    }
+}
+
 fn require_trust_hash_shape_core(
     core: &SketchReaderCore,
     skipped_key: Option<&str>,
@@ -1143,13 +1169,8 @@ fn require_trust_hash_shape_core(
     }
 
     if let Some(hash_scalar) = find_scalar_core(core, "hash") {
-        let val = &hash_scalar.value;
-        let is_placeholder = val == "sha256:SKETCH-NOT-A-REAL-HASH";
-        let is_sha256_like = val.starts_with("sha256:")
-            && val.len() == 71
-            && val[7..].chars().all(|c| c.is_ascii_hexdigit());
-
-        if !is_placeholder && !is_sha256_like {
+        let shape = classify_hash_shape(&hash_scalar.value);
+        if shape == "malformed" {
             return Err("malformed_hash_shape".to_string());
         }
     }
@@ -1166,13 +1187,8 @@ fn require_trust_signature_shape_core(
     }
 
     if let Some(sig_scalar) = find_scalar_core(core, "signature") {
-        let val = &sig_scalar.value;
-        let is_placeholder = val == "signature:SKETCH-NOT-A-REAL-SIGNATURE";
-        let is_signature_like = val.starts_with("signature:")
-            && val.len() == 74
-            && val[10..].chars().all(|c| c.is_ascii_hexdigit());
-
-        if !is_placeholder && !is_signature_like {
+        let shape = classify_signature_shape(&sig_scalar.value);
+        if shape == "malformed" {
             return Err("malformed_signature_shape".to_string());
         }
     }
@@ -2615,21 +2631,9 @@ fn run_probe(path: &str) -> Result<String, String> {
         for scalar in &core.scalars {
             if scalar.section == "projection_bundle/trust" {
                 if scalar.key == "hash" {
-                    if scalar.value == "sha256:SKETCH-NOT-A-REAL-HASH" {
-                        hash_shape = "placeholder";
-                    } else if scalar.value.starts_with("sha256:") && scalar.value.len() == 71 && scalar.value[7..].chars().all(|c| c.is_ascii_hexdigit()) {
-                        hash_shape = "sha256_like";
-                    } else {
-                        hash_shape = "malformed";
-                    }
+                    hash_shape = classify_hash_shape(&scalar.value);
                 } else if scalar.key == "signature" {
-                    if scalar.value == "signature:SKETCH-NOT-A-REAL-SIGNATURE" {
-                        signature_shape = "placeholder";
-                    } else if scalar.value.starts_with("signature:") && scalar.value.len() == 74 && scalar.value[10..].chars().all(|c| c.is_ascii_hexdigit()) {
-                        signature_shape = "signature_like";
-                    } else {
-                        signature_shape = "malformed";
-                    }
+                    signature_shape = classify_signature_shape(&scalar.value);
                 }
             }
             if !known_fields.contains(&(scalar.section.as_str(), scalar.key.as_str())) {


### PR DESCRIPTION
- Extracts \classify_hash_shape\ and \classify_signature_shape\ helpers.
- Eliminates duplication between \un_probe\ diagnostics and \equire_trust_*_shape_core\ rules.
- No behavior or snapshot changes.