### PR TITLE
docs(readme): normalize logo alt text to English

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,21 +1,21 @@
 task:
-  id: DOCS-ERROR-CODES-ENGLISH-TRANSLATION
-  title: Translate error codes reference to English
+  id: DOCS-README-LOGO-ALT-TEXT-ENGLISH
+  title: Normalize README logo alt text to English
   type: docs
   mode: active
 
 intent:
-  summary: docs(error-codes): translate reference to English
+  summary: docs(readme): normalize project logo alt text to English
 
 layer:
   name: documentation
-  owner: language
+  owner: readme
 
 scope:
   allowed_paths:
-    - docs/ERROR_CODES.md
+    - README.md
     - .harness/current.task.yaml
-    - .harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md
+    - .harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md
 
   forbidden_paths:
     - src/**
@@ -23,6 +23,7 @@ scope:
     - tests/**
     - tools/**
     - scripts/**
+    - docs/**
     - Cargo.toml
     - Cargo.lock
 
@@ -58,4 +59,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/DOCS-ERROR-CODES-ENGLISH-TRANSLATION.md
+  output: .harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md

--- a/.harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md
+++ b/.harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md
@@ -1,0 +1,32 @@
+# README Logo Alt Text Audit
+
+Status: PASS
+
+## Scope
+
+This audit records the normalization of the README project logo image alt text to English.
+
+This is an alt-text-only change.
+No README prose, badges, links, headings, status wording, roadmap wording, or claims were changed.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md`
+- `README.md`
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- No reader source changes.
+- No snapshot changes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/brand/semantic-logo.png" alt="Semantic" width="860">
+  <img src="assets/brand/semantic-logo.png" alt="Semantic Logo" width="860">
 </p>
 
 # Semantic Language


### PR DESCRIPTION
Normalizes README project logo image alt text to English. Documentation-only alt-text change; no README prose, status, runtime, loader, production, security, or trust-claim changes.