### PR TITLE
test(post-ui): harden ProjectionBundle trust required field probes

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-SHAPE-OVERLENGTH-PROBES
-  title: Harden ProjectionBundle trust shape overlength probes
+  id: POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-REQUIRED-FIELD-PROBES
+  title: Harden ProjectionBundle trust required field probes
   type: test
   mode: active
 
 intent:
-  summary: test(post-ui): harden ProjectionBundle trust shape overlength probes
+  summary: test(post-ui): harden ProjectionBundle trust required field probes
 
 layer:
   name: tooling
@@ -58,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-SHAPE-OVERLENGTH-PROBES.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-HARDEN-TRUST-REQUIRED-FIELD-PROBES.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -266,6 +266,92 @@ unknown_items: none
 validation_result: rejected
 primary_error: malformed_signature_shape
 ---
+fixture: probe_trust_missing_hash.sketch.md
+text_block: found
+sections: 8 total
+  projection_bundle (L1 - L51)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L34)
+  projection_bundle/activation_policy (L36 - L40)
+  projection_bundle/update_policy (L42 - L46)
+  projection_bundle/diagnostics (L48 - L50)
+scalars: 21 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L30)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L31)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L32)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L33)
+  [projection_bundle/activation_policy] require_verification = true (L37)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L38)
+  [projection_bundle/activation_policy] allow_production_activation = false (L39)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L43)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L45)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L49)
+hash_shape: unknown
+signature_shape: placeholder
+unknown_items: none
+validation_result: rejected
+primary_error: missing required field hash
+---
+fixture: probe_trust_missing_signature.sketch.md
+text_block: found
+sections: 8 total
+  projection_bundle (L1 - L51)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L34)
+  projection_bundle/activation_policy (L36 - L40)
+  projection_bundle/update_policy (L42 - L46)
+  projection_bundle/diagnostics (L48 - L50)
+scalars: 21 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L31)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L32)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L33)
+  [projection_bundle/activation_policy] require_verification = true (L37)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L38)
+  [projection_bundle/activation_policy] allow_production_activation = false (L39)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L43)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L45)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L49)
+hash_shape: placeholder
+signature_shape: unknown
+unknown_items: none
+validation_result: rejected
+primary_error: missing required field signature
+---
 fixture: probe_trust_non_hex_hash.sketch.md
 text_block: found
 sections: 8 total

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_missing_hash.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_missing_hash.sketch.md
@@ -1,0 +1,80 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_missing_signature.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_trust_missing_signature.sketch.md
@@ -1,0 +1,80 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+


### PR DESCRIPTION
- Adds \probe_trust_missing_hash.sketch.md\ to ensure missing hash triggers a required field error rather than a shape error.
- Adds \probe_trust_missing_signature.sketch.md\ to ensure missing signature triggers a required field error.
- Expected result is \missing required field hash\ and \missing required field signature\ respectively.
- No changes to existing probes.