### PR TITLE
bench(core-quad): add v1 relative benchmark closeout

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,30 +1,30 @@
 task:
-  id: CORE-QUAD-V1-QUALIFICATION-MATRIX
-  title: add public v1 qualification matrix
-  type: test
+  id: CORE-QUAD-V1-BENCHMARK-CLOSEOUT
+  title: add relative v1 benchmarks and close qualification
+  type: benchmark
   mode: active
 
 intent:
-  summary: "test(core-quad): add public v1 qualification matrix"
+  summary: "bench(core-quad): add v1 relative benchmark closeout"
   issue: "#1412"
 
 layer:
   name: core_quad
-  owner: semantic-core-quad
+  owner: semantic-core-bench
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-V1-QUALIFICATION-MATRIX.md
-    - crates/semantic-core-quad/tests/v1_qualification.rs
-    - docs/roadmap/core_quad/v1_qualification_matrix.md
+    - .harness/reports/CORE-QUAD-V1-BENCHMARK-CLOSEOUT.md
+    - crates/semantic-core-bench/src/lib.rs
+    - docs/roadmap/core_quad/v1_benchmark_closeout.md
 
 actions:
   allowed:
     - inspect
     - edit_harness
-    - create_tests
-    - modify_tests
+    - modify_benchmark
+    - modify_benchmark_tests
     - create_docs
     - test
     - commit
@@ -32,13 +32,14 @@ actions:
     - create_pr
 
   forbidden:
-    - modify_core_source
+    - modify_core_quad
     - modify_cargo
     - modify_specs
     - modify_other_crates
-    - add_equiv
-    - add_benchmarks
-    - modify_visual
     - add_dependency
+    - add_equiv
+    - add_performance_threshold
+    - add_cpu_specific_requirement
+    - modify_visual
     - force_push
     - merge

