### PR TITLE
feat(core-quad): lift v1 truth maps to QuadTile128

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: CORE-QUAD-TILE128-LAYOUT
-  title: align and qualify QuadTile128 core layout
+  id: CORE-QUAD-TILE-TRUTH-MAPS
+  title: lift default truth maps to QuadTile128
   type: implementation
   mode: active
 
 intent:
-  summary: "test(core-quad): correct QuadTile128 qualification evidence"
-  issue: "#1417"
+  summary: "feat(core-quad): lift v1 truth maps to QuadTile128"
+  issue: "#1411"
 
 layer:
   name: core_quad
@@ -15,9 +15,9 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-TILE128-LAYOUT.md
-    - docs/roadmap/core_quad/quad_tile128_layout_boundary.md
+    - .harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md
     - crates/semantic-core-quad/src/lib.rs
+    - docs/roadmap/core_quad/tile_truth_map_lifting.md
 
 actions:
   allowed:
@@ -33,12 +33,13 @@ actions:
   forbidden:
     - modify_other_crates
     - modify_docs_spec
-    - modify_visual
-    - modify_gpu_layout
-    - modify_tile_semantics
+    - modify_tile_layout
     - modify_mask_api
     - modify_delta_api
-    - modify_bank_api
+    - modify_reg_map_semantics
+    - add_equiv
+    - modify_banks
+    - modify_visual
     - add_dependency
     - force_push
     - merge

--- a/.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md
+++ b/.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md
@@ -1,0 +1,50 @@
+# Harness Report: CORE-QUAD-TILE-TRUTH-MAPS
+
+## Overview
+- **Starting main commit:** a17c3a86c3d2c666b015c32bf3e3d83707299707
+- **Branch:** core-quad/tile-truth-map-lifting
+- **PR:** (pending)
+
+## Inventory
+Existing register map inventory:
+`map_not`, `map_xor`, `map_and`, `map_or`, `map_implies`, `map_nand`, `map_nor`
+
+Added tile map inventory:
+`map_not`, `map_xor`, `map_and`, `map_or`, `map_implies`, `map_nand`, `map_nor`
+
+**EQUIV deferral:** `map_equiv` explicitly omitted per v1 compatibility policy.
+
+## Strategy
+Tile methods convert to four registers, apply register mapping, and reconstruct the tile. This is the deterministic reference implementation.
+
+## Tests
+- `tile_default_unary_map_matches_reg_oracle`
+- `tile_default_binary_maps_match_reg_oracle`
+- `tile_default_matrix_transitions`
+- `tile_default_boundary_lanes`
+- `tile128_lattice_stability`
+
+Lattice method preservation (`join`, `meet`, `inverse`) proved unchanged.
+
+## Posture
+- `no_std` compatibility remains intact.
+- `serde` compatibility remains intact.
+
+## Verification
+- Pinned fmt/clippy: passed
+- Tests (all, quiet, nocapture): passed
+- Legacy guards: passed
+- Harness check: passed
+- Diff check: passed
+
+## Changed Files
+- `.harness/current.task.yaml`
+- `.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md`
+- `crates/semantic-core-quad/src/lib.rs`
+- `docs/roadmap/core_quad/tile_truth_map_lifting.md`
+
+## Explicit Non-Changes
+- EQUIV maps
+- Bank-level maps (`QuadroBank`, `QuadTileBank`)
+- Plane optimizations
+- GPU transport

--- a/.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md
+++ b/.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md
@@ -1,50 +1,121 @@
 # Harness Report: CORE-QUAD-TILE-TRUTH-MAPS
 
-## Overview
-- **Starting main commit:** a17c3a86c3d2c666b015c32bf3e3d83707299707
-- **Branch:** core-quad/tile-truth-map-lifting
-- **PR:** (pending)
+## Status
 
-## Inventory
-Existing register map inventory:
-`map_not`, `map_xor`, `map_and`, `map_or`, `map_implies`, `map_nand`, `map_nor`
+- **Starting main commit:** `a17c3a86c3d2c666b015c32bf3e3d83707299707`
+- **Branch:** `core-quad/tile-truth-map-lifting`
+- **Implementation commit:** `bbfbf8be1ee68caae77964910dedfa7ea55bb156`
+- **Pull request:** `#1480`
+- **Issue slice:** first of two slices for `#1411`
 
