### PR TITLE
feat(core-quad): add SWAR AND/OR map methods

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-REG32-SWAR-NOT-XOR
-  title: Add SWAR NOT/XOR map methods
+  id: CORE-QUAD-REG32-SWAR-AND-OR
+  title: Add SWAR AND/OR map methods
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add SWAR NOT XOR map methods
+  summary: feat(core-quad): add SWAR AND OR map methods
   issue: "#1407"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md
+    - .harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,9 +46,9 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - SWAR NOT/XOR map methods only (map_not_swar, map_xor_swar)
+  - SWAR AND/OR map methods only (map_and_swar, map_or_swar)
   - compare with scalar oracle
-  - no AND/OR/IMPLIES/NAND/NOR SWAR yet
+  - no IMPLIES/NAND/NOR SWAR yet
   - no EQUIV
   - no aliases
   - no VM/opcode changes
@@ -63,4 +63,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-REG32-SWAR-NOT-XOR.md
+  output: .harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md

--- a/.harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md
+++ b/.harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md
@@ -1,0 +1,34 @@
+# Quad Logic Frame QuadroReg32 SWAR AND/OR Map Methods
+
+Status: PASS
+
+## Issue
+
+Implements the third slice of #1407
+
+## Scope
+
+This PR extends `QuadroReg32` in `semantic-core-quad` with explicit SWAR-backed `AND` and `OR` map methods, tested against the scalar map oracle.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+No other SWAR methods have been implemented yet.
+
+## Decisions made
+
+- Sliced PR into SWAR `AND` and `OR` only.
+- Implemented `map_and_swar` using truth-plane intersection and falsity-plane union (`(at & bt) | (af | bf)`).
+- Implemented `map_or_swar` using truth-plane union and falsity-plane intersection (`(at | bt) | (af & bf)`).
+- Tested exhaustively against `RAW_SAMPLES` pairs and `QuadState::ALL` repeated instance pairs, validating them against their corresponding scalar map methods.
+- `EQUIV` map is omitted in line with the deferred `EQUIV` policy.
+- `IMPLIES`, `NAND`, and `NOR` SWAR methods are omitted for future slices.
+- No default aliases were added.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -324,6 +324,26 @@ impl QuadroReg32 {
     pub const fn map_xor_swar(self, other: Self) -> Self {
         Self(self.0 ^ other.0)
     }
+
+    // SWAR AND computes truth-plane intersection and falsity-plane union.
+    pub const fn map_and_swar(self, other: Self) -> Self {
+        let af = self.0 & LSB_MASK_32;
+        let at = self.0 & MSB_MASK_32;
+        let bf = other.0 & LSB_MASK_32;
+        let bt = other.0 & MSB_MASK_32;
+
+        Self((at & bt) | (af | bf))
+    }
+
+    // SWAR OR computes truth-plane union and falsity-plane intersection.
+    pub const fn map_or_swar(self, other: Self) -> Self {
+        let af = self.0 & LSB_MASK_32;
+        let at = self.0 & MSB_MASK_32;
+        let bf = other.0 & LSB_MASK_32;
+        let bt = other.0 & MSB_MASK_32;
+
+        Self((at | bt) | (af & bf))
+    }
 }
 
 impl fmt::Debug for QuadroReg32 {
@@ -1469,6 +1489,49 @@ mod tests {
                 let a = reg_filled(a_state);
                 let b = reg_filled(b_state);
                 assert_eq!(a.map_xor_swar(b), a.map_xor_scalar(b));
+            }
+        }
+    }
+    #[test]
+    fn map_and_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_and_swar(b), a.map_and_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_or_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_or_swar(b), a.map_or_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_and_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_and_swar(b), a.map_and_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_or_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_or_swar(b), a.map_or_scalar(b));
             }
         }
     }


### PR DESCRIPTION
Third slice of #1407. Adds explicit SWAR-backed AND/OR map methods for QuadroReg32 and verifies them against the scalar map oracle. No IMPLIES/NAND/NOR SWAR yet, no EQUIV, no VM, opcode, runtime, mask, or default behavior changes.