### PR TITLE
refactor(post-ui): centralize ProjectionBundle expected section list

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-REJECT-DUPLICATE-SECTIONS
-  title: Reject duplicate ProjectionBundle sections
-  type: test
+  id: POST-UI-PROJECTION-BUNDLE-READER-CENTRALIZE-EXPECTED-SECTION-LIST
+  title: Centralize ProjectionBundle expected section list
+  type: refactor
   mode: active
 
 intent:
-  summary: test(post-ui): reject duplicate ProjectionBundle sections
+  summary: refactor(post-ui): centralize ProjectionBundle expected section list
 
 layer:
   name: tooling
@@ -42,9 +42,8 @@ actions:
     - level4_claim
 
 constraints:
-  - reader-draft validation behavior change only
-  - duplicate section rejection only
-  - duplicate scalar behavior unchanged
+  - refactor only
+  - no behavior changes
   - no docs changes
   - no Cargo changes
   - no loader claim

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -58,4 +58,4 @@ verification:
     - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-REJECT-DUPLICATE-SECTIONS.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-CENTRALIZE-EXPECTED-SECTION-LIST.md

--- a/tools/post_ui/projection_bundle_sketch_reader_draft.rs
+++ b/tools/post_ui/projection_bundle_sketch_reader_draft.rs
@@ -14,6 +14,16 @@ use std::fs;
 use std::path::Path;
 use std::process;
 
+const EXPECTED_SECTIONS: &[&str] = &[
+    "projection_bundle/artifacts",
+    "projection_bundle/compatibility",
+    "projection_bundle/safety",
+    "projection_bundle/trust",
+    "projection_bundle/activation_policy",
+    "projection_bundle/update_policy",
+    "projection_bundle/diagnostics",
+];
+
 const EXPECTED_SCALARS: &[(&str, &str, &str)] = &[
     ("bundle id", "bundle_id", "bundle.example.minimal"),
     ("bundle version", "bundle_version", "0-sketch"),
@@ -1265,16 +1275,7 @@ fn validate_sketch_except_core(
         "allow_critical_update_during_quarantine",
     ];
 
-    let expected_sections = [
-        "projection_bundle/artifacts",
-        "projection_bundle/compatibility",
-        "projection_bundle/safety",
-        "projection_bundle/trust",
-        "projection_bundle/activation_policy",
-        "projection_bundle/update_policy",
-        "projection_bundle/diagnostics",
-    ];
-    require_no_duplicate_sections_core(core, &expected_sections).map_err(|err| err.message)?;
+    require_no_duplicate_sections_core(core, EXPECTED_SECTIONS).map_err(|err| err.message)?;
 
     require_no_duplicate_scalars_core(core, &expected_keys, skipped_key).map_err(|err| err.message)?;
     require_no_known_unknown_fields_except_core(core, allowed_unknown_fields)?;
@@ -1552,16 +1553,7 @@ fn validate_sketch_except(
         "allow_critical_update_during_quarantine",
     ];
 
-    let expected_sections = [
-        "projection_bundle/artifacts",
-        "projection_bundle/compatibility",
-        "projection_bundle/safety",
-        "projection_bundle/trust",
-        "projection_bundle/activation_policy",
-        "projection_bundle/update_policy",
-        "projection_bundle/diagnostics",
-    ];
-    require_no_duplicate_sections(content, &expected_sections)?;
+    require_no_duplicate_sections(content, EXPECTED_SECTIONS)?;
 
     require_no_duplicate_scalars(content, &expected_keys, skipped_key)?;
     require_no_known_unknown_fields_except(content, allowed_unknown_fields)?;


### PR DESCRIPTION
Extracts \EXPECTED_SECTIONS\ into a single shared constant to reduce the risk of divergence between core and non-core validation paths. No snapshot changes (test behavior remains exactly the same).