### PR TITLE
feat(core-quad): add derived scalar NAND/NOR truth tables

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-SCALAR-IMPLIES-LUT
-  title: Add derived scalar IMPLIES truth table
+  id: CORE-QUAD-SCALAR-NAND-NOR-LUTS
+  title: Add derived scalar NAND/NOR truth tables
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add derived scalar IMPLIES truth table
+  summary: feat(core-quad): add derived scalar NAND NOR truth tables
   issue: "#1406"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/logic_frame.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md
+    - .harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,10 +46,9 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar IMPLIES only
-  - derived compatibility policy not(a).join(b)
-  - no primitive implication
-  - no EQUIV/NAND/NOR
+  - scalar NAND/NOR only
+  - derived from existing scalar LUTs
+  - no EQUIV
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -62,4 +61,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-SCALAR-IMPLIES-LUT.md
+  output: .harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md

--- a/.harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md
+++ b/.harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md
@@ -1,0 +1,33 @@
+# Quad Logic Frame scalar NAND/NOR LUT Creation
+
+Status: PASS
+
+## Issue
+
+Implements the fifth slice of #1406
+
+## Scope
+
+This PR extends the `logic_frame` module in `semantic-core-quad` with generated scalar LUT truth-tables for the `NAND` and `NOR` operations.
+This is the fifth small slice of #1406 after `NOT`, `AND/OR`, `XOR`, and `IMPLIES`.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Decisions made
+
+- Sliced PR into `NAND` and `NOR` implementations only. `EQUIV` is left out as it's deferred/separately named.
+- Implemented `NAND_LUT` and `NOR_LUT` arrays natively using `const fn` evaluators.
+- Generated purely from derived operations according to specs: `NAND = NOT(AND)` and `NOR = NOT(OR)`.
+- No new primitive implication or equivalence semantics were implemented.
+- Exported `nand` and `nor` methods exposing `QuadState` types.
+- Expanded `tests` module confirming logic formulas over the full 16 state pair domain against the derived operations, commutativity for both, and exact discrete identity checks.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -86,10 +86,42 @@ const fn make_implies_lut() -> [[QuadState; 4]; 4] {
     lut
 }
 
+const fn make_nand_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let and_res = AND_LUT[i as usize][j as usize];
+            lut[i as usize][j as usize] = NOT_LUT[and_res as usize];
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
+const fn make_nor_lut() -> [[QuadState; 4]; 4] {
+    let mut lut = [[QuadState::N; 4]; 4];
+    let mut i = 0;
+    while i < 4 {
+        let mut j = 0;
+        while j < 4 {
+            let or_res = OR_LUT[i as usize][j as usize];
+            lut[i as usize][j as usize] = NOT_LUT[or_res as usize];
+            j += 1;
+        }
+        i += 1;
+    }
+    lut
+}
+
 pub const AND_LUT: [[QuadState; 4]; 4] = make_and_lut();
 pub const OR_LUT: [[QuadState; 4]; 4] = make_or_lut();
 pub const XOR_LUT: [[QuadState; 4]; 4] = make_xor_lut();
 pub const IMPLIES_LUT: [[QuadState; 4]; 4] = make_implies_lut();
+pub const NAND_LUT: [[QuadState; 4]; 4] = make_nand_lut();
+pub const NOR_LUT: [[QuadState; 4]; 4] = make_nor_lut();
 
 /// Primitive truth-table complement operation.
 #[inline]
@@ -115,6 +147,16 @@ pub fn xor(a: QuadState, b: QuadState) -> QuadState {
 #[inline]
 pub fn implies(a: QuadState, b: QuadState) -> QuadState {
     IMPLIES_LUT[a as usize][b as usize]
+}
+
+#[inline]
+pub fn nand(a: QuadState, b: QuadState) -> QuadState {
+    NAND_LUT[a as usize][b as usize]
+}
+
+#[inline]
+pub fn nor(a: QuadState, b: QuadState) -> QuadState {
+    NOR_LUT[a as usize][b as usize]
 }
 
 #[cfg(test)]
@@ -188,12 +230,33 @@ mod tests {
     }
 
     #[test]
+    fn test_nand_nor_table() {
+        for a in QuadState::ALL {
+            for b in QuadState::ALL {
+                assert_eq!(nand(a, b), not(and(a, b)), "NAND derived policy mismatch");
+                assert_eq!(nor(a, b), not(or(a, b)), "NOR derived policy mismatch");
+            }
+        }
+
+        // Exact checks
+        assert_eq!(nand(QuadState::T, QuadState::T), QuadState::F);
+        assert_eq!(nand(QuadState::F, QuadState::T), QuadState::T);
+        assert_eq!(nand(QuadState::N, QuadState::T), QuadState::N);
+
+        assert_eq!(nor(QuadState::F, QuadState::F), QuadState::T);
+        assert_eq!(nor(QuadState::T, QuadState::F), QuadState::F);
+        assert_eq!(nor(QuadState::N, QuadState::F), QuadState::N);
+    }
+
+    #[test]
     fn test_commutativity() {
         for a in QuadState::ALL {
             for b in QuadState::ALL {
                 assert_eq!(and(a, b), and(b, a), "AND must be commutative");
                 assert_eq!(or(a, b), or(b, a), "OR must be commutative");
                 assert_eq!(xor(a, b), xor(b, a), "XOR must be commutative");
+                assert_eq!(nand(a, b), nand(b, a), "NAND must be commutative");
+                assert_eq!(nor(a, b), nor(b, a), "NOR must be commutative");
             }
         }
     }


### PR DESCRIPTION
Fifth slice of #1406. Adds generated derived scalar NAND/NOR truth tables to the Quad Logic Frame layer using NOT(AND) and NOT(OR). Scalar-only; no EQUIV, VM, opcode, runtime, mask, or behavior changes outside semantic-core-quad.