### PR TITLE
test(sm-ir): guard QTruth SemCode envelope emission

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: SM-IR-QTRUTH-ENCODING
-  title: encode explicit QTruth IR instructions to QTruth opcodes
-  type: feat
+  id: SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD
+  title: add SemCode envelope guard for QTruth IR encoding
+  type: test
   mode: active
 
 intent:
-  summary: "feat(sm-ir): encode explicit QTruth IR instructions to QTruth opcodes"
-  issue: "#1462"
+  summary: "test(sm-ir): add SemCode envelope guard for QTruth IR encoding"
+  issue: "#1464"
 
 layer:
   name: core_quad
@@ -16,7 +16,7 @@ scope:
   allowed_paths:
     - crates/sm-ir/src/legacy_lowering.rs
     - .harness/current.task.yaml
-    - .harness/reports/SM-IR-QTRUTH-ENCODING.md
+    - .harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md
 
   forbidden_paths:
     - crates/sm-format/**
@@ -46,10 +46,12 @@ actions:
     - change_verifier_behavior
     - change_vm_behavior
     - touch_sm_format
+    - touch_sm_vm
     - touch_sm_emit
     - touch_semantic_core_quad
     - add_parser_syntax
     - add_frontend_syntax
+    - add_cargo_dependencies
     - fold_qtruth_constants
     - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
@@ -65,4 +67,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/SM-IR-QTRUTH-ENCODING.md
+  output: .harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md

--- a/.harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md
+++ b/.harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md
@@ -1,0 +1,37 @@
+# SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD
+
+## Status
+
+Completed.
+
+## Summary
+
+Added sm-ir tests proving QTruth IR instructions survive full SemCode envelope emission.
+
+## Covered instructions
+
+- IrInstr::QTruthAnd
+- IrInstr::QTruthOr
+- IrInstr::QTruthNot
+- IrInstr::QTruthImpl
+
+## Boundary
+
+This slice is an sm-ir SemCode envelope guard only.
+
+No sm-format opcode values were changed.
+No sm-verify behavior was changed.
+No sm-vm behavior was changed.
+No sm-emit crate changes were made.
+No semantic-core-quad behavior was changed.
+No parser or frontend syntax was added.
+No Cargo dependencies were added.
+No QTruth constant folding was added.
+No legacy lattice QAnd/QOr/QNot/QImpl behavior was changed.
+
+## Verification
+
+- cargo test -p sm-ir --quiet
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -12298,4 +12298,68 @@ mod opt_tests {
             vec![Opcode::QImpl.byte(), 1, 0, 2, 0, 3, 0]
         );
     }
+
+    #[test]
+    fn qtruth_instructions_survive_semcode_envelope_emission() {
+        fn assert_opcode_in_envelope(instr: IrInstr, expected_opcode: u8) {
+            let semcode = emit_ir_to_semcode(
+                &[IrFunction {
+                    name: "main".to_string(),
+                    instrs: vec![
+                        IrInstr::LoadQ {
+                            dst: 0,
+                            val: QuadVal::N,
+                        },
+                        IrInstr::LoadQ {
+                            dst: 1,
+                            val: QuadVal::T,
+                        },
+                        instr,
+                        IrInstr::Ret { src: Some(2) },
+                    ],
+                    ownership_events: Vec::new(),
+                }],
+                false,
+            )
+            .expect("QTruth IR should emit through the SemCode envelope");
+
+            let (_, functions) =
+                decode_semcode_envelope(&semcode).expect("SemCode envelope should decode");
+            let main = functions
+                .iter()
+                .find(|function| function.name == "main")
+                .expect("main function should be present");
+            let instruction_stream = &main.code_slice[main.instr_start_offset..];
+            assert_eq!(instruction_stream[8], expected_opcode);
+        }
+
+        assert_opcode_in_envelope(
+            IrInstr::QTruthAnd {
+                dst: 2,
+                lhs: 0,
+                rhs: 1,
+            },
+            Opcode::QTruthAnd.byte(),
+        );
+        assert_opcode_in_envelope(
+            IrInstr::QTruthOr {
+                dst: 2,
+                lhs: 0,
+                rhs: 1,
+            },
+            Opcode::QTruthOr.byte(),
+        );
+        assert_opcode_in_envelope(
+            IrInstr::QTruthNot { dst: 2, src: 0 },
+            Opcode::QTruthNot.byte(),
+        );
+        assert_opcode_in_envelope(
+            IrInstr::QTruthImpl {
+                dst: 2,
+                lhs: 0,
+                rhs: 1,
+            },
+            Opcode::QTruthImpl.byte(),
+        );
+    }
 }


### PR DESCRIPTION
Closes #1464. Adds sm-ir tests proving QTruth IR instructions survive full SemCode envelope emission and produce the expected QTruth opcode bytes. This is an sm-ir emission guard only: no sm-format, sm-verify, sm-vm, sm-emit crate, semantic-core-quad, opcode byte, parser syntax, frontend syntax, Cargo dependency, QTruth folding, hidden adapter, falsity-plane inversion, or legacy lattice behavior changes.