### PR TITLE
test(post-ui): harden ProjectionBundle trust shape regression probes

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-SHARE-TRUST-SHAPE-HELPERS
-  title: Share trust shape classification helpers
-  type: refactor
+  id: POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-SHAPE-REGRESSION-PROBES
+  title: Harden ProjectionBundle trust shape regression probes
+  type: test
   mode: active
 
 intent:
-  summary: refactor(post-ui): share trust shape classification helpers in sketch reader probe
+  summary: test(post-ui): harden ProjectionBundle trust shape regression probes
 
 layer:
   name: tooling
@@ -42,9 +42,8 @@ actions:
     - level4_claim
 
 constraints:
-  - refactor only
+  - test only
   - no behavior changes
-  - no snapshot changes
   - no docs changes
   - no Cargo changes
   - no loader claim
@@ -59,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-SHARE-TRUST-SHAPE-HELPERS.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-SHAPE-REGRESSION-PROBES.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -266,6 +266,94 @@ unknown_items: none
 validation_result: rejected
 primary_error: malformed_signature_shape
 ---
+fixture: probe_trust_non_hex_hash.sketch.md
+text_block: found
+sections: 8 total
+  projection_bundle (L1 - L52)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/activation_policy (L37 - L41)
+  projection_bundle/update_policy (L43 - L47)
+  projection_bundle/diagnostics (L49 - L51)
+scalars: 22 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeX (L30)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/activation_policy] require_verification = true (L38)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L39)
+  [projection_bundle/activation_policy] allow_production_activation = false (L40)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L45)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L46)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L50)
+hash_shape: malformed
+signature_shape: placeholder
+unknown_items: none
+validation_result: rejected
+primary_error: malformed_hash_shape
+---
+fixture: probe_trust_non_hex_signature.sketch.md
+text_block: found
+sections: 8 total
+  projection_bundle (L1 - L52)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/activation_policy (L37 - L41)
+  projection_bundle/update_policy (L43 - L47)
+  projection_bundle/diagnostics (L49 - L51)
+scalars: 22 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] signature = signature:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeX (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/activation_policy] require_verification = true (L38)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L39)
+  [projection_bundle/activation_policy] allow_production_activation = false (L40)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L45)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L46)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L50)
+hash_shape: placeholder
+signature_shape: malformed
+unknown_items: none
+validation_result: rejected
+primary_error: malformed_signature_shape
+---
 fixture: probe_trust_wrong_fixture_identity.sketch.md
 text_block: found
 sections: 8 total

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_non_hex_hash.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_non_hex_hash.sketch.md
@@ -1,0 +1,80 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeX"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_non_hex_signature.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_non_hex_signature.sketch.md
@@ -1,0 +1,80 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdeX"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.


### PR DESCRIPTION
- Adds \probe_trust_non_hex_hash.sketch.md\ to test sha256-like hash string containing non-hex chars.
- Adds \probe_trust_non_hex_signature.sketch.md\ to test signature-like string containing non-hex chars.
- Ensures \is_ascii_hexdigit()\ boundaries are verified.
- Expected result is malformed_hash_shape and malformed_signature_shape respectively.
- No changes to existing probes.