### PR TITLE
test(post-ui): reject duplicate ProjectionBundle sections

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -42,8 +42,9 @@ actions:
     - level4_claim
 
 constraints:
-  - test only
-  - no behavior changes
+  - reader-draft validation behavior change only
+  - duplicate section rejection only
+  - duplicate scalar behavior unchanged
   - no docs changes
   - no Cargo changes
   - no loader claim

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-REQUIRED-SECTION-HANDLING
-  title: Probe duplicate ProjectionBundle required section handling
-  type: experiment
+  id: POST-UI-PROJECTION-BUNDLE-READER-REJECT-DUPLICATE-SECTIONS
+  title: Reject duplicate ProjectionBundle sections
+  type: test
   mode: active
 
 intent:
-  summary: experiment(post-ui): probe duplicate ProjectionBundle required section handling
+  summary: test(post-ui): reject duplicate ProjectionBundle sections
 
 layer:
   name: tooling
@@ -58,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-PROBE-DUPLICATE-REQUIRED-SECTION-HANDLING.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-REJECT-DUPLICATE-SECTIONS.md

--- a/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+++ b/tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
@@ -44,7 +44,7 @@ hash_shape: placeholder
 signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
-primary_error: duplicate_field: require_verification
+primary_error: duplicate_section: projection_bundle/activation_policy
 ---
 fixture: probe_duplicate_artifacts_section.sketch.md
 text_block: found
@@ -92,7 +92,7 @@ hash_shape: placeholder
 signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
-primary_error: duplicate_field: ui_ir_ref
+primary_error: duplicate_section: projection_bundle/artifacts
 ---
 fixture: probe_duplicate_conflicting_policy.sketch.md
 text_block: found
@@ -187,7 +187,7 @@ hash_shape: malformed
 signature_shape: malformed
 unknown_items: none
 validation_result: rejected
-primary_error: duplicate_field: hash
+primary_error: duplicate_section: projection_bundle/trust
 ---
 fixture: probe_duplicate_update_policy_section.sketch.md
 text_block: found
@@ -235,7 +235,7 @@ hash_shape: placeholder
 signature_shape: placeholder
 unknown_items: none
 validation_result: rejected
-primary_error: duplicate_field: require_safe_update_boundary
+primary_error: duplicate_section: projection_bundle/update_policy
 ---
 fixture: probe_missing_activation_policy_section.sketch.md
 text_block: found

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -572,6 +572,7 @@ enum ReaderErrorKind {
     MalformedField,
     UnknownField,
     DuplicateField,
+    DuplicateSection,
     FieldOrdering,
     InvalidPolicyValue,
 }
@@ -851,6 +852,10 @@ fn find_section_core<'a>(core: &'a SketchReaderCore, path: &str) -> Option<&'a S
     core.sections.iter().find(|section| section.path == path)
 }
 
+fn count_section_occurrences_core(core: &SketchReaderCore, path: &str) -> usize {
+    core.sections.iter().filter(|section| section.path == path).count()
+}
+
 fn find_array_core<'a>(
     core: &'a SketchReaderCore,
     section: &str,
@@ -962,6 +967,23 @@ fn require_no_duplicate_scalars_core(
                 ReaderErrorKind::DuplicateField,
                 *key,
                 format!("duplicate_field: {}", key),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn require_no_duplicate_sections_core(
+    core: &SketchReaderCore,
+    paths: &[&str],
+) -> Result<(), ReaderError> {
+    for path in paths {
+        if count_section_occurrences_core(core, path) > 1 {
+            return Err(ReaderError::new(
+                ReaderErrorKind::DuplicateSection,
+                *path,
+                format!("duplicate_section: {}", path),
             ));
         }
     }
@@ -1243,6 +1265,17 @@ fn validate_sketch_except_core(
         "allow_critical_update_during_quarantine",
     ];
 
+    let expected_sections = [
+        "projection_bundle/artifacts",
+        "projection_bundle/compatibility",
+        "projection_bundle/safety",
+        "projection_bundle/trust",
+        "projection_bundle/activation_policy",
+        "projection_bundle/update_policy",
+        "projection_bundle/diagnostics",
+    ];
+    require_no_duplicate_sections_core(core, &expected_sections).map_err(|err| err.message)?;
+
     require_no_duplicate_scalars_core(core, &expected_keys, skipped_key).map_err(|err| err.message)?;
     require_no_known_unknown_fields_except_core(core, allowed_unknown_fields)?;
 
@@ -1416,6 +1449,19 @@ fn require_no_duplicate_scalars(
     Ok(())
 }
 
+fn require_no_duplicate_sections(
+    content: &str,
+    expected_sections: &[&str],
+) -> Result<(), String> {
+    let core = parse_sketch_core(content).map_err(|err| err.message)?;
+    for path in expected_sections {
+        if count_section_occurrences_core(&core, path) > 1 {
+            return Err(format!("duplicate_section: {}", path));
+        }
+    }
+    Ok(())
+}
+
 fn require_no_known_unknown_fields_except(
     content: &str,
     allowed_unknown_fields: &[&str],
@@ -1505,6 +1551,17 @@ fn validate_sketch_except(
         "allow_critical_update_during_pending_unknown",
         "allow_critical_update_during_quarantine",
     ];
+
+    let expected_sections = [
+        "projection_bundle/artifacts",
+        "projection_bundle/compatibility",
+        "projection_bundle/safety",
+        "projection_bundle/trust",
+        "projection_bundle/activation_policy",
+        "projection_bundle/update_policy",
+        "projection_bundle/diagnostics",
+    ];
+    require_no_duplicate_sections(content, &expected_sections)?;
 
     require_no_duplicate_scalars(content, &expected_keys, skipped_key)?;
     require_no_known_unknown_fields_except(content, allowed_unknown_fields)?;


### PR DESCRIPTION
- Adds \equire_no_duplicate_sections_core\ to explicitly reject duplicate sections with a \duplicate_section\ error.
- Updates the reader validation logic to call this check before evaluating duplicate scalar fields.
- Existing snapshots correctly show the shift from \duplicate_field\ to \duplicate_section\ for repeated sections.