### PR TITLE
audit(docs): verify English-only documentation surface

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,21 +1,20 @@
 task:
-  id: DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH
-  title: Translate README architecture render alt text to English
-  type: docs
+  id: DOCS-ENGLISH-ONLY-SURFACE-VERIFY
+  title: Verify English-only documentation surface
+  type: audit
   mode: active
 
 intent:
-  summary: docs(readme): translate architecture render alt text to English
+  summary: audit(docs): verify English-only documentation surface
 
 layer:
   name: documentation
-  owner: readme
+  owner: docs
 
 scope:
   allowed_paths:
-    - README.md
     - .harness/current.task.yaml
-    - .harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md
+    - .harness/reports/DOCS-ENGLISH-ONLY-SURFACE-VERIFY.md
 
   forbidden_paths:
     - src/**
@@ -24,6 +23,7 @@ scope:
     - tools/**
     - scripts/**
     - docs/**
+    - README.md
     - Cargo.toml
     - Cargo.lock
 
@@ -35,6 +35,7 @@ actions:
     - create_pr
 
   forbidden:
+    - modify_docs
     - modify_cargo_toml
     - modify_cargo_lock
     - loader_claim
@@ -43,9 +44,9 @@ actions:
     - level4_claim
 
 constraints:
-  - translation only
-  - no technical meaning changes
+  - refactor only
   - no behavior changes
+  - no docs changes
   - no Cargo changes
   - no loader claim
   - no runtime claim
@@ -59,4 +60,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/DOCS-README-ARCHITECTURE-RENDER-ALT-TEXT-ENGLISH.md
+  output: .harness/reports/DOCS-ENGLISH-ONLY-SURFACE-VERIFY.md

--- a/.harness/reports/DOCS-ENGLISH-ONLY-SURFACE-VERIFY.md
+++ b/.harness/reports/DOCS-ENGLISH-ONLY-SURFACE-VERIFY.md
@@ -1,0 +1,57 @@
+# English-only Documentation Surface Verification
+
+Status: PASS
+
+## Scope
+
+This audit verifies that the official documentation surface no longer contains Cyrillic/Russian text.
+
+No source, tests, tools, scripts, Cargo files, README content, docs content, snapshots, runtime, loader, or production behavior was changed.
+
+## Cleanup chain
+
+- #1420 translated `docs/ERROR_CODES.md`.
+- #1421 normalized README logo alt text.
+- #1422 inventoried remaining Cyrillic content.
+- #1423 translated remaining README architecture render alt text.
+
+## Search command
+
+```powershell
+$files = @()
+$files += Get-Item README.md
+$files += Get-ChildItem docs -Recurse -File -Include *.md
+$files += Get-ChildItem . -File -Include *.md
+
+$files |
+  Sort-Object FullName -Unique |
+  Where-Object {
+    $_.FullName -notmatch '\\.git\\' -and
+    $_.FullName -notmatch '\\target\\' -and
+    $_.FullName -notmatch '\\.harness\\reports\\'
+  } |
+  Select-String -Pattern '[А-Яа-яЁё]' |
+  Select-Object Path, LineNumber, Line
+```
+
+## Findings
+
+Result: `0`
+
+PASS: no Cyrillic text found in official documentation surface.
+
+## Non-claims
+
+This audit does not claim:
+
+- loader contract readiness;
+- runtime integration;
+- production UI activation;
+- Level 4 or Level 5 readiness;
+- cryptographic trust verification.
+
+## Verification
+
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`


### PR DESCRIPTION
Verifies that the official documentation surface no longer contains Cyrillic/Russian text after #1420-#1423. Audit/report-only; no source, docs content, README content, tests, tools, scripts, Cargo, runtime, loader, production, security, or trust-claim changes.