### PR TITLE
audit(docs): inventory remaining Cyrillic content

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,21 +1,20 @@
 task:
-  id: DOCS-README-LOGO-ALT-TEXT-ENGLISH
-  title: Normalize README logo alt text to English
-  type: docs
+  id: DOCS-CYRILLIC-CONTENT-INVENTORY
+  title: Inventory remaining Cyrillic documentation content
+  type: audit
   mode: active
 
 intent:
-  summary: docs(readme): normalize project logo alt text to English
+  summary: audit(docs): inventory remaining Cyrillic content
 
 layer:
   name: documentation
-  owner: readme
+  owner: docs
 
 scope:
   allowed_paths:
-    - README.md
     - .harness/current.task.yaml
-    - .harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md
+    - .harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md
 
   forbidden_paths:
     - src/**
@@ -24,6 +23,7 @@ scope:
     - tools/**
     - scripts/**
     - docs/**
+    - README.md
     - Cargo.toml
     - Cargo.lock
 
@@ -35,6 +35,7 @@ actions:
     - create_pr
 
   forbidden:
+    - modify_docs
     - modify_cargo_toml
     - modify_cargo_lock
     - loader_claim
@@ -43,9 +44,9 @@ actions:
     - level4_claim
 
 constraints:
-  - translation only
-  - no technical meaning changes
+  - refactor only
   - no behavior changes
+  - no docs changes
   - no Cargo changes
   - no loader claim
   - no runtime claim
@@ -59,4 +60,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/DOCS-README-LOGO-ALT-TEXT-ENGLISH.md
+  output: .harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md

--- a/.harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md
+++ b/.harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md
@@ -1,0 +1,37 @@
+# Cyrillic Documentation Content Inventory
+
+Status: PASS
+
+## Scope
+
+This audit inventories remaining Cyrillic/Russian text in documentation-like files.
+
+No source, tests, tools, scripts, Cargo files, snapshots, README prose, or documentation content was changed.
+
+## Findings
+
+| Path | Line | Classification | Excerpt |
+|---|---:|---|---|
+| `README.md` | 66 | `translate_candidate` | `alt="ChatGPT Image 29 мая 2026 г , 23_09_24"` |
+
+*(Note: `output.txt` and `output2.txt` contain Cyrillic output from CLI runs, but they are temporary artifacts and not considered official documentation.)*
+
+## Recommended next PRs
+
+- `docs(readme): translate architecture render alt text to English`
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`


### PR DESCRIPTION
Inventories remaining Cyrillic/Russian text in documentation-like files. Audit/report-only; no source, docs content, README prose, tests, tools, scripts, Cargo, runtime, loader, production, security, or trust-claim changes.