### PR TITLE
feat(core-quad): add logic_frame module skeleton + NOT table + tests

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: CORE-QUAD-LOGIC-FRAME-V1-SPEC
-  title: Freeze Quad Logic Frame v1 spec
-  type: docs
+  id: CORE-QUAD-SCALAR-NOT-LUT
+  title: Add Quad Logic Frame scalar skeleton and NOT LUT
+  type: feat
   mode: active
 
 intent:
-  summary: docs(core-quad): freeze Quad Logic Frame v1 spec
-  issue: "#1405"
+  summary: feat(core-quad): add logic_frame module skeleton + NOT table + tests
+  issue: "#1406"
 
 layer:
   name: core-quad
@@ -14,14 +14,15 @@ layer:
 
 scope:
   allowed_paths:
-    - docs/spec/quad_logic_frame_v1.md
-    - tests/legacy_guards.rs
+    - crates/semantic-core-quad/src/logic_frame.rs
+    - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-LOGIC-FRAME-V1-SPEC.md
+    - .harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
 
   forbidden_paths:
+    - crates/ton618-core/**
     - src/**
-    - crates/**
+    - tests/**
     - tools/**
     - scripts/**
     - README.md
@@ -44,19 +45,18 @@ actions:
     - level4_claim
 
 constraints:
-  - docs only
-  - no behavior changes
-  - no Cargo changes
-  - no loader claim
-  - no runtime claim
-  - no production UI claim
-  - no Level 4 claim
+  - semantic-core-quad only
+  - scalar LUT truth-table only (first slice: NOT)
+  - no VM/opcode changes
+  - no runtime changes
+  - no mask migration
 
 verification:
   required:
+    - cargo test -p semantic-core-quad --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-LOGIC-FRAME-V1-SPEC.md
+  output: .harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md

--- a/.harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
@@ -26,6 +26,13 @@ No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask
 - Implemented `NOT_LUT` using `QuadState` explicitly.
 - Added `tests` submodule ensuring `NOT` output correctly conforms to the Logic Frame v1 specification.
 
+## Fixup: Style Cleanup
+
+- `cargo fmt/clippy` cleanup: Removed trailing whitespace and replaced `#[inline(always)]` with `#[inline]`.
+- No behavior change.
+- No public API change.
+- No VM/opcode/runtime changes.
+
 ## Verification
 
 - `cargo test -p semantic-core-quad --quiet`

--- a/.harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
@@ -1,0 +1,34 @@
+# Quad Logic Frame scalar NOT LUT Creation
+
+Status: PASS
+
+## Issue
+
+Implements the first slice of #1406
+
+## Scope
+
+This PR adds the `logic_frame` module skeleton to `semantic-core-quad` and implements the generated scalar LUT truth-table for the `NOT` operation.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md`
+- `crates/semantic-core-quad/src/lib.rs`
+- `crates/semantic-core-quad/src/logic_frame.rs`
+
+## Decisions made
+
+- Sliced PR into `NOT` implementation only to minimize risk.
+- Implemented `NOT_LUT` using `QuadState` explicitly.
+- Added `tests` submodule ensuring `NOT` output correctly conforms to the Logic Frame v1 specification.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::new_without_default, clippy::zero_repeat_side_effects)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod logic_frame;
+
 use core::fmt;
 
 #[cfg(feature = "serde")]

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -1,7 +1,7 @@
 use crate::QuadState;
 
 /// Generated scalar LUT truth-table layer for the Quad Logic Frame v1.
-/// 
+///
 /// NOT operations:
 /// - NOT(N) = N
 /// - NOT(F) = T
@@ -15,7 +15,7 @@ pub const NOT_LUT: [QuadState; 4] = [
 ];
 
 /// Primitive truth-table complement operation.
-#[inline(always)]
+#[inline]
 pub fn not(state: QuadState) -> QuadState {
     NOT_LUT[state as usize]
 }

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -1,0 +1,34 @@
+use crate::QuadState;
+
+/// Generated scalar LUT truth-table layer for the Quad Logic Frame v1.
+/// 
+/// NOT operations:
+/// - NOT(N) = N
+/// - NOT(F) = T
+/// - NOT(T) = F
+/// - NOT(S) = S
+pub const NOT_LUT: [QuadState; 4] = [
+    QuadState::N, // N -> N
+    QuadState::T, // F -> T
+    QuadState::F, // T -> F
+    QuadState::S, // S -> S
+];
+
+/// Primitive truth-table complement operation.
+#[inline(always)]
+pub fn not(state: QuadState) -> QuadState {
+    NOT_LUT[state as usize]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_table() {
+        assert_eq!(not(QuadState::N), QuadState::N, "NOT(Null) must be Null");
+        assert_eq!(not(QuadState::F), QuadState::T, "NOT(False) must be True");
+        assert_eq!(not(QuadState::T), QuadState::F, "NOT(True) must be False");
+        assert_eq!(not(QuadState::S), QuadState::S, "NOT(Super) must be Super");
+    }
+}


### PR DESCRIPTION
First slice of #1406. Adds the \logic_frame\ module skeleton, generated scalar LUT truth-table layer for \NOT\, and relevant tests. Spec-compliant, scalar-only, no VM/opcode/runtime changes.