### PR TITLE
feat(visual): add GPU quad tile transport layout

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,30 +1,36 @@
 task:
-  id: CORE-QUAD-V1-BENCHMARK-CLOSEOUT
-  title: add relative v1 benchmarks and close qualification
-  type: benchmark
+  id: CORE-QUAD-GPU-TILE-TRANSPORT
+  title: add feature-gated GPU quad tile transport
+  type: implementation
   mode: active
 
 intent:
-  summary: "bench(core-quad): add v1 relative benchmark closeout"
-  issue: "#1412"
+  summary: "feat(visual): add GPU quad tile transport layout"
+  issue: "#1417"
 
 layer:
-  name: core_quad
-  owner: semantic-core-bench
+  name: visual_transport
+  owner: prom-ui-backend-native
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-V1-BENCHMARK-CLOSEOUT.md
-    - crates/semantic-core-bench/src/lib.rs
-    - docs/roadmap/core_quad/v1_benchmark_closeout.md
+    - .harness/reports/CORE-QUAD-GPU-TILE-TRANSPORT.md
+    - Cargo.lock
+    - crates/prom-ui-backend-native/Cargo.toml
+    - crates/prom-ui-backend-native/src/lib.rs
+    - crates/prom-ui-backend-native/src/quad_tile_upload.rs
+    - crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
+    - docs/roadmap/core_quad/gpu_quad_tile128_transport.md
 
 actions:
   allowed:
     - inspect
     - edit_harness
-    - modify_benchmark
-    - modify_benchmark_tests
+    - modify_visual_transport
+    - modify_feature_wiring
+    - update_lockfile
+    - create_tests
     - create_docs
     - test
     - commit
@@ -33,13 +39,15 @@ actions:
 
   forbidden:
     - modify_core_quad
-    - modify_cargo
+    - modify_prom_ui_runtime
+    - modify_prom_ui
     - modify_specs
-    - modify_other_crates
-    - add_dependency
-    - add_equiv
-    - add_performance_threshold
-    - add_cpu_specific_requirement
-    - modify_visual
+    - add_external_dependency
+    - add_pod
+    - add_byte_cast
+    - add_wgsl
+    - add_shader
+    - add_gpu_buffer
+    - modify_vm
     - force_push
     - merge

