### PR TITLE
experiment(post-ui): probe duplicate ProjectionBundle required section handling

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-SECTION-HANDLING
-  title: Probe duplicate ProjectionBundle section handling
+  id: POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-REQUIRED-SECTION-HANDLING
+  title: Probe duplicate ProjectionBundle required section handling
   type: experiment
   mode: active
 
 intent:
-  summary: experiment(post-ui): probe duplicate ProjectionBundle section handling
+  summary: experiment(post-ui): probe duplicate ProjectionBundle required section handling
 
 layer:
   name: tooling
@@ -58,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-SECTION-HANDLING.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-REQUIRED-SECTION-HANDLING.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -1,3 +1,99 @@
+fixture: probe_duplicate_activation_policy_section.sketch.md
+text_block: found
+sections: 9 total
+  projection_bundle (L1 - L58)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/activation_policy (L37 - L41)
+  projection_bundle/activation_policy (L43 - L47)
+  projection_bundle/update_policy (L49 - L53)
+  projection_bundle/diagnostics (L55 - L57)
+scalars: 25 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/activation_policy] require_verification = true (L38)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L39)
+  [projection_bundle/activation_policy] allow_production_activation = false (L40)
+  [projection_bundle/activation_policy] require_verification = true (L44)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = true (L45)
+  [projection_bundle/activation_policy] allow_production_activation = true (L46)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L50)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L51)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L52)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L56)
+hash_shape: placeholder
+signature_shape: placeholder
+unknown_items: none
+validation_result: rejected
+primary_error: duplicate_field: require_verification
+---
+fixture: probe_duplicate_artifacts_section.sketch.md
+text_block: found
+sections: 9 total
+  projection_bundle (L1 - L58)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/artifacts (L17 - L21)
+  projection_bundle/compatibility (L23 - L26)
+  projection_bundle/safety (L28 - L33)
+  projection_bundle/trust (L35 - L41)
+  projection_bundle/activation_policy (L43 - L47)
+  projection_bundle/update_policy (L49 - L53)
+  projection_bundle/diagnostics (L55 - L57)
+scalars: 25 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal-2 (L18)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal-2 (L19)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal-2 (L20)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L24)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L25)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L29)
+  [projection_bundle/safety] criticality = NonCritical (L30)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L32)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L36)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L37)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L38)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L39)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L40)
+  [projection_bundle/activation_policy] require_verification = true (L44)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L45)
+  [projection_bundle/activation_policy] allow_production_activation = false (L46)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L50)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L51)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L52)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L31)
+  [projection_bundle/diagnostics] expected = [] (L56)
+hash_shape: placeholder
+signature_shape: placeholder
+unknown_items: none
+validation_result: rejected
+primary_error: duplicate_field: ui_ir_ref
+---
 fixture: probe_duplicate_conflicting_policy.sketch.md
 text_block: found
 sections: 8 total
@@ -92,6 +188,54 @@ signature_shape: malformed
 unknown_items: none
 validation_result: rejected
 primary_error: duplicate_field: hash
+---
+fixture: probe_duplicate_update_policy_section.sketch.md
+text_block: found
+sections: 9 total
+  projection_bundle (L1 - L58)
+  projection_bundle/artifacts (L11 - L15)
+  projection_bundle/compatibility (L17 - L20)
+  projection_bundle/safety (L22 - L27)
+  projection_bundle/trust (L29 - L35)
+  projection_bundle/activation_policy (L37 - L41)
+  projection_bundle/update_policy (L43 - L47)
+  projection_bundle/update_policy (L49 - L53)
+  projection_bundle/diagnostics (L55 - L57)
+scalars: 25 total
+  [projection_bundle] bundle_id = bundle.example.minimal (L2)
+  [projection_bundle] bundle_version = 0-sketch (L3)
+  [projection_bundle] projection_id = ExampleMinimalProjection (L4)
+  [projection_bundle/artifacts] ui_ir_ref = ui_ir.example.minimal (L12)
+  [projection_bundle/artifacts] binding_graph_ref = binding_graph.example.minimal (L13)
+  [projection_bundle/artifacts] action_ir_ref = action_ir.example.minimal (L14)
+  [projection_bundle/compatibility] role_dictionary_version = ui-roles.0-sketch (L18)
+  [projection_bundle/compatibility] renderer_profile = semantic-shell.reference-sketch (L19)
+  [projection_bundle/safety] safety_class = VerifiedDynamic (L23)
+  [projection_bundle/safety] criticality = NonCritical (L24)
+  [projection_bundle/safety] freshness_policy = FreshForControl (L26)
+  [projection_bundle/trust] hash = sha256:SKETCH-NOT-A-REAL-HASH (L30)
+  [projection_bundle/trust] signature = signature:SKETCH-NOT-A-REAL-SIGNATURE (L31)
+  [projection_bundle/trust] created_by = semantic-projection-compiler.SKETCH (L32)
+  [projection_bundle/trust] created_at = not-a-real-timestamp (L33)
+  [projection_bundle/trust] compiler_identity = semantic-projection-compiler.0-sketch (L34)
+  [projection_bundle/activation_policy] require_verification = true (L38)
+  [projection_bundle/activation_policy] allow_runtime_tree_streaming = false (L39)
+  [projection_bundle/activation_policy] allow_production_activation = false (L40)
+  [projection_bundle/update_policy] require_safe_update_boundary = true (L44)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = false (L45)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = false (L46)
+  [projection_bundle/update_policy] require_safe_update_boundary = false (L50)
+  [projection_bundle/update_policy] allow_critical_update_during_pending_unknown = true (L51)
+  [projection_bundle/update_policy] allow_critical_update_during_quarantine = true (L52)
+arrays: 3 total
+  [projection_bundle] source_refs = [semantic.source.example, projection.source.example] (L6)
+  [projection_bundle/safety] required_capabilities = [] (L25)
+  [projection_bundle/diagnostics] expected = [] (L56)
+hash_shape: placeholder
+signature_shape: placeholder
+unknown_items: none
+validation_result: rejected
+primary_error: duplicate_field: require_safe_update_boundary
 ---
 fixture: probe_missing_activation_policy_section.sketch.md
 text_block: found

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_activation_policy_section.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_activation_policy_section.sketch.md
@@ -1,0 +1,87 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: true
+    allow_production_activation: true
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_artifacts_section.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_artifacts_section.sketch.md
@@ -1,0 +1,87 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal-2"
+    binding_graph_ref: "binding_graph.example.minimal-2"
+    action_ir_ref: "action_ir.example.minimal-2"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+

