### PR TITLE
experiment(post-ui): probe duplicate ProjectionBundle section handling

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-HARDEN-OPTIONAL-DIAGNOSTICS-SECTION-PROBE
-  title: Harden ProjectionBundle optional diagnostics section probe
-  type: test
+  id: POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-SECTION-HANDLING
+  title: Probe duplicate ProjectionBundle section handling
+  type: experiment
   mode: active
 
 intent:
-  summary: test(post-ui): harden ProjectionBundle optional diagnostics section probe
+  summary: experiment(post-ui): probe duplicate ProjectionBundle section handling
 
 layer:
   name: tooling
@@ -58,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-HARDEN-OPTIONAL-DIAGNOSTICS-SECTION-PROBE.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-SECTION-HANDLING.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -43,6 +43,56 @@ unknown_items: none
 validation_result: rejected
 primary_error: duplicate_field: allow_runtime_tree_streaming
 ---
+fixture: probe_duplicate_trust_section.sketch.md
+text_block: found
+sections: 9 total
+  projection_bundle (L1 - L60)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/trust (L37 - L43)
+  projection_bundle/activation_policy (L45 - L49)
+  projection_bundle/update_policy (L51 - L55)
+  projection_bundle/diagnostics (L57 - L59)
+scalars: 27 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH-2 (L38)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE-2 (L39)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH-2 (L40)
+  [projection_bundle/trust] created_at = not-a-real-timestamp-2 (L41)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch-2 (L42)
+  [projection_bundle/activation_policy] require_verification = true (L46)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L47)
+  [projection_bundle/activation_policy] allow_production_activation = false (L48)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L52)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L53)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L54)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L58)
+hash_shape: malformed
+signature_shape: malformed
+unknown_items: none
+validation_result: rejected
+primary_error: duplicate_field: hash
+---
 fixture: probe_missing_activation_policy_section.sketch.md
 text_block: found
 sections: 7 total

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_trust_section.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_trust_section.sketch.md
@@ -1,0 +1,89 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH-2"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE-2"
+    created_by: "semantic-projection-compiler.SKETCH-2"
+    created_at: "not-a-real-timestamp-2"
+    compiler_identity: "semantic-projection-compiler.0-sketch-2"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+


### PR DESCRIPTION
- Adds \probe_duplicate_trust_section.sketch.md\ to observe the parser's behavior when encountering a duplicated section.
- The snapshot reveals that the reader flattens/merges the sections and detects the duplicate required fields (e.g., \hash\) across the sections, resulting in a \duplicate_field: hash\ error.
- \hash_shape\ and \signature_shape\ also become \malformed\ due to the multiple occurrences.
- No changes to reader code.