### PR TITLE
audit(core_quad): close QTruth source-level execution contour

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,31 +1,24 @@
 task:
-  id: VM-QTRUTH-SOURCE-INTRINSIC-E2E
-  title: guard source-level QTruth intrinsic execution
-  type: test
+  id: QTRUTH-SOURCE-CONTOUR-CLOSEOUT
+  title: close QTruth source-level execution contour
+  type: audit
   mode: active
 
 intent:
-  summary: "test(sm-vm): guard source-level QTruth intrinsic execution"
-  issue: "#1472"
+  summary: "audit(core_quad): close QTruth source-level execution contour"
+  issue: "#1474"
 
 layer:
   name: core_quad
-  owner: sm-vm
+  owner: cross-layer-audit
 
 scope:
   allowed_paths:
-    - crates/sm-vm/src/semcode_vm.rs
     - .harness/current.task.yaml
-    - .harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md
+    - .harness/reports/QTRUTH-SOURCE-CONTOUR-CLOSEOUT.md
 
   forbidden_paths:
-    - crates/sm-front/**
-    - crates/sm-ir/**
-    - crates/sm-format/**
-    - crates/sm-verify/**
-    - crates/sm-emit/**
-    - crates/semantic-core-quad/**
-    - crates/ton618-core/**
+    - crates/**
     - src/**
     - docs/**
     - tests/**
@@ -37,36 +30,32 @@ scope:
 actions:
   allowed:
     - inspect
-    - edit
+    - edit_harness
     - test
     - commit
     - create_pr
 
   forbidden:
-    - change_vm_behavior
-    - change_verifier_behavior
-    - change_source_admission
+    - modify_crates
+    - modify_docs
     - add_parser_syntax
-    - add_lexer_tokens
+    - add_source_behavior
     - modify_opcode_byte_values
-    - touch_sm_format
-    - touch_sm_front
-    - touch_sm_ir
-    - touch_sm_emit
+    - change_verifier_behavior
+    - change_vm_behavior
     - touch_semantic_core_quad
-    - route_qtruth_through_legacy_q_ops
     - route_qtruth_through_lattice_aliases
     - use_hidden_adapters
     - invert_falsity_planes
     - add_equiv_nand_nor
     - change_legacy_lattice_behavior
+    - reinterpret_legacy_source_operators
 
 verification:
   required:
-    - cargo test -p sm-vm --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/VM-QTRUTH-SOURCE-INTRINSIC-E2E.md
+  output: .harness/reports/QTRUTH-SOURCE-CONTOUR-CLOSEOUT.md

--- a/.harness/reports/QTRUTH-SOURCE-CONTOUR-CLOSEOUT.md
+++ b/.harness/reports/QTRUTH-SOURCE-CONTOUR-CLOSEOUT.md
@@ -1,0 +1,108 @@
+# QTRUTH-SOURCE-CONTOUR-CLOSEOUT
+
+## Status
+
+Completed.
+
+## Summary
+
+The QTruth source-level execution contour is closed.
+
+Source-level QTruth intrinsics now compile, verify, lower to explicit QTruth IR/opcodes, and execute through the VM.
+
+## Completed PR chain
+
+| PR | Role |
+|---:|---|
+| #1455 | Added sm-format QTruth opcode enum slots |
+| #1457 | Locked verifier/vm unsupported-boundary behavior |
+| #1459 | Added sm-vm QTruth opcode execution |
+| #1461 | Added sm-ir explicit QTruth instruction representation |
+| #1463 | Encoded sm-ir QTruth instructions to QTruth opcodes |
+| #1465 | Guarded full sm-ir SemCode envelope emission |
+| #1467 | Inventoried QTruth source admission path |
+| #1469 | Defined explicit QTruth source intrinsic contract |
+| #1471 | Admitted qtruth_* source intrinsics in sm-front/sm-ir |
+| #1473 | Added source-level VM E2E execution guard |
+
+## Final accepted source surface
+
+Accepted QTruth source intrinsics:
+
+- qtruth_and(a, b)
+- qtruth_or(a, b)
+- qtruth_not(a)
+- qtruth_impl(a, b)
+
+All arguments are quad.
+All results are quad.
+No implicit bool or numeric conversion is admitted.
+
+## Pipeline
+
+qtruth_* source intrinsic
+-> sm-front builtin type admission
+-> sm-ir lowering
+-> IrInstr::QTruth*
+-> Opcode::QTruth*
+-> SemCode envelope
+-> sm-verify admission
+-> sm-vm execution
+-> observable Quad result
+
+## Legacy non-interference
+
+Existing source operators remain legacy lattice operators:
+
+| Source operator | Legacy IR |
+|---|---|
+| && | IrInstr::QAnd |
+| || | IrInstr::QOr |
+| ! | IrInstr::QNot |
+| -> | IrInstr::QImpl |
+
+They must not be silently reinterpreted as QTruth operations.
+
+## Explicit non-goals
+
+The following are intentionally out of scope:
+
+- EQUIV
+- NAND
+- NOR
+- parser operator syntax for QTruth
+- lexer tokens for QTruth
+- hidden adapters
+- falsity-plane inversion
+- routing through lattice aliases
+- changing semantic-core-quad truth maps
+- changing sm-format opcode values
+- changing sm-verify behavior
+- changing sm-vm behavior
+- changing legacy QAnd/QOr/QNot/QImpl behavior
+
+## Remaining future work
+
+No functional work is required for the current QTruth source-level contour.
+
+Any future QTruth expansion must be a separate explicitly scoped contour.
+
+## Boundary
+
+This closeout is audit-only.
+
+No crate files were changed.
+No docs were changed.
+No source behavior was changed.
+No parser or lexer behavior was changed.
+No verifier behavior was changed.
+No VM behavior was changed.
+No sm-format opcode values were changed.
+No semantic-core-quad behavior was changed.
+No legacy lattice behavior was changed.
+
+## Verification
+
+- git diff --check
+- pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+- git status --short


### PR DESCRIPTION
Closes #1474. Closes out the completed QTruth source-level execution contour from opcode slots through source intrinsics and VM E2E guard. Audit-only: no crate, source, docs, tests, tools, Cargo, opcode, verifier, VM, semantic-core-quad, hidden adapter, falsity-plane inversion, EQUIV/NAND/NOR, or legacy lattice behavior changes.