### PR TITLE
feat(core-quad): add scalar XOR truth table

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-SCALAR-AND-OR-LUTS
-  title: Add scalar AND/OR truth tables
+  id: CORE-QUAD-SCALAR-XOR-LUT
+  title: Add scalar XOR truth table
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add scalar AND/OR truth tables
+  summary: feat(core-quad): add scalar XOR truth table
   issue: "#1406"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/logic_frame.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md
+    - .harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,8 +46,8 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar AND/OR only
-  - no XOR
+  - scalar XOR only
+  - raw-code derived policy matching raw_xor
   - no IMPLIES/EQUIV/NAND/NOR
   - no VM/opcode changes
   - no runtime changes
@@ -61,4 +61,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-SCALAR-AND-OR-LUTS.md
+  output: .harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md

--- a/.harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md
@@ -1,0 +1,37 @@
+# Quad Logic Frame scalar XOR LUT Creation
+
+Status: PASS
+
+## Issue
+
+Implements the third slice of #1406
+
+## Scope
+
+This PR extends the `logic_frame` module in `semantic-core-quad` with a generated scalar LUT truth-table for the `XOR` operation.
+This is the third small slice of #1406 after the merged `NOT` and `AND/OR` LUT PRs.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Changed files
+
+- `.harness/current.task.yaml`
+- `.harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md`
+- `crates/semantic-core-quad/src/logic_frame.rs`
+
+## Decisions made
+
+- Sliced PR into `XOR` implementation only, no `IMPLIES`, `EQUIV`, `NAND`, `NOR` to minimize risk.
+- Implemented `XOR_LUT` array natively using a `const fn` evaluator. The generation explicitly utilizes the `a.bits() ^ b.bits()` raw-code derived policy.
+- Exported `xor` method exposing `QuadState` types.
+- Expanded `tests` module confirming logic formulas over the full 16 state pair domain against `raw_xor`, including commutativity and identity expectations (e.g. `xor(x, x) == N` and `xor(N, x) == x`).
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -54,8 +54,25 @@ const fn make_or_lut() -> [[QuadState; 4]; 4] {
     lut
 }
 
+const fn make_xor_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let a_bits = i as u8;
+            let b_bits = j as u8;
+            lut[i as usize][j as usize] = QuadState::from_bits_unchecked(a_bits ^ b_bits);
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
 pub const AND_LUT: [[QuadState; 4]; 4] = make_and_lut();
 pub const OR_LUT: [[QuadState; 4]; 4] = make_or_lut();
+pub const XOR_LUT: [[QuadState; 4]; 4] = make_xor_lut();
 
 /// Primitive truth-table complement operation.
 #[inline]
@@ -71,6 +88,11 @@ pub fn and(a: QuadState, b: QuadState) -> QuadState {
 #[inline]
 pub fn or(a: QuadState, b: QuadState) -> QuadState {
     OR_LUT[a as usize][b as usize]
+}
+
+#[inline]
+pub fn xor(a: QuadState, b: QuadState) -> QuadState {
+    XOR_LUT[a as usize][b as usize]
 }
 
 #[cfg(test)]
@@ -108,11 +130,21 @@ mod tests {
     }
 
     #[test]
+    fn test_xor_table() {
+        for a in QuadState::ALL {
+            for b in QuadState::ALL {
+                assert_eq!(xor(a, b), a.raw_xor(b), "XOR raw match mismatch");
+            }
+        }
+    }
+
+    #[test]
     fn test_commutativity() {
         for a in QuadState::ALL {
             for b in QuadState::ALL {
                 assert_eq!(and(a, b), and(b, a), "AND must be commutative");
                 assert_eq!(or(a, b), or(b, a), "OR must be commutative");
+                assert_eq!(xor(a, b), xor(b, a), "XOR must be commutative");
             }
         }
     }
@@ -124,11 +156,19 @@ mod tests {
         for x in QuadState::ALL {
             assert_eq!(and(QuadState::T, x), x, "T AND x should be x");
             assert_eq!(or(QuadState::F, x), x, "F OR x should be x");
+            assert_eq!(xor(x, x), QuadState::N, "x XOR x should be N");
+            assert_eq!(xor(QuadState::N, x), x, "N XOR x should be x");
         }
 
         assert_eq!(and(QuadState::N, QuadState::T), QuadState::N);
         assert_eq!(or(QuadState::N, QuadState::F), QuadState::N);
         assert_eq!(and(QuadState::S, QuadState::T), QuadState::S);
         assert_eq!(or(QuadState::S, QuadState::F), QuadState::S);
+
+        // Exact checks for XOR
+        assert_eq!(xor(QuadState::F, QuadState::T), QuadState::S);
+        assert_eq!(xor(QuadState::T, QuadState::S), QuadState::F);
+        assert_eq!(xor(QuadState::F, QuadState::S), QuadState::T);
+        assert_eq!(xor(QuadState::N, QuadState::S), QuadState::S);
     }
 }


### PR DESCRIPTION
Third slice of #1406. Adds generated scalar XOR truth table to the Quad Logic Frame layer using raw-code derived policy matching QuadState::raw_xor. Scalar-only; no IMPLIES, EQUIV, NAND, NOR, VM, opcode, runtime, mask, or behavior changes outside semantic-core-quad.