### PR TITLE
docs(format): reserve explicit QTruth opcode slots

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,28 +1,29 @@
 task:
-  id: VM-FORMAT-INVENTORY-QTRUTH-OPCODES
-  title: Inventory requirements for explicit QTruth opcodes
+  id: FORMAT-RESERVE-QTRUTH-SLOTS
+  title: Reserve explicit QTruth opcode slots
   type: docs
   mode: active
 
 intent:
-  summary: docs(vm/format): inventory requirements for explicit QTruth opcodes
-  issue: "#1450"
+  summary: docs(format): reserve explicit QTruth opcode slots
+  issue: "#1452"
 
 layer:
   name: core_quad
-  owner: sm-vm
+  owner: sm-format
 
 scope:
   allowed_paths:
-    - docs/roadmap/core_quad/inventory_qtruth_opcodes.md
+    - docs/roadmap/core_quad/qtruth_opcode_reservation.md
     - .harness/current.task.yaml
-    - .harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md
+    - .harness/reports/FORMAT-RESERVE-QTRUTH-SLOTS.md
 
   forbidden_paths:
     - crates/sm-format/**
     - crates/sm-ir/**
     - crates/sm-emit/**
     - crates/sm-verify/**
+    - crates/sm-vm/**
     - crates/semantic-core-quad/**
     - crates/ton618-core/**
     - src/**
@@ -40,7 +41,6 @@ actions:
     - create_pr
 
   forbidden:
-    - change_opcodes
     - modify_rust_code
 
 verification:
@@ -50,4 +50,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/VM-FORMAT-INVENTORY-QTRUTH-OPCODES.md
+  output: .harness/reports/FORMAT-RESERVE-QTRUTH-SLOTS.md

--- a/.harness/reports/FORMAT-RESERVE-QTRUTH-SLOTS.md
+++ b/.harness/reports/FORMAT-RESERVE-QTRUTH-SLOTS.md
@@ -1,0 +1,7 @@
+# FORMAT-RESERVE-QTRUTH-SLOTS
+
+## Status
+Completed
+
+## Details
+Created the formal format decision document determining exactly which byte slots will be allocated to `QTruthAnd`, `QTruthOr`, `QTruthNot`, and `QTruthImpl` to guarantee full backward compatibility across existing compiled artifacts. No Rust code was modified.

--- a/docs/roadmap/core_quad/qtruth_opcode_reservation.md
+++ b/docs/roadmap/core_quad/qtruth_opcode_reservation.md
@@ -1,0 +1,32 @@
+# QTruth Opcode Reservation
+
+## 1. Goal
+Record the format decision detailing exactly where and how the new explicit `QTruth` opcodes will be mapped in the `sm-format` byte enumeration to ensure full backward compatibility.
+
+## 2. Backward Compatibility Policy
+The `sm-format` canonical byte values are permanently frozen for all existing opcodes. Modifying the numeric value of an existing opcode constitutes a breaking change to the language and runtime, invalidating previously compiled modules.
+- **Rule 1: Byte-Value Freeze:** No existing opcode may change its assigned numeric ID.
+- **Rule 2: Append-Only unless Reserved:** New opcodes must either append to the highest available contiguous integer range or utilize explicitly empty blocks of unused slots that group logically with their domain.
+
+## 3. Byte Layout Analysis
+Within `crates/sm-format/src/local_format.rs`, logical and quad operations occupy the `0x10` through `0x16` range:
+- `QAnd` = 0x10
+- `QOr` = 0x11
+- `QNot` = 0x12
+- `QImpl` = 0x13
+- `BoolAnd` = 0x14
+- `BoolOr` = 0x15
+- `BoolNot` = 0x16
+
+The contiguous byte slots immediately following this block (`0x17`, `0x18`, `0x19`, `0x1a`) are currently unused. Comparisons (`Cmp*`) begin at `0x20`.
+
+## 4. Slot Reservations
+To group the new truth-table semantic operations with the existing logical/boolean operations without disrupting the layout, we reserve the unused `0x17` through `0x1A` block.
+
+The formal reservations are:
+- `QTruthAnd` = 0x17
+- `QTruthOr`  = 0x18
+- `QTruthNot` = 0x19
+- `QTruthImpl` = 0x1A
+
+This allocation strictly adheres to the append/reserve policy and protects all existing compiled binaries.


### PR DESCRIPTION
Closes #1452. Documents the format decision establishing the strict byte-value freeze for existing opcodes, and formally reserves the 0x17-0x1A block for QTruthAnd, QTruthOr, QTruthNot, and QTruthImpl to preserve backward compatibility. No Rust code modified.