### PR TITLE
audit(post-ui): record ProjectionBundle reader vocabulary split

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-CENTRALIZE-KNOWN-ITEM-LISTS
-  title: Centralize ProjectionBundle known item lists
-  type: refactor
+  id: POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT
+  title: Audit ProjectionBundle reader vocabulary split
+  type: audit
   mode: active
 
 intent:
-  summary: refactor(post-ui): centralize ProjectionBundle known item lists
+  summary: audit(post-ui): record ProjectionBundle reader vocabulary split
 
 layer:
   name: tooling
@@ -14,12 +14,11 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - tools/post_ui/projection_bundle_sketch_reader_draft.rs
-    - tools/post_ui/check_projection_bundle_reader_probes.ps1
-    - tests/fixtures/post_ui/projection_bundle/probes/**
-    - tests/fixtures/post_ui/projection_bundle/expected/probes.reader.out.txt
+    - .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md
 
   forbidden_paths:
+    - tools/post_ui/projection_bundle_sketch_reader_draft.rs
+    - tests/fixtures/**
     - docs/**
     - scripts/**
     - Cargo.toml
@@ -55,7 +54,7 @@ verification:
   required:
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
-    - pwsh -NoProfile -ExecutionPolicy Bypass -File tools/post_ui/check_projection_bundle_reader_probes.ps1
+    - git status --short
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-CENTRALIZE-KNOWN-ITEM-LISTS.md
+  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md

--- a/.harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md
+++ b/.harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md
@@ -1,0 +1,65 @@
+# ProjectionBundle Reader Vocabulary Split Audit
+
+Status: PASS
+
+## Scope
+
+This audit records the reader vocabulary split after the completed post-ui cleanup chain.
+
+No reader code, probe fixture, snapshot, docs, Cargo, loader, runtime, or production UI behavior is changed by this slice.
+
+## Cleanup chain
+
+- #1402 centralized `EXPECTED_SECTIONS`.
+- #1403 centralized `EXPECTED_SCALAR_KEYS`.
+- #1418 centralized `KNOWN_SECTIONS` / `KNOWN_FIELDS`.
+
+## Vocabulary layers
+
+### `EXPECTED_SECTIONS`
+
+Baseline expected section list used by reader validation.
+
+This is not the complete known section vocabulary.
+
+### `EXPECTED_SCALAR_KEYS`
+
+Expected scalar key list used by duplicate-scalar validation.
+
+This does not include array keys.
+
+### `KNOWN_SECTIONS` / `KNOWN_FIELDS`
+
+Allowed vocabulary used by:
+
+- unknown-item detection;
+- probe snapshot unknown item classification.
+
+This vocabulary includes scalar fields and array fields.
+
+## Important distinction
+
+`EXPECTED_*` and `KNOWN_*` are intentionally separate.
+
+Examples:
+
+- `projection_bundle` root is known vocabulary but is not part of `EXPECTED_SECTIONS`.
+- `source_refs` is a known field but is an array field, not a scalar key.
+- `required_capabilities` is a known field but is an array field, not a scalar key.
+- `diagnostics.expected` is known vocabulary for optional diagnostics handling.
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- No reader source changes.
+- No snapshot changes.


### PR DESCRIPTION
Records the completed ProjectionBundle reader vocabulary split after #1402, #1403, and #1418. Audit/report-only; no reader behavior, snapshot, docs, Cargo, loader, runtime, or production UI changes.