### PR TITLE
feat(sm-ir): add explicit QTruth instruction representation

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,27 +1,28 @@
 task:
-  id: VM-QTRUTH-EXECUTION
-  title: execute QTruth opcodes through semantic-core-quad truth maps
+  id: SM-IR-QTRUTH-REPRESENTATION
+  title: add explicit QTruth instruction representation
   type: feat
   mode: active
 
 intent:
-  summary: "feat(vm): execute QTruth opcodes through semantic-core-quad truth maps"
-  issue: "#1458"
+  summary: "feat(sm-ir): add explicit QTruth instruction representation"
+  issue: "#1460"
 
 layer:
   name: core_quad
-  owner: sm-vm
+  owner: sm-ir
 
 scope:
   allowed_paths:
-    - crates/sm-vm/src/semcode_vm.rs
+    - crates/sm-ir/src/legacy_lowering.rs
+    - crates/sm-ir/src/passes/crystalfold.rs
     - .harness/current.task.yaml
-    - .harness/reports/VM-QTRUTH-EXECUTION.md
+    - .harness/reports/SM-IR-QTRUTH-REPRESENTATION.md
 
   forbidden_paths:
     - crates/sm-format/**
     - crates/sm-verify/**
-    - crates/sm-ir/**
+    - crates/sm-vm/**
     - crates/sm-emit/**
     - crates/semantic-core-quad/**
     - crates/ton618-core/**
@@ -35,31 +36,32 @@ scope:
 
 actions:
   allowed:
-    - read
-    - edit_allowed_paths
-    - push
+    - inspect
+    - edit
+    - test
+    - commit
     - create_pr
 
   forbidden:
     - modify_opcode_byte_values
     - change_verifier_behavior
-    - add_ir_instructions
+    - change_vm_behavior
     - add_emitter_support
+    - add_lowering_support
     - touch_semantic_core_quad
     - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
     - invert_falsity_planes
     - add_equiv_nand_nor
     - change_legacy_lattice_behavior
+    - fold_qtruth_constants
 
 verification:
   required:
-    - cargo test -p sm-vm --quiet
-    - cargo test -p sm-vm --features vm-profile --quiet
-    - cargo test -p sm-verify --quiet
+    - cargo test -p sm-ir --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/VM-QTRUTH-EXECUTION.md
+  output: .harness/reports/SM-IR-QTRUTH-REPRESENTATION.md

--- a/.harness/reports/SM-IR-QTRUTH-REPRESENTATION.md
+++ b/.harness/reports/SM-IR-QTRUTH-REPRESENTATION.md
@@ -1,0 +1,37 @@
+# SM-IR-QTRUTH-REPRESENTATION
+
+## Status
+
+Completed.
+
+## Summary
+
+Added explicit sm-ir representation for QTruth operations.
+
+## Added representation
+
+- QTruthAnd
+- QTruthOr
+- QTruthNot
+- QTruthImpl
+
+## Boundary
+
+This slice is IR representation only.
+
+No sm-format opcode values were changed.
+No sm-verify behavior was changed.
+No sm-vm behavior was changed.
+No sm-emit lowering was added.
+No semantic-core-quad behavior was changed.
+No legacy lattice QAnd/QOr/QNot/QImpl behavior was changed.
+CrystalFold was updated only to keep exhaustive IR matching representation-preserving for QTruth operations.
+
+No QTruth constant folding was added.
+
+## Verification
+
+- cargo test -p sm-ir --quiet
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -212,6 +212,25 @@ pub enum IrInstr {
         lhs: u16,
         rhs: u16,
     },
+    QTruthAnd {
+        dst: u16,
+        lhs: u16,
+        rhs: u16,
+    },
+    QTruthOr {
+        dst: u16,
+        lhs: u16,
+        rhs: u16,
+    },
+    QTruthNot {
+        dst: u16,
+        src: u16,
+    },
+    QTruthImpl {
+        dst: u16,
+        lhs: u16,
+        rhs: u16,
+    },
     BoolAnd {
         dst: u16,
         lhs: u16,
@@ -1310,6 +1329,9 @@ fn encoded_size(instr: &IrInstr) -> Option<usize> {
         IrInstr::QAnd { .. }
         | IrInstr::QOr { .. }
         | IrInstr::QImpl { .. }
+        | IrInstr::QTruthAnd { .. }
+        | IrInstr::QTruthOr { .. }
+        | IrInstr::QTruthImpl { .. }
         | IrInstr::BoolAnd { .. }
         | IrInstr::BoolOr { .. }
         | IrInstr::CmpEq { .. }
@@ -1329,7 +1351,7 @@ fn encoded_size(instr: &IrInstr) -> Option<usize> {
         | IrInstr::SubFx { .. }
         | IrInstr::MulFx { .. }
         | IrInstr::DivFx { .. } => 1 + 2 + 2 + 2,
-        IrInstr::QNot { .. } | IrInstr::BoolNot { .. } => 1 + 2 + 2,
+        IrInstr::QNot { .. } | IrInstr::QTruthNot { .. } | IrInstr::BoolNot { .. } => 1 + 2 + 2,
         IrInstr::Jmp { .. } => 1 + 4,
         IrInstr::JmpIf { .. } => 1 + 2 + 4,
         IrInstr::Assert { .. } => 1 + 2,
@@ -1620,6 +1642,15 @@ fn emit_instr(
         IrInstr::QOr { dst, lhs, rhs } => emit_3reg(Opcode::QOr, *dst, *lhs, *rhs, out),
         IrInstr::QNot { dst, src } => emit_2reg(Opcode::QNot, *dst, *src, out),
         IrInstr::QImpl { dst, lhs, rhs } => emit_3reg(Opcode::QImpl, *dst, *lhs, *rhs, out),
+        IrInstr::QTruthAnd { .. }
+        | IrInstr::QTruthOr { .. }
+        | IrInstr::QTruthNot { .. }
+        | IrInstr::QTruthImpl { .. } => {
+            return Err(FrontendError {
+                pos: 0,
+                message: "QTruth IR instructions are not encodable yet".to_string(),
+            });
+        }
         IrInstr::BoolAnd { dst, lhs, rhs } => emit_3reg(Opcode::BoolAnd, *dst, *lhs, *rhs, out),
         IrInstr::BoolOr { dst, lhs, rhs } => emit_3reg(Opcode::BoolOr, *dst, *lhs, *rhs, out),
         IrInstr::BoolNot { dst, src } => emit_2reg(Opcode::BoolNot, *dst, *src, out),
@@ -12152,5 +12183,49 @@ mod opt_tests {
             i,
             IrInstr::LoadF64 { dst: 5, val } if (*val - 5.0).abs() < f64::EPSILON
         )));
+    }
+
+    #[test]
+    fn qtruth_instructions_are_distinct_from_legacy_lattice_instructions() {
+        assert_ne!(
+            IrInstr::QTruthAnd {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            },
+            IrInstr::QAnd {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            }
+        );
+        assert_ne!(
+            IrInstr::QTruthOr {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            },
+            IrInstr::QOr {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            }
+        );
+        assert_ne!(
+            IrInstr::QTruthNot { dst: 0, src: 1 },
+            IrInstr::QNot { dst: 0, src: 1 }
+        );
+        assert_ne!(
+            IrInstr::QTruthImpl {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            },
+            IrInstr::QImpl {
+                dst: 0,
+                lhs: 1,
+                rhs: 2,
+            }
+        );
     }
 }

--- a/crates/sm-ir/src/passes/crystalfold.rs
+++ b/crates/sm-ir/src/passes/crystalfold.rs
@@ -444,6 +444,22 @@ fn fold_constants_and_identities(instrs: &mut Vec<IrInstr>) -> u32 {
                     }
                 }
             }
+            IrInstr::QTruthAnd { dst, lhs, rhs } => {
+                cst.remove(&dst);
+                out.push(IrInstr::QTruthAnd { dst, lhs, rhs });
+            }
+            IrInstr::QTruthOr { dst, lhs, rhs } => {
+                cst.remove(&dst);
+                out.push(IrInstr::QTruthOr { dst, lhs, rhs });
+            }
+            IrInstr::QTruthNot { dst, src } => {
+                cst.remove(&dst);
+                out.push(IrInstr::QTruthNot { dst, src });
+            }
+            IrInstr::QTruthImpl { dst, lhs, rhs } => {
+                cst.remove(&dst);
+                out.push(IrInstr::QTruthImpl { dst, lhs, rhs });
+            }
             IrInstr::CmpEq { dst, lhs, rhs } => {
                 match (cst.get(&lhs).copied(), cst.get(&rhs).copied()) {
                     (Some(a), Some(b)) => {


### PR DESCRIPTION
Closes #1460. Adds explicit sm-ir representation for QTruthAnd/QTruthOr/QTruthNot/QTruthImpl, distinct from legacy lattice QAnd/QOr/QNot/QImpl. CrystalFold preserves QTruth instructions without folding. This is representation only: no sm-format, sm-verify, sm-vm, sm-emit, semantic-core-quad, opcode byte, lowering, truth-table folding, hidden adapter, falsity-plane inversion, or legacy lattice behavior changes.