### PR TITLE
test(core-quad): guard deferred EQUIV policy

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-SCALAR-NAND-NOR-LUTS
-  title: Add derived scalar NAND/NOR truth tables
-  type: feat
+  id: CORE-QUAD-EQUIV-POLICY-GUARD
+  title: Guard deferred EQUIV policy
+  type: test
   mode: active
 
 intent:
-  summary: feat(core-quad): add derived scalar NAND NOR truth tables
+  summary: test(core-quad): guard deferred EQUIV policy
   issue: "#1406"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/logic_frame.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md
+    - .harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,9 +46,10 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar NAND/NOR only
-  - derived from existing scalar LUTs
-  - no EQUIV
+  - EQUIV policy guard only
+  - no equiv public API
+  - no EQUIV_LUT
+  - policy is deferred/separately named
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -61,4 +62,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-SCALAR-NAND-NOR-LUTS.md
+  output: .harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md

--- a/.harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md
+++ b/.harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md
@@ -1,0 +1,33 @@
+# Quad Logic Frame EQUIV Policy Guard
+
+Status: PASS
+
+## Issue
+
+Implements the sixth slice of #1406
+
+## Scope
+
+This PR extends the `logic_frame` module in `semantic-core-quad` with an explicit policy guard for the deferred `EQUIV` operation.
+This is the sixth small slice of #1406 after `NOT`, `AND/OR`, `XOR`, `IMPLIES`, and `NAND/NOR`.
+
+This is an isolated test/documentation addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Decisions made
+
+- Sliced PR into `EQUIV` policy guard only.
+- Documented that `EQUIV` is intentionally not exposed as `equiv`.
+- Added the constant marker `EQUIV_POLICY = "deferred_or_separately_named"`.
+- Added test `test_equiv_policy_is_deferred` asserting the constant marker.
+- Explicitly refrained from implementing `EQUIV_LUT` or an `equiv()` public API, preventing unqualified equivalence operations.
+- No existing LUT semantics were modified.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -291,6 +291,9 @@ mod tests {
 
     #[test]
     fn test_equiv_policy_is_deferred() {
-        assert_eq!(EQUIV_POLICY, "deferred_or_separately_named", "EQUIV policy must remain deferred until explicitly standardized");
+        assert_eq!(
+            EQUIV_POLICY, "deferred_or_separately_named",
+            "EQUIV policy must remain deferred until explicitly standardized"
+        );
     }
 }

--- a/crates/semantic-core-quad/src/logic_frame.rs
+++ b/crates/semantic-core-quad/src/logic_frame.rs
@@ -123,6 +123,11 @@ pub const IMPLIES_LUT: [[QuadState; 4]; 4] = make_implies_lut();
 pub const NAND_LUT: [[QuadState; 4]; 4] = make_nand_lut();
 pub const NOR_LUT: [[QuadState; 4]; 4] = make_nor_lut();
 
+// EQUIV is intentionally not exposed as `equiv`.
+// Quad Logic Frame v1 marks equivalence as deferred / separately named.
+// Do not add an unqualified `equiv(a, b)` API without a dedicated spec update.
+pub const EQUIV_POLICY: &str = "deferred_or_separately_named";
+
 /// Primitive truth-table complement operation.
 #[inline]
 pub fn not(state: QuadState) -> QuadState {
@@ -282,5 +287,10 @@ mod tests {
         assert_eq!(xor(QuadState::T, QuadState::S), QuadState::F);
         assert_eq!(xor(QuadState::F, QuadState::S), QuadState::T);
         assert_eq!(xor(QuadState::N, QuadState::S), QuadState::S);
+    }
+
+    #[test]
+    fn test_equiv_policy_is_deferred() {
+        assert_eq!(EQUIV_POLICY, "deferred_or_separately_named", "EQUIV policy must remain deferred until explicitly standardized");
     }
 }


### PR DESCRIPTION
Sixth slice of #1406. Adds an explicit policy guard documenting that EQUIV remains deferred/separately named in the Quad Logic Frame layer. No equiv API, no EQUIV_LUT, no VM, opcode, runtime, mask, or behavior changes.