### PR TITLE
feat(core-quad): add SWAR NOT/XOR map methods

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-REG32-SCALAR-MAP-ORACLE
-  title: Add scalar QuadroReg32 truth-map oracle
+  id: CORE-QUAD-REG32-SWAR-NOT-XOR
+  title: Add SWAR NOT/XOR map methods
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add scalar QuadroReg32 truth-map oracle
+  summary: feat(core-quad): add SWAR NOT XOR map methods
   issue: "#1407"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md
+    - .harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,10 +46,11 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - scalar map methods only (map_not_scalar, map_and_scalar, etc.)
-  - iterate 32 lanes via logic_frame
-  - no SWAR methods yet
-  - no EQUIV map
+  - SWAR NOT/XOR map methods only (map_not_swar, map_xor_swar)
+  - compare with scalar oracle
+  - no AND/OR/IMPLIES/NAND/NOR SWAR yet
+  - no EQUIV
+  - no aliases
   - no VM/opcode changes
   - no runtime changes
   - no mask migration
@@ -62,4 +63,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-REG32-SCALAR-MAP-ORACLE.md
+  output: .harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md

--- a/.harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md
+++ b/.harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md
@@ -1,0 +1,34 @@
+# Quad Logic Frame QuadroReg32 SWAR NOT/XOR Map Methods
+
+Status: PASS
+
+## Issue
+
+Implements the second slice of #1407
+
+## Scope
+
+This PR extends `QuadroReg32` in `semantic-core-quad` with explicit SWAR-backed `NOT` and `XOR` map methods, tested against the scalar map oracle.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+No other SWAR methods have been implemented yet.
+
+## Decisions made
+
+- Sliced PR into SWAR `NOT` and `XOR` only.
+- Implemented `map_not_swar` using `self.inverse()`.
+- Implemented `map_xor_swar` using raw bitwise XOR.
+- Tested exhaustively against `RAW_SAMPLES` and `QuadState::ALL` repeated instances, validating them against their corresponding scalar map methods.
+- `EQUIV` map is omitted in line with the deferred `EQUIV` policy.
+- `AND`, `OR`, `IMPLIES`, `NAND`, and `NOR` SWAR methods are omitted for future slices.
+- No default aliases were added.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -314,6 +314,16 @@ impl QuadroReg32 {
         }
         self
     }
+
+    // SWAR NOT swaps the falsity and truth bit planes.
+    pub const fn map_not_swar(self) -> Self {
+        self.inverse()
+    }
+
+    // SWAR XOR is raw-code XOR across packed quadit lanes.
+    pub const fn map_xor_swar(self, other: Self) -> Self {
+        Self(self.0 ^ other.0)
+    }
 }
 
 impl fmt::Debug for QuadroReg32 {
@@ -1414,4 +1424,52 @@ mod tests {
     bank_tail_case!(bank_tail_len_127, 127);
     bank_tail_case!(bank_tail_len_128, 128);
     bank_tail_case!(bank_tail_len_129, 129);
+
+    const RAW_SAMPLES: [u64; 7] = [
+        0x0000_0000_0000_0000,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0x5555_5555_5555_5555,
+        0xAAAA_AAAA_AAAA_AAAA,
+        0x0123_4567_89AB_CDEF,
+        0xE4E4_E4E4_E4E4_E4E4,
+        0xBADC_0FFE_DEAD_BEEF,
+    ];
+
+    #[test]
+    fn map_not_swar_matches_scalar_samples() {
+        for raw in RAW_SAMPLES {
+            let reg = QuadroReg32::from_raw(raw);
+            assert_eq!(reg.map_not_swar(), reg.map_not_scalar());
+        }
+    }
+
+    #[test]
+    fn map_xor_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_xor_swar(b), a.map_xor_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_not_swar_matches_scalar_repeated_states() {
+        for state in QuadState::ALL {
+            let reg = reg_filled(state);
+            assert_eq!(reg.map_not_swar(), reg.map_not_scalar());
+        }
+    }
+
+    #[test]
+    fn map_xor_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_xor_swar(b), a.map_xor_scalar(b));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Second slice of #1407. Adds explicit SWAR-backed NOT/XOR map methods for QuadroReg32 and verifies them against the scalar map oracle. No AND/OR/IMPLIES/NAND/NOR SWAR yet, no EQUIV, no VM, opcode, runtime, mask, or default behavior changes.