### PR TITLE
feat(core-quad): add derived scalar IMPLIES truth table

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-SCALAR-XOR-LUT
-  title: Add scalar XOR truth table
+  id: CORE-QUAD-SCALAR-IMPLIES-LUT
+  title: Add derived scalar IMPLIES truth table
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add scalar XOR truth table
+  summary: feat(core-quad): add derived scalar IMPLIES truth table
   issue: "#1406"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/logic_frame.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md
+    - .harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,9 +46,10 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar XOR only
-  - raw-code derived policy matching raw_xor
-  - no IMPLIES/EQUIV/NAND/NOR
+  - scalar IMPLIES only
+  - derived compatibility policy not(a).join(b)
+  - no primitive implication
+  - no EQUIV/NAND/NOR
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -61,4 +62,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-SCALAR-XOR-LUT.md
+  output: .harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md

--- a/.harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md
@@ -1,0 +1,33 @@
+# Quad Logic Frame scalar IMPLIES LUT Creation
+
+Status: PASS
+
+## Issue
+
+Implements the fourth slice of #1406
+
+## Scope
+
+This PR extends the `logic_frame` module in `semantic-core-quad` with a generated scalar LUT truth-table for the `IMPLIES` operation.
+This is the fourth small slice of #1406 after `NOT`, `AND/OR`, and `XOR`.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Decisions made
+
+- Sliced PR into `IMPLIES` implementation only. `EQUIV` is left out as it's deferred/separately named.
+- Implemented `IMPLIES_LUT` array natively using a `const fn` evaluator.
+- Used the frozen derived compatibility policy: `implies(a, b) == not(a).join(b)`.
+- No primitive implication semantics were implemented or introduced.
+- Exported `implies` method exposing `QuadState` types.
+- Expanded `tests` module confirming logic formulas over the full 16 state pair domain against `not(a).join(b)`. Added checks for directionality (`T -> F != F -> T`) and exact values.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -70,9 +70,26 @@ const fn make_xor_lut() -> [[QuadState; 4]; 4] {
     lut
 }
 
+const fn make_implies_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let b_state = QuadState::from_bits_unchecked(j as u8);
+            let not_a = NOT_LUT[i as usize];
+            lut[i as usize][j as usize] = not_a.join(b_state);
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
 pub const AND_LUT: [[QuadState; 4]; 4] = make_and_lut();
 pub const OR_LUT: [[QuadState; 4]; 4] = make_or_lut();
 pub const XOR_LUT: [[QuadState; 4]; 4] = make_xor_lut();
+pub const IMPLIES_LUT: [[QuadState; 4]; 4] = make_implies_lut();
 
 /// Primitive truth-table complement operation.
 #[inline]
@@ -93,6 +110,11 @@ pub fn or(a: QuadState, b: QuadState) -> QuadState {
 #[inline]
 pub fn xor(a: QuadState, b: QuadState) -> QuadState {
     XOR_LUT[a as usize][b as usize]
+}
+
+#[inline]
+pub fn implies(a: QuadState, b: QuadState) -> QuadState {
+    IMPLIES_LUT[a as usize][b as usize]
 }
 
 #[cfg(test)]
@@ -136,6 +158,33 @@ mod tests {
                 assert_eq!(xor(a, b), a.raw_xor(b), "XOR raw match mismatch");
             }
         }
+    }
+
+    #[test]
+    fn test_implies_table() {
+        for a in QuadState::ALL {
+            for b in QuadState::ALL {
+                assert_eq!(
+                    implies(a, b),
+                    not(a).join(b),
+                    "IMPLIES derived policy mismatch"
+                );
+            }
+        }
+
+        assert_ne!(
+            implies(QuadState::T, QuadState::F),
+            implies(QuadState::F, QuadState::T),
+            "Implication must be directional"
+        );
+
+        // Exact checks
+        assert_eq!(implies(QuadState::T, QuadState::F), QuadState::F);
+        assert_eq!(implies(QuadState::F, QuadState::T), QuadState::T);
+        assert_eq!(implies(QuadState::F, QuadState::N), QuadState::T);
+        assert_eq!(implies(QuadState::N, QuadState::F), QuadState::F);
+        assert_eq!(implies(QuadState::T, QuadState::T), QuadState::S);
+        assert_eq!(implies(QuadState::S, QuadState::N), QuadState::S);
     }
 
     #[test]


### PR DESCRIPTION
Fourth slice of #1406. Adds generated scalar IMPLIES truth table to the Quad Logic Frame layer using the frozen derived compatibility policy A -> B = NOT(A) join B. Scalar-only; no primitive implication, EQUIV, NAND, NOR, VM, opcode, runtime, mask, or behavior changes outside semantic-core-quad.