### PR TITLE
feat(sm-ir): encode explicit QTruth IR instructions

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: SM-IR-QTRUTH-REPRESENTATION
-  title: add explicit QTruth instruction representation
+  id: SM-IR-QTRUTH-ENCODING
+  title: encode explicit QTruth IR instructions to QTruth opcodes
   type: feat
   mode: active
 
 intent:
-  summary: "feat(sm-ir): add explicit QTruth instruction representation"
-  issue: "#1460"
+  summary: "feat(sm-ir): encode explicit QTruth IR instructions to QTruth opcodes"
+  issue: "#1462"
 
 layer:
   name: core_quad
@@ -15,9 +15,8 @@ layer:
 scope:
   allowed_paths:
     - crates/sm-ir/src/legacy_lowering.rs
-    - crates/sm-ir/src/passes/crystalfold.rs
     - .harness/current.task.yaml
-    - .harness/reports/SM-IR-QTRUTH-REPRESENTATION.md
+    - .harness/reports/SM-IR-QTRUTH-ENCODING.md
 
   forbidden_paths:
     - crates/sm-format/**
@@ -46,15 +45,17 @@ actions:
     - modify_opcode_byte_values
     - change_verifier_behavior
     - change_vm_behavior
-    - add_emitter_support
-    - add_lowering_support
+    - touch_sm_format
+    - touch_sm_emit
     - touch_semantic_core_quad
+    - add_parser_syntax
+    - add_frontend_syntax
+    - fold_qtruth_constants
     - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
     - invert_falsity_planes
     - add_equiv_nand_nor
     - change_legacy_lattice_behavior
-    - fold_qtruth_constants
 
 verification:
   required:
@@ -64,4 +65,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/SM-IR-QTRUTH-REPRESENTATION.md
+  output: .harness/reports/SM-IR-QTRUTH-ENCODING.md

--- a/.harness/reports/SM-IR-QTRUTH-ENCODING.md
+++ b/.harness/reports/SM-IR-QTRUTH-ENCODING.md
@@ -1,0 +1,36 @@
+# SM-IR-QTRUTH-ENCODING
+
+## Status
+
+Completed.
+
+## Summary
+
+Encoded explicit QTruth IR instructions to their reserved QTruth opcodes.
+
+## Mapping
+
+- IrInstr::QTruthAnd -> Opcode::QTruthAnd
+- IrInstr::QTruthOr -> Opcode::QTruthOr
+- IrInstr::QTruthNot -> Opcode::QTruthNot
+- IrInstr::QTruthImpl -> Opcode::QTruthImpl
+
+## Boundary
+
+This slice is IR-to-bytecode encoding only.
+
+No sm-format opcode values were changed.
+No sm-verify behavior was changed.
+No sm-vm behavior was changed.
+No sm-emit crate changes were made.
+No semantic-core-quad behavior was changed.
+No parser or frontend syntax was added.
+No QTruth constant folding was added.
+No legacy lattice QAnd/QOr/QNot/QImpl behavior was changed.
+
+## Verification
+
+- cargo test -p sm-ir --quiet
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -1642,14 +1642,11 @@ fn emit_instr(
         IrInstr::QOr { dst, lhs, rhs } => emit_3reg(Opcode::QOr, *dst, *lhs, *rhs, out),
         IrInstr::QNot { dst, src } => emit_2reg(Opcode::QNot, *dst, *src, out),
         IrInstr::QImpl { dst, lhs, rhs } => emit_3reg(Opcode::QImpl, *dst, *lhs, *rhs, out),
-        IrInstr::QTruthAnd { .. }
-        | IrInstr::QTruthOr { .. }
-        | IrInstr::QTruthNot { .. }
-        | IrInstr::QTruthImpl { .. } => {
-            return Err(FrontendError {
-                pos: 0,
-                message: "QTruth IR instructions are not encodable yet".to_string(),
-            });
+        IrInstr::QTruthAnd { dst, lhs, rhs } => emit_3reg(Opcode::QTruthAnd, *dst, *lhs, *rhs, out),
+        IrInstr::QTruthOr { dst, lhs, rhs } => emit_3reg(Opcode::QTruthOr, *dst, *lhs, *rhs, out),
+        IrInstr::QTruthNot { dst, src } => emit_2reg(Opcode::QTruthNot, *dst, *src, out),
+        IrInstr::QTruthImpl { dst, lhs, rhs } => {
+            emit_3reg(Opcode::QTruthImpl, *dst, *lhs, *rhs, out)
         }
         IrInstr::BoolAnd { dst, lhs, rhs } => emit_3reg(Opcode::BoolAnd, *dst, *lhs, *rhs, out),
         IrInstr::BoolOr { dst, lhs, rhs } => emit_3reg(Opcode::BoolOr, *dst, *lhs, *rhs, out),
@@ -12226,6 +12223,79 @@ mod opt_tests {
                 lhs: 1,
                 rhs: 2,
             }
+        );
+    }
+
+    #[test]
+    fn qtruth_and_legacy_instructions_encode_to_distinct_opcode_bytes() {
+        fn encode(instr: IrInstr) -> Vec<u8> {
+            let mut out = Vec::new();
+            emit_instr(
+                &instr,
+                &HashMap::new(),
+                &StringInterner::default(),
+                &mut out,
+            )
+            .expect("instruction should encode");
+            out
+        }
+
+        assert_eq!(
+            encode(IrInstr::QTruthAnd {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QTruthAnd.byte(), 1, 0, 2, 0, 3, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QTruthOr {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QTruthOr.byte(), 1, 0, 2, 0, 3, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QTruthNot { dst: 1, src: 2 }),
+            vec![Opcode::QTruthNot.byte(), 1, 0, 2, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QTruthImpl {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QTruthImpl.byte(), 1, 0, 2, 0, 3, 0]
+        );
+
+        assert_eq!(
+            encode(IrInstr::QAnd {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QAnd.byte(), 1, 0, 2, 0, 3, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QOr {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QOr.byte(), 1, 0, 2, 0, 3, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QNot { dst: 1, src: 2 }),
+            vec![Opcode::QNot.byte(), 1, 0, 2, 0]
+        );
+        assert_eq!(
+            encode(IrInstr::QImpl {
+                dst: 1,
+                lhs: 2,
+                rhs: 3,
+            }),
+            vec![Opcode::QImpl.byte(), 1, 0, 2, 0, 3, 0]
         );
     }
 }


### PR DESCRIPTION
Closes #1462. Encodes explicit QTruth IR instructions to their reserved QTruth opcodes: QTruthAnd/QTruthOr/QTruthNot/QTruthImpl. This is IR-to-bytecode encoding only: no sm-format, sm-verify, sm-vm, sm-emit crate, semantic-core-quad, opcode byte, parser syntax, frontend syntax, QTruth folding, hidden adapter, falsity-plane inversion, or legacy lattice behavior changes.