--- a/.harness/reports/CORE-QUAD-GPU-TILE-TRANSPORT.md
+++ b/.harness/reports/CORE-QUAD-GPU-TILE-TRANSPORT.md
@@ -1,0 +1,117 @@
+# CORE-QUAD-GPU-TILE-TRANSPORT
+
+## Starting main commit
+
+`890f17439eaaa8f89440cfdd017a8c7afb31f584`
+
+## Branch, issue, and parent
+
+- Branch: `core-quad/gpu-tile-transport`
+- Issue: #1417
+- Parent: #1404
+- Slice: 1 of 2; this PR does not close #1417.
+
+## Exact allowed boundary
+
+```text
+.harness/current.task.yaml
+.harness/reports/CORE-QUAD-GPU-TILE-TRANSPORT.md
+Cargo.lock
+crates/prom-ui-backend-native/Cargo.toml
+crates/prom-ui-backend-native/src/lib.rs
+crates/prom-ui-backend-native/src/quad_tile_upload.rs
+crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
+docs/roadmap/core_quad/gpu_quad_tile128_transport.md
+```
+
+`Cargo.lock` was reviewed and did not require a diff because the local package
+inventory already contained `semantic-core-quad`; no unrelated resolution
+change was made.
+
+## Existing layout and WGPU owner evidence
+
+Core `QuadTile128` remains `repr(C, align(16))`, 32 bytes, aligned to 16 bytes,
+with truth/falsity plane offsets 0/16. Its direct plane accessors and register
+conversion APIs remain the semantic source of truth. WGPU context, surface,
+pipeline, and existing bytemuck vertex usage remain owned by
+`prom-ui-backend-native::wgpu_integration`.
+
+## Dependency direction and feature wiring
+
+```text
+prom-ui-backend-native -> semantic-core-quad
+```
+
+The optional path dependency is enabled only by the existing `wgpu-backend`
+feature. Default and no-default dependency trees do not acquire
+`semantic-core-quad`; the WGPU tree does. No dependency was added to
+`semantic-core-quad`.
+
+## Transport shape and layout
+
+`GpuQuadTile128` is `repr(C, align(16))` with public `t: [u32; 4]` and
+`f: [u32; 4]` fields, deriving only ordinary value traits. Compile-time and
+integration assertions qualify size 32, alignment 16, and offsets 0/16.
+
+## Word order and conversions
+
+`split_u128` and `join_u128` use least-significant 32-bit word first. Core-to-
+transport reads `true_plane()`/`false_plane()`; transport-to-core calls
+`QuadTile128::from_planes` after joining words. Both are deterministic and
+allocation-free.
+
+## Integration-test inventory
+
+- layout freeze;
+- known least-significant-word ordering;
+- deterministic split/join roundtrips;
+- core plane roundtrip;
+- transport fields matching core planes;
+- four-register construction preserving lanes;
+- zero/default transport.
+
+Tests use no adapter, device, window, display server, surface, or physical GPU.
+
+## Default/no-default posture
+
+The default native backend remains unchanged. No-default dependency inspection
+passes and confirms no core-quad dependency. The requested no-default compile
+is currently blocked by pre-existing `prom-ui` no_std errors for missing
+`alloc` imports (`Vec`, `String`, `vec!`, `format!`, and `ToString`) in files
+outside this PR's allowed boundary. No such files were modified.
+
+## Deferred boundaries
+
+No Pod/Zeroable implementation, byte casting, byte-slice upload helper, WGPU
+buffer, WGSL mirror, shader source, runtime upload, buffer submission, or
+render integration was added. Those belong to the final #1417 slice.
+
+## Exact verification commands and results
+
+```text
+cargo +1.93.1 fmt --all --check                                      PASS
+cargo +1.93.1 clippy --workspace --all-targets -- -D warnings        PASS
+cargo +1.93.1 clippy -p prom-ui-backend-native --all-targets --features wgpu-backend -- -D warnings PASS
+cargo +1.93.1 test -p prom-ui-backend-native --features wgpu-backend --test gpu_quad_tile128_transport -- --nocapture PASS (7 tests)
+cargo +1.93.1 test -p prom-ui-backend-native --features wgpu-backend --quiet PASS
+cargo +1.93.1 check -p prom-ui-backend-native --no-default-features   BLOCKED by pre-existing prom-ui no_std errors
+cargo +1.93.1 check -p prom-ui-backend-native --all-features          PASS
+cargo +1.93.1 test -p semantic-core-quad --quiet                      PASS (134 inline, 9 integration)
+cargo +1.93.1 test -p semantic-core-capsule --quiet                   PASS (8 tests)
+cargo +1.93.1 test --test legacy_guards --quiet                       PASS (10 tests)
+cargo +1.93.1 test --all-targets --quiet                              PASS
+git diff --check                                                       PASS
+dependency tree checks                                                PASS
+Cargo.lock unrelated-resolution review                                PASS (no diff)
+```
+
+## Explicit non-changes
+
+No `semantic-core-quad` source, `prom-ui-runtime`, `prom-ui`, spec, shader,
+WGPU buffer, byte upload, Pod/Zeroable trait, WGSL mirror, renderer behavior,
+VM/runtime behavior, or unrelated untracked file was modified or staged.
+
+## Second-slice boundary
+
+The final #1417 slice remains responsible for Pod/Zeroable qualification,
+byte-slice boundary helpers, WGSL mirror, byte-order tests, and issue closeout.

--- a/crates/prom-ui-backend-native/Cargo.toml
+++ b/crates/prom-ui-backend-native/Cargo.toml
@@ -10,11 +10,18 @@ path = "src/lib.rs"
 default = ["std"]
 std = ["prom-ui-runtime/std"]
 winit-backend = ["std", "dep:winit"]
-wgpu-backend = ["std", "dep:wgpu", "dep:pollster", "dep:bytemuck"]
+wgpu-backend = [
+    "std",
+    "dep:wgpu",
+    "dep:pollster",
+    "dep:bytemuck",
+    "dep:semantic-core-quad",
+]
 
 [dependencies]
 prom-ui = { path = "../prom-ui", default-features = false }
 prom-ui-runtime = { path = "../prom-ui-runtime", default-features = false }
+semantic-core-quad = { path = "../semantic-core-quad", optional = true, default-features = false }
 winit = { version = "0.30.13", optional = true, default-features = false, features = ["rwh_06", "x11"] }
 wgpu = { version = "0.20", optional = true, default-features = false, features = ["wgsl"] }
 pollster = { version = "0.3", optional = true }

--- a/crates/prom-ui-backend-native/src/lib.rs
+++ b/crates/prom-ui-backend-native/src/lib.rs
@@ -25,9 +25,15 @@ pub mod frame_sink;
 pub mod interaction;
 pub mod session_hook;
 
