### PR TITLE
feat(core-quad): add SWAR IMPLIES/NAND/NOR map methods

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-REG32-SWAR-AND-OR
-  title: Add SWAR AND/OR map methods
+  id: CORE-QUAD-REG32-SWAR-IMPLIES-NAND-NOR
+  title: Add SWAR IMPLIES/NAND/NOR map methods
   type: feat
   mode: active
 
 intent:
-  summary: feat(core-quad): add SWAR AND OR map methods
+  summary: feat(core-quad): add SWAR IMPLIES NAND NOR map methods
   issue: "#1407"
 
 layer:
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/semantic-core-quad/src/lib.rs
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md
+    - .harness/reports/CORE-QUAD-REG32-SWAR-IMPLIES-NAND-NOR.md
 
   forbidden_paths:
     - crates/ton618-core/**
@@ -46,9 +46,8 @@ actions:
 
 constraints:
   - semantic-core-quad only
-  - SWAR AND/OR map methods only (map_and_swar, map_or_swar)
+  - SWAR IMPLIES/NAND/NOR map methods only
   - compare with scalar oracle
-  - no IMPLIES/NAND/NOR SWAR yet
   - no EQUIV
   - no aliases
   - no VM/opcode changes
@@ -63,4 +62,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-REG32-SWAR-AND-OR.md
+  output: .harness/reports/CORE-QUAD-REG32-SWAR-IMPLIES-NAND-NOR.md

--- a/.harness/reports/CORE-QUAD-REG32-SWAR-IMPLIES-NAND-NOR.md
+++ b/.harness/reports/CORE-QUAD-REG32-SWAR-IMPLIES-NAND-NOR.md
@@ -1,0 +1,33 @@
+# Quad Logic Frame QuadroReg32 SWAR IMPLIES/NAND/NOR Map Methods
+
+Status: PASS
+
+## Issue
+
+Implements the fourth slice of #1407
+
+## Scope
+
+This PR extends `QuadroReg32` in `semantic-core-quad` with explicit SWAR-backed `IMPLIES`, `NAND`, and `NOR` map methods, tested against the scalar map oracle.
+
+This is an isolated feature addition.
+No behavior changes to VM, opcode execution, loader, or runtime boundaries. Mask evaluation remains unmodified.
+
+## Decisions made
+
+- Sliced PR into SWAR `IMPLIES`, `NAND`, and `NOR` only.
+- Implemented `map_implies_swar` using `self.map_not_swar().join(other)`.
+- Implemented `map_nand_swar` using `self.map_and_swar(other).map_not_swar()`.
+- Implemented `map_nor_swar` using `self.map_or_swar(other).map_not_swar()`.
+- Tested exhaustively against `RAW_SAMPLES` pairs, `QuadState::ALL` repeated instance pairs, and exact check rules, validating them against their corresponding scalar map methods.
+- `EQUIV` map is omitted in line with the deferred `EQUIV` policy.
+- No default aliases were added.
+
+## Verification
+
+- `cargo test -p semantic-core-quad --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`
+
+*(If local `cargo clippy --workspace` fails, it's due to unrelated workspace warnings from other crates outside this PR's scope.)*

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -344,6 +344,22 @@ impl QuadroReg32 {
 
         Self((at | bt) | (af & bf))
     }
+
+    // SWAR IMPLIES uses the frozen derived compatibility policy:
+    // A -> B = NOT(A) join B.
+    pub const fn map_implies_swar(self, other: Self) -> Self {
+        self.map_not_swar().join(other)
+    }
+
+    // SWAR NAND is derived from existing SWAR AND followed by SWAR NOT.
+    pub const fn map_nand_swar(self, other: Self) -> Self {
+        self.map_and_swar(other).map_not_swar()
+    }
+
+    // SWAR NOR is derived from existing SWAR OR followed by SWAR NOT.
+    pub const fn map_nor_swar(self, other: Self) -> Self {
+        self.map_or_swar(other).map_not_swar()
+    }
 }
 
 impl fmt::Debug for QuadroReg32 {
@@ -1534,5 +1550,96 @@ mod tests {
                 assert_eq!(a.map_or_swar(b), a.map_or_scalar(b));
             }
         }
+    }
+    #[test]
+    fn map_implies_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_implies_swar(b), a.map_implies_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_nand_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_nand_swar(b), a.map_nand_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_nor_swar_matches_scalar_samples() {
+        for a_raw in RAW_SAMPLES {
+            for b_raw in RAW_SAMPLES {
+                let a = QuadroReg32::from_raw(a_raw);
+                let b = QuadroReg32::from_raw(b_raw);
+                assert_eq!(a.map_nor_swar(b), a.map_nor_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_implies_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_implies_swar(b), a.map_implies_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_nand_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_nand_swar(b), a.map_nand_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_nor_swar_matches_scalar_repeated_state_pairs() {
+        for a_state in QuadState::ALL {
+            for b_state in QuadState::ALL {
+                let a = reg_filled(a_state);
+                let b = reg_filled(b_state);
+                assert_eq!(a.map_nor_swar(b), a.map_nor_scalar(b));
+            }
+        }
+    }
+
+    #[test]
+    fn map_implies_nand_nor_exact_checks() {
+        let t = reg_filled(QuadState::T);
+        let f = reg_filled(QuadState::F);
+        let n = reg_filled(QuadState::N);
+        let s = reg_filled(QuadState::S);
+
+        // IMPLIES
+        assert_eq!(t.map_implies_swar(f), f);
+        assert_eq!(f.map_implies_swar(t), t);
+        assert_eq!(f.map_implies_swar(n), t);
+        assert_eq!(n.map_implies_swar(f), f);
+        assert_eq!(t.map_implies_swar(t), s);
+        assert_eq!(s.map_implies_swar(n), s);
+
+        // NAND
+        assert_eq!(t.map_nand_swar(t), f);
+        assert_eq!(f.map_nand_swar(t), t);
+        assert_eq!(n.map_nand_swar(t), n);
+
+        // NOR
+        assert_eq!(f.map_nor_swar(f), t);
+        assert_eq!(t.map_nor_swar(f), f);
+        assert_eq!(n.map_nor_swar(f), n);
     }
 }


### PR DESCRIPTION
Fourth slice of #1407. Adds explicit SWAR-backed IMPLIES/NAND/NOR map methods for QuadroReg32 and verifies them against the scalar map oracle. IMPLIES uses NOT(A) join B; NAND/NOR derive from NOT(AND)/NOT(OR). No EQUIV, VM, opcode, runtime, mask, or default behavior changes.