--- a/.harness/reports/CORE-QUAD-V1-BENCHMARK-CLOSEOUT.md
+++ b/.harness/reports/CORE-QUAD-V1-BENCHMARK-CLOSEOUT.md
@@ -1,0 +1,132 @@
+# CORE-QUAD-V1-BENCHMARK-CLOSEOUT
+
+## Starting main commit
+
+`ceee937b87e3b97519a9bbd2ff52fb727a499f31`
+
+## Branch, issue, and parent
+
+- Branch: `core-quad/v1-benchmark-closeout`
+- Issue: #1412
+- Parent: #1404
+
+## Exact changed-file boundary
+
+```text
+.harness/current.task.yaml
+.harness/reports/CORE-QUAD-V1-BENCHMARK-CLOSEOUT.md
+crates/semantic-core-bench/src/lib.rs
+docs/roadmap/core_quad/v1_benchmark_closeout.md
+```
+
+## Existing benchmark mechanism reviewed
+
+`semantic-core-bench` already exposes the `core-bench` CLI, dispatches through
+`run_benchmark`, uses `std::time::Instant`, and depends on
+`semantic-core-quad`. The implementation reuses this mechanism without adding
+a framework or dependency. Existing command behavior and the existing `all`
+composition remain unchanged.
+
+## New command and benchmark inventory
+
+```text
+cargo run -p semantic-core-bench --release -- quad-v1
+```
+
+The command reports:
+
+- register NOT through scalar, SWAR, and default APIs;
+- register AND through scalar, SWAR, and default APIs;
+- default tile XOR;
+- in-place XOR for `QuadroBank<64>`;
+- in-place XOR for `QuadTileBank<32>`;
+- dense/physical mask roundtrip;
+- dense-mask iteration;
+- relative register NOT and AND summaries.
+
+The production iteration count is 100,000 API calls per sample.
+
+## Deterministic vectors
+
+The exact seven canonical raw vectors from PR #1483 are scheduled in a fixed
+order. No randomness, current-time input, environment seed, or detected CPU
+capability changes the operation set.
+
+## Optimization-barrier policy
+
+`std::hint::black_box` wraps benchmark inputs and consumed results. Every
+timed iteration contributes to an emitted checksum. The checksum prevents
+dead-code elimination; it is not a correctness or compatibility promise.
+Fixed arrays are initialized outside bank hot loops, and no heap allocation
+occurs inside the new timed loops.
+
+## Relative and threshold policy
+
+Relative ratios use `baseline elapsed time / candidate elapsed time`, with
+elapsed nanoseconds clamped to at least one. A ratio above 1.0 describes only
+that local run. There is no timing threshold, performance assertion,
+benchmark-driven behavior selection, universal speedup claim, or cross-machine
+comparison claim. No optional CPU feature is required.
+
+## Qualification dependency and EQUIV
+
+PR #1483's public integration matrix owns correctness. This closeout adds only
+observational performance evidence. EQUIV remains excluded by the #1413
+compatibility policy and is not part of the qualified v1 public API.
+
+## Feature posture and core capsule
+
+- `std`: tested.
+- `no_std`: check-qualified through `--no-default-features`.
+- `serde`: compile/test-qualified under `--all-features`.
+- `semantic-core-capsule`: minimum downstream smoke consumer; 8 tests passed.
+
+## Exact verification commands and results
+
+```text
+cargo +1.93.1 fmt --all --check                              PASS
+cargo +1.93.1 clippy --workspace --all-targets -- -D warnings PASS
+cargo test -p semantic-core-bench --quiet                    PASS (2 tests)
+cargo +1.93.1 run --quiet -p semantic-core-bench --release -- quad-v1 PASS
+release output required-label and finite-value validation    PASS
+cargo test -p semantic-core-quad --test v1_qualification -- --nocapture PASS (9 tests)
+cargo test -p semantic-core-quad --quiet                     PASS (134 inline, 9 integration)
+cargo check -p semantic-core-quad --no-default-features      PASS
+cargo test -p semantic-core-quad --all-features --quiet      PASS (134 inline, 9 integration)
+cargo test -p semantic-core-capsule --quiet                   PASS (8 tests)
+cargo test --test legacy_guards --quiet                       PASS (10 tests)
+cargo test --all-targets --quiet                              PASS
+git diff --check                                              PASS
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1 PASS
+```
+
+The release command completed and emitted every required benchmark group,
+checksums, and finite relative summaries. Local numeric observations are not
+recorded as normative values.
+
+## #1412 acceptance mapping
+
+| Criterion | Evidence |
+| --- | --- |
+| State encoding freeze | PR #1483 integration matrix |
+| Truth-policy invariants | PR #1483 integration matrix |
+| Scalar/SWAR equivalence | PR #1483 integration matrix |
+| 4x4 delta matrix | PR #1483 integration matrix |
+| Mask model | PR #1483 integration matrix |
+| Tile/bank lifting | PR #1483 integration matrix |
+| Core capsule smoke | Retained command, 8 passing tests |
+| Minimal performance evidence | `quad-v1` release command |
+| Relative-output policy | Relative summary implementation and closeout doc |
+| Workspace qualification | Full local command set above and PR CI |
+
+## Remaining work
+
+- #1417 remains open for GPU transport representation.
+- #1404 remains open for umbrella roadmap closeout.
+
+## Explicit non-changes
+
+No `semantic-core-quad` file, Cargo file, dependency, public Quad API, spec,
+other crate, EQUIV surface, timing threshold, CPU-specific requirement,
+visual/GPU code, VM/runtime behavior, or unrelated untracked file was modified
+or staged.

