### PR TITLE
spec(core_quad): define explicit QTruth source intrinsic contract

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY
-  title: inventory QTruth source admission path
-  type: audit
+  id: QTRUTH-SOURCE-INTRINSIC-CONTRACT
+  title: define explicit QTruth source intrinsic contract
+  type: spec
   mode: active
 
 intent:
-  summary: "audit(sm-ir): inventory QTruth source admission path"
-  issue: "#1466"
+  summary: "spec(core_quad): define explicit QTruth source intrinsic contract"
+  issue: "#1468"
 
 layer:
   name: core_quad
@@ -15,7 +15,7 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md
+    - .harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md
 
   forbidden_paths:
     - crates/**
@@ -37,9 +37,11 @@ actions:
 
   forbidden:
     - modify_crates
+    - modify_docs
     - add_source_syntax
     - add_parser_behavior
     - add_frontend_lowering
+    - add_typechecker_behavior
     - modify_opcode_byte_values
     - change_verifier_behavior
     - change_vm_behavior
@@ -57,4 +59,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/SM-IR-QTRUTH-SOURCE-ADMISSION-INVENTORY.md
+  output: .harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md

--- a/.harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md
+++ b/.harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md
@@ -1,0 +1,75 @@
+# QTRUTH-SOURCE-INTRINSIC-CONTRACT
+
+## Status
+
+Completed.
+
+## Purpose
+
+Define explicit source admission for QTruth operations without changing parser, frontend, verifier, VM, format, or runtime behavior.
+
+## Intrinsic contract
+
+| Intrinsic | Arity | Argument types | Return type | Future IR target |
+|---|---:|---|---|---|
+| qtruth_and | 2 | quad, quad | quad | IrInstr::QTruthAnd |
+| qtruth_or | 2 | quad, quad | quad | IrInstr::QTruthOr |
+| qtruth_not | 1 | quad | quad | IrInstr::QTruthNot |
+| qtruth_impl | 2 | quad, quad | quad | IrInstr::QTruthImpl |
+
+The contract requires explicit quad operands and a quad result. There is no implicit bool conversion or numeric conversion.
+
+## Legacy non-interference
+
+The existing source operators remain legacy lattice operators:
+
+| Source operator | Existing IR target |
+|---|---|
+| && | IrInstr::QAnd |
+| || | IrInstr::QOr |
+| ! | IrInstr::QNot |
+| -> | IrInstr::QImpl |
+
+These operators must not be silently reinterpreted as QTruth operations.
+
+## Forbidden fallback
+
+QTruth intrinsics must not be implemented by:
+
+- mapping to QAnd/QOr/QNot/QImpl;
+- using lattice aliases;
+- using hidden adapters;
+- inverting falsity planes;
+- changing semantic-core-quad;
+- changing opcode values;
+- adding EQUIV/NAND/NOR.
+
+## Recommended implementation slice
+
+Recommended next implementation title:
+
+`feat(sm-front/sm-ir): admit explicit QTruth intrinsics`
+
+The implementation should add only `qtruth_and`, `qtruth_or`, `qtruth_not`, and `qtruth_impl` admission, with tests proving they lower to the matching `IrInstr::QTruth*` variants while legacy operators continue to lower to `IrInstr::Q*`.
+
+The later PR should touch only the exact parser/typechecker/lowering owners discovered during implementation, plus its harness/report files. It must not broaden into format, verifier, VM, runtime, or legacy lattice changes.
+
+## Boundary
+
+This slice is specification only.
+
+No crate files were changed.
+No source syntax was added.
+No parser behavior was added.
+No frontend lowering was added.
+No verifier behavior was changed.
+No VM behavior was changed.
+No sm-format opcode values were changed.
+No semantic-core-quad behavior was changed.
+No legacy lattice behavior was changed.
+
+## Verification
+
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short


### PR DESCRIPTION
Closes #1468. Defines the explicit QTruth source intrinsic contract qtruth_and/qtruth_or/qtruth_not/qtruth_impl before parser/typechecker/lowering implementation. This is specification-only: no crate, source, docs, tests, tools, Cargo, opcode, verifier, VM, semantic-core-quad, hidden adapter, falsity-plane inversion, or legacy lattice behavior changes.