### PR TITLE
feat(core-quad): add scalar AND/OR truth tables

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-SCALAR-NOT-LUT
-  title: Add Quad Logic Frame scalar skeleton and NOT LUT
+  id: CORE-QUAD-SCALAR-AND-OR-LUTS
+  title: Add scalar AND/OR truth tables
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add logic_frame module skeleton + NOT table + tests
+  summary: feat(core-quad): add scalar AND/OR truth tables
   issue: "#1406"
 
 layer:
@@ -15,9 +15,8 @@ layer:
 scope:
   allowed_paths:
     - crates/semantic-core-quad/src/logic_frame.rs
-    - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
+    - .harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -25,6 +24,7 @@ scope:
     - tests/**
     - tools/**
     - scripts/**
+    - docs/**
     - README.md
     - Cargo.toml
     - Cargo.lock
@@ -46,7 +46,9 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar LUT truth-table only (first slice: NOT)
+  - scalar AND/OR only
+  - no XOR
+  - no IMPLIES/EQUIV/NAND/NOR
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -59,4 +61,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-SCALAR-NOT-LUT.md
+  output: .harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md

--- a/.harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md
@@ -1,0 +1,39 @@
+# Quad Logic Frame scalar AND/OR LUTs Creation
+
+Status: PASS
+
+## Issue
+
+Implements the second slice of #1406
+
+## Scope
+
+This PR extends the `logic_frame` module in `semantic-core-quad` with generated scalar LUT truth-tables for `AND` and `OR` operations.
+This is the second small slice of #1406 after the merged `NOT` LUT PR.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md`
+- `crates/semantic-core-quad/src/logic_frame.rs`
+
+## Decisions made
+
+- Sliced PR into `AND` and `OR` implementations only, no `XOR`, `IMPLIES`, `EQUIV`, `NAND`, `NOR` to minimize risk.
+- Implemented `AND_LUT` and `OR_LUT` arrays natively using `const fn` evaluators. The generation explicitly leverages the truth and falsity planes according to the formulas:
+    - AND: `truth = a.truth & b.truth`, `falsity = a.falsity | b.falsity`
+    - OR: `truth = a.truth | b.truth`, `falsity = a.falsity & b.falsity`
+- Exported `and` and `or` methods exposing `QuadState` types.
+- Expanded `tests` module confirming logic formulas over the full 16 state pair domain, including commutativity and identity expectations.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -14,10 +14,63 @@ pub const NOT_LUT: [QuadState; 4] = [
     QuadState::S, // S -> S
 ];
 
+const fn make_and_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let a_t = (i >> 1) & 1;
+            let a_f = i & 1;
+            let b_t = (j >> 1) & 1;
+            let b_f = j & 1;
+            let r_t = a_t & b_t;
+            let r_f = a_f | b_f;
+            lut[i as usize][j as usize] = QuadState::from_bits_unchecked((r_t << 1) | r_f);
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
+const fn make_or_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let a_t = (i >> 1) & 1;
+            let a_f = i & 1;
+            let b_t = (j >> 1) & 1;
+            let b_f = j & 1;
+            let r_t = a_t | b_t;
+            let r_f = a_f & b_f;
+            lut[i as usize][j as usize] = QuadState::from_bits_unchecked((r_t << 1) | r_f);
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
+pub const AND_LUT: [[QuadState; 4]; 4] = make_and_lut();
+pub const OR_LUT: [[QuadState; 4]; 4] = make_or_lut();
+
 /// Primitive truth-table complement operation.
 #[inline]
 pub fn not(state: QuadState) -> QuadState {
     NOT_LUT[state as usize]
+}
+
+#[inline]
+pub fn and(a: QuadState, b: QuadState) -> QuadState {
+    AND_LUT[a as usize][b as usize]
+}
+
+#[inline]
+pub fn or(a: QuadState, b: QuadState) -> QuadState {
+    OR_LUT[a as usize][b as usize]
 }
 
 #[cfg(test)]
@@ -30,5 +83,52 @@ mod tests {
         assert_eq!(not(QuadState::F), QuadState::T, "NOT(False) must be True");
         assert_eq!(not(QuadState::T), QuadState::F, "NOT(True) must be False");
         assert_eq!(not(QuadState::S), QuadState::S, "NOT(Super) must be Super");
+    }
+
+    #[test]
+    fn test_and_or_plane_formulas() {
+        for a in QuadState::ALL {
+            for b in QuadState::ALL {
+                let a_t = (a as u8 >> 1) & 1;
+                let a_f = a as u8 & 1;
+                let b_t = (b as u8 >> 1) & 1;
+                let b_f = b as u8 & 1;
+
+                let and_t = a_t & b_t;
+                let and_f = a_f | b_f;
+                let exp_and = QuadState::from_bits_unchecked((and_t << 1) | and_f);
+                assert_eq!(and(a, b), exp_and, "AND plane formula mismatch");
+
+                let or_t = a_t | b_t;
+                let or_f = a_f & b_f;
+                let exp_or = QuadState::from_bits_unchecked((or_t << 1) | or_f);
+                assert_eq!(or(a, b), exp_or, "OR plane formula mismatch");
+            }
+        }
+    }
+
+    #[test]
+    fn test_commutativity() {
+        for a in QuadState::ALL {
+            for b in QuadState::ALL {
+                assert_eq!(and(a, b), and(b, a), "AND must be commutative");
+                assert_eq!(or(a, b), or(b, a), "OR must be commutative");
+            }
+        }
+    }
+
+    #[test]
+    fn test_identity_checks() {
+        // T AND x behaves as truth-table pass-through where defined by plane formula
+        // F OR x behaves as truth-table pass-through where defined by plane formula
+        for x in QuadState::ALL {
+            assert_eq!(and(QuadState::T, x), x, "T AND x should be x");
+            assert_eq!(or(QuadState::F, x), x, "F OR x should be x");
+        }
+
+        assert_eq!(and(QuadState::N, QuadState::T), QuadState::N);
+        assert_eq!(or(QuadState::N, QuadState::F), QuadState::N);
+        assert_eq!(and(QuadState::S, QuadState::T), QuadState::S);
+        assert_eq!(or(QuadState::S, QuadState::F), QuadState::S);
     }
 }


### PR DESCRIPTION
Second slice of #1406. Adds generated scalar AND/OR truth tables to the Quad Logic Frame layer. Scalar-only; no XOR, IMPLIES, EQUIV, NAND, NOR, VM, opcode, runtime, mask, or behavior changes outside semantic-core-quad.