--- a/crates/semantic-core-bench/src/lib.rs
+++ b/crates/semantic-core-bench/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write as _;
+use std::hint::black_box;
 use std::time::Instant;
 
 use semantic_core_backend::{
@@ -6,12 +7,15 @@ use semantic_core_backend::{
 };
 use semantic_core_capsule::CoreCapsule;
 use semantic_core_exec::{CoreConfig, CoreFunction, CoreProgram, CoreValue, Fx, Instr, RegId};
-use semantic_core_quad::{QuadState, QuadTile128, QuadroReg32};
+use semantic_core_quad::{
+    QuadMask32, QuadState, QuadTile128, QuadTileBank, QuadroBank, QuadroReg32,
+};
 use semantic_core_runtime::{FunctionId, SymbolId};
 
 pub fn run_benchmark(name: &str) -> Result<String, String> {
     match name {
         "quad-reg" => Ok(bench_quad_reg()),
+        "quad-v1" => Ok(bench_quad_v1()),
         "tile" => Ok(bench_tile()),
         "exec" => Ok(bench_exec()),
         "all" => Ok(format!(
@@ -114,6 +118,345 @@ fn bench_exec() -> String {
     text
 }
 
+const QUAD_V1_ITERATIONS: u64 = 100_000;
+const REG_BANK_LEN: usize = 64;
+const TILE_BANK_LEN: usize = 32;
+const QUAD_V1_RAW_SAMPLES: [u64; 7] = [
+    0x0000_0000_0000_0000,
+    0xFFFF_FFFF_FFFF_FFFF,
+    0x5555_5555_5555_5555,
+    0xAAAA_AAAA_AAAA_AAAA,
+    0x0123_4567_89AB_CDEF,
+    0xE4E4_E4E4_E4E4_E4E4,
+    0xBADC_0FFE_DEAD_BEEF,
+];
+
+struct BenchSample {
+    name: &'static str,
+    ops: u64,
+    nanos: u64,
+    checksum: u64,
+}
+
+fn bench_quad_v1() -> String {
+    bench_quad_v1_with_iterations(QUAD_V1_ITERATIONS)
+}
+
+fn bench_quad_v1_with_iterations(iterations: u64) -> String {
+    let iterations = iterations.max(1);
+    let reg_not_scalar = time_reg_unary(
+        "quad-v1/reg-not-scalar",
+        iterations,
+        QuadroReg32::map_not_scalar,
+    );
+    let reg_not_swar = time_reg_unary(
+        "quad-v1/reg-not-swar",
+        iterations,
+        QuadroReg32::map_not_swar,
+    );
+    let reg_not_default =
+        time_reg_unary("quad-v1/reg-not-default", iterations, QuadroReg32::map_not);
+    let reg_and_scalar = time_reg_binary(
+        "quad-v1/reg-and-scalar",
+        iterations,
+        QuadroReg32::map_and_scalar,
+    );
+    let reg_and_swar = time_reg_binary(
+        "quad-v1/reg-and-swar",
+        iterations,
+        QuadroReg32::map_and_swar,
+    );
+    let reg_and_default =
+        time_reg_binary("quad-v1/reg-and-default", iterations, QuadroReg32::map_and);
+    let tile_xor = time_tile_xor(iterations);
+    let reg_bank_xor = time_reg_bank_xor(iterations);
+    let tile_bank_xor = time_tile_bank_xor(iterations);
+    let mask_roundtrip = time_mask_roundtrip(iterations);
+    let (mask_iteration, visited_lanes) = time_mask_iteration(iterations);
+
+    let build_mode = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let mut text = format!(
+        "quad-v1 benchmark\narchitecture: {}\nbuild mode: {build_mode}\niteration count: {iterations}\npolicy: observational relative timings; no performance threshold",
+        std::env::consts::ARCH
+    );
+    for sample in [
+        &reg_not_scalar,
+        &reg_not_swar,
+        &reg_not_default,
+        &reg_and_scalar,
+        &reg_and_swar,
+        &reg_and_default,
+    ] {
+        let _ = write!(text, "\n{}", format_quad_v1_sample(sample, &[]));
+    }
+    let _ = write!(
+        text,
+        "\n{}",
+        format_quad_v1_sample(
+            &tile_xor,
+            &[
+                ("tiles/s", tile_xor.ops),
+                ("quadits/s", tile_xor.ops * QuadTile128::LANES as u64),
+            ],
+        )
+    );
+    let _ = write!(
+        text,
+        "\n{}",
+        format_quad_v1_sample(
+            &reg_bank_xor,
+            &[
+                ("registers/s", reg_bank_xor.ops * REG_BANK_LEN as u64),
+                (
+                    "quadits/s",
+                    reg_bank_xor.ops * REG_BANK_LEN as u64 * QuadroReg32::LANES as u64,
+                ),
+            ],
+        )
+    );
+    let _ = write!(
+        text,
+        "\n{}",
+        format_quad_v1_sample(
+            &tile_bank_xor,
+            &[
+                ("tiles/s", tile_bank_xor.ops * TILE_BANK_LEN as u64),
+                (
+                    "quadits/s",
+                    tile_bank_xor.ops * TILE_BANK_LEN as u64 * QuadTile128::LANES as u64,
+                ),
+            ],
+        )
+    );
+    let _ = write!(
+        text,
+        "\n{}",
+        format_quad_v1_sample(&mask_roundtrip, &[("conversions/s", mask_roundtrip.ops)],)
+    );
+    let _ = write!(
+        text,
+        "\n{}",
+        format_quad_v1_sample(&mask_iteration, &[("visited-lanes/s", visited_lanes)],)
+    );
+    let _ = write!(
+        text,
+        "\nquad-v1/relative-reg-not: swar_vs_scalar={:.4} default_vs_scalar={:.4}",
+        relative_ratio(&reg_not_scalar, &reg_not_swar),
+        relative_ratio(&reg_not_scalar, &reg_not_default),
+    );
+    let _ = write!(
+        text,
+        "\nquad-v1/relative-reg-and: swar_vs_scalar={:.4} default_vs_scalar={:.4}",
+        relative_ratio(&reg_and_scalar, &reg_and_swar),
+        relative_ratio(&reg_and_scalar, &reg_and_default),
+    );
+    text
+}
+
+fn time_reg_unary(
+    name: &'static str,
+    iterations: u64,
+    operation: fn(QuadroReg32) -> QuadroReg32,
+) -> BenchSample {
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for index in 0..iterations {
+        let input = QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[index as usize % 7]);
+        let result = operation(black_box(input));
+        checksum = mix_checksum(checksum, black_box(result.raw()));
+    }
+    BenchSample {
+        name,
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_reg_binary(
+    name: &'static str,
+    iterations: u64,
+    operation: fn(QuadroReg32, QuadroReg32) -> QuadroReg32,
+) -> BenchSample {
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for index in 0..iterations {
+        let lhs = QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[index as usize % 7]);
+        let rhs = QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[(index as usize + 3) % 7]);
+        let result = operation(black_box(lhs), black_box(rhs));
+        checksum = mix_checksum(checksum, black_box(result.raw()));
+    }
+    BenchSample {
+        name,
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_tile_xor(iterations: u64) -> BenchSample {
+    let lhs = QuadTile128::from_regs([
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[0]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[1]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[2]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[3]),
+    ]);
+    let rhs = QuadTile128::from_regs([
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[4]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[5]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[6]),
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[0]),
+    ]);
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for _ in 0..iterations {
+        let result = black_box(lhs).map_xor(black_box(rhs));
+        checksum = mix_checksum(checksum, black_box(tile_checksum(result)));
+    }
+    BenchSample {
+        name: "quad-v1/tile-xor-default",
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_reg_bank_xor(iterations: u64) -> BenchSample {
+    let lhs_regs = std::array::from_fn(|index| {
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[index % QUAD_V1_RAW_SAMPLES.len()])
+    });
+    let rhs_regs = std::array::from_fn(|index| {
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[(index + 3) % QUAD_V1_RAW_SAMPLES.len()])
+    });
+    let mut lhs = QuadroBank::<REG_BANK_LEN>::from_array(lhs_regs);
+    let rhs = QuadroBank::<REG_BANK_LEN>::from_array(rhs_regs);
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for index in 0..iterations {
+        black_box(&mut lhs).map_xor_inplace(black_box(&rhs));
+        checksum = mix_checksum(
+            checksum,
+            black_box(lhs.as_array()[index as usize % REG_BANK_LEN].raw()),
+        );
+    }
+    BenchSample {
+        name: "quad-v1/reg-bank-xor-inplace",
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_tile_bank_xor(iterations: u64) -> BenchSample {
+    let lhs_tiles = std::array::from_fn(tile_from_offset);
+    let rhs_tiles = std::array::from_fn(|index| tile_from_offset(index + 3));
+    let mut lhs = QuadTileBank::<TILE_BANK_LEN>::from_array(lhs_tiles);
+    let rhs = QuadTileBank::<TILE_BANK_LEN>::from_array(rhs_tiles);
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for index in 0..iterations {
+        black_box(&mut lhs).map_xor_inplace(black_box(&rhs));
+        checksum = mix_checksum(
+            checksum,
+            black_box(tile_checksum(
+                lhs.as_array()[index as usize % TILE_BANK_LEN],
+            )),
+        );
+    }
+    BenchSample {
+        name: "quad-v1/tile-bank-xor-inplace",
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_mask_roundtrip(iterations: u64) -> BenchSample {
+    let masks = [
+        QuadMask32::try_new(0x0000_0000).expect("valid mask"),
+        QuadMask32::try_new(0x0000_0001).expect("valid mask"),
+        QuadMask32::try_new(0x8000_0000).expect("valid mask"),
+        QuadMask32::try_new(0x8000_0001).expect("valid mask"),
+        QuadMask32::try_new(0xFFFF_FFFF).expect("valid mask"),
+    ];
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    for index in 0..iterations {
+        let mask = black_box(masks[index as usize % masks.len()]);
+        let roundtrip = mask
+            .to_physical()
+            .try_to_lane()
+            .expect("physical mask from a lane mask must be valid");
+        checksum = mix_checksum(checksum, black_box(roundtrip.raw()));
+    }
+    BenchSample {
+        name: "quad-v1/mask-roundtrip",
+        ops: iterations,
+        nanos: start.elapsed().as_nanos() as u64,
+        checksum: black_box(checksum),
+    }
+}
+
+fn time_mask_iteration(iterations: u64) -> (BenchSample, u64) {
+    let masks = [
+        QuadMask32::try_new(0x0000_0000).expect("valid mask"),
+        QuadMask32::try_new(0x0000_0001).expect("valid mask"),
+        QuadMask32::try_new(0x8000_0000).expect("valid mask"),
+        QuadMask32::try_new(0x5555_AAAA).expect("valid mask"),
+        QuadMask32::try_new(0xFFFF_FFFF).expect("valid mask"),
+    ];
+    let start = Instant::now();
+    let mut checksum = 0u64;
+    let mut visited_lanes = 0u64;
+    for index in 0..iterations {
+        let mask = black_box(masks[index as usize % masks.len()]);
+        checksum = mix_checksum(checksum, mask.raw());
+        for lane in mask.iter() {
+            checksum = mix_checksum(checksum, black_box(lane as u64));
+            visited_lanes += 1;
+        }
+    }
+    (
+        BenchSample {
+            name: "quad-v1/mask-iteration",
+            ops: iterations,
+            nanos: start.elapsed().as_nanos() as u64,
+            checksum: black_box(checksum),
+        },
+        visited_lanes,
+    )
+}
+
+fn tile_from_offset(offset: usize) -> QuadTile128 {
+    QuadTile128::from_regs(std::array::from_fn(|index| {
+        QuadroReg32::from_raw(QUAD_V1_RAW_SAMPLES[(offset + index) % QUAD_V1_RAW_SAMPLES.len()])
+    }))
+}
+
+fn tile_checksum(tile: QuadTile128) -> u64 {
+    tile.to_regs()
+        .into_iter()
+        .fold(0u64, |checksum, reg| mix_checksum(checksum, reg.raw()))
+}
+
+fn mix_checksum(checksum: u64, value: u64) -> u64 {
+    checksum.rotate_left(7) ^ value.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+}
+
+fn format_quad_v1_sample(sample: &BenchSample, extra_rates: &[(&str, u64)]) -> String {
+    let mut text = format_bench_line(sample.name, sample.ops, sample.nanos, extra_rates);
+    let _ = write!(text, " checksum={:016x}", sample.checksum);
+    text
+}
+
+fn relative_ratio(baseline: &BenchSample, candidate: &BenchSample) -> f64 {
+    baseline.nanos.max(1) as f64 / candidate.nanos.max(1) as f64
+}
+
 fn format_bench_line(name: &str, ops: u64, nanos: u64, extra_rates: &[(&str, u64)]) -> String {
     let nanos = nanos.max(1);
     let ops = ops.max(1);
@@ -171,5 +514,47 @@ fn sample_program() -> CoreProgram {
             ],
         }],
         entry: FunctionId(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quad_v1_benchmark_smoke_output_is_complete() {
+        let output = bench_quad_v1_with_iterations(2);
+        for required in [
+            "quad-v1 benchmark",
+            "quad-v1/reg-not-scalar",
+            "quad-v1/reg-not-swar",
+            "quad-v1/reg-not-default",
+            "quad-v1/reg-and-scalar",
+            "quad-v1/reg-and-swar",
+            "quad-v1/reg-and-default",
+            "quad-v1/tile-xor-default",
+            "quad-v1/reg-bank-xor-inplace",
+            "quad-v1/tile-bank-xor-inplace",
+            "quad-v1/mask-roundtrip",
+            "quad-v1/mask-iteration",
+            "quad-v1/relative-reg-not",
+            "quad-v1/relative-reg-and",
+            "checksum=",
+        ] {
+            assert!(
+                output.contains(required),
+                "missing output label: {required}"
+            );
+        }
+        assert!(!output.contains("NaN"));
+        assert!(!output.contains("inf"));
+    }
+
+    #[test]
+    fn unknown_benchmark_behavior_is_unchanged() {
+        assert_eq!(
+            run_benchmark("not-a-benchmark"),
+            Err("unknown benchmark 'not-a-benchmark'".to_string())
+        );
     }
 }

--- a/docs/roadmap/core_quad/v1_benchmark_closeout.md
+++ b/docs/roadmap/core_quad/v1_benchmark_closeout.md
@@ -1,0 +1,133 @@
+# Quad Logic Engine v1 Benchmark and Qualification Closeout
+
+## Purpose
+
+Complete the v1 qualification track with deterministic, observational relative
+benchmarks using the workspace's existing benchmark CLI.
+
+## Issue
+
+- Closes #1412.
+- Parent: #1404.
+
+## Starting main commit
+
+`ceee937b87e3b97519a9bbd2ff52fb727a499f31`
+
+## Existing benchmark mechanism
+
+The owner is `semantic-core-bench`, exposed as the `core-bench` CLI. It already
+uses `std::time::Instant` and already depends on `semantic-core-quad`; no
+external benchmark framework or dependency is added.
+
+## Command
+
+```text
+cargo run -p semantic-core-bench --release -- quad-v1
+```
+
+The command also remains runnable in debug mode and reports the active build
+mode in its header.
+
+## Benchmark inventory
+
+- Register NOT: scalar, SWAR, and default APIs.
+- Register AND: scalar, SWAR, and default APIs.
+- Default tile XOR lifting.
+- In-place XOR for `QuadroBank<64>`.
+- In-place XOR for `QuadTileBank<32>`.
+- Dense-to-physical-to-dense mask conversion.
+- Dense-mask iteration with every visited lane consumed.
+
+Each sample reports API calls as `ops`, elapsed nanoseconds, `ops/s`, `ns/op`,
+the applicable structural rate, and a checksum.
+
+## Canonical deterministic vectors
+
+The register schedule uses the same seven vectors as PR #1483:
+
+```text
+0x0000_0000_0000_0000
+0xFFFF_FFFF_FFFF_FFFF
+0x5555_5555_5555_5555
+0xAAAA_AAAA_AAAA_AAAA
+0x0123_4567_89AB_CDEF
+0xE4E4_E4E4_E4E4_E4E4
+0xBADC_0FFE_DEAD_BEEF
+```
+
+Scheduling is deterministic. Randomness, wall-clock input, environment seeds,
+and CPU-capability-dependent operation selection are excluded.
+
+## Relative comparison policy
+
+The register summaries report `swar_vs_scalar` and `default_vs_scalar`. Each
+ratio is:
+
+```text
+baseline elapsed time / candidate elapsed time
+```
+
+A ratio above 1.0 means only that the candidate was faster in that specific
+run. It is not a guaranteed speedup. Elapsed nanoseconds are clamped to at
+least one so ratios remain finite.
+
+## Checksum and black-box policy
+
+Inputs and consumed results cross `std::hint::black_box`. Every timed iteration
+contributes to an emitted checksum. These are optimization barriers, not
+correctness, compatibility, or cryptographic promises.
+
+## Performance boundaries
+
+There is no timing threshold and no performance assertion. Output is local
+diagnostic evidence only. It is not a cross-machine baseline and makes no
+stability claim across hardware, operating systems, toolchains, thermal
+states, or background load. No optional CPU feature is required.
+
+## Relationship to PR #1483
+
+PR #1483's downstream integration matrix owns correctness for encoding,
+truth-policy invariants, scalar/SWAR/default equivalence, masks, deltas, tiles,
+banks, and lattice separation. This benchmark owns only observational
+performance evidence and does not select runtime behavior from timings.
+
+## EQUIV deferral
+
+EQUIV is excluded by the closed #1413 compatibility policy and is not part of
+the qualified v1 public API. Its absence is policy, not unfinished benchmark
+coverage.
+
+## Feature posture and core capsule
+
+- `std`: tested.
+- `no_std`: check-qualified through `--no-default-features`.
+- `serde`: compile/test-qualified under `--all-features`.
+- `semantic-core-capsule`: retained as the minimum downstream smoke consumer.
+
+## #1412 acceptance mapping
+
+| Criterion | Evidence |
+| --- | --- |
+| State encoding freeze | PR #1483 integration matrix |
+| Truth-policy invariants | PR #1483 integration matrix |
+| Scalar/SWAR equivalence | PR #1483 integration matrix |
+| 4x4 delta matrix | PR #1483 integration matrix |
+| Mask model | PR #1483 integration matrix |
+| Tile/bank lifting | PR #1483 integration matrix |
+| Core capsule smoke | Retained verification command |
+| Minimal performance evidence | `quad-v1` benchmark command |
+| Relative-output policy | This closeout and relative summary lines |
+| Workspace qualification | Local and CI checks for the closeout PR |
+
+## Explicit non-claims
+
+This closeout does not claim stable absolute throughput, universal speedups,
+cross-machine comparability, benchmark-driven runtime selection, serialized
+cross-version compatibility, EQUIV support, GPU transport, or completion of
+#1417 or #1404.
+
+## Remaining core-quad work
+
+- #1417: GPU transport representation and visual adapter boundary.
+- #1404: umbrella roadmap closeout.


### PR DESCRIPTION
## Summary

- add a `quad-v1` command to the existing dependency-free `core-bench` CLI;
- provide representative scalar, SWAR, default, tile, bank, and mask measurements;
- emit observational relative ratios without performance thresholds;
- close the Quad Logic Engine v1 qualification track.

## Benchmark command

```text
cargo run -p semantic-core-bench --release -- quad-v1
```

## Output policy

Results are local observations. They are not absolute guarantees, cross-machine baselines, release gates, or CPU-feature requirements.

Correctness remains owned by the public qualification matrix added in PR #1483.

## Boundaries

This PR does not modify `semantic-core-quad`, public quad APIs, Cargo configuration, dependencies, EQUIV policy, GPU transport, VM behavior, or runtime behavior.

## Verification

- `cargo +1.93.1 fmt --all --check` — PASS
- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings` — PASS
- `cargo test -p semantic-core-bench --quiet` — PASS (2 tests)
- release `quad-v1` command and required-label/finite-value validation — PASS
- `cargo test -p semantic-core-quad --test v1_qualification -- --nocapture` — PASS (9 tests)
- `cargo test -p semantic-core-quad --quiet` — PASS (134 inline, 9 integration)
- `cargo check -p semantic-core-quad --no-default-features` — PASS
- `cargo test -p semantic-core-quad --all-features --quiet` — PASS
- `cargo test -p semantic-core-capsule --quiet` — PASS (8 tests)
- `cargo test --test legacy_guards --quiet` — PASS (10 tests)
- `cargo test --all-targets --quiet` — PASS
- `git diff --check` — PASS
- `scripts/harness-check.ps1` — PASS

Closes #1412
Refs #1404