-Added tile map inventory:
-`map_not`, `map_xor`, `map_and`, `map_or`, `map_implies`, `map_nand`, `map_nor`
+## Register Map Inventory
 
-**EQUIV deferral:** `map_equiv` explicitly omitted per v1 compatibility policy.
+The existing default `QuadroReg32` truth maps used as the oracle are:
 
-## Strategy
-Tile methods convert to four registers, apply register mapping, and reconstruct the tile. This is the deterministic reference implementation.
+- `map_not`
+- `map_xor`
+- `map_and`
+- `map_or`
+- `map_implies`
+- `map_nand`
+- `map_nor`
 
-## Tests
+## Added Tile Map Inventory
+
+`QuadTile128` now exposes:
+
+- `map_not`
+- `map_xor`
+- `map_and`
+- `map_or`
+- `map_implies`
+- `map_nand`
+- `map_nor`
+
+`map_equiv` remains explicitly deferred under the current v1 compatibility policy.
+
+## Implementation Strategy
+
+Each tile method follows the deterministic reference path:
+
+1. convert `QuadTile128` into four `QuadroReg32` values with `to_regs()`;
+2. apply the corresponding default register-level `map_*` operation;
+3. reconstruct the tile with `from_regs()`.
+
+The implementation:
+
+- performs no allocation;
+- uses no `unsafe`;
+- adds no direct `u128` plane formulas;
+- does not duplicate scalar truth tables;
+- remains compatible with the crate's `no_std` posture.
+
+## Test Inventory
+
 - `tile_default_unary_map_matches_reg_oracle`
 - `tile_default_binary_maps_match_reg_oracle`
 - `tile_default_matrix_transitions`
 - `tile_default_boundary_lanes`
 - `tile128_lattice_stability`
 
-Lattice method preservation (`join`, `meet`, `inverse`) proved unchanged.
+The tests prove:
 
-## Posture
-- `no_std` compatibility remains intact.
-- `serde` compatibility remains intact.
+- tile NOT matches the four-register oracle;
+- all six binary tile maps match the four-register oracle;
+- all `4 × 4` repeated-state binary combinations match register behavior;
+- register-boundary lane ordering is preserved;
+- `join`, `meet`, and `inverse` retain their knowledge-lattice behavior.
+
+## Semantic Separation
+
+Truth maps remain distinct from:
+
+- `join`
+- `meet`
+- `inverse`
+- `raw_delta`
+
+No truth-map operation was implemented as a renamed lattice operation.
 
 ## Verification
-- Pinned fmt/clippy: passed
-- Tests (all, quiet, nocapture): passed
-- Legacy guards: passed
-- Harness check: passed
-- Diff check: passed
 
-## Changed Files
-- `.harness/current.task.yaml`
-- `.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md`
-- `crates/semantic-core-quad/src/lib.rs`
-- `docs/roadmap/core_quad/tile_truth_map_lifting.md`
+Local fail-fast verification passed:
+
+- `cargo +1.93.1 fmt --all --check`
+- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings`
+- `cargo test -p semantic-core-quad tile_default_ -- --nocapture`
+- `cargo test -p semantic-core-quad --quiet`
+- `cargo check -p semantic-core-quad --no-default-features`
+- `cargo test -p semantic-core-quad --all-features --quiet`
+- `cargo test -p semantic-core-capsule --quiet`
+- `cargo test --test legacy_guards --quiet`
+- `cargo test --all-targets --quiet`
+- `git diff --check`
+- `scripts/harness-check.ps1`
+
+GitHub Actions run `#4351` passed all eight jobs at implementation head:
+
+```text
+bbfbf8be1ee68caae77964910dedfa7ea55bb156
+```
+
+## Changed Files in PR
+
+* `.harness/current.task.yaml`
+* `.harness/reports/CORE-QUAD-TILE-TRUTH-MAPS.md`
+* `crates/semantic-core-quad/src/lib.rs`
+* `docs/roadmap/core_quad/tile_truth_map_lifting.md`
 
 ## Explicit Non-Changes
-- EQUIV maps
-- Bank-level maps (`QuadroBank`, `QuadTileBank`)
-- Plane optimizations
-- GPU transport
+
+* No `map_equiv`.
+* No `QuadroBank<N>` map helpers.
+* No `QuadTileBank<N>` map helpers.
+* No tile layout change.
+* No mask API change.
+* No delta API change.
+* No register truth-map semantic change.
+* No direct plane optimization.
+* No GPU transport implementation.
+* No VM or runtime change.
+* No dependency addition.

