### PR TITLE
docs(error-codes): translate reference to English

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,25 +1,27 @@
 task:
-  id: POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT
-  title: Audit ProjectionBundle reader vocabulary split
-  type: audit
+  id: DOCS-ERROR-CODES-ENGLISH-TRANSLATION
+  title: Translate error codes reference to English
+  type: docs
   mode: active
 
 intent:
-  summary: audit(post-ui): record ProjectionBundle reader vocabulary split
+  summary: docs(error-codes): translate reference to English
 
 layer:
-  name: tooling
-  owner: post-ui
+  name: documentation
+  owner: language
 
 scope:
   allowed_paths:
+    - docs/ERROR_CODES.md
     - .harness/current.task.yaml
-    - .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md
+    - .harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md
 
   forbidden_paths:
-    - tools/post_ui/projection_bundle_sketch_reader_draft.rs
-    - tests/fixtures/**
-    - docs/**
+    - src/**
+    - crates/**
+    - tests/**
+    - tools/**
     - scripts/**
     - Cargo.toml
     - Cargo.lock
@@ -57,4 +59,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/POST-UI-PROJECTION-BUNDLE-READER-VOCABULARY-SPLIT-AUDIT.md
+  output: .harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -34,7 +34,6 @@ actions:
     - create_pr
 
   forbidden:
-    - modify_docs
     - modify_cargo_toml
     - modify_cargo_lock
     - loader_claim
@@ -43,9 +42,9 @@ actions:
     - level4_claim
 
 constraints:
-  - refactor only
+  - translation only
+  - no technical meaning changes
   - no behavior changes
-  - no docs changes
   - no Cargo changes
   - no loader claim
   - no runtime claim

--- a/.harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md
+++ b/.harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md
@@ -1,0 +1,37 @@
+# Error Codes English Translation Audit
+
+Status: PASS
+
+## Scope
+
+This audit records the English translation of the `docs/ERROR_CODES.md` reference document.
+
+No reader code, probe fixture, snapshot, docs (outside of translation), Cargo, loader, runtime, or production UI behavior is changed by this slice.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md`
+- `docs/ERROR_CODES.md`
+
+## Translation Statement
+
+This is a documentation-only translation. The technical meaning of all content was strictly preserved.
+All error code identifiers, command names, file paths, and code blocks were left untouched.
+The heading structure was preserved.
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- No reader source changes.
+- No snapshot changes.

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,16 +1,16 @@
 # Semantic Error Codes
 
-Справочник диагностических кодов Semantic.  
-CLI-источник: `smc explain <code>` и `smc explain --list`.
+Semantic diagnostic codes reference.
+CLI source: `smc explain <code>` and `smc explain --list`.
 
-## Как использовать
+## How to use
 
-- Просмотр конкретного кода:
+- View a specific code:
   - `smc explain E0201`
-- Список всех кодов:
+- List all codes:
   - `smc explain --list`
 
-## Каталог
+## Catalog
 
 - `E0000`: Generic frontend parse/type error. See caret span for exact location.
 - `E0001`: Unexpected character in source input.
@@ -46,9 +46,9 @@ CLI-источник: `smc explain <code>` и `smc explain --list`.
 - `W0252`: Unused Entity field warning (`state/prop` not referenced).
 - `W0253`: Magic number warning (consider named constant).
 
-## Поддержка
+## Maintenance
 
-При добавлении новых кодов:
+When adding new codes:
 
-1. Обновить каталог в `src/bin/smc.rs` (`diagnostic_catalog`).
-2. Обновить этот документ.
+1. Update the catalog in `src/bin/smc.rs` (`diagnostic_catalog`).
+2. Update this document.


### PR DESCRIPTION
Translates docs/ERROR_CODES.md to English. Documentation-only translation; no error-code, diagnostic, CLI, runtime, loader, production, security, or trust-claim changes.