--- a/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_update_policy_section.sketch.md
+++ b/tests/fixtures/post_ui/projection_bundle/probes/probe_duplicate_update_policy_section.sketch.md
@@ -1,0 +1,87 @@
+# Minimal ProjectionBundle Manifest Sketch
+
+Status: non-executing sketch
+Track: POST-UI / Intent-Driven Projection
+Scope type: fixture sketch only
+Serialization status: not final
+Execution status: non-executing
+Implementation status: blocked
+
+This sketch is not final serialization.
+It must not be parsed by production code.
+It must not be loaded by a ProjectionBundle loader.
+It must not be treated as a runtime contract.
+It exists only as planning evidence.
+
+```text
+projection_bundle {
+  bundle_id: "bundle.example.minimal"
+  bundle_version: "0-sketch"
+  projection_id: "ExampleMinimalProjection"
+
+  source_refs: [
+    "semantic.source.example",
+    "projection.source.example"
+  ]
+
+  artifacts {
+    ui_ir_ref: "ui_ir.example.minimal"
+    binding_graph_ref: "binding_graph.example.minimal"
+    action_ir_ref: "action_ir.example.minimal"
+  }
+
+  compatibility {
+    role_dictionary_version: "ui-roles.0-sketch"
+    renderer_profile: "semantic-shell.reference-sketch"
+  }
+
+  safety {
+    safety_class: "VerifiedDynamic"
+    criticality: "NonCritical"
+    required_capabilities: []
+    freshness_policy: "FreshForControl"
+  }
+
+  trust {
+    hash: "sha256:SKETCH-NOT-A-REAL-HASH"
+    signature: "signature:SKETCH-NOT-A-REAL-SIGNATURE"
+    created_by: "semantic-projection-compiler.SKETCH"
+    created_at: "not-a-real-timestamp"
+    compiler_identity: "semantic-projection-compiler.0-sketch"
+  }
+
+  activation_policy {
+    require_verification: true
+    allow_runtime_tree_streaming: false
+    allow_production_activation: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: true
+    allow_critical_update_during_pending_unknown: false
+    allow_critical_update_during_quarantine: false
+  }
+
+  update_policy {
+    require_safe_update_boundary: false
+    allow_critical_update_during_pending_unknown: true
+    allow_critical_update_during_quarantine: true
+  }
+
+  diagnostics {
+    expected: []
+  }
+}
+```
+
+This sketch intentionally uses placeholder identity, hash, signature, compiler, and timestamp values.
+
+These placeholders must not pass future verification.
+
+## Boundary Notes
+
+A future reader may use this sketch only as fixture evidence after a separate approved task.
+A future loader must not treat this sketch as loadable.
+A future verifier must reject the placeholder hash and signature if verification is implemented.
+A future runtime must not activate this sketch.
+


### PR DESCRIPTION
Adds probes for duplicating other required sections: artifacts, activation_policy, and update_policy. The snapshot reveals that the parser consistently flattens duplicated sections, resulting in a duplicate_field error for the first required field encountered twice. No changes to reader code.