### PR TITLE
docs(vm/format): inventory requirements for explicit QTruth opcodes

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: VM-QUAD-OPCODE-LATTICE-BRIDGE
-  title: Route quad opcodes through core-quad lattice aliases
-  type: feat
+  id: VM-FORMAT-INVENTORY-QTRUTH-OPCODES
+  title: Inventory requirements for explicit QTruth opcodes
+  type: docs
   mode: active
 
 intent:
-  summary: feat(vm): route quad opcodes through core-quad lattice aliases
-  issue: "#1446"
+  summary: docs(vm/format): inventory requirements for explicit QTruth opcodes
+  issue: "#1450"
 
 layer:
   name: core_quad
@@ -14,10 +14,9 @@ layer:
 
 scope:
   allowed_paths:
-    - crates/sm-vm/Cargo.toml
-    - crates/sm-vm/src/semcode_vm.rs
+    - docs/roadmap/core_quad/inventory_qtruth_opcodes.md
     - .harness/current.task.yaml
-    - .harness/reports/VM-QUAD-OPCODE-LATTICE-BRIDGE.md
+    - .harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md
 
   forbidden_paths:
     - crates/sm-format/**
@@ -27,7 +26,6 @@ scope:
     - crates/semantic-core-quad/**
     - crates/ton618-core/**
     - src/**
-    - docs/**
     - tests/**
     - tools/**
     - README.md
@@ -43,15 +41,13 @@ actions:
 
   forbidden:
     - change_opcodes
-    - modify_core_quad
+    - modify_rust_code
 
 verification:
   required:
-    - cargo test -p sm-vm --quiet
-    - cargo test -p semantic-core-quad --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/VM-QUAD-OPCODE-LATTICE-BRIDGE.md
+  output: .harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md

--- a/.harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md
+++ b/.harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md
@@ -1,0 +1,7 @@
+# VM-FORMAT-INVENTORY-QTRUTH-OPCODES
+
+## Status
+Completed
+
+## Details
+Created a docs-only inventory covering the required cross-crate changes needed to properly introduce explicit `QTruthAnd`, `QTruthOr`, `QTruthNot`, and `QTruthImpl` opcodes without touching any Rust code or altering VM/verifier behavior.

--- a/docs/roadmap/core_quad/inventory_qtruth_opcodes.md
+++ b/docs/roadmap/core_quad/inventory_qtruth_opcodes.md
@@ -1,0 +1,43 @@
+# QTruth Opcodes: Inventory & Implementation Roadmap
+
+## 1. Current Lattice Opcode Status
+The VM currently executes four legacy scalar quad opcodes: `QAnd`, `QOr`, `QNot`, and `QImpl`.
+As established by previous architectural audits (#1440, #1442) and the VM lattice bridge (#1444, #1446), these opcodes operate strictly on **Lattice semantics** (bitwise operations over the 2-bit state encoding mapping to mathematical meet and join). They do NOT utilize Belnap logic truth mappings.
+
+## 2. Proposed QTruth Opcode Names
+To introduce genuine truth-table semantics into the VM (evaluating the 4-state domain across orthogonal truth and falsity planes), we will introduce four distinct opcodes corresponding to the `semantic-core-quad` `map_*` methods:
+- `QTruthAnd` (Backed by `map_and`)
+- `QTruthOr` (Backed by `map_or`)
+- `QTruthNot` (Backed by `map_not`)
+- `QTruthImpl` (Backed by `map_implies`)
+
+## 3. Affected Crates
+Introducing these opcodes touches the full language and runtime contour. The affected crates are:
+- `sm-format`: Adding new opcode values to the canonical byte format representation.
+- `sm-ir`: Adding IR instructions representing the truth operations.
+- `sm-emit` / lowering: Compiling source level constructs/IR down to the new `QTruth*` opcodes.
+- `sm-verify`: Validation rules and instruction length checking for the new opcodes.
+- `sm-vm`: The actual execution block within the virtual machine loop.
+
+## 4. Required Implementation Sequence
+To prevent semantic leakage or breaking the harness, the implementation must proceed in isolated slices, strictly in this order:
+1. **Format & IR (`sm-format`, `sm-ir`)**: Register the new opcodes in the binary format enumerations and IR node structures. No logic changes.
+2. **Verifier (`sm-verify`)**: Add admission rules for the new opcodes so the runtime can successfully parse and validate modules containing them.
+3. **Execution (`sm-vm`)**: Add the execution paths for `QTruth*` in the VM instruction loop, wiring them directly to the `map_*` methods in `semantic-core-quad`.
+4. **Emitter & Lowering (`sm-emit`)**: Wire the frontend compiler/lowering layers to emit the new opcodes when truth semantics are explicitly requested by the user code.
+5. **Fixtures & Tests**: Generate updated golden SemCode fixtures and assert correct end-to-end execution.
+
+## 5. Compatibility Risks
+- **Opcode ID Shifting**: Adding opcodes to `sm-format` might shift subsequent opcode IDs if not carefully appended to the end of the current opcode range or carefully slotted into reserved spaces. This would break all existing compiled SemCode modules.
+- **Naming Confusion**: The similarity in names (`QAnd` vs `QTruthAnd`) might lead to incorrect lowering if the emitter is updated indiscriminately.
+
+## 6. Tests Required Before Implementation
+- Format snapshot tests proving existing opcodes retain their current byte values.
+- Verifier tests asserting rejection of malformed or unexpected opcode arguments for the new types.
+- VM tests explicitly comparing `QTruth*` behavior against the `semantic-core-quad` truth mappings, alongside tests confirming legacy `QAnd` etc. remain unchanged.
+
+## 7. Explicit Out-of-Scope List
+- Renaming or deprecating existing `QAnd`, `QOr`, `QNot`, `QImpl` opcodes.
+- Modifying any logic inside `semantic-core-quad`.
+- Introducing equivalence checking (`EQUIV`) or NAND/NOR opcodes.
+- Any "hidden adapters" or falsity plane inversions to make lattice opcodes behave like truth opcodes.


### PR DESCRIPTION
Closes #1450. Creates a docs-only inventory outlining the required sequence, affected crates, and compatibility risks for properly introducing explicit Belnap truth-table quad opcodes (QTruthAnd, QTruthOr, QTruthNot, QTruthImpl) to the semantic runtime. No code changes.