### PR TITLE
core-quad: establish v1 compatibility, mask bridge, and delta split

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,48 +1,63 @@
 task:
-  id: CORE-QUAD-V1-COMPATIBILITY-ROLLOUT
-  title: define v1 compatibility rollout policy
-  type: docs
+  id: CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE
+  title: define dense and physical mask bridge
+  type: implementation
   mode: active
 
 intent:
-  summary: "docs(core-quad): define v1 compatibility rollout policy"
-  issue: "#1413"
+  summary: "refactor(core-quad): add explicit lane and physical mask bridge"
+  issue: "#1408"
 
 layer:
   name: core_quad
-  owner: cross-layer-audit
+  owner: semantic-core-quad
 
 scope:
   allowed_paths:
-    - docs/roadmap/core_quad/v1_compatibility_rollout.md
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md
+    - .harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md
+    - docs/roadmap/core_quad/dense_physical_mask_bridge.md
+    - crates/semantic-core-quad/src/lib.rs
 
   forbidden_paths:
-    - crates/**
-    - src/**
-    - tests/**
-    - tools/**
-    - Cargo.toml
-    - Cargo.lock
-    - README.md
+    - crates/semantic-core-quad/Cargo.toml
+    - crates/ton618-core/**
     - docs/spec/**
 
 actions:
   allowed:
     - inspect
     - edit_harness
+    - modify_core_quad
     - create_docs
     - test
   forbidden:
-    - modify_crates
+    - modify_other_crates
     - modify_docs_spec
+    - modify_delta_api
+    - modify_tile_layout
+    - modify_bank_api
+    - modify_truth_semantics
+    - modify_lattice_semantics
+    - modify_parser
+    - modify_verifier
+    - modify_vm
+    - add_dependency
+    - commit
+    - push
+    - create_pr
+    - merge
 
 verification:
   required:
+    - cargo fmt -p semantic-core-quad -- --check
+    - cargo test -p semantic-core-quad --quiet
+    - cargo check -p semantic-core-quad --no-default-features
+    - cargo test -p semantic-core-quad --all-features --quiet
+    - cargo test -p semantic-core-capsule --quiet
     - git diff --check
     - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md
+  output: .harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE
-  title: define dense and physical mask bridge
+  id: CORE-QUAD-EXACT-PLANE-DELTA-SPLIT
+  title: split exact-state and plane delta APIs
   type: implementation
   mode: active
 
 intent:
-  summary: "refactor(core-quad): add explicit lane and physical mask bridge"
-  issue: "#1408"
+  summary: "feat(core-quad): split exact-state and plane delta APIs"
+  issue: "#1409"
 
 layer:
   name: core_quad
@@ -15,8 +15,8 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md
-    - docs/roadmap/core_quad/dense_physical_mask_bridge.md
+    - .harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md
+    - docs/roadmap/core_quad/exact_plane_delta_split.md
     - crates/semantic-core-quad/src/lib.rs
 
   forbidden_paths:
@@ -34,7 +34,8 @@ actions:
   forbidden:
     - modify_other_crates
     - modify_docs_spec
-    - modify_delta_api
+    - modify_mask_api
+    - modify_tile_api
     - modify_tile_layout
     - modify_bank_api
     - modify_truth_semantics
@@ -60,4 +61,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md
+  output: .harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: LEGACY-LATTICE-Q-CONTOUR-CLOSEOUT
-  title: close legacy lattice Q operator contour
-  type: audit
+  id: CORE-QUAD-V1-COMPATIBILITY-ROLLOUT
+  title: define v1 compatibility rollout policy
+  type: docs
   mode: active
 
 intent:
-  summary: "audit(core_quad): close legacy lattice Q operator contour"
-  issue: "#1476"
+  summary: "docs(core-quad): define v1 compatibility rollout policy"
+  issue: "#1413"
 
 layer:
   name: core_quad
@@ -14,44 +14,29 @@ layer:
 
 scope:
   allowed_paths:
+    - docs/roadmap/core_quad/v1_compatibility_rollout.md
     - .harness/current.task.yaml
-    - .harness/reports/LEGACY-LATTICE-Q-CONTOUR-CLOSEOUT.md
+    - .harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md
 
   forbidden_paths:
     - crates/**
     - src/**
-    - docs/**
     - tests/**
     - tools/**
-    - README.md
     - Cargo.toml
     - Cargo.lock
+    - README.md
+    - docs/spec/**
 
 actions:
   allowed:
     - inspect
     - edit_harness
+    - create_docs
     - test
-    - commit
-    - create_pr
-
   forbidden:
     - modify_crates
-    - modify_docs
-    - add_parser_syntax
-    - add_source_behavior
-    - modify_opcode_byte_values
-    - change_verifier_behavior
-    - change_vm_behavior
-    - touch_semantic_core_quad
-    - touch_qtruth
-    - route_legacy_lattice_through_qtruth
-    - route_qtruth_through_legacy_lattice
-    - use_hidden_adapters
-    - invert_falsity_planes
-    - add_equiv_nand_nor
-    - change_legacy_lattice_behavior
-    - reinterpret_legacy_source_operators
+    - modify_docs_spec
 
 verification:
   required:
@@ -60,4 +45,4 @@ verification:
     - git status --short
 
 report:
-  output: .harness/reports/LEGACY-LATTICE-Q-CONTOUR-CLOSEOUT.md
+  output: .harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,64 +1,37 @@
 task:
-  id: CORE-QUAD-EXACT-PLANE-DELTA-SPLIT
-  title: split exact-state and plane delta APIs
-  type: implementation
+  id: CORE-QUAD-V1-CI-INVENTORY-FIX
+  title: register core quad policy in legacy content inventory
+  type: test
   mode: active
 
 intent:
-  summary: "feat(core-quad): split exact-state and plane delta APIs"
-  issue: "#1409"
+  summary: "test(boundaries): register core-quad compatibility policy reference"
+  issue: "#1408, #1409"
 
 layer:
-  name: core_quad
-  owner: semantic-core-quad
+  name: boundary_enforcement
+  owner: repository_governance
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md
-    - docs/roadmap/core_quad/exact_plane_delta_split.md
-    - crates/semantic-core-quad/src/lib.rs
-
-  forbidden_paths:
-    - crates/semantic-core-quad/Cargo.toml
-    - crates/ton618-core/**
-    - docs/spec/**
+    - .harness/reports/CORE-QUAD-V1-CI-INVENTORY-FIX.md
+    - tests/legacy_guards.rs
 
 actions:
   allowed:
     - inspect
     - edit_harness
-    - modify_core_quad
-    - create_docs
+    - modify_tests
     - test
-  forbidden:
-    - modify_other_crates
-    - modify_docs_spec
-    - modify_mask_api
-    - modify_tile_api
-    - modify_tile_layout
-    - modify_bank_api
-    - modify_truth_semantics
-    - modify_lattice_semantics
-    - modify_parser
-    - modify_verifier
-    - modify_vm
-    - add_dependency
     - commit
     - push
+
+  forbidden:
+    - modify_core_quad
+    - modify_docs
+    - modify_other_crates
+    - add_dependency
+    - force_push
     - create_pr
     - merge
-
-verification:
-  required:
-    - cargo fmt -p semantic-core-quad -- --check
-    - cargo test -p semantic-core-quad --quiet
-    - cargo check -p semantic-core-quad --no-default-features
-    - cargo test -p semantic-core-quad --all-features --quiet
-    - cargo test -p semantic-core-capsule --quiet
-    - git diff --check
-    - pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
-    - git status --short
-
-report:
-  output: .harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md

--- a/.harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md
+++ b/.harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md
@@ -1,0 +1,38 @@
+# Harness Report: CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE
+
+## Status
+* **Starting Commit:** `1845115f0b3ce75744758f5bb0faf6213792dfd0`
+* **Changed Files:**
+  * `.harness/current.task.yaml`
+  * `.harness/reports/CORE-QUAD-DENSE-PHYSICAL-MASK-BRIDGE.md`
+  * `docs/roadmap/core_quad/dense_physical_mask_bridge.md`
+  * `crates/semantic-core-quad/src/lib.rs`
+
+## Implementation
+* **Chosen Design:** Defined `QuadLaneMask32` as a type alias of `QuadMask32`. Created `QuadPhysicalMask32` as a distinct validated struct holding a `u64`.
+* **Public API Added:**
+  * `QuadLaneMask32`
+  * `QuadPhysicalMask32`
+  * `QuadMaskError::InvalidPhysicalBits`
+  * `QuadPhysicalMask32::bits`
+  * `QuadPhysicalMask32::try_from_bits`
+  * `QuadPhysicalMask32::try_to_lane`
+  * `QuadMask32::to_physical`
+  * `From`/`TryFrom` trait implementations.
+* **Validation Invariant:** Physical mask rejects any bit not present in `LSB_MASK_32`.
+* **Conversion Algorithm:** Loop based spreading/compression, preserving `no_std` support without unsafe SIMD instructions.
+* **Compatibility:**
+  * Existing `QuadMask32` meaning was preserved (dense lane mask).
+  * `QuadroReg32::set_by_mask` behavior was preserved exactly, with explicit lane mask documentation added.
+* **Explicit Non-changes:** `StateDelta32`, `QuadTile128`, 128-lane masks, delta semantics, and truth-table operations remain unchanged.
+* **Tests:** 6 test cases added (dense preservation, valid physical, invalid physical, lane conversion, roundtrip, type distinctness).
+
+## Verification
+* `cargo fmt -p semantic-core-quad -- --check`: Passed implicitly after formatting.
+* `cargo test -p semantic-core-quad --quiet`: Passed (110 tests ok).
+* `cargo check -p semantic-core-quad --no-default-features`: Passed.
+* `cargo test -p semantic-core-quad --all-features --quiet`: Passed (110 tests ok).
+* `cargo test -p semantic-core-capsule --quiet`: Passed (8 tests ok).
+* `git diff --check`: Passed (no whitespace errors).
+* `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`: Passed (`[harness] ok`).
+* `git status --short`: Verified untracked files are untouched.

--- a/.harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md
+++ b/.harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md
@@ -1,0 +1,66 @@
+# Harness Report: CORE-QUAD-EXACT-PLANE-DELTA-SPLIT
+
+## Status
+* **Starting Commit:** `a46024ccf3898786ce89ae7995811aef9ef36589`
+* **Changed Files:**
+  * `.harness/current.task.yaml`
+  * `.harness/reports/CORE-QUAD-EXACT-PLANE-DELTA-SPLIT.md`
+  * `docs/roadmap/core_quad/exact_plane_delta_split.md`
+  * `crates/semantic-core-quad/src/lib.rs`
+
+## Inventory and Design
+* **Existing `StateDelta32`:** The public data shape and from_regs computation of StateDelta32 remain unchanged. Rust documentation was clarified.
+* **Compatibility Posture:** The four legacy truth/falsity plane fields of StateDelta32 are semantically equivalent to the corresponding fields of PlaneDelta32. StateDelta32 remains a broader mixed compatibility structure and also contains exact-super/conflict and aggregate changed/known events.
+  * Plane subset:
+    * entered_true
+    * left_true
+    * entered_false
+    * left_false
+  * Exact S/conflict subset:
+    * entered_super
+    * left_super
+    * became_conflicted
+    * resolved_conflict
+  * Aggregate subset:
+    * changed
+    * became_known
+    * became_unknown
+* **New Public API:**
+  * `PlaneDelta32` struct
+  * `ExactStateDelta32` struct
+  * `QuadroReg32::plane_delta` method
+  * `QuadroReg32::exact_state_delta` method
+
+## Plane Formulas
+* `entered_truth = current_truth AND NOT previous_truth`
+* `left_truth = previous_truth AND NOT current_truth`
+* `entered_falsity = current_false AND NOT previous_false`
+* `left_falsity = previous_false AND NOT current_false`
+
+## Exact-State Formulas
+* N/F/T/S coverage: All 4 quad states are fully covered by the exact-state API.
+* `entered_Q = current_exact_Q AND NOT previous_exact_Q`
+* `left_Q = previous_exact_Q AND NOT current_exact_Q`
+
+## Tests Added
+* **10 Explicit Transitions:** T->S, S->T, F->S, S->F, N->S, S->N, N->T, T->N, N->F, F->N.
+* **4x4 Exhaustive Matrix:** Tests all 16 `previous x current` transitions for both exact state and plane events using scalar logic.
+* **Identity Transitions:** N->N, F->F, T->T, S->S tested; all delta fields are empty.
+* **Mixed-Lane Register Test:** Lane 0 (T->S), Lane 1 (S->T), Lane 2 (F->N), Lane 3 (N->F) transitioning concurrently within one delta operation.
+* **Compatibility Test:** Verifies `delta32_plane_field_compatibility_matrix` behavior is equivalent to `PlaneDelta32`. `legacy_delta32_full_field_matrix_remains_stable` verifies all legacy fields.
+
+## Verification
+* `cargo fmt -p semantic-core-quad -- --check`: Passed
+* `cargo test -p semantic-core-quad --quiet`: Passed (117 tests ok)
+* `cargo check -p semantic-core-quad --no-default-features`: Passed
+* `cargo test -p semantic-core-quad --all-features --quiet`: Passed (117 tests ok)
+* `cargo test -p semantic-core-capsule --quiet`: Passed (8 tests ok)
+* `git diff --check`: Passed
+* `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`: Passed (`[harness] ok`)
+* `git status --short`: Verified untracked files are untouched.
+
+## Explicit Non-Changes
+* `StateDelta32` logic remains exactly the same.
+* Tile APIs (`StateDelta128`, `QuadTile128`) are explicitly not modified, deferred to tile-level slice.
+* No changes to physical mask or parsing/execution logic.
+

--- a/.harness/reports/CORE-QUAD-V1-CI-INVENTORY-FIX.md
+++ b/.harness/reports/CORE-QUAD-V1-CI-INVENTORY-FIX.md
@@ -1,0 +1,35 @@
+# Harness Report: CORE-QUAD-V1-CI-INVENTORY-FIX
+
+## Status
+* **Starting Commit:** `e8d926f985c4d92f341d840a83a5749f952767b6`
+* **Changed Files:**
+  * `.harness/current.task.yaml`
+  * `.harness/reports/CORE-QUAD-V1-CI-INVENTORY-FIX.md`
+  * `tests/legacy_guards.rs`
+
+## Root Cause Analysis
+The CI boundary enforcement test `legacy_guards.rs` explicitly checks for the legacy compatibility crate name across all tracked `rs`, `md`, `toml`, and `lock` files. The new compatibility rollout policy `docs/roadmap/core_quad/v1_compatibility_rollout.md` naturally mentions this compatibility crate name, which caused the test to fail because this new document path was not listed in the rigid explicit inventory. Because `cargo test --test legacy_guards` runs inside boundary enforcement and `cargo test --all-targets` also picks it up, this caused a repeated failure across CI jobs.
+
+## Resolution
+Added the precise path to the inventory in `tests/legacy_guards.rs`:
+`"./docs/roadmap/core_quad/v1_compatibility_rollout.md"`
+
+This strictly preserves the nature of the test without widening any wildcard rules or stripping the compatibility terms out of the documentation.
+
+## Explicit Non-Changes
+* Did not change the compatibility wording in the documentation.
+* Did not weaken the legacy guard scan.
+* Did not exclude `docs/roadmap/core_quad/**`.
+* Did not modify any production code.
+* Unrelated untracked files are perfectly preserved.
+
+## Verification
+* `cargo fmt --all --check`: Passed
+* `cargo test --test legacy_guards --quiet`: Passed
+* `cargo test --all-targets --quiet`: Passed
+* `cargo test -p semantic-core-quad --quiet`: Passed
+* `git diff --check`: Passed
+* `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`: Passed
+
+## Pushed Commit
+The resolved fix is pushed as a single commit into the existing `core-quad/v1-compat-mask-delta` branch.

--- a/.harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md
+++ b/.harness/reports/CORE-QUAD-V1-COMPATIBILITY-ROLLOUT.md
@@ -1,0 +1,24 @@
+# Harness Verification Report: CORE-QUAD-V1-COMPATIBILITY-ROLLOUT
+
+## Task Verification
+
+**Command:** `cargo test -p semantic-core-quad --quiet`
+**Result:** Passed. 104 tests ok.
+
+**Command:** `cargo check -p semantic-core-quad --no-default-features`
+**Result:** Passed. Checked semantic-core-quad v0.1.0 in 0.41s.
+
+**Command:** `cargo test -p semantic-core-quad --all-features --quiet`
+**Result:** Passed. 104 tests ok.
+
+**Command:** `cargo test -p semantic-core-capsule --quiet`
+**Result:** Passed. 8 tests ok.
+
+**Command:** `git diff --check`
+**Result:** Clean.
+
+**Command:** `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1`
+**Result:** Passed.
+
+**Command:** `git status --short`
+**Result:** Displayed changes in allowed paths.

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -17,6 +17,29 @@ pub struct QuadBoundsError {
     lanes: usize,
 }
 
+/// Error indicating that a mask operation encountered an invalid representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuadMaskError {
+    /// Physical bits contained a `1` at an odd bit position.
+    InvalidPhysicalBits { bits: u64 },
+}
+
+impl core::fmt::Display for QuadMaskError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidPhysicalBits { bits } => {
+                write!(
+                    f,
+                    "Invalid physical mask bits: {bits:#018X} (odd positions must be 0)"
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for QuadMaskError {}
+
 impl QuadBoundsError {
     pub const fn new(index: usize, lanes: usize) -> Self {
         Self { index, lanes }
@@ -225,6 +248,7 @@ impl QuadroReg32 {
         QuadMask32::new_unchecked(raw)
     }
 
+    /// Sets the state of lanes specified by a dense logical lane mask.
     pub fn set_by_mask(&mut self, mask: QuadMask32, state: QuadState) {
         for lane in mask.iter() {
             self.set_unchecked(lane, state);
@@ -421,13 +445,110 @@ impl fmt::Debug for QuadroReg32 {
     }
 }
 
+/// An additive compatibility alias representing a dense logical lane mask, where bit `i` selects logical lane `i`.
+pub type QuadLaneMask32 = QuadMask32;
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct QuadMask32(u64);
 
+/// A strictly validated physical packed mask, where bit `i * 2` selects packed lane `i`. Odd physical positions are invalid.
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct QuadPhysicalMask32(u64);
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QuadPhysicalMask32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bits = u64::deserialize(deserializer)?;
+        Self::try_from_bits(bits).map_err(serde::de::Error::custom)
+    }
+}
+
+impl QuadPhysicalMask32 {
+    /// Returns the raw validated physical mask bits.
+    pub const fn bits(self) -> u64 {
+        self.0
+    }
+
+    /// Attempts to construct a physical mask from raw bits, returning an error if any odd bits are set.
+    pub const fn try_from_bits(bits: u64) -> Result<Self, QuadMaskError> {
+        if bits & !LSB_MASK_32 == 0 {
+            Ok(Self(bits))
+        } else {
+            Err(QuadMaskError::InvalidPhysicalBits { bits })
+        }
+    }
+
+    /// Converts this physical mask to a dense lane mask, returning an error if internal representation is invalid.
+    pub const fn try_to_lane(self) -> Result<QuadMask32, QuadMaskError> {
+        if self.0 & !LSB_MASK_32 != 0 {
+            return Err(QuadMaskError::InvalidPhysicalBits { bits: self.0 });
+        }
+        let mut out = 0u64;
+        let mut raw = self.0;
+        let mut lane = 0usize;
+        while lane < 32 {
+            if raw & 1 != 0 {
+                out |= 1 << lane;
+            }
+            raw >>= 2;
+            lane += 1;
+        }
+        Ok(QuadMask32::new_unchecked(out))
+    }
+}
+
+impl From<QuadMask32> for QuadPhysicalMask32 {
+    fn from(mask: QuadMask32) -> Self {
+        mask.to_physical()
+    }
+}
+
+impl TryFrom<QuadPhysicalMask32> for QuadMask32 {
+    type Error = QuadMaskError;
+
+    fn try_from(mask: QuadPhysicalMask32) -> Result<Self, Self::Error> {
+        mask.try_to_lane()
+    }
+}
+
+impl TryFrom<u64> for QuadPhysicalMask32 {
+    type Error = QuadMaskError;
+
+    fn try_from(bits: u64) -> Result<Self, Self::Error> {
+        Self::try_from_bits(bits)
+    }
+}
+
+impl From<QuadPhysicalMask32> for u64 {
+    fn from(mask: QuadPhysicalMask32) -> u64 {
+        mask.0
+    }
+}
+
 impl QuadMask32 {
     pub const VALID_MASK: u64 = 0xFFFF_FFFF;
+
+    /// Converts this dense lane mask to a physical mask where each bit `i` maps to bit `i * 2`.
+    pub const fn to_physical(self) -> QuadPhysicalMask32 {
+        let mut out = 0u64;
+        let mut raw = self.0;
+        let mut lane = 0usize;
+        while lane < 32 {
+            if raw & 1 != 0 {
+                out |= 1 << (lane * 2);
+            }
+            raw >>= 1;
+            lane += 1;
+        }
+        QuadPhysicalMask32(out)
+    }
 
     pub const fn try_new(raw: u64) -> Option<Self> {
         if raw & !Self::VALID_MASK == 0 {
@@ -929,6 +1050,97 @@ mod tests {
     extern crate alloc;
     use alloc::format;
     use alloc::vec::Vec;
+
+    #[test]
+    fn mask_bridge_dense_preservation() {
+        let mask = QuadMask32::new_unchecked(0b1010);
+        assert_eq!(mask.raw(), 0b1010);
+
+        let mut reg = reg_filled(QuadState::F);
+        reg.set_by_mask(mask, QuadState::T);
+        assert_eq!(reg.get_unchecked(0), QuadState::F);
+        assert_eq!(reg.get_unchecked(1), QuadState::T);
+        assert_eq!(reg.get_unchecked(2), QuadState::F);
+        assert_eq!(reg.get_unchecked(3), QuadState::T);
+    }
+
+    #[test]
+    fn mask_bridge_valid_physical() {
+        assert!(QuadPhysicalMask32::try_from_bits(0).is_ok());
+        assert!(QuadPhysicalMask32::try_from_bits(1).is_ok());
+        assert!(QuadPhysicalMask32::try_from_bits(1 << 2).is_ok());
+        assert!(QuadPhysicalMask32::try_from_bits(1 << 62).is_ok());
+        assert!(QuadPhysicalMask32::try_from_bits(LSB_MASK_32).is_ok());
+        assert!(QuadPhysicalMask32::try_from_bits((1 << 2) | (1 << 8)).is_ok());
+    }
+
+    #[test]
+    fn mask_bridge_invalid_physical() {
+        assert!(QuadPhysicalMask32::try_from_bits(2).is_err());
+        assert!(QuadPhysicalMask32::try_from_bits(8).is_err());
+        assert!(QuadPhysicalMask32::try_from_bits(1 << 63).is_err());
+        assert!(QuadPhysicalMask32::try_from_bits((1 << 1) | (1 << 3)).is_err());
+        assert!(QuadPhysicalMask32::try_from_bits(3).is_err());
+
+        let invalid = QuadPhysicalMask32(1 << 1);
+        assert!(invalid.try_to_lane().is_err());
+    }
+
+    #[test]
+    fn mask_bridge_trait_conversions() {
+        assert!(QuadPhysicalMask32::try_from(2u64).is_err());
+
+        let phys = QuadPhysicalMask32::try_from_bits(1 << 2).unwrap();
+        let dense = QuadMask32::try_from(phys).unwrap();
+        assert_eq!(dense.raw(), 1 << 1);
+
+        let raw: u64 = phys.into();
+        assert_eq!(raw, 1 << 2);
+    }
+
+    #[test]
+    fn mask_bridge_conversion_each_lane() {
+        for lane in 0..32 {
+            let dense = QuadMask32::new_unchecked(1 << lane);
+            let phys = dense.to_physical();
+            assert_eq!(phys.bits(), 1 << (lane * 2));
+
+            let dense_back = phys.try_to_lane().unwrap();
+            assert_eq!(dense_back.raw(), 1 << lane);
+        }
+    }
+
+    #[test]
+    fn mask_bridge_roundtrip() {
+        let cases = [
+            0x0000_0000,
+            0x0000_0001,
+            0x8000_0000,
+            0xFFFF_FFFF,
+            0x5555_5555,
+            0xAAAA_AAAA,
+            0x8000_0001,
+        ];
+
+        for &raw in &cases {
+            let dense = QuadMask32::new_unchecked(raw);
+            let phys = dense.to_physical();
+            let dense_back = phys.try_to_lane().unwrap();
+            assert_eq!(dense.raw(), dense_back.raw());
+        }
+    }
+
+    #[test]
+    fn mask_bridge_type_distinctness() {
+        use core::any::TypeId;
+
+        assert_ne!(
+            TypeId::of::<QuadMask32>(),
+            TypeId::of::<QuadPhysicalMask32>()
+        );
+
+        assert_eq!(TypeId::of::<QuadMask32>(), TypeId::of::<QuadLaneMask32>());
+    }
 
     fn reg_filled(state: QuadState) -> QuadroReg32 {
         let mut reg = QuadroReg32::new();

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -188,6 +188,38 @@ impl QuadroReg32 {
         self.0 ^ other.0
     }
 
+    /// Computes plane-based membership events (truth plane and falsity plane).
+    pub fn plane_delta(previous: Self, current: Self) -> PlaneDelta32 {
+        let prev_true = previous.mask_true();
+        let prev_false = previous.mask_false();
+        let curr_true = current.mask_true();
+        let curr_false = current.mask_false();
+
+        PlaneDelta32 {
+            entered_truth: curr_true.and(prev_true.not_valid()),
+            left_truth: prev_true.and(curr_true.not_valid()),
+            entered_falsity: curr_false.and(prev_false.not_valid()),
+            left_falsity: prev_false.and(curr_false.not_valid()),
+        }
+    }
+
+    /// Computes exact-state transition events for all four states (N, F, T, S).
+    pub fn exact_state_delta(previous: Self, current: Self) -> ExactStateDelta32 {
+        let prev_masks = previous.masks();
+        let curr_masks = current.masks();
+
+        ExactStateDelta32 {
+            entered_neither: curr_masks.n.and(prev_masks.n.not_valid()),
+            left_neither: prev_masks.n.and(curr_masks.n.not_valid()),
+            entered_strict_false: curr_masks.f.and(prev_masks.f.not_valid()),
+            left_strict_false: prev_masks.f.and(curr_masks.f.not_valid()),
+            entered_strict_true: curr_masks.t.and(prev_masks.t.not_valid()),
+            left_strict_true: prev_masks.t.and(curr_masks.t.not_valid()),
+            entered_super: curr_masks.s.and(prev_masks.s.not_valid()),
+            left_super: prev_masks.s.and(curr_masks.s.not_valid()),
+        }
+    }
+
     pub fn masks(self) -> QuadMasks32 {
         let mut n = 0u64;
         let mut f = 0u64;
@@ -844,6 +876,49 @@ impl Iterator for QuadMask128Iter {
     }
 }
 
+/// Describes changes in truth-plane and falsity-plane membership.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct PlaneDelta32 {
+    /// Lanes that entered truth-plane membership.
+    pub entered_truth: QuadMask32,
+    /// Lanes that left truth-plane membership.
+    pub left_truth: QuadMask32,
+    /// Lanes that entered falsity-plane membership.
+    pub entered_falsity: QuadMask32,
+    /// Lanes that left falsity-plane membership.
+    pub left_falsity: QuadMask32,
+}
+
+/// Describes entry into and exit from each exact Quad state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct ExactStateDelta32 {
+    /// Lanes that transitioned exactly into state `N` (neither).
+    pub entered_neither: QuadMask32,
+    /// Lanes that transitioned exactly out of state `N` (neither).
+    pub left_neither: QuadMask32,
+    /// Lanes that transitioned exactly into state `F` (strict_false).
+    pub entered_strict_false: QuadMask32,
+    /// Lanes that transitioned exactly out of state `F` (strict_false).
+    pub left_strict_false: QuadMask32,
+    /// Lanes that transitioned exactly into state `T` (strict_true).
+    pub entered_strict_true: QuadMask32,
+    /// Lanes that transitioned exactly out of state `T` (strict_true).
+    pub left_strict_true: QuadMask32,
+    /// Lanes that transitioned exactly into state `S` (super).
+    pub entered_super: QuadMask32,
+    /// Lanes that transitioned exactly out of state `S` (super).
+    pub left_super: QuadMask32,
+}
+
+/// Compatibility type representing a legacy mixed compatibility structure containing:
+/// * truth/falsity plane events;
+/// * exact `S`/conflict events;
+/// * aggregate changed/known/unknown events.
+///
+/// NOTE:
+/// * `entered_true` / `left_true`: truth-plane membership, not exact T
+/// * `entered_false` / `left_false`: falsity-plane membership, not exact F
+/// * `entered_super` / `left_super`: entry into and exit from exact S
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateDelta32 {
     pub entered_true: QuadMask32,
@@ -2002,5 +2077,446 @@ mod tests {
         // F lattice_join T = S, but F map_or T = T
         assert_eq!(f.lattice_join(t).get_unchecked(0), QuadState::S);
         assert_eq!(f.map_or(t).get_unchecked(0), QuadState::T);
+    }
+
+    #[test]
+    fn delta32_plane_and_exact_state_transitions() {
+        let run_test = |prev_s,
+                        curr_s,
+                        e_neither,
+                        l_neither,
+                        e_f,
+                        l_f,
+                        e_t,
+                        l_t,
+                        e_s,
+                        l_s,
+                        p_e_t,
+                        p_l_t,
+                        p_e_f,
+                        p_l_f| {
+            let prev = reg_filled(prev_s);
+            let curr = reg_filled(curr_s);
+            let exact = QuadroReg32::exact_state_delta(prev, curr);
+            let plane = QuadroReg32::plane_delta(prev, curr);
+
+            assert_eq!(
+                exact.entered_neither.count() == 32,
+                e_neither,
+                "exact.entered_neither"
+            );
+            assert_eq!(
+                exact.left_neither.count() == 32,
+                l_neither,
+                "exact.left_neither"
+            );
+            assert_eq!(
+                exact.entered_strict_false.count() == 32,
+                e_f,
+                "exact.entered_strict_false"
+            );
+            assert_eq!(
+                exact.left_strict_false.count() == 32,
+                l_f,
+                "exact.left_strict_false"
+            );
+            assert_eq!(
+                exact.entered_strict_true.count() == 32,
+                e_t,
+                "exact.entered_strict_true"
+            );
+            assert_eq!(
+                exact.left_strict_true.count() == 32,
+                l_t,
+                "exact.left_strict_true"
+            );
+            assert_eq!(
+                exact.entered_super.count() == 32,
+                e_s,
+                "exact.entered_super"
+            );
+            assert_eq!(exact.left_super.count() == 32, l_s, "exact.left_super");
+
+            assert_eq!(
+                plane.entered_truth.count() == 32,
+                p_e_t,
+                "plane.entered_truth"
+            );
+            assert_eq!(plane.left_truth.count() == 32, p_l_t, "plane.left_truth");
+            assert_eq!(
+                plane.entered_falsity.count() == 32,
+                p_e_f,
+                "plane.entered_falsity"
+            );
+            assert_eq!(
+                plane.left_falsity.count() == 32,
+                p_l_f,
+                "plane.left_falsity"
+            );
+        };
+
+        // prev_s, curr_s, e_neither, l_neither, e_f, l_f, e_t, l_t, e_s, l_s, p_e_t, p_l_t, p_e_f, p_l_f
+        run_test(
+            QuadState::T,
+            QuadState::S,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+            true,
+            false,
+        );
+        run_test(
+            QuadState::S,
+            QuadState::T,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+        );
+        run_test(
+            QuadState::F,
+            QuadState::S,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            true,
+            false,
+            true,
+            false,
+            false,
+            false,
+        );
+        run_test(
+            QuadState::S,
+            QuadState::F,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            true,
+            false,
+            false,
+        );
+        run_test(
+            QuadState::N,
+            QuadState::S,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+        );
+        run_test(
+            QuadState::S,
+            QuadState::N,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+        );
+        run_test(
+            QuadState::N,
+            QuadState::T,
+            false,
+            true,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+        );
+        run_test(
+            QuadState::T,
+            QuadState::N,
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+            false,
+            false,
+        );
+        run_test(
+            QuadState::N,
+            QuadState::F,
+            false,
+            true,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+        );
+        run_test(
+            QuadState::F,
+            QuadState::N,
+            true,
+            false,
+            false,
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+        );
+    }
+
+    fn scalar_truth_present(state: QuadState) -> bool {
+        matches!(state, QuadState::T | QuadState::S)
+    }
+
+    fn scalar_falsity_present(state: QuadState) -> bool {
+        matches!(state, QuadState::F | QuadState::S)
+    }
+
+    #[test]
+    fn delta32_exhaustive_4x4_matrix() {
+        for prev_state in QuadState::ALL {
+            for curr_state in QuadState::ALL {
+                let prev = reg_filled(prev_state);
+                let curr = reg_filled(curr_state);
+
+                let exact = QuadroReg32::exact_state_delta(prev, curr);
+                let plane = QuadroReg32::plane_delta(prev, curr);
+
+                for state in QuadState::ALL {
+                    let entered = prev_state != state && curr_state == state;
+                    let left = prev_state == state && curr_state != state;
+
+                    let (e_mask, l_mask) = match state {
+                        QuadState::N => (exact.entered_neither, exact.left_neither),
+                        QuadState::F => (exact.entered_strict_false, exact.left_strict_false),
+                        QuadState::T => (exact.entered_strict_true, exact.left_strict_true),
+                        QuadState::S => (exact.entered_super, exact.left_super),
+                    };
+
+                    if entered {
+                        assert_eq!(e_mask.count(), 32);
+                    } else {
+                        assert!(e_mask.is_empty());
+                    }
+                    if left {
+                        assert_eq!(l_mask.count(), 32);
+                    } else {
+                        assert!(l_mask.is_empty());
+                    }
+                }
+
+                let prev_t = scalar_truth_present(prev_state);
+                let curr_t = scalar_truth_present(curr_state);
+                let prev_f = scalar_falsity_present(prev_state);
+                let curr_f = scalar_falsity_present(curr_state);
+
+                let entered_t = !prev_t && curr_t;
+                let left_t = prev_t && !curr_t;
+                let entered_f = !prev_f && curr_f;
+                let left_f = prev_f && !curr_f;
+
+                if entered_t {
+                    assert_eq!(plane.entered_truth.count(), 32);
+                } else {
+                    assert!(plane.entered_truth.is_empty());
+                }
+                if left_t {
+                    assert_eq!(plane.left_truth.count(), 32);
+                } else {
+                    assert!(plane.left_truth.is_empty());
+                }
+                if entered_f {
+                    assert_eq!(plane.entered_falsity.count(), 32);
+                } else {
+                    assert!(plane.entered_falsity.is_empty());
+                }
+                if left_f {
+                    assert_eq!(plane.left_falsity.count(), 32);
+                } else {
+                    assert!(plane.left_falsity.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn delta32_plane_field_compatibility_matrix() {
+        for prev_state in QuadState::ALL {
+            for curr_state in QuadState::ALL {
+                let prev = reg_filled(prev_state);
+                let curr = reg_filled(curr_state);
+
+                let legacy = StateDelta32::from_regs(prev, curr);
+                let plane = QuadroReg32::plane_delta(prev, curr);
+
+                assert_eq!(legacy.entered_true, plane.entered_truth);
+                assert_eq!(legacy.left_true, plane.left_truth);
+                assert_eq!(legacy.entered_false, plane.entered_falsity);
+                assert_eq!(legacy.left_false, plane.left_falsity);
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_delta32_full_field_matrix_remains_stable() {
+        for prev_state in QuadState::ALL {
+            for curr_state in QuadState::ALL {
+                let prev = reg_filled(prev_state);
+                let curr = reg_filled(curr_state);
+                let legacy = StateDelta32::from_regs(prev, curr);
+
+                let prev_t = scalar_truth_present(prev_state);
+                let curr_t = scalar_truth_present(curr_state);
+                let prev_f = scalar_falsity_present(prev_state);
+                let curr_f = scalar_falsity_present(curr_state);
+
+                let entered_t = !prev_t && curr_t;
+                let left_t = prev_t && !curr_t;
+                let entered_f = !prev_f && curr_f;
+                let left_f = prev_f && !curr_f;
+
+                let entered_s = prev_state != QuadState::S && curr_state == QuadState::S;
+                let left_s = prev_state == QuadState::S && curr_state != QuadState::S;
+                let changed = prev_state != curr_state;
+                let became_known = !prev_state.is_known() && curr_state.is_known();
+                let became_unknown = prev_state.is_known() && !curr_state.is_known();
+
+                let became_conflicted = prev_state != QuadState::S && curr_state == QuadState::S;
+                let resolved_conflict = prev_state == QuadState::S && curr_state != QuadState::S;
+
+                let exp = |b| if b { 0xFFFF_FFFF } else { 0x0000_0000 };
+
+                assert_eq!(legacy.entered_true.raw(), exp(entered_t));
+                assert_eq!(legacy.left_true.raw(), exp(left_t));
+                assert_eq!(legacy.entered_false.raw(), exp(entered_f));
+                assert_eq!(legacy.left_false.raw(), exp(left_f));
+
+                assert_eq!(legacy.entered_super.raw(), exp(entered_s));
+                assert_eq!(legacy.left_super.raw(), exp(left_s));
+                assert_eq!(legacy.changed.raw(), exp(changed));
+                assert_eq!(legacy.became_known.raw(), exp(became_known));
+                assert_eq!(legacy.became_unknown.raw(), exp(became_unknown));
+                assert_eq!(legacy.became_conflicted.raw(), exp(became_conflicted));
+                assert_eq!(legacy.resolved_conflict.raw(), exp(resolved_conflict));
+            }
+        }
+    }
+
+    #[test]
+    fn delta32_identity_transitions() {
+        for state in QuadState::ALL {
+            let reg = reg_filled(state);
+            let exact = QuadroReg32::exact_state_delta(reg, reg);
+            let plane = QuadroReg32::plane_delta(reg, reg);
+
+            assert!(exact.entered_neither.is_empty());
+            assert!(exact.left_neither.is_empty());
+            assert!(exact.entered_strict_false.is_empty());
+            assert!(exact.left_strict_false.is_empty());
+            assert!(exact.entered_strict_true.is_empty());
+            assert!(exact.left_strict_true.is_empty());
+            assert!(exact.entered_super.is_empty());
+            assert!(exact.left_super.is_empty());
+
+            assert!(plane.entered_truth.is_empty());
+            assert!(plane.left_truth.is_empty());
+            assert!(plane.entered_falsity.is_empty());
+            assert!(plane.left_falsity.is_empty());
+        }
+    }
+
+    #[test]
+    fn delta32_mixed_lane_test() {
+        let mut prev = QuadroReg32::new();
+        let mut curr = QuadroReg32::new();
+
+        // lane 0: T -> S
+        prev.set_unchecked(0, QuadState::T);
+        curr.set_unchecked(0, QuadState::S);
+        // lane 1: S -> T
+        prev.set_unchecked(1, QuadState::S);
+        curr.set_unchecked(1, QuadState::T);
+        // lane 2: F -> N
+        prev.set_unchecked(2, QuadState::F);
+        curr.set_unchecked(2, QuadState::N);
+        // lane 3: N -> F
+        prev.set_unchecked(3, QuadState::N);
+        curr.set_unchecked(3, QuadState::F);
+
+        let exact = QuadroReg32::exact_state_delta(prev, curr);
+        let plane = QuadroReg32::plane_delta(prev, curr);
+
+        // Exact state assertions
+        assert_eq!(exact.left_strict_true.raw(), 1 << 0);
+        assert_eq!(exact.entered_super.raw(), 1 << 0);
+
+        assert_eq!(exact.left_super.raw(), 1 << 1);
+        assert_eq!(exact.entered_strict_true.raw(), 1 << 1);
+
+        assert_eq!(exact.left_strict_false.raw(), 1 << 2);
+        assert_eq!(exact.entered_neither.raw(), 1 << 2);
+
+        assert_eq!(exact.left_neither.raw(), 1 << 3);
+        assert_eq!(exact.entered_strict_false.raw(), 1 << 3);
+
+        // Plane assertions
+        assert_eq!(plane.entered_falsity.raw(), (1 << 0) | (1 << 3));
+        assert_eq!(plane.left_falsity.raw(), (1 << 1) | (1 << 2));
+        assert!(plane.entered_truth.is_empty());
+        assert!(plane.left_truth.is_empty());
     }
 }

--- a/docs/roadmap/core_quad/dense_physical_mask_bridge.md
+++ b/docs/roadmap/core_quad/dense_physical_mask_bridge.md
@@ -1,0 +1,24 @@
+# Core Quad Dense and Physical Mask Bridge
+
+## Ownership
+* **Owner:** `semantic-core-quad`
+
+## Representations
+* **Dense lane mask (`QuadLaneMask32` / `QuadMask32`):** Represents logical lane selection (lane `i` maps to bit `i`). Valid bits are `0` through `31`.
+* **Physical packed mask (`QuadPhysicalMask32`):** Represents physical selection within packed two-bit quadits (lane `i` maps to bit `i * 2`).
+
+## Validation Invariant
+* `QuadPhysicalMask32` valid bits are restricted to the LSBs of each quadit (even bits from `0` to `62`).
+* An explicit constructor `try_from_bits` validates that all odd bits are exactly `0` (`bits & !LSB_MASK_32 == 0`), rejecting invalid bits with a `QuadMaskError::InvalidPhysicalBits`.
+
+## Conversion Direction
+* **Dense to Physical:** `QuadMask32::to_physical(self) -> QuadPhysicalMask32` exactly spreads bit `i` to bit `i * 2`.
+* **Physical to Dense:** `QuadPhysicalMask32::try_to_lane(self) -> Result<QuadMask32, QuadMaskError>` exactly compresses bit `i * 2` to bit `i`.
+
+## Compatibility
+* **`QuadMask32` Status:** The existing semantic meaning remains stable. Bit `i` continues to refer to logical lane `i`. It now has a semantic alias `QuadLaneMask32`.
+* **Raw API Naming Rule:** Conversion to and from raw integers correctly respects the internal invariants and errors on failure, utilizing names like `bits()`, `raw()`, and `try_from_bits()`.
+* **Scope boundaries:**
+  * 128-lane physical masks (`QuadPhysicalMask128`) are explicitly **not** introduced here.
+  * This bridge fulfills the mask splitting required by #1408 under the compatibility policy #1413.
+  * Delta API and Tile Layout changes are out of scope.

--- a/docs/roadmap/core_quad/exact_plane_delta_split.md
+++ b/docs/roadmap/core_quad/exact_plane_delta_split.md
@@ -1,0 +1,56 @@
+# Core Quad Exact-State and Plane Delta Split
+
+## Ownership
+* **Owner:** `semantic-core-quad`
+
+## API Split Definition
+The original `StateDelta32` conceptually mixed plane changes (entering/leaving truth and falsity) and exact state transitions. To formalize the API:
+* **Plane Delta (`PlaneDelta32`):** Describes changes in truth-plane and falsity-plane membership.
+* **Exact-State Delta (`ExactStateDelta32`):** Describes entry into and exit from each exact Quad state independently.
+
+## State Mapping
+The exact state APIs use the established crate terminology:
+* `N` (00) -> `neither`
+* `F` (01) -> `strict_false`
+* `T` (10) -> `strict_true`
+* `S` (11) -> `super`
+
+## Formulas
+
+### Plane Formulas
+* `entered_truth = current_truth AND NOT previous_truth`
+* `left_truth = previous_truth AND NOT current_truth`
+* `entered_falsity = current_false AND NOT previous_false`
+* `left_falsity = previous_false AND NOT current_false`
+
+### Exact-State Formulas
+For any state `Q` in `{N, F, T, S}`:
+* `entered_Q = current_exact_Q AND NOT previous_exact_Q`
+* `left_Q = previous_exact_Q AND NOT current_exact_Q`
+
+## Representative Transition Table
+
+| Transition | Exact-state result | Plane result |
+| ---------- | ------------------------ | ------------------------- |
+| `T → S` | left strict T; entered S | falsity entered |
+| `S → T` | left S; entered strict T | falsity left |
+| `F → S` | left strict F; entered S | truth entered |
+| `S → F` | left S; entered strict F | truth left |
+| `N → S` | left N; entered S | truth and falsity entered |
+| `S → N` | left S; entered N | truth and falsity left |
+
+## Compatibility Posture
+* The public data shape and from_regs computation of `StateDelta32` remain unchanged. Rust documentation was clarified.
+* The four legacy truth/falsity plane fields of `StateDelta32` are semantically equivalent to the corresponding fields of `PlaneDelta32`. `StateDelta32` remains a broader mixed compatibility structure and also contains exact-super/conflict and aggregate changed/known events.
+* Inventory of `StateDelta32` legacy fields:
+  * Plane subset: `entered_true`, `left_true`, `entered_false`, `left_false`
+  * Exact S/conflict subset: `entered_super`, `left_super`, `became_conflicted`, `resolved_conflict`
+  * Aggregate subset: `changed`, `became_known`, `became_unknown`
+
+## Rationale
+All four states (including `N`) must be covered by `ExactStateDelta32` so transitions such as `N -> S` or `S -> N` are modeled fully as entry and exit events across the logic domain, preventing missing event coverage for variables dropping into or out of nullity. This satisfies issue #1409 under compatibility policy #1413.
+
+## Out of Scope
+Explicitly deferred:
+* 128-lane APIs (`StateDelta128`, `QuadTile128`) are deferred to a subsequent tile-level modification slice.
+* No changes made to mask, tile layout, bank semantics, parser, verifier, or VM behavior.

--- a/docs/roadmap/core_quad/v1_compatibility_rollout.md
+++ b/docs/roadmap/core_quad/v1_compatibility_rollout.md
@@ -1,0 +1,114 @@
+# Quad Logic Engine v1 Compatibility & Rollout Policy
+
+## 1. Ownership Boundary
+* **canonical owner:** `semantic-core-quad`
+* **compatibility-only owner:** `ton618-core`
+* **qualification consumer:** `semantic-core-capsule`
+
+## 2. Compatibility Dimensions
+The policy distinguishes the following compatibility dimensions. An item may be semantically and source-compatible while its ABI/layout remains unqualified.
+* **source/API compatibility:** The ability to compile against the public API without breakage.
+* **semantic compatibility:** The logical execution and behavior remaining correct according to specifications.
+* **binary ABI/layout compatibility:** The in-memory or on-disk byte representation of data structures.
+* **serialized-data compatibility:** The ability to correctly serialize/deserialize data across versions or environments (e.g. via `serde`).
+
+## 3. Public API Registry
+
+### `QuadState`
+* **semantic contract:** stable
+* **binary ABI/layout:** numeric representation or ABI must only be claimed if already explicitly qualified elsewhere.
+
+### `QuadroReg32`
+* **source/API and lane semantics:** stable
+* **binary ABI/layout:** not independently frozen by this policy unless backed by an explicit representation contract.
+* **forbidden silent change:** silent semantic reinterpretation remains forbidden.
+
+### `QuadMask32`
+* **status:** migration-candidate (ambiguous u64 mask)
+* **v1 guarantee:** strict isolation
+* **migration note:** will be split into physical vs logical mask types in upcoming PRs.
+
+### `QuadTile128`
+* **semantic contract:** lane count and semantic behavior are stable.
+* **binary ABI/layout:** alignment and binary/GPU transport layout are under review in #1417.
+* **allowed change:** an explicit qualified layout change is permitted through #1417.
+* **forbidden silent change:** silent layout mutation remains forbidden.
+
+### `QuadMask128`
+* **status:** migration-candidate (ambiguous u128 mask)
+* **v1 guarantee:** strict isolation
+* **migration note:** will be split into physical vs logical mask types in upcoming PRs.
+
+### `StateDelta32`
+* **status:** migration-candidate (diff of two 32-lane regs)
+* **migration note:** will split into exact-state and plane-delta types in upcoming PRs.
+
+### `StateDelta128`
+* **status:** migration-candidate (diff of two 128-lane regs)
+* **migration note:** will split into exact-state and plane-delta types in upcoming PRs.
+
+### `QuadroBank<N>` and `QuadTileBank<N>`
+* **semantic contract:** container and indexing semantics are preserved.
+* **binary ABI/layout:** not declared frozen by this policy.
+* **allowed change:** layout changes require explicit qualification and regression evidence.
+
+## 4. Additive-first rollout policy
+Early v1 changes are strictly bound to an additive-first approach. They may add:
+* typed mask wrappers
+* new exact-state delta types
+* new plane-delta types
+* new tile truth-map APIs
+* new bank helpers
+* qualification tests
+
+They must not *initially* remove or silently redefine existing APIs. Removal or renaming of legacy APIs is only permitted through an explicit, qualified breaking-change process (see Section 9).
+
+## 5. Ambiguous-name policy
+* `QuadMask32`: Currently an ambiguous raw mask. Will migrate to separate dense lane masks and physical packed masks.
+* `StateDelta32`: Currently a raw diff mask. Will migrate to separate exact-state events and plane events.
+* `entered_true` / `left_true`: Currently vague exact/plane boundaries. Will migrate to explicit plane event APIs.
+* `raw_delta`: Currently raw bitwise XOR. Will be migrated or isolated to prevent ambiguous event semantics.
+* `map_*`: truth-table operations.
+* `join` / `meet` / `inverse`: knowledge-lattice operations.
+Do not mix truth-table outputs with knowledge-lattice outputs under the same API family.
+
+## 6. Feature guarantees
+* `std`: currently verified (default feature flag)
+* `no_std`: check-qualified for the current crate under `cargo check -p semantic-core-quad --no-default-features`; full target/runtime qualification is not claimed.
+* `serde`: feature compilation verified via `--all-features`, but full round-trip semantic compatibility is not yet formally qualified.
+
+## 7. Core capsule qualification path
+Minimum checks required after each `core-quad` rollout PR:
+* `cargo test -p semantic-core-quad --quiet`
+* `cargo check -p semantic-core-quad --no-default-features`
+* `cargo test -p semantic-core-quad --all-features --quiet`
+* `cargo test -p semantic-core-capsule --quiet`
+
+*(Note: Passing `semantic-core-capsule` tests provides baseline downstream evidence, but does not prove total compatibility for all external consumers. It acts as an initial integration invariant.)*
+
+## 8. PR Sequence
+The controlled merge order:
+1. compatibility policy
+2. typed mask bridge
+3. delta split
+4. core tile layout decision
+5. tile truth maps
+6. bank helpers
+7. qualification and benches
+8. optional default-backend decision in a separate PR
+
+## 9. Breaking-change rule
+Any future change that modifies:
+* state encoding
+* mask interpretation
+* delta meaning
+* tile layout
+* truth-map output
+* legacy VM/source semantics
+
+must require:
+* dedicated issue
+* explicit compatibility classification
+* migration note
+* golden/regression evidence
+* separate PR

--- a/tests/legacy_guards.rs
+++ b/tests/legacy_guards.rs
@@ -324,6 +324,7 @@ fn ton618_content_inventory_is_explicit() {
         "./docs/architecture/dependency_boundary_rules.md",
         "./docs/architecture/module_ownership_map.md",
         "./docs/legacy-map.md",
+        "./docs/roadmap/core_quad/v1_compatibility_rollout.md",
         "./docs/roadmap/language_maturity/root_legacy_cleanup_full_scope.md",
         "./docs/roadmap/language_maturity/ton618_compatibility_perimeter_scope.md",
         "./docs/roadmap/pcc/ctf_no_std_qualification_audit.md",


### PR DESCRIPTION
## Summary

Publishes the accumulated Core Quad v1 foundation work as one controlled review stack:

1. Define the v1 compatibility and rollout policy.
2. Add an explicit dense-lane / physical-mask bridge while preserving `QuadMask32` semantics.
3. Split plane-delta and exact-state delta APIs while preserving `StateDelta32` compatibility behavior.

## Commits

- `1845115` — `docs(core-quad): define v1 compatibility rollout policy`
- `a46024c` — `refactor(core-quad): add explicit lane and physical mask bridge`
- `e8d926f` — `feat(core-quad): split exact-state and plane delta APIs`

## Compatibility posture

- `QuadMask32` remains the dense logical lane-mask API.
- `QuadPhysicalMask32` is a distinct validated packed-position mask type.
- Existing `QuadroReg32::set_by_mask` behavior is preserved.
- `StateDelta32` remains the broader legacy compatibility structure.
- `PlaneDelta32` exposes explicit truth/falsity-plane events.
- `ExactStateDelta32` exposes exact entry/exit events for `N`, `F`, `T`, and `S`.
- Tile-level layout and 128-lane delta forms remain out of scope.

## Verification

- `cargo test -p semantic-core-quad --quiet` — 117 passed
- `cargo check -p semantic-core-quad --no-default-features` — passed
- `cargo test -p semantic-core-quad --all-features --quiet` — 117 passed
- `cargo test -p semantic-core-capsule --quiet` — 8 passed
- `git diff --check` — passed
- `scripts/harness-check.ps1` — passed

Closes #1408
Closes #1409
Refs #1413
Refs #1404