### PR TITLE
test(sm-vm): guard source-level QTruth intrinsic execution

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,30 +1,28 @@
 task:
-  id: QTRUTH-SOURCE-INTRINSIC-ADMISSION
-  title: admit explicit QTruth source intrinsics
-  type: feat
+  id: VM-QTRUTH-SOURCE-INTRINSIC-E2E
+  title: guard source-level QTruth intrinsic execution
+  type: test
   mode: active
 
 intent:
-  summary: "feat(sm-front/sm-ir): admit explicit QTruth intrinsics"
-  issue: "#1470"
+  summary: "test(sm-vm): guard source-level QTruth intrinsic execution"
+  issue: "#1472"
 
 layer:
   name: core_quad
-  owner: sm-front/sm-ir
+  owner: sm-vm
 
 scope:
   allowed_paths:
-    - crates/sm-front/src/lib.rs
-    - crates/sm-ir/src/legacy_lowering.rs
+    - crates/sm-vm/src/semcode_vm.rs
     - .harness/current.task.yaml
-    - .harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md
+    - .harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md
 
   forbidden_paths:
-    - crates/sm-front/src/parser.rs
-    - crates/sm-front/src/lexer.rs
+    - crates/sm-front/**
+    - crates/sm-ir/**
     - crates/sm-format/**
     - crates/sm-verify/**
-    - crates/sm-vm/**
     - crates/sm-emit/**
     - crates/semantic-core-quad/**
     - crates/ton618-core/**
@@ -45,29 +43,30 @@ actions:
     - create_pr
 
   forbidden:
+    - change_vm_behavior
+    - change_verifier_behavior
+    - change_source_admission
     - add_parser_syntax
     - add_lexer_tokens
     - modify_opcode_byte_values
-    - change_verifier_behavior
-    - change_vm_behavior
     - touch_sm_format
+    - touch_sm_front
+    - touch_sm_ir
     - touch_sm_emit
     - touch_semantic_core_quad
-    - route_qtruth_through_lattice_aliases
     - route_qtruth_through_legacy_q_ops
+    - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
     - invert_falsity_planes
     - add_equiv_nand_nor
     - change_legacy_lattice_behavior
-    - reinterpret_legacy_source_operators
 
 verification:
   required:
-    - cargo test -p sm-front --quiet
-    - cargo test -p sm-ir --quiet
+    - cargo test -p sm-vm --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/QTRUTH-SOURCE-INTRINSIC-ADMISSION.md
+  output: .harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md

--- a/.harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md
+++ b/.harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md
@@ -1,0 +1,42 @@
+# VM-QTRUTH-SOURCE-INTRINSIC-E2E
+
+## Status
+
+Completed.
+
+## Summary
+
+Added sm-vm end-to-end tests proving source-level QTruth intrinsics compile, verify, and execute through the VM.
+
+## Covered intrinsics
+
+- qtruth_and
+- qtruth_or
+- qtruth_not
+- qtruth_impl
+
+## Boundary
+
+This slice is test-only.
+
+No VM behavior was changed.
+No verifier behavior was changed.
+No source admission was changed.
+No parser or lexer behavior was changed.
+No sm-format opcode values were changed.
+No sm-front files were changed.
+No sm-ir files were changed.
+No sm-emit files were changed.
+No semantic-core-quad behavior was changed.
+No QTruth constant folding was added.
+No hidden adapter was added.
+No falsity-plane inversion was added.
+No EQUIV/NAND/NOR operations were added.
+Legacy QAnd/QOr/QNot/QImpl behavior was unchanged.
+
+## Verification
+
+- cargo test -p sm-vm --quiet
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short

--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -3459,6 +3459,51 @@ mod tests {
             assert!(observable.contains("locals=[]"));
         }
 
+        #[test]
+        fn source_qtruth_intrinsics_compile_verify_and_execute() {
+            let cases = [
+                (
+                    "qtruth_and",
+                    "fn main() { let result: quad = qtruth_and(T, F); return; }",
+                    "return=Unit; locals=[result=Quad(F)]",
+                ),
+                (
+                    "qtruth_or",
+                    "fn main() { let result: quad = qtruth_or(T, F); return; }",
+                    "return=Unit; locals=[result=Quad(T)]",
+                ),
+                (
+                    "qtruth_not",
+                    "fn main() { let result: quad = qtruth_not(T); return; }",
+                    "return=Unit; locals=[result=Quad(F)]",
+                ),
+                (
+                    "qtruth_impl",
+                    "fn main() { let result: quad = qtruth_impl(T, F); return; }",
+                    "return=Unit; locals=[result=Quad(F)]",
+                ),
+            ];
+
+            for (name, source, expected) in cases {
+                let observation = observe_verified_entry_semcode(name, source);
+                assert_eq!(
+                    observation.status,
+                    VmTestStatus::Completed,
+                    "{name} did not complete"
+                );
+                assert!(
+                    observation.trap.is_none(),
+                    "{name} trapped: {:?}",
+                    observation.trap
+                );
+                assert_eq!(
+                    observation.observable.as_deref(),
+                    Some(expected),
+                    "{name} result"
+                );
+            }
+        }
+
         struct HelperBoundaryPair {
             name: &'static str,
             helper_fixture: &'static str,


### PR DESCRIPTION
Closes #1472. Adds sm-vm end-to-end tests proving source-level qtruth_and/qtruth_or/qtruth_not/qtruth_impl compile, verify, and execute through the VM. Test-only: no VM behavior, verifier behavior, source admission, parser/lexer, sm-format, sm-front, sm-ir, sm-emit, semantic-core-quad, opcode, hidden adapter, falsity-plane inversion, EQUIV/NAND/NOR, or legacy lattice behavior changes.