--- a/crates/semantic-core-quad/src/lib.rs
+++ b/crates/semantic-core-quad/src/lib.rs
@@ -834,6 +834,100 @@ impl QuadTile128 {
         }
         regs
     }
+
+    /// Applies the `NOT` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation and is not an alias for the knowledge-lattice `inverse`.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_not(self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        Self::from_regs([a0.map_not(), a1.map_not(), a2.map_not(), a3.map_not()])
+    }
+
+    /// Applies the `XOR` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_xor(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([
+            a0.map_xor(b0),
+            a1.map_xor(b1),
+            a2.map_xor(b2),
+            a3.map_xor(b3),
+        ])
+    }
+
+    /// Applies the `AND` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation and is not an alias for the knowledge-lattice `meet`.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_and(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([
+            a0.map_and(b0),
+            a1.map_and(b1),
+            a2.map_and(b2),
+            a3.map_and(b3),
+        ])
+    }
+
+    /// Applies the `OR` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation and is not an alias for the knowledge-lattice `join`.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_or(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([a0.map_or(b0), a1.map_or(b1), a2.map_or(b2), a3.map_or(b3)])
+    }
+
+    /// Applies the `IMPLIES` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_implies(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([
+            a0.map_implies(b0),
+            a1.map_implies(b1),
+            a2.map_implies(b2),
+            a3.map_implies(b3),
+        ])
+    }
+
+    /// Applies the `NAND` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_nand(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([
+            a0.map_nand(b0),
+            a1.map_nand(b1),
+            a2.map_nand(b2),
+            a3.map_nand(b3),
+        ])
+    }
+
+    /// Applies the `NOR` truth map independently across four 32-lane registers.
+    /// This lifts the default register map semantics to the 128-lane tile.
+    /// This is a truth-table operation.
+    /// The implementation uses four-register decomposition as the deterministic reference path.
+    pub fn map_nor(self, other: Self) -> Self {
+        let [a0, a1, a2, a3] = self.to_regs();
+        let [b0, b1, b2, b3] = other.to_regs();
+        Self::from_regs([
+            a0.map_nor(b0),
+            a1.map_nor(b1),
+            a2.map_nor(b2),
+            a3.map_nor(b3),
+        ])
+    }
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -2598,5 +2692,174 @@ mod tests {
         assert_eq!(tile.known_mask().raw(), known_bits);
         assert_eq!(tile.conflict_mask().raw(), conflict_bits);
         assert_eq!(tile.null_mask().raw(), null_bits);
+    }
+
+    #[test]
+    fn tile_default_unary_map_matches_reg_oracle() {
+        let mut r0 = QuadroReg32::new();
+        let mut r1 = QuadroReg32::new();
+        let mut r2 = QuadroReg32::new();
+        let mut r3 = QuadroReg32::new();
+        for lane in 0..32 {
+            r0.set_unchecked(lane, QuadState::ALL[lane % 4]);
+            r1.set_unchecked(lane, QuadState::ALL[(lane + 1) % 4]);
+            r2.set_unchecked(lane, QuadState::ALL[(lane + 2) % 4]);
+            r3.set_unchecked(lane, QuadState::ALL[(lane + 3) % 4]);
+        }
+        let tile = QuadTile128::from_regs([r0, r1, r2, r3]);
+
+        assert_eq!(
+            tile.map_not().to_regs(),
+            [r0.map_not(), r1.map_not(), r2.map_not(), r3.map_not()]
+        );
+    }
+
+    #[test]
+    fn tile_default_binary_maps_match_reg_oracle() {
+        let mut r0_a = QuadroReg32::new();
+        let mut r1_a = QuadroReg32::new();
+        let mut r2_a = QuadroReg32::new();
+        let mut r3_a = QuadroReg32::new();
+
+        let mut r0_b = QuadroReg32::new();
+        let mut r1_b = QuadroReg32::new();
+        let mut r2_b = QuadroReg32::new();
+        let mut r3_b = QuadroReg32::new();
+
+        for lane in 0..32 {
+            r0_a.set_unchecked(lane, QuadState::ALL[lane % 4]);
+            r1_a.set_unchecked(lane, QuadState::ALL[(lane + 1) % 4]);
+            r2_a.set_unchecked(lane, QuadState::ALL[(lane + 2) % 4]);
+            r3_a.set_unchecked(lane, QuadState::ALL[(lane + 3) % 4]);
+
+            r0_b.set_unchecked(lane, QuadState::ALL[(lane + 3) % 4]);
+            r1_b.set_unchecked(lane, QuadState::ALL[(lane + 2) % 4]);
+            r2_b.set_unchecked(lane, QuadState::ALL[(lane + 1) % 4]);
+            r3_b.set_unchecked(lane, QuadState::ALL[lane % 4]);
+        }
+
+        let tile_a = QuadTile128::from_regs([r0_a, r1_a, r2_a, r3_a]);
+        let tile_b = QuadTile128::from_regs([r0_b, r1_b, r2_b, r3_b]);
+
+        assert_eq!(
+            tile_a.map_xor(tile_b).to_regs(),
+            [
+                r0_a.map_xor(r0_b),
+                r1_a.map_xor(r1_b),
+                r2_a.map_xor(r2_b),
+                r3_a.map_xor(r3_b)
+            ]
+        );
+        assert_eq!(
+            tile_a.map_and(tile_b).to_regs(),
+            [
+                r0_a.map_and(r0_b),
+                r1_a.map_and(r1_b),
+                r2_a.map_and(r2_b),
+                r3_a.map_and(r3_b)
+            ]
+        );
+        assert_eq!(
+            tile_a.map_or(tile_b).to_regs(),
+            [
+                r0_a.map_or(r0_b),
+                r1_a.map_or(r1_b),
+                r2_a.map_or(r2_b),
+                r3_a.map_or(r3_b)
+            ]
+        );
+        assert_eq!(
+            tile_a.map_implies(tile_b).to_regs(),
+            [
+                r0_a.map_implies(r0_b),
+                r1_a.map_implies(r1_b),
+                r2_a.map_implies(r2_b),
+                r3_a.map_implies(r3_b)
+            ]
+        );
+        assert_eq!(
+            tile_a.map_nand(tile_b).to_regs(),
+            [
+                r0_a.map_nand(r0_b),
+                r1_a.map_nand(r1_b),
+                r2_a.map_nand(r2_b),
+                r3_a.map_nand(r3_b)
+            ]
+        );
+        assert_eq!(
+            tile_a.map_nor(tile_b).to_regs(),
+            [
+                r0_a.map_nor(r0_b),
+                r1_a.map_nor(r1_b),
+                r2_a.map_nor(r2_b),
+                r3_a.map_nor(r3_b)
+            ]
+        );
+    }
+
+    #[test]
+    fn tile_default_matrix_transitions() {
+        for lhs in QuadState::ALL {
+            for rhs in QuadState::ALL {
+                let tile_a = tile_filled(lhs);
+                let tile_b = tile_filled(rhs);
+
+                let reg_a = reg_filled(lhs);
+                let reg_b = reg_filled(rhs);
+
+                assert_eq!(tile_a.map_xor(tile_b).to_regs(), [reg_a.map_xor(reg_b); 4]);
+                assert_eq!(tile_a.map_and(tile_b).to_regs(), [reg_a.map_and(reg_b); 4]);
+                assert_eq!(tile_a.map_or(tile_b).to_regs(), [reg_a.map_or(reg_b); 4]);
+                assert_eq!(
+                    tile_a.map_implies(tile_b).to_regs(),
+                    [reg_a.map_implies(reg_b); 4]
+                );
+                assert_eq!(
+                    tile_a.map_nand(tile_b).to_regs(),
+                    [reg_a.map_nand(reg_b); 4]
+                );
+                assert_eq!(tile_a.map_nor(tile_b).to_regs(), [reg_a.map_nor(reg_b); 4]);
+            }
+        }
+    }
+
+    #[test]
+    fn tile_default_boundary_lanes() {
+        let mut tile_a = QuadTile128::new();
+        let mut tile_b = QuadTile128::new();
+
+        let lanes = [0, 31, 32, 63, 64, 95, 96, 127];
+        for (i, &lane) in lanes.iter().enumerate() {
+            tile_a.set_unchecked(lane, QuadState::ALL[i % 4]);
+            tile_b.set_unchecked(lane, QuadState::ALL[(i + 1) % 4]);
+        }
+
+        let regs_a = tile_a.to_regs();
+        let regs_b = tile_b.to_regs();
+
+        let res = tile_a.map_xor(tile_b);
+        let res_regs = res.to_regs();
+
+        for i in 0..4 {
+            assert_eq!(res_regs[i], regs_a[i].map_xor(regs_b[i]));
+        }
+    }
+
+    #[test]
+    fn tile128_lattice_stability() {
+        let lhs = QuadTile128::from_planes(0b1010, 0b1100);
+        let rhs = QuadTile128::from_planes(0b0110, 0b1010);
+
+        let joined = lhs.join(rhs);
+        assert_eq!(joined.true_plane(), 0b1110);
+        assert_eq!(joined.false_plane(), 0b1110);
+
+        let met = lhs.meet(rhs);
+        assert_eq!(met.true_plane(), 0b0010);
+        assert_eq!(met.false_plane(), 0b1000);
+
+        let inv = lhs.inverse();
+        assert_eq!(inv.true_plane(), 0b1100);
+        assert_eq!(inv.false_plane(), 0b1010);
     }
 }