+#[cfg(feature = "wgpu-backend")]
+pub mod quad_tile_upload;
+
 pub use action_translation::{DefaultNativeActionTranslator, NativeActionTranslator};
 pub use frame_sink::{UiBackendFrame, UiBackendFrameEntry, UiFrameSink};
 pub use interaction::RoutedInteraction;
+
+#[cfg(feature = "wgpu-backend")]
+pub use quad_tile_upload::{join_u128, split_u128, GpuQuadTile128};
 
 /// Raw button state representing physical input evidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/prom-ui-backend-native/src/quad_tile_upload.rs
+++ b/crates/prom-ui-backend-native/src/quad_tile_upload.rs
@@ -1,0 +1,59 @@
+//! Deterministic GPU transport representation for the semantic quad tile.
+//!
+//! `semantic_core_quad::QuadTile128` remains the canonical semantic storage.
+//! `GpuQuadTile128` is a transport representation only. Word order is the
+//! least-significant 32-bit word first. This module creates no WGPU object and
+//! does not authorize raw byte casting. Pod/Zeroable derivation and byte-slice
+//! upload helpers remain deferred to the final transport qualification slice.
+
+use semantic_core_quad::QuadTile128;
+
+/// Portable word representation of a 128-lane quad tile's two planes.
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct GpuQuadTile128 {
+    /// Truth-plane words, least-significant word first.
+    pub t: [u32; 4],
+    /// Falsity-plane words, least-significant word first.
+    pub f: [u32; 4],
+}
+
+const _: () = {
+    assert!(core::mem::size_of::<GpuQuadTile128>() == 32);
+    assert!(core::mem::align_of::<GpuQuadTile128>() == 16);
+    assert!(core::mem::offset_of!(GpuQuadTile128, t) == 0);
+    assert!(core::mem::offset_of!(GpuQuadTile128, f) == 16);
+};
+
+/// Splits a `u128` into least-significant 32-bit words first.
+pub const fn split_u128(value: u128) -> [u32; 4] {
+    [
+        value as u32,
+        (value >> 32) as u32,
+        (value >> 64) as u32,
+        (value >> 96) as u32,
+    ]
+}
+
+/// Joins least-significant-first 32-bit words into a `u128`.
+pub const fn join_u128(words: [u32; 4]) -> u128 {
+    (words[0] as u128)
+        | ((words[1] as u128) << 32)
+        | ((words[2] as u128) << 64)
+        | ((words[3] as u128) << 96)
+}
+
+impl From<QuadTile128> for GpuQuadTile128 {
+    fn from(tile: QuadTile128) -> Self {
+        Self {
+            t: split_u128(tile.true_plane()),
+            f: split_u128(tile.false_plane()),
+        }
+    }
+}
+
+impl From<GpuQuadTile128> for QuadTile128 {
+    fn from(tile: GpuQuadTile128) -> Self {
+        QuadTile128::from_planes(join_u128(tile.t), join_u128(tile.f))
+    }
+}

