### PR TITLE
test(core-quad): add public v1 qualification matrix

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: CORE-QUAD-V1-COMPATIBILITY-CLOSEOUT
-  title: close out the Quad Logic Engine v1 compatibility policy
-  type: documentation
+  id: CORE-QUAD-V1-QUALIFICATION-MATRIX
+  title: add public v1 qualification matrix
+  type: test
   mode: active
 
 intent:
-  summary: "docs(core-quad): close v1 compatibility rollout policy"
-  issue: "#1413"
+  summary: "test(core-quad): add public v1 qualification matrix"
+  issue: "#1412"
 
 layer:
   name: core_quad
@@ -15,15 +15,16 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-V1-COMPATIBILITY-CLOSEOUT.md
-    - docs/roadmap/core_quad/v1_compatibility_rollout.md
-    - docs/roadmap/core_quad/v1_compatibility_closeout.md
+    - .harness/reports/CORE-QUAD-V1-QUALIFICATION-MATRIX.md
+    - crates/semantic-core-quad/tests/v1_qualification.rs
+    - docs/roadmap/core_quad/v1_qualification_matrix.md
 
 actions:
   allowed:
     - inspect
     - edit_harness
-    - modify_docs
+    - create_tests
+    - modify_tests
     - create_docs
     - test
     - commit
@@ -31,13 +32,13 @@ actions:
     - create_pr
 
   forbidden:
-    - modify_rust
-    - modify_tests
+    - modify_core_source
     - modify_cargo
     - modify_specs
     - modify_other_crates
-    - modify_visual
     - add_equiv
+    - add_benchmarks
+    - modify_visual
     - add_dependency
     - force_push
     - merge

--- a/.harness/reports/CORE-QUAD-V1-QUALIFICATION-MATRIX.md
+++ b/.harness/reports/CORE-QUAD-V1-QUALIFICATION-MATRIX.md
@@ -1,0 +1,114 @@
+# CORE-QUAD-V1-QUALIFICATION-MATRIX
+
+## Starting main commit
+
+`f563e39015db7d3a0ed0f727666b6481e5c44764`
+
+## Branch
+
+`core-quad/v1-qualification-matrix`
+
+## Issue and parent
+
+- Issue: #1412
+- Parent: #1404
+
+## Exact changed-file boundary
+
+```text
+.harness/current.task.yaml
+.harness/reports/CORE-QUAD-V1-QUALIFICATION-MATRIX.md
+crates/semantic-core-quad/tests/v1_qualification.rs
+docs/roadmap/core_quad/v1_qualification_matrix.md
+```
+
+## Existing inline inventory reviewed
+
+The reviewed inline inventory includes frozen state encoding, mask bridge
+roundtrips and type distinction, odd physical-mask rejection, scalar/SWAR map
+equivalence for all seven maps, 4x4 delta transitions, register/tile
+roundtrips, tile map oracles, register and tile bank elementwise oracles, and
+the repeated-state bank matrix.
+
+## Downstream/public integration purpose
+
+`v1_qualification.rs` imports `semantic_core_quad` as an external consumer and
+uses only public API. It complements the inline tests by checking the actual
+downstream surface instead of relying on implementation-local access.
+
+## Integration test inventory
+
+- `qualification_state_encoding_is_frozen`
+- `qualification_register_scalar_swar_and_default_maps_agree`
+- `qualification_truth_policy_invariants`
+- `qualification_mask_bridge_roundtrip_and_rejection`
+- `qualification_exact_and_plane_delta_matrix`
+- `qualification_tile_maps_match_four_register_oracle`
+- `qualification_reg_bank_maps_match_elementwise_oracle`
+- `qualification_tile_bank_maps_match_elementwise_oracle`
+- `qualification_truth_and_lattice_families_remain_distinct`
+
+## Canonical vectors and matrix coverage
+
+The exact seven canonical raw vectors from the task are used. Register binary
+equivalence covers the complete 7x7 vector matrix. Delta coverage covers all
+16 previous/current pairs in `[N, F, T, S]` with only lane 9 set. Tile and bank
+fixtures use observably distinct elements. The suite is deterministic and uses
+no randomness, wall-clock input, environment-specific CPU features, or
+platform-dependent values.
+
+## Qualification coverage
+
+- **State encoding:** public `bits()` and `from_bits()` freeze `N/F/T/S` as `00/01/10/11`.
+- **Register equivalence:** scalar, SWAR, and default unary plus six binary maps.
+- **Policy invariants:** NOT involution, XOR identity, NAND/NOR derivation,
+  IMPLIES policy, commutativity set, and directional witness.
+- **Mask bridge:** dense roundtrips, alias passage, physical-bit validation,
+  odd-bit rejection, and highest valid lane.
+- **Delta matrix:** all exact-state fields and plane fields, with no unrelated
+  lanes set.
+- **Tile lifting:** public four-register construction, roundtrip, and seven
+  default map oracles.
+- **Register-bank lifting:** unary and six binary in-place maps, ordering, and
+  right-bank preservation.
+- **Tile-bank lifting:** unary and six binary in-place maps, ordering, and
+  right-bank preservation.
+- **Lattice boundary:** truth-map results are checked separately from meet,
+  join, and inverse API-family results.
+
+## EQUIV and benchmark deferral
+
+EQUIV is excluded from the qualified v1 API and is not introduced here. No
+benchmark implementation is included. The second #1412 slice is reserved for
+benchmark inventory, execution method, relative-output policy, and issue
+closeout without absolute performance promises.
+
+## Feature posture and core capsule
+
+- `std`: tested.
+- `no_std`: check-qualified through `--no-default-features`.
+- `serde`: all-features compile/test-qualified.
+- `semantic-core-capsule`: retained as the minimum downstream smoke path.
+
+## Exact local verification commands and results
+
+```text
+cargo +1.93.1 fmt --all --check                              PASS
+cargo +1.93.1 clippy --workspace --all-targets -- -D warnings PASS
+cargo test -p semantic-core-quad --test v1_qualification -- --nocapture PASS (9 tests)
+cargo test -p semantic-core-quad --quiet                     PASS (134 inline, 9 integration)
+cargo check -p semantic-core-quad --no-default-features      PASS
+cargo test -p semantic-core-quad --all-features --quiet      PASS (134 inline, 9 integration)
+cargo test -p semantic-core-capsule --quiet                   PASS (8 tests)
+cargo test --test legacy_guards --quiet                       PASS (10 tests)
+cargo test --all-targets --quiet                              PASS
+git diff --check                                              PASS
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1 PASS
+```
+
+## Explicit non-changes
+
+No production Rust source, Cargo file, public API, specification, other crate,
+dependency, EQUIV surface, benchmark code, CPU-specific intrinsic, visual/GPU
+code, runtime behavior, or unrelated untracked file was modified or staged.
+This test-only slice does not close #1412.

