### PR TITLE
feat(core-quad): add scalar QuadroReg32 truth-map oracle

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: CORE-QUAD-EQUIV-POLICY-GUARD
-  title: Guard deferred EQUIV policy
-  type: test
+  id: CORE-QUAD-REG32-SCALAR-MAP-ORACLE
+  title: Add scalar QuadroReg32 truth-map oracle
+  type: feat
   mode: active
 
 intent:
-  summary: test(core-quad): guard deferred EQUIV policy
-  issue: "#1406"
+  summary: feat(core-quad): add scalar QuadroReg32 truth-map oracle
+  issue: "#1407"
 
 layer:
   name: core-quad
@@ -14,9 +14,9 @@ layer:
 
 scope:
   allowed_paths:
-    - crates/semantic-core-quad/src/logic_frame.rs
+    - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md
+    - .harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,10 +46,10 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - EQUIV policy guard only
-  - no equiv public API
-  - no EQUIV_LUT
-  - policy is deferred/separately named
+  - scalar map methods only (map_not_scalar, map_and_scalar, etc.)
+  - iterate 32 lanes via logic_frame
+  - no SWAR methods yet
+  - no EQUIV map
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -62,4 +62,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-EQUIV-POLICY-GUARD.md
+  output: .harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md

--- a/.harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md
+++ b/.harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md
@@ -1,0 +1,33 @@
+# Quad Logic Frame QuadroReg32 Scalar Map Oracle
+
+Status: PASS
+
+## Issue
+
+Implements the first slice of #1407
+
+## Scope
+
+This PR extends `QuadroReg32` in `semantic-core-quad` with scalar mapping oracle methods for future SWAR verification.
+It uses the `logic_frame` truth tables to map states lane-by-lane.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+No SWAR methods have been implemented yet.
+
+## Decisions made
+
+- Sliced PR into scalar map oracle only.
+- Implemented `map_not_scalar`, `map_and_scalar`, `map_or_scalar`, `map_xor_scalar`, `map_implies_scalar`, `map_nand_scalar`, and `map_nor_scalar`.
+- Each method loops `0..32` and calls the corresponding `logic_frame` scalar function to update the lane in-place.
+- `EQUIV` map is omitted in line with the deferred `EQUIV` policy.
+- No SWAR optimizations or default aliases were added.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -238,6 +238,82 @@ impl QuadroReg32 {
     pub fn force_super(&mut self, mask: QuadMask32) {
         self.set_by_mask(mask, QuadState::S);
     }
+
+    pub fn map_not_scalar(mut self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let state = self.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::not(state));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_and_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::and(a, b));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_or_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::or(a, b));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_xor_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::xor(a, b));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_implies_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::implies(a, b));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_nand_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::nand(a, b));
+            lane += 1;
+        }
+        self
+    }
+
+    pub fn map_nor_scalar(mut self, other: Self) -> Self {
+        let mut lane = 0;
+        while lane < Self::LANES {
+            let a = self.get_unchecked(lane);
+            let b = other.get_unchecked(lane);
+            self.set_unchecked(lane, logic_frame::nor(a, b));
+            lane += 1;
+        }
+        self
+    }
 }
 
 impl fmt::Debug for QuadroReg32 {


### PR DESCRIPTION
First slice of #1407. Adds lane-wise scalar map methods for QuadroReg32 using logic_frame scalar functions as the oracle for future SWAR methods. No SWAR implemented yet, no EQUIV map, no VM/opcode integration.