--- a/crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
+++ b/crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "wgpu-backend")]
+
+use prom_ui_backend_native::{join_u128, split_u128, GpuQuadTile128};
+use semantic_core_quad::{QuadTile128, QuadroReg32};
+
+#[test]
+fn gpu_quad_tile128_layout_is_frozen() {
+    assert_eq!(core::mem::size_of::<GpuQuadTile128>(), 32);
+    assert_eq!(core::mem::align_of::<GpuQuadTile128>(), 16);
+    assert_eq!(core::mem::offset_of!(GpuQuadTile128, t), 0);
+    assert_eq!(core::mem::offset_of!(GpuQuadTile128, f), 16);
+}
+
+#[test]
+fn gpu_quad_tile128_known_word_order() {
+    let value = 0xDDEE_FF00_99AA_BBCC_5566_7788_1122_3344u128;
+    let expected = [0x1122_3344, 0x5566_7788, 0x99AA_BBCC, 0xDDEE_FF00];
+
+    assert_eq!(split_u128(value), expected);
+    assert_eq!(join_u128(expected), value);
+}
+
+#[test]
+fn gpu_quad_tile128_split_join_roundtrips() {
+    let values = [
+        0u128,
+        u128::MAX,
+        1u128,
+        1u128 << 127,
+        0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210u128,
+        0xAAAA_AAAA_AAAA_AAAA_5555_5555_5555_5555u128,
+    ];
+    for value in values {
+        assert_eq!(join_u128(split_u128(value)), value);
+    }
+
+    let words = [
+        [0, 0, 0, 0],
+        [u32::MAX, u32::MAX, u32::MAX, u32::MAX],
+        [0x0123_4567, 0x89AB_CDEF, 0xFEDC_BA98, 0x7654_3210],
+        [0xAAAA_AAAA, 0x5555_5555, 0x1357_9BDF, 0x2468_ACE0],
+    ];
+    for words in words {
+        assert_eq!(split_u128(join_u128(words)), words);
+    }
+}
+
+#[test]
+fn gpu_quad_tile128_core_plane_roundtrip() {
+    let truth = 0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210u128;
+    let falsity = 0xAAAA_AAAA_AAAA_AAAA_5555_5555_5555_5555u128;
+    let original = QuadTile128::from_planes(truth, falsity);
+    let transport = GpuQuadTile128::from(original);
+    let roundtrip = QuadTile128::from(transport);
+
+    assert_eq!(original, roundtrip);
+    assert_eq!(roundtrip.true_plane(), truth);
+    assert_eq!(roundtrip.false_plane(), falsity);
+}
+
+#[test]
+fn gpu_quad_tile128_fields_match_core_planes() {
+    let truth = 0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210u128;
+    let falsity = 0x1357_9BDF_2468_ACE0_0F0F_F0F0_55AA_AA55u128;
+    let core = QuadTile128::from_planes(truth, falsity);
+    let gpu = GpuQuadTile128::from(core);
+
+    assert_eq!(gpu.t, split_u128(core.true_plane()));
+    assert_eq!(gpu.f, split_u128(core.false_plane()));
+}
+
+#[test]
+fn gpu_quad_tile128_from_regs_roundtrip_preserves_lanes() {
+    let regs = [
+        QuadroReg32::from_raw(0x0123_4567_89AB_CDEF),
+        QuadroReg32::from_raw(0xFEDC_BA98_7654_3210),
+        QuadroReg32::from_raw(0x5555_AAAA_3333_CCCC),
+        QuadroReg32::from_raw(0xBADC_0FFE_DEAD_BEEF),
+    ];
+    let original = QuadTile128::from_regs(regs);
+    let transport = GpuQuadTile128::from(original);
+    let roundtrip = QuadTile128::from(transport);
+
+    assert_eq!(roundtrip.to_regs(), regs);
+}
+
+#[test]
+fn gpu_quad_tile128_default_is_zero_transport() {
+    let transport = GpuQuadTile128::default();
+
+    assert_eq!(transport.t, [0; 4]);
+    assert_eq!(transport.f, [0; 4]);
+    assert_eq!(QuadTile128::from(transport), QuadTile128::new());
+}

