### PR TITLE
audit(sm-ir): inventory QTruth source admission path

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD
-  title: add SemCode envelope guard for QTruth IR encoding
-  type: test
+  id: SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY
+  title: inventory QTruth source admission path
+  type: audit
   mode: active
 
 intent:
-  summary: "test(sm-ir): add SemCode envelope guard for QTruth IR encoding"
-  issue: "#1464"
+  summary: "audit(sm-ir): inventory QTruth source admission path"
+  issue: "#1466"
 
 layer:
   name: core_quad
@@ -14,17 +14,11 @@ layer:
 
 scope:
   allowed_paths:
-    - crates/sm-ir/src/legacy_lowering.rs
     - .harness/current.task.yaml
-    - .harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md
+    - .harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md
 
   forbidden_paths:
-    - crates/sm-format/**
-    - crates/sm-verify/**
-    - crates/sm-vm/**
-    - crates/sm-emit/**
-    - crates/semantic-core-quad/**
-    - crates/ton618-core/**
+    - crates/**
     - src/**
     - docs/**
     - tests/**
@@ -36,23 +30,20 @@ scope:
 actions:
   allowed:
     - inspect
-    - edit
+    - edit_harness
     - test
     - commit
     - create_pr
 
   forbidden:
+    - modify_crates
+    - add_source_syntax
+    - add_parser_behavior
+    - add_frontend_lowering
     - modify_opcode_byte_values
     - change_verifier_behavior
     - change_vm_behavior
-    - touch_sm_format
-    - touch_sm_vm
-    - touch_sm_emit
     - touch_semantic_core_quad
-    - add_parser_syntax
-    - add_frontend_syntax
-    - add_cargo_dependencies
-    - fold_qtruth_constants
     - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
     - invert_falsity_planes
@@ -61,10 +52,9 @@ actions:
 
 verification:
   required:
-    - cargo test -p sm-ir --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/SM-IR-QTRUTH-SEMCODE-ENVELOPE-GUARD.md
+  output: .harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md

--- a/.harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md
+++ b/.harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md
@@ -1,0 +1,62 @@
+# SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY
+
+## Status
+
+Completed.
+
+## Current state
+
+### Legacy Quad IR construction
+
+Legacy Quad instructions are constructed in `crates/sm-ir/src/legacy_lowering.rs`:
+
+- `UnaryOp::Not` with `Type::Quad` constructs `IrInstr::QNot`.
+- `BinaryOp::AndAnd` with `Type::Quad` constructs `IrInstr::QAnd`.
+- `BinaryOp::OrOr` with `Type::Quad` constructs `IrInstr::QOr`.
+- `BinaryOp::Implies` with two `Type::Quad` operands constructs `IrInstr::QImpl`.
+
+The frontend typechecker accepts the existing quad surface for `!`, `&&`, `||`, and `->`. The parser builds `Expr::Unary`/`Expr::Binary` nodes for these operators, and the lexer recognizes `&&`, `||`, and `->`. Quad literals `N`, `F`, `T`, and `S`, plus the `quad` type, are also existing source constructs.
+
+Therefore legacy `QAnd`, `QOr`, `QNot`, and `QImpl` are reachable from source syntax today.
+
+### QTruth source reachability
+
+No source parser, frontend typechecker, or sm-ir lowering path currently constructs `IrInstr::QTruthAnd`, `IrInstr::QTruthOr`, `IrInstr::QTruthNot`, or `IrInstr::QTruthImpl`.
+
+The current `QTruth*` occurrences are IR enum representation, encoding, CrystalFold passthrough, envelope tests, and manual-IR tests. QTruth operations are therefore manual-IR-only at present.
+
+## Boundary
+
+The existing `&&`, `||`, `!`, and `->` source operators must continue to map to legacy lattice `QAnd`, `QOr`, `QNot`, and `QImpl`. They must not be silently reinterpreted as QTruth operations.
+
+The following remain unchanged for a later implementation slice:
+
+- sm-format opcode values;
+- sm-verify admission behavior;
+- sm-vm execution behavior;
+- sm-emit ownership;
+- semantic-core-quad truth-map semantics;
+- legacy lattice behavior and opcode mapping.
+
+No crate changes were made by this audit.
+
+## Recommended next implementation slice
+
+Recommended title: `feat(sm-front/sm-ir): add explicit QTruth source admission intrinsic`
+
+The smallest safe source admission is a dedicated, explicitly named intrinsic or builtin contract, with source/typecheck/lowering changes reviewed together. Reusing `&&`, `||`, `!`, or `->` would erase the required distinction between legacy lattice and explicit truth-map operations.
+
+Until that explicit source contract is named and specified, QTruth should remain manual-IR-only. A later implementation should be allowed to touch only the selected parser/typecheck/lowering owners and should still forbid sm-format, sm-verify, sm-vm, sm-emit, semantic-core-quad, and legacy lattice rewrites.
+
+## Risks
+
+- Mapping QTruth to existing operators could silently route truth-map operations through lattice aliases.
+- Touching sm-format is unnecessary because QTruth opcode slots already exist.
+- Adding parser syntax before the semantic admission contract is selected could create an unstable public surface.
+- A generic builtin name without an explicit Quad/truth-map contract could blur the `quad` meaning boundary.
+
+## Verification
+
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`


### PR DESCRIPTION
Closes #1466. Inventories the source admission path for QTruth IR operations before adding parser/frontend/lowering behavior. This is audit-only: no crate, source, docs, tests, tools, Cargo, opcode, verifier, VM, semantic-core-quad, QTruth folding, hidden adapter, falsity-plane inversion, or legacy lattice behavior changes.