--- a/crates/semantic-core-quad/tests/v1_qualification.rs
+++ b/crates/semantic-core-quad/tests/v1_qualification.rs
@@ -1,0 +1,464 @@
+use semantic_core_quad::{
+    ExactStateDelta32, PlaneDelta32, QuadLaneMask32, QuadMask32, QuadPhysicalMask32, QuadState,
+    QuadTile128, QuadTileBank, QuadroBank, QuadroReg32,
+};
+
+const RAW_SAMPLES: [u64; 7] = [
+    0x0000_0000_0000_0000,
+    0xFFFF_FFFF_FFFF_FFFF,
+    0x5555_5555_5555_5555,
+    0xAAAA_AAAA_AAAA_AAAA,
+    0x0123_4567_89AB_CDEF,
+    0xE4E4_E4E4_E4E4_E4E4,
+    0xBADC_0FFE_DEAD_BEEF,
+];
+
+fn reg(raw: u64) -> QuadroReg32 {
+    QuadroReg32::from_raw(raw)
+}
+
+fn repeated(state: QuadState) -> QuadroReg32 {
+    let mut value = QuadroReg32::new();
+    for lane in 0..QuadroReg32::LANES {
+        value.set_unchecked(lane, state);
+    }
+    value
+}
+
+fn tile_binary_oracle(
+    lhs: [QuadroReg32; 4],
+    rhs: [QuadroReg32; 4],
+    operation: fn(QuadroReg32, QuadroReg32) -> QuadroReg32,
+) -> QuadTile128 {
+    QuadTile128::from_regs([
+        operation(lhs[0], rhs[0]),
+        operation(lhs[1], rhs[1]),
+        operation(lhs[2], rhs[2]),
+        operation(lhs[3], rhs[3]),
+    ])
+}
+
+#[test]
+fn qualification_state_encoding_is_frozen() {
+    assert_eq!(QuadState::N.bits(), 0b00);
+    assert_eq!(QuadState::F.bits(), 0b01);
+    assert_eq!(QuadState::T.bits(), 0b10);
+    assert_eq!(QuadState::S.bits(), 0b11);
+
+    assert_eq!(QuadState::from_bits(0), Some(QuadState::N));
+    assert_eq!(QuadState::from_bits(1), Some(QuadState::F));
+    assert_eq!(QuadState::from_bits(2), Some(QuadState::T));
+    assert_eq!(QuadState::from_bits(3), Some(QuadState::S));
+    assert_eq!(QuadState::from_bits(4), None);
+}
+
+#[test]
+fn qualification_register_scalar_swar_and_default_maps_agree() {
+    for lhs_raw in RAW_SAMPLES {
+        let lhs = reg(lhs_raw);
+        assert_eq!(lhs.map_not_scalar(), lhs.map_not_swar());
+        assert_eq!(lhs.map_not_swar(), lhs.map_not());
+
+        for rhs_raw in RAW_SAMPLES {
+            let rhs = reg(rhs_raw);
+            assert_eq!(lhs.map_xor_scalar(rhs), lhs.map_xor_swar(rhs));
+            assert_eq!(lhs.map_xor_swar(rhs), lhs.map_xor(rhs));
+            assert_eq!(lhs.map_and_scalar(rhs), lhs.map_and_swar(rhs));
+            assert_eq!(lhs.map_and_swar(rhs), lhs.map_and(rhs));
+            assert_eq!(lhs.map_or_scalar(rhs), lhs.map_or_swar(rhs));
+            assert_eq!(lhs.map_or_swar(rhs), lhs.map_or(rhs));
+            assert_eq!(lhs.map_implies_scalar(rhs), lhs.map_implies_swar(rhs));
+            assert_eq!(lhs.map_implies_swar(rhs), lhs.map_implies(rhs));
+            assert_eq!(lhs.map_nand_scalar(rhs), lhs.map_nand_swar(rhs));
+            assert_eq!(lhs.map_nand_swar(rhs), lhs.map_nand(rhs));
+            assert_eq!(lhs.map_nor_scalar(rhs), lhs.map_nor_swar(rhs));
+            assert_eq!(lhs.map_nor_swar(rhs), lhs.map_nor(rhs));
+        }
+    }
+}
+
+#[test]
+fn qualification_truth_policy_invariants() {
+    for a in QuadState::ALL {
+        let a_reg = repeated(a);
+        assert_eq!(a_reg.map_not().map_not(), a_reg, "NOT is not involutive");
+        assert_eq!(a_reg.map_xor(a_reg), repeated(QuadState::N));
+
+        for b in QuadState::ALL {
+            let b_reg = repeated(b);
+            assert_eq!(
+                a_reg.map_nand(b_reg),
+                a_reg.map_and(b_reg).map_not(),
+                "NAND derivation mismatch"
+            );
+            assert_eq!(
+                a_reg.map_nor(b_reg),
+                a_reg.map_or(b_reg).map_not(),
+                "NOR derivation mismatch"
+            );
+            assert_eq!(
+                a_reg.map_implies(b_reg),
+                repeated(a.inverse().join(b)),
+                "IMPLIES policy mismatch"
+            );
+
+            assert_eq!(a_reg.map_xor(b_reg), b_reg.map_xor(a_reg));
+            assert_eq!(a_reg.map_and(b_reg), b_reg.map_and(a_reg));
+            assert_eq!(a_reg.map_or(b_reg), b_reg.map_or(a_reg));
+            assert_eq!(a_reg.map_nand(b_reg), b_reg.map_nand(a_reg));
+            assert_eq!(a_reg.map_nor(b_reg), b_reg.map_nor(a_reg));
+        }
+    }
+
+    assert_ne!(
+        repeated(QuadState::F).map_implies(repeated(QuadState::N)),
+        repeated(QuadState::N).map_implies(repeated(QuadState::F))
+    );
+    assert_eq!(
+        repeated(QuadState::F).map_implies(repeated(QuadState::N)),
+        repeated(QuadState::T)
+    );
+    assert_eq!(
+        repeated(QuadState::N).map_implies(repeated(QuadState::F)),
+        repeated(QuadState::F)
+    );
+}
+
+#[test]
+fn qualification_mask_bridge_roundtrip_and_rejection() {
+    let dense_masks = [
+        0x0000_0000,
+        0x0000_0001,
+        0x8000_0000,
+        0x8000_0001,
+        0xFFFF_FFFF,
+    ];
+    for dense in dense_masks {
+        let mask = QuadMask32::try_new(dense).expect("dense mask must be valid");
+        let lane_mask: QuadLaneMask32 = mask;
+        let physical = lane_mask.to_physical();
+        assert_eq!(physical.bits() & 0xAAAA_AAAA_AAAA_AAAA, 0);
+        assert_eq!(physical.try_to_lane().unwrap().raw(), dense);
+    }
+
+    for odd_bit in [1u64 << 1, 1u64 << 3, 1u64 << 63] {
+        assert!(QuadPhysicalMask32::try_from_bits(odd_bit).is_err());
+    }
+
+    let highest_lane = QuadPhysicalMask32::try_from_bits(1u64 << 62).unwrap();
+    assert_eq!(highest_lane.try_to_lane().unwrap().raw(), 1u64 << 31);
+}
+
+#[test]
+fn qualification_exact_and_plane_delta_matrix() {
+    let lane = 9usize;
+    let lane_bit = 1u64 << lane;
+    for previous_state in QuadState::ALL {
+        for current_state in QuadState::ALL {
+            let mut previous = QuadroReg32::new();
+            let mut current = QuadroReg32::new();
+            previous.set_unchecked(lane, previous_state);
+            current.set_unchecked(lane, current_state);
+
+            let exact: ExactStateDelta32 = QuadroReg32::exact_state_delta(previous, current);
+            let exact_fields = [
+                (exact.entered_neither, QuadState::N, true),
+                (exact.left_neither, QuadState::N, false),
+                (exact.entered_strict_false, QuadState::F, true),
+                (exact.left_strict_false, QuadState::F, false),
+                (exact.entered_strict_true, QuadState::T, true),
+                (exact.left_strict_true, QuadState::T, false),
+                (exact.entered_super, QuadState::S, true),
+                (exact.left_super, QuadState::S, false),
+            ];
+            for (mask, target, entered) in exact_fields {
+                let expected = if (entered && current_state == target && previous_state != target)
+                    || (!entered && previous_state == target && current_state != target)
+                {
+                    lane_bit
+                } else {
+                    0
+                };
+                assert_eq!(mask.raw(), expected, "exact delta mask mismatch");
+                assert_eq!(mask.raw() & !lane_bit, 0);
+            }
+
+            let plane: PlaneDelta32 = QuadroReg32::plane_delta(previous, current);
+            let previous_truth = previous_state.bits() & 0b10 != 0;
+            let current_truth = current_state.bits() & 0b10 != 0;
+            let previous_falsity = previous_state.bits() & 0b01 != 0;
+            let current_falsity = current_state.bits() & 0b01 != 0;
+            let plane_fields = [
+                (plane.entered_truth, !previous_truth && current_truth),
+                (plane.left_truth, previous_truth && !current_truth),
+                (plane.entered_falsity, !previous_falsity && current_falsity),
+                (plane.left_falsity, previous_falsity && !current_falsity),
+            ];
+            for (mask, should_be_set) in plane_fields {
+                assert_eq!(mask.raw(), if should_be_set { lane_bit } else { 0 });
+                assert_eq!(mask.raw() & !lane_bit, 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn qualification_tile_maps_match_four_register_oracle() {
+    let lhs = [
+        reg(RAW_SAMPLES[0]),
+        reg(RAW_SAMPLES[1]),
+        reg(RAW_SAMPLES[2]),
+        reg(RAW_SAMPLES[3]),
+    ];
+    let rhs = [
+        reg(RAW_SAMPLES[4]),
+        reg(RAW_SAMPLES[5]),
+        reg(RAW_SAMPLES[6]),
+        reg(RAW_SAMPLES[0]),
+    ];
+    let lhs_tile = QuadTile128::from_regs(lhs);
+    let rhs_tile = QuadTile128::from_regs(rhs);
+    assert_eq!(lhs_tile.to_regs(), lhs);
+    assert_eq!(rhs_tile.to_regs(), rhs);
+    assert_eq!(
+        lhs_tile.map_not(),
+        QuadTile128::from_regs(lhs.map(QuadroReg32::map_not))
+    );
+    assert_eq!(
+        lhs_tile.map_xor(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_xor)
+    );
+    assert_eq!(
+        lhs_tile.map_and(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_and)
+    );
+    assert_eq!(
+        lhs_tile.map_or(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_or)
+    );
+    assert_eq!(
+        lhs_tile.map_implies(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_implies)
+    );
+    assert_eq!(
+        lhs_tile.map_nand(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_nand)
+    );
+    assert_eq!(
+        lhs_tile.map_nor(rhs_tile),
+        tile_binary_oracle(lhs, rhs, QuadroReg32::map_nor)
+    );
+}
+
+fn assert_reg_binary_map(
+    operation: &str,
+    lhs: [QuadroReg32; 4],
+    rhs: [QuadroReg32; 4],
+    apply: fn(&mut QuadroBank<4>, &QuadroBank<4>),
+    oracle: fn(QuadroReg32, QuadroReg32) -> QuadroReg32,
+) {
+    let rhs_bank = QuadroBank::from_array(rhs);
+    let rhs_before = *rhs_bank.as_array();
+    let mut actual = QuadroBank::from_array(lhs);
+    apply(&mut actual, &rhs_bank);
+    for index in 0..4 {
+        assert_eq!(
+            actual.get(index).unwrap(),
+            oracle(lhs[index], rhs[index]),
+            "{operation} register bank element {index}"
+        );
+    }
+    assert_eq!(
+        *rhs_bank.as_array(),
+        rhs_before,
+        "{operation} changed rhs bank"
+    );
+}
+
+#[test]
+fn qualification_reg_bank_maps_match_elementwise_oracle() {
+    let lhs = [
+        reg(RAW_SAMPLES[0]),
+        reg(RAW_SAMPLES[1]),
+        reg(RAW_SAMPLES[2]),
+        reg(RAW_SAMPLES[3]),
+    ];
+    let rhs = [
+        reg(RAW_SAMPLES[4]),
+        reg(RAW_SAMPLES[5]),
+        reg(RAW_SAMPLES[6]),
+        reg(RAW_SAMPLES[0]),
+    ];
+    let mut unary = QuadroBank::from_array(lhs);
+    unary.map_not_inplace();
+    for (index, value) in lhs.iter().enumerate() {
+        assert_eq!(unary.get(index).unwrap(), value.map_not());
+    }
+    assert_reg_binary_map(
+        "xor",
+        lhs,
+        rhs,
+        QuadroBank::map_xor_inplace,
+        QuadroReg32::map_xor,
+    );
+    assert_reg_binary_map(
+        "and",
+        lhs,
+        rhs,
+        QuadroBank::map_and_inplace,
+        QuadroReg32::map_and,
+    );
+    assert_reg_binary_map(
+        "or",
+        lhs,
+        rhs,
+        QuadroBank::map_or_inplace,
+        QuadroReg32::map_or,
+    );
+    assert_reg_binary_map(
+        "implies",
+        lhs,
+        rhs,
+        QuadroBank::map_implies_inplace,
+        QuadroReg32::map_implies,
+    );
+    assert_reg_binary_map(
+        "nand",
+        lhs,
+        rhs,
+        QuadroBank::map_nand_inplace,
+        QuadroReg32::map_nand,
+    );
+    assert_reg_binary_map(
+        "nor",
+        lhs,
+        rhs,
+        QuadroBank::map_nor_inplace,
+        QuadroReg32::map_nor,
+    );
+}
+
+fn assert_tile_binary_map(
+    operation: &str,
+    lhs: [QuadTile128; 4],
+    rhs: [QuadTile128; 4],
+    apply: fn(&mut QuadTileBank<4>, &QuadTileBank<4>),
+    oracle: fn(QuadTile128, QuadTile128) -> QuadTile128,
+) {
+    let rhs_bank = QuadTileBank::from_array(rhs);
+    let rhs_before = *rhs_bank.as_array();
+    let mut actual = QuadTileBank::from_array(lhs);
+    apply(&mut actual, &rhs_bank);
+    for index in 0..4 {
+        assert_eq!(
+            actual.get(index).unwrap(),
+            oracle(lhs[index], rhs[index]),
+            "{operation} tile bank element {index}"
+        );
+    }
+    assert_eq!(
+        *rhs_bank.as_array(),
+        rhs_before,
+        "{operation} changed rhs bank"
+    );
+}
+
+#[test]
+fn qualification_tile_bank_maps_match_elementwise_oracle() {
+    let lhs_regs = [
+        reg(RAW_SAMPLES[0]),
+        reg(RAW_SAMPLES[1]),
+        reg(RAW_SAMPLES[2]),
+        reg(RAW_SAMPLES[3]),
+    ];
+    let rhs_regs = [
+        reg(RAW_SAMPLES[4]),
+        reg(RAW_SAMPLES[5]),
+        reg(RAW_SAMPLES[6]),
+        reg(RAW_SAMPLES[0]),
+    ];
+    let lhs = [
+        QuadTile128::from_regs([lhs_regs[0]; 4]),
+        QuadTile128::from_regs([lhs_regs[1]; 4]),
+        QuadTile128::from_regs([lhs_regs[2]; 4]),
+        QuadTile128::from_regs([lhs_regs[3]; 4]),
+    ];
+    let rhs = [
+        QuadTile128::from_regs([rhs_regs[0]; 4]),
+        QuadTile128::from_regs([rhs_regs[1]; 4]),
+        QuadTile128::from_regs([rhs_regs[2]; 4]),
+        QuadTile128::from_regs([rhs_regs[3]; 4]),
+    ];
+    let mut unary = QuadTileBank::from_array(lhs);
+    unary.map_not_inplace();
+    for (index, value) in lhs.iter().enumerate() {
+        assert_eq!(unary.get(index).unwrap(), value.map_not());
+    }
+    assert_tile_binary_map(
+        "xor",
+        lhs,
+        rhs,
+        QuadTileBank::map_xor_inplace,
+        QuadTile128::map_xor,
+    );
+    assert_tile_binary_map(
+        "and",
+        lhs,
+        rhs,
+        QuadTileBank::map_and_inplace,
+        QuadTile128::map_and,
+    );
+    assert_tile_binary_map(
+        "or",
+        lhs,
+        rhs,
+        QuadTileBank::map_or_inplace,
+        QuadTile128::map_or,
+    );
+    assert_tile_binary_map(
+        "implies",
+        lhs,
+        rhs,
+        QuadTileBank::map_implies_inplace,
+        QuadTile128::map_implies,
+    );
+    assert_tile_binary_map(
+        "nand",
+        lhs,
+        rhs,
+        QuadTileBank::map_nand_inplace,
+        QuadTile128::map_nand,
+    );
+    assert_tile_binary_map(
+        "nor",
+        lhs,
+        rhs,
+        QuadTileBank::map_nor_inplace,
+        QuadTile128::map_nor,
+    );
+}
+
+#[test]
+fn qualification_truth_and_lattice_families_remain_distinct() {
+    assert_eq!(
+        repeated(QuadState::F).map_and(repeated(QuadState::T)),
+        repeated(QuadState::F)
+    );
+    assert_eq!(
+        repeated(QuadState::F).meet(repeated(QuadState::T)),
+        repeated(QuadState::N)
+    );
+    assert_eq!(
+        repeated(QuadState::F).map_or(repeated(QuadState::T)),
+        repeated(QuadState::T)
+    );
+    assert_eq!(
+        repeated(QuadState::F).join(repeated(QuadState::T)),
+        repeated(QuadState::S)
+    );
+
+    for state in QuadState::ALL {
+        assert_eq!(repeated(state).map_not(), repeated(state.inverse()));
+        assert_eq!(repeated(state).inverse(), repeated(state.inverse()));
+    }
+}

--- a/docs/roadmap/core_quad/v1_qualification_matrix.md
+++ b/docs/roadmap/core_quad/v1_qualification_matrix.md
@@ -1,0 +1,80 @@
+# Quad Logic Engine v1 Public Qualification Matrix
+
+## Scope
+
+- **Owner:** `semantic-core-quad`
+- **Issue:** #1412
+- **Parent:** #1404
+- **Slice:** qualification slice 1 of 2
+
+This PR qualifies the landed v1 public API through an external-consumer
+integration test. It does not close #1412.
+
+## Why an integration suite
+
+`crates/semantic-core-quad/tests/v1_qualification.rs` imports
+`semantic_core_quad` as a downstream crate and uses only public constructors,
+methods, fields, and accessors. It complements rather than replaces the inline
+unit tests: inline tests can inspect implementation-local behavior, while this
+matrix proves that the qualified contract is reachable through the public
+surface.
+
+## Existing inline unit-test inventory
+
+The review covered the existing tests for frozen state encoding, mask bridge
+roundtrips and type distinction, odd physical-mask rejection, scalar/SWAR map
+equivalence for all seven maps, the 4x4 delta matrices, register/tile
+roundtrips, tile map oracles, register and tile bank elementwise maps, and the
+repeated-state bank matrix. The new suite exercises those contracts as public
+downstream behavior rather than copying their internal helpers.
+
+## Public qualification layers
+
+The integration matrix covers:
+
+- state encoding through `bits()` and `from_bits()`;
+- scalar, SWAR, and default register truth maps;
+- the dense/physical typed-mask bridge and rejection rules;
+- exact-state and plane deltas across the complete 4x4 state matrix;
+- tile lifting through four public register values;
+- register-bank and tile-bank in-place lifting;
+- truth-map versus knowledge-lattice API-family separation.
+
+## Deterministic vectors and matrices
+
+The suite uses exactly these canonical raw register vectors:
+
+```text
+0x0000_0000_0000_0000
+0xFFFF_FFFF_FFFF_FFFF
+0x5555_5555_5555_5555
+0xAAAA_AAAA_AAAA_AAAA
+0x0123_4567_89AB_CDEF
+0xE4E4_E4E4_E4E4_E4E4
+0xBADC_0FFE_DEAD_BEEF
+```
+
+Register equivalence covers the complete 7x7 binary matrix. Delta assertions
+cover every previous/current pair in `[N, F, T, S]` and isolate lane 9. Tile
+and bank fixtures contain observably distinct elements. No randomness, wall
+clock, environment-specific CPU feature, or platform-dependent value is used.
+
+## Policy boundaries
+
+EQUIV remains deferred and is not part of the qualified v1 API. This PR adds no
+benchmark implementation. The second #1412 slice is reserved for benchmark
+inventory, an available no-new-dependency execution method, relative-output
+policy, and issue closeout without absolute performance promises.
+
+## Feature posture and smoke path
+
+- `std`: tested.
+- `no_std`: check-qualified through `--no-default-features`.
+- `serde`: compile/test-qualified under `--all-features`.
+- `semantic-core-capsule`: retained as the minimum downstream smoke consumer.
+
+## Explicit non-changes
+
+No production source, Cargo configuration, public API, specification, other
+crate, dependency, visual/GPU layer, runtime behavior, EQUIV surface, or
+benchmark code is changed. This PR does not close #1412.


### PR DESCRIPTION
## Summary

- add downstream-style integration qualification for the public Quad Logic Engine v1 API;
- freeze scalar, SWAR, and default register-map equivalence over canonical vectors;
- qualify mask, delta, tile, bank, and lattice boundaries through public APIs;
- keep EQUIV and benchmark implementation deferred.

## Qualification layers

- state encoding
- register truth maps
- typed mask bridge
- exact-state and plane deltas
- tile lifting
- bank lifting
- truth-map/lattice separation

## Boundaries

This PR adds integration tests and qualification documentation only. It does not modify production Rust source, Cargo configuration, public APIs, EQUIV policy, benchmarks, GPU transport, VM behavior, or runtime behavior.

## Verification

- `cargo +1.93.1 fmt --all --check` — PASS
- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings` — PASS
- `cargo test -p semantic-core-quad --test v1_qualification -- --nocapture` — PASS (9 tests)
- `cargo test -p semantic-core-quad --quiet` — PASS (134 inline, 9 integration)
- `cargo check -p semantic-core-quad --no-default-features` — PASS
- `cargo test -p semantic-core-quad --all-features --quiet` — PASS (134 inline, 9 integration)
- `cargo test -p semantic-core-capsule --quiet` — PASS (8 tests)
- `cargo test --test legacy_guards --quiet` — PASS (10 tests)
- `cargo test --all-targets --quiet` — PASS
- `git diff --check` — PASS
- `scripts/harness-check.ps1` — PASS

Refs #1412
Refs #1404