--- a/docs/roadmap/core_quad/gpu_quad_tile128_transport.md
+++ b/docs/roadmap/core_quad/gpu_quad_tile128_transport.md
@@ -1,0 +1,141 @@
+# GPU `QuadTile128` Transport Representation
+
+## Purpose
+
+Define the first controlled transport slice for the qualified core tile while
+keeping semantic storage and visual transport ownership separate.
+
+## Issue
+
+- Slice 1 of 2 for #1417.
+- Parent: #1404.
+
+This PR does not close #1417.
+
+## Starting main commit
+
+`890f17439eaaa8f89440cfdd017a8c7afb31f584`
+
+## Owner boundary
+
+- Core semantic owner: `semantic-core-quad` and `QuadTile128`.
+- Transport owner: `prom-ui-backend-native` and `GpuQuadTile128`.
+
+The transport type does not own Semantic truth, admission, execution, or quad
+operations. It is a representation consumed by a later admitted visual path.
+
+## Dependency direction
+
+```text
+prom-ui-backend-native -> semantic-core-quad
+```
+
+The reverse dependency is forbidden. `semantic-core-quad` remains free of
+WGPU and byte-upload assumptions.
+
+## Core layout
+
+`QuadTile128` remains canonical CPU/core semantic storage with `repr(C,
+align(16))`, size 32 bytes, alignment 16 bytes, truth plane at offset 0, and
+falsity plane at offset 16. Its `u128` planes remain owned by the core.
+
+## GPU transport layout
+
+Feature-gated `GpuQuadTile128` is:
+
+```rust
+#[repr(C, align(16))]
+pub struct GpuQuadTile128 {
+    pub t: [u32; 4],
+    pub f: [u32; 4],
+}
+```
+
+It is 32 bytes, aligned to 16 bytes, and has field offsets 0 and 16. The
+transport fields represent truth and falsity planes as portable words.
+
+## Word ordering
+
+`split_u128` and `join_u128` define least-significant 32-bit word first:
+
+```text
+words[0] = bits 0..31
+words[1] = bits 32..63
+words[2] = bits 64..95
+words[3] = bits 96..127
+```
+
+This is a word-order contract, not a host byte-order claim.
+
+## Conversion APIs
+
+Core-to-transport conversion reads only `true_plane()` and `false_plane()` and
+splits them into words. Transport-to-core conversion joins the two word arrays
+and calls `QuadTile128::from_planes`. Both conversions are deterministic and
+allocation-free.
+
+## Static layout assertions
+
+The transport module asserts size 32, alignment 16, truth offset 0, and falsity
+offset 16 at compile time. Integration tests repeat these assertions through
+the public feature-gated surface.
+
+## Feature gating
+
+The optional `semantic-core-quad` dependency is enabled only by the existing
+`wgpu-backend` feature. The transport module and its re-exports are gated by
+the same feature. Default and no-default builds do not acquire the core-quad
+dependency.
+
+## No-std/default-feature posture
+
+The default native backend remains unchanged. `--no-default-features` remains a
+core-free native-backend configuration. The WGPU feature is an opt-in visual
+transport path and does not alter core feature ownership.
+
+## Semantic non-authority
+
+`GpuQuadTile128` does not perform semantic operations, admission, execution,
+rendering, buffer submission, or effect authorization. A transport value is not
+Semantic truth, and successful conversion is not semantic validation.
+
+## Why transport uses `[u32; 4]`
+
+Four 32-bit words make alignment and layout explicit for a portable transport
+boundary and avoid assuming that a graphics API consumes Rust `u128` layout
+directly.
+
+## Why core keeps `u128` planes
+
+The core representation preserves the existing semantic-storage contract and
+its efficient plane operations. Transport concerns do not redefine that core
+representation.
+
+## Byte-cast deferral
+
+This slice does not derive or implement Pod/Zeroable, authorize raw byte
+casting, or add byte-slice upload helpers. Layout qualification precedes any
+byte-cast decision.
+
+## WGSL deferral
+
+No WGSL mirror or shader source is added. Word-array shader mapping remains part
+of the final #1417 slice.
+
+## Testing inventory
+
+The feature-gated integration suite covers layout, known word order, split/join
+vectors, core plane roundtrip, field-to-plane correspondence, register-array
+roundtrip, and zero/default transport. Tests require no adapter, device,
+window, display server, native surface, or physical GPU.
+
+## Explicit non-changes
+
+No `semantic-core-quad` source, `prom-ui-runtime`, shader, WGPU buffer, byte
+upload, Pod/Zeroable implementation, renderer behavior, or unrelated crate is
+changed.
+
+## Second slice
+
+The final #1417 slice remains responsible for Pod/Zeroable qualification,
+byte-slice boundary helpers, WGSL mirror, byte-order tests, and issue closeout.


### PR DESCRIPTION
## Summary

- add feature-gated `GpuQuadTile128` ownership to `prom-ui-backend-native`;
- represent truth and falsity planes as deterministic `[u32; 4]` word arrays;
- add allocation-free conversion to and from core `QuadTile128`;
- freeze size, alignment, offsets, and least-significant-word-first ordering.

## Boundary

`QuadTile128` remains canonical semantic storage in `semantic-core-quad`.

`GpuQuadTile128` is a visual transport representation only and does not own Semantic truth, admission, execution, or quad operations.

## Deferred

This slice does not add Pod/Zeroable, raw byte-casting, upload buffers, WGSL source, shader files, or rendering integration. Those remain in the final #1417 qualification slice.

## Verification

- pinned fmt — PASS
- workspace clippy — PASS
- WGPU transport clippy — PASS
- transport integration tests — PASS (7 tests)
- WGPU feature tests — PASS
- all-features native check — PASS
- core quad tests — PASS (134 inline, 9 integration)
- core capsule tests — PASS (8 tests)
- legacy guards — PASS (10 tests)
- root all-targets — PASS
- dependency boundary checks — PASS
- harness check — PASS
- `git diff --check` — PASS

The requested native no-default compile is blocked by pre-existing `prom-ui` no_std missing `alloc` imports outside this PR's allowed boundary; no such files were changed. No-default dependency-tree isolation itself passes.

Refs #1417
Refs #1404