### PR TITLE
docs(readme): translate architecture render alt text to English

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,20 +1,21 @@
 task:
-  id: DOCS-CYRILLIC-CONTENT-INVENTORY
-  title: Inventory remaining Cyrillic documentation content
-  type: audit
+  id: DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH
+  title: Translate README architecture render alt text to English
+  type: docs
   mode: active
 
 intent:
-  summary: audit(docs): inventory remaining Cyrillic content
+  summary: docs(readme): translate architecture render alt text to English
 
 layer:
   name: documentation
-  owner: docs
+  owner: readme
 
 scope:
   allowed_paths:
+    - README.md
     - .harness/current.task.yaml
-    - .harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md
+    - .harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md
 
   forbidden_paths:
     - src/**
@@ -23,7 +24,6 @@ scope:
     - tools/**
     - scripts/**
     - docs/**
-    - README.md
     - Cargo.toml
     - Cargo.lock
 
@@ -35,7 +35,6 @@ actions:
     - create_pr
 
   forbidden:
-    - modify_docs
     - modify_cargo_toml
     - modify_cargo_lock
     - loader_claim
@@ -44,9 +43,9 @@ actions:
     - level4_claim
 
 constraints:
-  - refactor only
+  - translation only
+  - no technical meaning changes
   - no behavior changes
-  - no docs changes
   - no Cargo changes
   - no loader claim
   - no runtime claim
@@ -60,4 +59,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/DOCS-CYRILLIC-CONTENT-INVENTORY.md
+  output: .harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md

--- a/.harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md
+++ b/.harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md
@@ -1,0 +1,37 @@
+# README Architecture Render Alt Text Audit
+
+Status: PASS
+
+## Scope
+
+This audit records the translation of the remaining Cyrillic README image alt text to English.
+
+This is an alt-text-only change.
+No README prose, badges, links, headings, status wording, roadmap wording, or claims were changed.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md`
+- `README.md`
+
+## Translation Details
+
+- **Old alt text:** `ChatGPT Image 29 мая 2026 г , 23_09_24`
+- **New alt text:** `Semantic Visual Architecture Render`
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- No reader source changes.
+- No snapshot changes.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is a zero-effect program. It is useful for checking the core path without c
 
 ## Visual Architecture Render
 
-<img width="1693" height="929" alt="ChatGPT Image 29 мая 2026 г , 23_09_24" src="https://github.com/user-attachments/assets/d8fd9017-062e-45a2-b0cf-695dc320ae24" />
+<img width="1693" height="929" alt="Semantic Visual Architecture Render" src="https://github.com/user-attachments/assets/d8fd9017-062e-45a2-b0cf-695dc320ae24" />
 
 > Visual prototype for rendering execution pipelines, verifier gates, capability boundaries, runtime-state overlays, and architecture graphs.
 


### PR DESCRIPTION
Translates the remaining Cyrillic README image alt text to English. Documentation-only alt-text change; no README prose, status, runtime, loader, production, security, or trust-claim changes.