--- a/docs/roadmap/core_quad/tile_truth_map_lifting.md
+++ b/docs/roadmap/core_quad/tile_truth_map_lifting.md
@@ -1,0 +1,52 @@
+# Roadmap: Tile Truth Map Lifting (#1411)
+
+## Metadata
+* **Owner:** `semantic-core-quad`
+* **Issue:** #1411
+* **Context:** This is the first slice of #1411. Relates to #1413 (API compatibility) and #1404 (v1 roadmap).
+
+## Supported Tile Truth Maps
+The following default truth maps have been lifted to `QuadTile128`:
+- NOT
+- XOR
+- AND
+- OR
+- IMPLIES
+- NAND
+- NOR
+
+## Explicit Omission of EQUIV
+`map_equiv` is intentionally omitted from this layer to adhere to the v1 compatibility policy.
+
+## Implementation Strategy
+This is the deterministic reference path:
+1. Decompose the 128-lane tile into four 32-lane `QuadroReg32` registers.
+2. Apply the default register-level map to each.
+3. Reconstruct the tile from the four resulting registers.
+
+This avoids duplicating the complex boolean combinations and provides an indisputable source of truth.
+
+## Distinction from Lattice Methods
+Truth maps apply pure logic operations on states. They are distinct from the knowledge lattice operations:
+- `join`: least upper bound in the knowledge lattice
+- `meet`: greatest lower bound
+- `inverse`: truth and falsity swap
+- `raw_delta`: XOR of plane bitmasks
+
+## Posture
+- **Allocation:** None.
+- **Environment:** `no_std` compatible.
+- **Layout:** The 32-byte, 16-byte-aligned `QuadTile128` layout remains unchanged.
+
+## Deferred Optimization
+- Direct plane formulas for `QuadTile128`.
+- Benchmarking of reference vs direct implementations.
+
+## Deferred Second Slice (#1411)
+- Additive helpers for `QuadroBank<N>`
+- Additive helpers for `QuadTileBank<N>`
+
+## Explicit Non-Changes
+- No GPU transport implementation
+- No visual layer or wgpu
+- No changes to underlying masks or tile layouts


### PR DESCRIPTION
## Summary

- lift the seven proven default `QuadroReg32` truth maps to `QuadTile128`;
- use four-register decomposition as the deterministic reference implementation;
- preserve the existing tile layout and knowledge-lattice methods;
- keep EQUIV and bank-level helpers deferred.

## Supported tile maps

- NOT
- XOR
- AND
- OR
- IMPLIES
- NAND
- NOR

## Boundaries

This PR does not add EQUIV, direct plane formulas, bank helpers, GPU transport code, dependencies, VM changes, or runtime changes.

## Verification

- `cargo +1.93.1 fmt --all --check`: passed
- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings`: passed
- tile oracle tests: passed
- `cargo test -p semantic-core-quad --quiet`: passed
- `cargo check -p semantic-core-quad --no-default-features`: passed
- all-features tests: passed
- capsule tests: passed
- legacy guards: passed
- root all-target tests: passed
- harness check: passed
- GitHub Actions run #4351: passed

Refs #1411
Refs #1413
Refs #1404
