### PR TITLE
test(verify/vm): lock unsupported QTruth opcode boundary

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,27 +1,26 @@
 task:
-  id: FORMAT-QTRUTH-OPCODE-SLOTS
-  title: Add QTruth opcode enum slots
-  type: feat
+  id: VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY
+  title: lock unsupported QTruth opcode boundary
+  type: test
   mode: active
 
 intent:
-  summary: feat(format): add QTruth opcode enum slots
-  issue: "#1454"
+  summary: test(verify/vm): lock unsupported QTruth opcode boundary
+  issue: "#1456"
 
 layer:
   name: core_quad
-  owner: sm-format
+  owner: sm-verify
 
 scope:
   allowed_paths:
-    - crates/sm-format/src/local_format.rs
-    - crates/sm-format/src/lib.rs
     - crates/sm-verify/src/lib.rs
     - crates/sm-vm/src/semcode_vm.rs
     - .harness/current.task.yaml
-    - .harness/reports/FORMAT-QTRUTH-OPCODE-SLOTS.md
+    - .harness/reports/VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY.md
 
   forbidden_paths:
+    - crates/sm-format/**
     - crates/sm-ir/**
     - crates/sm-emit/**
     - crates/semantic-core-quad/**
@@ -43,17 +42,22 @@ actions:
 
   forbidden:
     - implement_qtruth_execution
-    - modify_ir
-    - modify_emit
+    - add_ir_instructions
+    - add_emitter_support
+    - modify_opcode_byte_values
     - modify_core_quad
-    - add_qtruth_lowering
+    - use_hidden_adapters
+    - route_qtruth_through_lattice_aliases
+    - add_equiv_nand_nor
 
 verification:
   required:
-    - cargo test -p sm-format --quiet
+    - cargo test -p sm-verify --quiet
+    - cargo test -p sm-vm --quiet
+    - cargo test -p sm-vm --features vm-profile --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/FORMAT-QTRUTH-OPCODE-SLOTS.md
+  output: .harness/reports/VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY.md

--- a/.harness/reports/VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY.md
+++ b/.harness/reports/VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY.md
@@ -1,0 +1,19 @@
+# VERIFY-VM-QTRUTH-UNSUPPORTED-BOUNDARY
+
+## Status
+Completed
+
+## Details
+Added tests locking the transitional QTruth opcode boundary after #1455.
+
+- sm-verify accepts structurally valid QTruth operand encodings.
+- sm-verify rejects truncated QTruth operands.
+- sm-vm rejects QTruth opcodes at load/disassembly boundaries as unsupported.
+- No QTruth execution, lowering, IR, emitter, semantic-core-quad, opcode byte, hidden adapter, or lattice fallback changes were added.
+
+## Verification
+- cargo test -p sm-verify --quiet
+- cargo test -p sm-vm --quiet
+- cargo test -p sm-vm --features vm-profile --quiet
+- git diff --check
+- scripts/harness-check.ps1

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -2383,7 +2383,6 @@ mod tests {
 
         bytes.splice(opcode_pos..opcode_pos + 2, new_code.iter().copied());
 
-        let old_code_len = 4; // 2 bytes for string count + 2 bytes for instructions
         let new_code_len = 2 + new_code.len();
         bytes[code_len_pos..code_len_pos + 4].copy_from_slice(&(new_code_len as u32).to_le_bytes());
 

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -2350,4 +2350,61 @@ mod tests {
         assert_eq!(entry_token.bytes(), token.bytes());
         assert_eq!(entry_token.program(), token.program());
     }
+
+    #[test]
+    fn verifier_accepts_unsupported_qtruth_opcodes() {
+        let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
+        let (_, code_start, code_end) = function_code_span(&bytes, "main");
+
+        let mut new_code = Vec::new();
+        // QTruthAnd (0x17)
+        new_code.push(0x17);
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        // QTruthOr (0x18)
+        new_code.push(0x18);
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        // QTruthNot (0x19)
+        new_code.push(0x19);
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        // QTruthImpl (0x1A)
+        new_code.push(0x1A);
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes());
+        // Ret
+        new_code.push(Opcode::Ret as u8);
+        new_code.push(0);
+
+        bytes.splice(code_start..code_end, new_code.iter().copied());
+
+        let new_code_len = new_code.len();
+        bytes[code_start - 4..code_start].copy_from_slice(&(new_code_len as u32).to_le_bytes());
+
+        let verified = verify_semcode(&bytes).expect("verify");
+        assert_eq!(verified.functions.len(), 1);
+    }
+
+    #[test]
+    fn verifier_rejects_truncated_qtruth_opcodes() {
+        let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
+        let (_, code_start, code_end) = function_code_span(&bytes, "main");
+
+        let mut new_code = Vec::new();
+        // QTruthAnd (0x17) with truncated src
+        new_code.push(0x17);
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
+
+        bytes.splice(code_start..code_end, new_code.iter().copied());
+
+        let new_code_len = new_code.len();
+        bytes[code_start - 4..code_start].copy_from_slice(&(new_code_len as u32).to_le_bytes());
+
+        let report = verify_semcode(&bytes).expect_err("must reject");
+        assert_eq!(
+            report.diagnostics[0].code,
+            VerificationCode::OperandOutOfBounds
+        );
+    }
 }

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -2354,34 +2354,39 @@ mod tests {
     #[test]
     fn verifier_accepts_unsupported_qtruth_opcodes() {
         let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
-        let (_, code_start, code_end) = function_code_span(&bytes, "main");
-
+        let code_len_pos = 8 + 2 + 4;
+        let opcode_pos = code_len_pos + 4 + 2;
+        
         let mut new_code = Vec::new();
         // QTruthAnd (0x17)
         new_code.push(0x17);
-        new_code.extend_from_slice(&0u16.to_le_bytes());
-        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
         // QTruthOr (0x18)
         new_code.push(0x18);
-        new_code.extend_from_slice(&0u16.to_le_bytes());
-        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
         // QTruthNot (0x19)
         new_code.push(0x19);
-        new_code.extend_from_slice(&0u16.to_le_bytes());
-        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // src
         // QTruthImpl (0x1A)
         new_code.push(0x1A);
-        new_code.extend_from_slice(&0u16.to_le_bytes());
-        new_code.extend_from_slice(&0u16.to_le_bytes());
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
+        new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
         // Ret
         new_code.push(Opcode::Ret as u8);
         new_code.push(0);
-
-        bytes.splice(code_start..code_end, new_code.iter().copied());
-
-        let new_code_len = new_code.len();
-        bytes[code_start - 4..code_start].copy_from_slice(&(new_code_len as u32).to_le_bytes());
-
+        
+        bytes.splice(opcode_pos..opcode_pos + 2, new_code.iter().copied());
+        
+        let old_code_len = 4; // 2 bytes for string count + 2 bytes for instructions
+        let new_code_len = 2 + new_code.len();
+        bytes[code_len_pos..code_len_pos + 4].copy_from_slice(&(new_code_len as u32).to_le_bytes());
+        
         let verified = verify_semcode(&bytes).expect("verify");
         assert_eq!(verified.functions.len(), 1);
     }
@@ -2389,18 +2394,10 @@ mod tests {
     #[test]
     fn verifier_rejects_truncated_qtruth_opcodes() {
         let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
-        let (_, code_start, code_end) = function_code_span(&bytes, "main");
-
-        let mut new_code = Vec::new();
-        // QTruthAnd (0x17) with truncated src
-        new_code.push(0x17);
-        new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
-
-        bytes.splice(code_start..code_end, new_code.iter().copied());
-
-        let new_code_len = new_code.len();
-        bytes[code_start - 4..code_start].copy_from_slice(&(new_code_len as u32).to_le_bytes());
-
+        let opcode_pos = 8 + 2 + 4 + 4 + 2;
+        
+        bytes[opcode_pos] = 0x17; // QTruthAnd (requires 4 operands bytes, only 1 left)
+        
         let report = verify_semcode(&bytes).expect_err("must reject");
         assert_eq!(
             report.diagnostics[0].code,

--- a/crates/sm-verify/src/lib.rs
+++ b/crates/sm-verify/src/lib.rs
@@ -2356,37 +2356,37 @@ mod tests {
         let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
         let code_len_pos = 8 + 2 + 4;
         let opcode_pos = code_len_pos + 4 + 2;
-        
+
         let mut new_code = Vec::new();
         // QTruthAnd (0x17)
         new_code.push(0x17);
         new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
         new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
         new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
-        // QTruthOr (0x18)
+                                                         // QTruthOr (0x18)
         new_code.push(0x18);
         new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
         new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
         new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
-        // QTruthNot (0x19)
+                                                         // QTruthNot (0x19)
         new_code.push(0x19);
         new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
         new_code.extend_from_slice(&0u16.to_le_bytes()); // src
-        // QTruthImpl (0x1A)
+                                                         // QTruthImpl (0x1A)
         new_code.push(0x1A);
         new_code.extend_from_slice(&0u16.to_le_bytes()); // dst
         new_code.extend_from_slice(&0u16.to_le_bytes()); // lhs
         new_code.extend_from_slice(&0u16.to_le_bytes()); // rhs
-        // Ret
+                                                         // Ret
         new_code.push(Opcode::Ret as u8);
         new_code.push(0);
-        
+
         bytes.splice(opcode_pos..opcode_pos + 2, new_code.iter().copied());
-        
+
         let old_code_len = 4; // 2 bytes for string count + 2 bytes for instructions
         let new_code_len = 2 + new_code.len();
         bytes[code_len_pos..code_len_pos + 4].copy_from_slice(&(new_code_len as u32).to_le_bytes());
-        
+
         let verified = verify_semcode(&bytes).expect("verify");
         assert_eq!(verified.functions.len(), 1);
     }
@@ -2395,9 +2395,9 @@ mod tests {
     fn verifier_rejects_truncated_qtruth_opcodes() {
         let mut bytes = compile_program_to_semcode("fn main() { return; }").expect("compile");
         let opcode_pos = 8 + 2 + 4 + 4 + 2;
-        
+
         bytes[opcode_pos] = 0x17; // QTruthAnd (requires 4 operands bytes, only 1 left)
-        
+
         let report = verify_semcode(&bytes).expect_err("must reject");
         assert_eq!(
             report.diagnostics[0].code,

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -4733,6 +4733,30 @@ mod tests {
     }
 
     #[test]
+    fn vm_rejects_unsupported_qtruth_opcodes_on_load() {
+        for opcode in [0x17, 0x18, 0x19, 0x1A] {
+            let src = "fn main() { return; }";
+            let mut bytes = compile_program_to_semcode(src).expect("compile");
+            let opcode_pos = 8 + 2 + 4 + 4 + 2;
+            bytes[opcode_pos] = opcode;
+            let err = run_semcode(&bytes).expect_err("must fail");
+            assert!(matches!(err, RuntimeError::BadFormat(_)));
+        }
+    }
+
+    #[test]
+    fn vm_disassembler_rejects_unsupported_qtruth_opcodes() {
+        for opcode in [0x17, 0x18, 0x19, 0x1A] {
+            let src = "fn main() { return; }";
+            let mut bytes = compile_program_to_semcode(src).expect("compile");
+            let opcode_pos = 8 + 2 + 4 + 4 + 2;
+            bytes[opcode_pos] = opcode;
+            let err = disasm_semcode(&bytes).expect_err("must fail disasm");
+            assert!(matches!(err, RuntimeError::BadFormat(_)));
+        }
+    }
+
+    #[test]
     fn vm_rejects_unsupported_bytecode_version_with_hint() {
         let src = "fn main() { return; }";
         let mut bytes = compile_program_to_semcode(src).expect("compile");


### PR DESCRIPTION
Closes #1456. Adds tests that lock the transitional QTruth boundary after #1455. sm-verify now explicitly accepts structurally valid QTruth operand encodings and rejects malformed/truncated QTruth bytecode, while sm-vm load/disassembly paths explicitly reject QTruth opcodes as unsupported until the dedicated execution slice. No sm-format, sm-ir, sm-emit, semantic-core-quad, QTruth lowering, QTruth execution semantics, hidden adapters, or lattice fallback changes are added.