### PR TITLE
feat(sm-front/sm-ir): admit explicit QTruth intrinsics

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,24 +1,33 @@
 task:
-  id: QTRUTH-SOURCE-INTRINSIC-CONTRACT
-  title: define explicit QTruth source intrinsic contract
-  type: spec
+  id: QTRUTH-SOURCE-INTRINSIC-ADMISSION
+  title: admit explicit QTruth source intrinsics
+  type: feat
   mode: active
 
 intent:
-  summary: "spec(core_quad): define explicit QTruth source intrinsic contract"
-  issue: "#1468"
+  summary: "feat(sm-front/sm-ir): admit explicit QTruth intrinsics"
+  issue: "#1470"
 
 layer:
   name: core_quad
-  owner: sm-ir
+  owner: sm-front/sm-ir
 
 scope:
   allowed_paths:
+    - crates/sm-front/src/lib.rs
+    - crates/sm-ir/src/legacy_lowering.rs
     - .harness/current.task.yaml
-    - .harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md
+    - .harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md
 
   forbidden_paths:
-    - crates/**
+    - crates/sm-front/src/parser.rs
+    - crates/sm-front/src/lexer.rs
+    - crates/sm-format/**
+    - crates/sm-verify/**
+    - crates/sm-vm/**
+    - crates/sm-emit/**
+    - crates/semantic-core-quad/**
+    - crates/ton618-core/**
     - src/**
     - docs/**
     - tests/**
@@ -30,33 +39,35 @@ scope:
 actions:
   allowed:
     - inspect
-    - edit_harness
+    - edit
     - test
     - commit
     - create_pr
 
   forbidden:
-    - modify_crates
-    - modify_docs
-    - add_source_syntax
-    - add_parser_behavior
-    - add_frontend_lowering
-    - add_typechecker_behavior
+    - add_parser_syntax
+    - add_lexer_tokens
     - modify_opcode_byte_values
     - change_verifier_behavior
     - change_vm_behavior
+    - touch_sm_format
+    - touch_sm_emit
     - touch_semantic_core_quad
     - route_qtruth_through_lattice_aliases
+    - route_qtruth_through_legacy_q_ops
     - use_hidden_adapters
     - invert_falsity_planes
     - add_equiv_nand_nor
     - change_legacy_lattice_behavior
+    - reinterpret_legacy_source_operators
 
 verification:
   required:
+    - cargo test -p sm-front --quiet
+    - cargo test -p sm-ir --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/QTRUTH-SOURCE-INTRINSIC-CONTRACT.md
+  output: .harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md

--- a/.harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md
+++ b/.harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md
@@ -1,0 +1,50 @@
+# QTRUTH-SOURCE-INTRINSIC-ADMISSION
+
+## Status
+
+Completed.
+
+## Summary
+
+Admitted explicit QTruth source intrinsics and lowered them to `IrInstr::QTruth*`.
+
+## Intrinsics
+
+- `qtruth_and(a, b)`
+- `qtruth_or(a, b)`
+- `qtruth_not(a)`
+- `qtruth_impl(a, b)`
+
+## Mapping
+
+- `qtruth_and(a, b)` -> `IrInstr::QTruthAnd`
+- `qtruth_or(a, b)` -> `IrInstr::QTruthOr`
+- `qtruth_not(a)` -> `IrInstr::QTruthNot`
+- `qtruth_impl(a, b)` -> `IrInstr::QTruthImpl`
+
+All intrinsic arguments are admitted only as `quad`, and each intrinsic returns `quad`. Named arguments, wrong arity, and non-quad arguments are rejected.
+
+## Boundary
+
+Only explicit QTruth intrinsics were added.
+
+No parser syntax was added.
+No lexer tokens were added.
+No sm-format opcode values were changed.
+No sm-verify behavior was changed.
+No sm-vm behavior was changed.
+No sm-emit crate changes were made.
+No semantic-core-quad behavior was changed.
+No QTruth constant folding was added.
+No hidden adapter was added.
+No falsity-plane inversion was added.
+No EQUIV/NAND/NOR operations were added.
+Legacy `&&`, `||`, `!`, and `->` behavior remains unchanged and continues to lower to legacy lattice IR variants.
+
+## Verification
+
+- `cargo test -p sm-front --quiet`
+- `cargo test -p sm-ir --quiet`
+- `git diff --check`
+- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+- `git status --short`

--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -885,6 +885,22 @@ pub fn builtin_sig(name: &str) -> Option<FnSig> {
             param_defaults: None,
             ret: Type::F64,
         }),
+        "qtruth_and" | "qtruth_or" | "qtruth_impl" => Some(FnSig {
+            type_params: Vec::new(),
+            trait_bounds: Vec::new(),
+            params: vec![Type::Quad, Type::Quad],
+            param_names: None,
+            param_defaults: None,
+            ret: Type::Quad,
+        }),
+        "qtruth_not" => Some(FnSig {
+            type_params: Vec::new(),
+            trait_bounds: Vec::new(),
+            params: vec![Type::Quad],
+            param_names: None,
+            param_defaults: None,
+            ret: Type::Quad,
+        }),
         _ => None,
     }
 }

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -3679,6 +3679,70 @@ fn lower_expr_with_expected(
                 });
                 return Ok((dst, Type::Text));
             }
+            let name_str = resolve_symbol_name(arena, *name)?;
+            if matches!(
+                name_str,
+                "qtruth_and" | "qtruth_or" | "qtruth_not" | "qtruth_impl"
+            ) {
+                let expected_arity = if name_str == "qtruth_not" { 1 } else { 2 };
+                if args.len() != expected_arity || args.iter().any(|arg| arg.name.is_some()) {
+                    return Err(FrontendError {
+                        pos: 0,
+                        message: format!(
+                            "builtin '{name_str}' takes exactly {expected_arity} positional argument{}",
+                            if expected_arity == 1 { "" } else { "s" }
+                        ),
+                    });
+                }
+                let mut regs = Vec::with_capacity(expected_arity);
+                for arg in args {
+                    let (reg, arg_ty) = lower_expr_with_expected(
+                        arg.value,
+                        arena,
+                        next,
+                        out,
+                        env,
+                        loop_stack,
+                        fn_table,
+                        record_table,
+                        adt_table,
+                        Some(Type::Quad),
+                        ret_ty.clone(),
+                        closure_state,
+                    )?;
+                    if arg_ty != Type::Quad {
+                        return Err(FrontendError {
+                            pos: 0,
+                            message: format!(
+                                "builtin '{name_str}' expects quad arguments, got {:?}",
+                                arg_ty
+                            ),
+                        });
+                    }
+                    regs.push(reg);
+                }
+                let dst = alloc(next);
+                match name_str {
+                    "qtruth_and" => out.push(IrInstr::QTruthAnd {
+                        dst,
+                        lhs: regs[0],
+                        rhs: regs[1],
+                    }),
+                    "qtruth_or" => out.push(IrInstr::QTruthOr {
+                        dst,
+                        lhs: regs[0],
+                        rhs: regs[1],
+                    }),
+                    "qtruth_not" => out.push(IrInstr::QTruthNot { dst, src: regs[0] }),
+                    "qtruth_impl" => out.push(IrInstr::QTruthImpl {
+                        dst,
+                        lhs: regs[0],
+                        rhs: regs[1],
+                    }),
+                    _ => unreachable!("qtruth intrinsic was checked above"),
+                }
+                return Ok((dst, Type::Quad));
+            }
             if resolve_symbol_name(arena, *name)? == "random_seed" {
                 if args.len() != 1 || args.iter().any(|a| a.name.is_some()) {
                     return Err(FrontendError {
@@ -12361,5 +12425,109 @@ mod opt_tests {
             },
             Opcode::QTruthImpl.byte(),
         );
+    }
+
+    #[test]
+    fn qtruth_intrinsics_lower_to_explicit_ir_variants() {
+        let src = r#"
+            fn main() {
+                let a: quad = qtruth_and(T, F);
+                let b: quad = qtruth_or(T, F);
+                let c: quad = qtruth_not(T);
+                let d: quad = qtruth_impl(T, F);
+                return;
+            }
+        "#;
+        let ir = compile_program_to_ir(src).expect("QTruth intrinsics should lower");
+        let main = ir
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("main function should be present");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QTruthAnd { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QTruthOr { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QTruthNot { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QTruthImpl { .. })));
+    }
+
+    #[test]
+    fn legacy_quad_operators_keep_legacy_ir_variants() {
+        let src = r#"
+            fn main() {
+                let a: quad = T && F;
+                let b: quad = T || F;
+                let c: quad = !T;
+                let d: quad = T -> F;
+                return;
+            }
+        "#;
+        let ir = compile_program_to_ir(src).expect("legacy quad operators should lower");
+        let main = ir
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("main function should be present");
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QAnd { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QOr { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QNot { .. })));
+        assert!(main
+            .instrs
+            .iter()
+            .any(|instr| matches!(instr, IrInstr::QImpl { .. })));
+        assert!(main.instrs.iter().all(|instr| {
+            !matches!(
+                instr,
+                IrInstr::QTruthAnd { .. }
+                    | IrInstr::QTruthOr { .. }
+                    | IrInstr::QTruthNot { .. }
+                    | IrInstr::QTruthImpl { .. }
+            )
+        }));
+    }
+
+    #[test]
+    fn qtruth_intrinsics_reject_invalid_arguments_arity_and_named_args() {
+        let non_quad = r#"
+            fn main() {
+                let x: quad = qtruth_and(true, T);
+                return;
+            }
+        "#;
+        assert!(compile_program_to_ir(non_quad).is_err());
+
+        let wrong_arity = r#"
+            fn main() {
+                let x: quad = qtruth_not(T, F);
+                return;
+            }
+        "#;
+        assert!(compile_program_to_ir(wrong_arity).is_err());
+
+        let named_args = r#"
+            fn main() {
+                let x: quad = qtruth_and(a: T, b: F);
+                return;
+            }
+        "#;
+        assert!(compile_program_to_ir(named_args).is_err());
     }
 }


### PR DESCRIPTION
Closes #1470. Admits explicit qtruth_and/qtruth_or/qtruth_not/qtruth_impl source intrinsics and lowers them to IrInstr::QTruth*. This preserves legacy &&, ||, !, and -> lattice behavior and does not touch parser syntax, lexer tokens, sm-format, sm-verify, sm-vm, sm-emit, semantic-core-quad, opcode values, hidden adapters, falsity-plane inversion, or EQUIV/NAND/NOR.