### PR TITLE
feat(visual): qualify GPU quad tile upload boundary

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,11 +1,11 @@
 task:
-  id: CORE-QUAD-GPU-TILE-TRANSPORT
-  title: add feature-gated GPU quad tile transport
+  id: CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT
+  title: qualify GPU quad tile byte upload boundary
   type: implementation
   mode: active
 
 intent:
-  summary: "feat(visual): add GPU quad tile transport layout"
+  summary: "feat(visual): qualify GPU quad tile upload boundary"
   issue: "#1417"
 
 layer:
@@ -15,22 +15,17 @@ layer:
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/CORE-QUAD-GPU-TILE-TRANSPORT.md
-    - Cargo.lock
-    - crates/prom-ui-backend-native/Cargo.toml
-    - crates/prom-ui-backend-native/src/lib.rs
+    - .harness/reports/CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT.md
     - crates/prom-ui-backend-native/src/quad_tile_upload.rs
     - crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
-    - docs/roadmap/core_quad/gpu_quad_tile128_transport.md
+    - docs/roadmap/core_quad/gpu_quad_tile128_upload_closeout.md
 
 actions:
   allowed:
     - inspect
     - edit_harness
     - modify_visual_transport
-    - modify_feature_wiring
-    - update_lockfile
-    - create_tests
+    - modify_tests
     - create_docs
     - test
     - commit
@@ -39,15 +34,15 @@ actions:
 
   forbidden:
     - modify_core_quad
+    - modify_cargo
+    - modify_lockfile
     - modify_prom_ui_runtime
     - modify_prom_ui
     - modify_specs
     - add_external_dependency
-    - add_pod
-    - add_byte_cast
-    - add_wgsl
-    - add_shader
     - add_gpu_buffer
+    - add_shader
+    - add_runtime_upload
     - modify_vm
     - force_push
     - merge

--- a/.harness/reports/CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT.md
+++ b/.harness/reports/CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT.md
@@ -1,0 +1,76 @@
+# CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT
+
+Starting main commit: `1644fd8643937427265e39f415ce6b553044f4be`
+
+Branch: `core-quad/gpu-tile-upload-closeout`
+
+Issue: #1417. Parent: #1404.
+
+Exact five-file boundary:
+
+- `.harness/current.task.yaml`
+- `.harness/reports/CORE-QUAD-GPU-TILE-UPLOAD-CLOSEOUT.md`
+- `crates/prom-ui-backend-native/src/quad_tile_upload.rs`
+- `crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs`
+- `docs/roadmap/core_quad/gpu_quad_tile128_upload_closeout.md`
+
+## Scope evidence
+
+PR #1485's transport state was reviewed: `GpuQuadTile128`, split/join helpers, deterministic core conversions, and static layout qualification were already present. This slice retains those guarantees and adds Pod/Zeroable qualification, a read-only byte-slice helper, and the WGSL mirror layout contract.
+
+`bytemuck` was already an optional dependency under the existing `wgpu-backend` feature. No Cargo or `Cargo.lock` file changed, and `semantic-core-quad` was not modified.
+
+The helper is `gpu_quad_tiles_as_bytes(&[GpuQuadTile128]) -> &[u8]` and uses `bytemuck::cast_slice`. It allocates no memory, creates no GPU buffer, submits no runtime upload, and has no mutable byte variant. The WGSL mirror is a string contract only.
+
+## Tests and boundaries
+
+Static size, alignment, and field-offset assertions remain. Existing split/join and conversion tests remain. New tests cover:
+
+- Pod and Zeroable compile proof and zeroed default;
+- byte-slice length, including an empty slice;
+- typed byte exposure roundtrip;
+- required WGSL mirror shape;
+- core tile conversion before byte exposure and roundtrip preservation.
+
+No GPU buffer, shader, renderer, or runtime-upload integration was added. `semantic-core-quad` remains the semantic owner; `GpuQuadTile128` remains visual transport state.
+
+## Dependency isolation and warning
+
+The no-default dependency tree was checked and does not contain `semantic-core-quad`. The `wgpu-backend` dependency tree contains `semantic-core-quad`. The pre-existing native no-default compilation blocker outside this PR was not run or claimed as a pass; dependency-tree isolation is the relevant guard for this slice.
+
+## Verification
+
+The exact verification sequence is:
+
+```text
+cargo +1.93.1 tree -p prom-ui-backend-native --no-default-features
+cargo +1.93.1 tree -p prom-ui-backend-native --features wgpu-backend
+cargo +1.93.1 fmt --all --check
+cargo +1.93.1 clippy --workspace --all-targets -- -D warnings
+cargo +1.93.1 clippy -p prom-ui-backend-native --all-targets --features wgpu-backend -- -D warnings
+cargo +1.93.1 test -p prom-ui-backend-native --features wgpu-backend --test gpu_quad_tile128_transport -- --nocapture
+cargo +1.93.1 test -p prom-ui-backend-native --features wgpu-backend --quiet
+cargo +1.93.1 check -p prom-ui-backend-native --all-features
+cargo +1.93.1 test -p semantic-core-quad --quiet
+cargo +1.93.1 test -p semantic-core-capsule --quiet
+cargo +1.93.1 test --test legacy_guards --quiet
+cargo +1.93.1 test --all-targets --quiet
+git diff --check
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/harness-check.ps1
+```
+
+The dependency isolation checks, formatting, clippy, transport tests, feature tests, core tests, capsule tests, legacy guards, root all-target tests, diff check, and harness check completed successfully. The release/published CI result is intentionally not recorded here.
+
+## Acceptance mapping for #1417
+
+- Core/visual memory boundary documented -> module rustdoc and roadmap closeout
+- `QuadTile128` alignment decision explicit -> retained static assertions
+- No WGPU dependency added to `semantic-core-quad` -> unchanged dependency boundary
+- No bytemuck dependency added to `semantic-core-quad` -> visual/backend-only derive
+- GPU-facing layout uses `[u32; 4]` -> transport fields and WGSL mirror
+- Byte-casting permitted only after layout tests -> Pod/Zeroable and byte tests
+- Static layout assertions exist -> retained size/alignment/offset checks
+- Conversion helpers deterministic and tested -> retained conversion inventory
+- Existing tile/bank behavior remains intact -> no core or runtime changes
+
+This PR closes #1417. EQUIV, renderer/runtime integration, GPU buffers, shader files, and full WGPU upload submission remain outside this slice. #1404 is not complete.

--- a/crates/prom-ui-backend-native/src/quad_tile_upload.rs
+++ b/crates/prom-ui-backend-native/src/quad_tile_upload.rs
@@ -2,15 +2,17 @@
 //!
 //! `semantic_core_quad::QuadTile128` remains the canonical semantic storage.
 //! `GpuQuadTile128` is a transport representation only. Word order is the
-//! least-significant 32-bit word first. This module creates no WGPU object and
-//! does not authorize raw byte casting. Pod/Zeroable derivation and byte-slice
-//! upload helpers remain deferred to the final transport qualification slice.
+//! least-significant 32-bit word first. Under `wgpu-backend`, it is the sole
+//! byte-cast-qualified transport type in this boundary: `Pod`/`Zeroable`
+//! belongs to this visual/backend crate, not to core `QuadTile128`. The byte
+//! helper returns a read-only view and performs no GPU upload. The WGSL mirror
+//! is a layout contract only; renderer integration remains out of scope.
 
 use semantic_core_quad::QuadTile128;
 
 /// Portable word representation of a 128-lane quad tile's two planes.
 #[repr(C, align(16))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, bytemuck::Zeroable, bytemuck::Pod)]
 pub struct GpuQuadTile128 {
     /// Truth-plane words, least-significant word first.
     pub t: [u32; 4],
@@ -24,6 +26,20 @@ const _: () = {
     assert!(core::mem::offset_of!(GpuQuadTile128, t) == 0);
     assert!(core::mem::offset_of!(GpuQuadTile128, f) == 16);
 };
+
+/// WGSL layout mirror for the GPU transport type; this is not a shader module.
+pub const GPU_QUAD_TILE128_WGSL: &str = r#"struct GpuQuadTile128 {
+    t: vec4<u32>,
+    f: vec4<u32>,
+};"#;
+
+/// Returns a read-only byte view over already-converted GPU transport tiles.
+///
+/// This helper allocates nothing, creates no GPU buffer, submits no WGPU
+/// upload, and does not own the caller's transfer or use lifetime.
+pub fn gpu_quad_tiles_as_bytes(tiles: &[GpuQuadTile128]) -> &[u8] {
+    bytemuck::cast_slice(tiles)
+}
 
 /// Splits a `u128` into least-significant 32-bit words first.
 pub const fn split_u128(value: u128) -> [u32; 4] {

--- a/crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
+++ b/crates/prom-ui-backend-native/tests/gpu_quad_tile128_transport.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "wgpu-backend")]
 
+use prom_ui_backend_native::quad_tile_upload::{gpu_quad_tiles_as_bytes, GPU_QUAD_TILE128_WGSL};
 use prom_ui_backend_native::{join_u128, split_u128, GpuQuadTile128};
 use semantic_core_quad::{QuadTile128, QuadroReg32};
 
@@ -91,4 +92,60 @@ fn gpu_quad_tile128_default_is_zero_transport() {
     assert_eq!(transport.t, [0; 4]);
     assert_eq!(transport.f, [0; 4]);
     assert_eq!(QuadTile128::from(transport), QuadTile128::new());
+}
+
+#[test]
+fn gpu_quad_tile128_is_pod_and_zeroable() {
+    fn assert_pod<T: bytemuck::Pod>() {}
+    fn assert_zeroable<T: bytemuck::Zeroable>() {}
+
+    assert_pod::<GpuQuadTile128>();
+    assert_zeroable::<GpuQuadTile128>();
+    assert_eq!(
+        <GpuQuadTile128 as bytemuck::Zeroable>::zeroed(),
+        GpuQuadTile128::default()
+    );
+}
+
+#[test]
+fn gpu_quad_tile128_byte_slice_has_expected_length() {
+    let tiles = [GpuQuadTile128::default(); 3];
+
+    assert_eq!(
+        gpu_quad_tiles_as_bytes(&tiles).len(),
+        3 * core::mem::size_of::<GpuQuadTile128>()
+    );
+    assert_eq!(gpu_quad_tiles_as_bytes(&[]).len(), 0);
+}
+
+#[test]
+fn gpu_quad_tile128_byte_slice_preserves_word_storage() {
+    let tile = GpuQuadTile128 {
+        t: [0x1122_3344, 0x5566_7788, 0x99AA_BBCC, 0xDDEE_FF00],
+        f: [0x0102_0304, 0x0506_0708, 0x090A_0B0C, 0x0D0E_0F10],
+    };
+
+    let bytes = gpu_quad_tiles_as_bytes(core::slice::from_ref(&tile));
+    let recovered: &[GpuQuadTile128] = bytemuck::cast_slice(bytes);
+    assert_eq!(recovered, &[tile]);
+}
+
+#[test]
+fn gpu_quad_tile128_wgsl_mirror_contract_is_present() {
+    assert!(GPU_QUAD_TILE128_WGSL.contains("struct GpuQuadTile128"));
+    assert!(GPU_QUAD_TILE128_WGSL.contains("t: vec4<u32>"));
+    assert!(GPU_QUAD_TILE128_WGSL.contains("f: vec4<u32>"));
+}
+
+#[test]
+fn gpu_quad_tile128_core_tile_is_not_upload_surface() {
+    let core = QuadTile128::from_planes(
+        0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210,
+        0xAAAA_AAAA_AAAA_AAAA_5555_5555_5555_5555,
+    );
+    let gpu = GpuQuadTile128::from(core);
+    let bytes = gpu_quad_tiles_as_bytes(core::slice::from_ref(&gpu));
+
+    assert_eq!(bytes.len(), core::mem::size_of::<GpuQuadTile128>());
+    assert_eq!(QuadTile128::from(gpu), core);
 }

--- a/docs/roadmap/core_quad/gpu_quad_tile128_upload_closeout.md
+++ b/docs/roadmap/core_quad/gpu_quad_tile128_upload_closeout.md
@@ -1,0 +1,92 @@
+# GPU QuadTile128 Upload Boundary Closeout
+
+## Purpose
+
+This document closes the controlled GPU transport qualification slice for `GpuQuadTile128`. It qualifies byte exposure at the visual/backend boundary while preserving semantic-core ownership of quad meaning.
+
+## Issue
+
+This PR closes #1417. The work belongs to parent #1404; the umbrella remains open for its remaining closeout work.
+
+## Starting main commit
+
+The starting `main` commit was `1644fd8643937427265e39f415ce6b553044f4be`.
+
+## Prior slice
+
+PR #1485 introduced `GpuQuadTile128` in `prom-ui-backend-native`, including its split/join helpers, deterministic conversions, and layout qualification. That slice established the visual transport representation without byte-cast authorization.
+
+## Upload boundary
+
+This slice adds the read-only `gpu_quad_tiles_as_bytes` boundary for already-converted `GpuQuadTile128` values. It is a borrowed byte view only: it allocates nothing, creates no GPU buffer, performs no WGPU submission, and does not own transfer or use lifetime.
+
+## Pod/Zeroable qualification
+
+`GpuQuadTile128` derives `bytemuck::Pod` and `bytemuck::Zeroable` under the existing `wgpu-backend` feature. The derive is validated by compile-proof tests and a zeroed-value equality test. No manual unsafe implementation is used.
+
+## Byte-slice helper
+
+The public helper uses `bytemuck::cast_slice` and accepts only `&[GpuQuadTile128]`. There is no mutable byte helper. Core `QuadTile128` must first be converted into the visual transport type.
+
+## WGSL mirror
+
+`GPU_QUAD_TILE128_WGSL` contains the layout mirror:
+
+```text
+struct GpuQuadTile128 {
+    t: vec4<u32>,
+    f: vec4<u32>,
+};
+```
+
+This is a layout contract only. It is not a shader file, shader module, or bind-group declaration.
+
+## Core versus transport
+
+`semantic-core-quad::QuadTile128` remains canonical semantic storage and is not byte-cast qualified. `GpuQuadTile128` is owned by the visual/backend crate and is the only upload-surface type in this boundary. Conversion to and from core tiles remains deterministic and tested.
+
+## Dependency direction
+
+The existing optional dependency direction is from `prom-ui-backend-native` to `semantic-core-quad` through `wgpu-backend`. No dependency was added to `semantic-core-quad`, and no Cargo or lockfile change is part of this slice.
+
+## Feature gating
+
+The transport module and its tests remain behind `wgpu-backend`. The existing optional `bytemuck` dependency supplies the derive and cast operations; no new dependency is required.
+
+## No semantic authority
+
+Byte exposure transports already-qualified values. It does not grant the visual/backend layer semantic authority, alter truth-policy behavior, or change core execution.
+
+## No renderer/runtime integration
+
+This PR adds no renderer integration, GPU buffers, shader files, runtime upload submission, frame rendering, or visual metadata. Production renderer readiness and a full WGPU upload pipeline are explicit non-claims.
+
+## Testing inventory
+
+The prior seven transport tests remain, covering size/alignment/offsets, word ordering, split/join, core-plane roundtrip, field correspondence, register-array roundtrip, and zero/default transport. New tests cover Pod/Zeroable, byte-slice length, typed byte roundtrip, WGSL mirror presence, and the core-versus-transport upload boundary.
+
+## No-default warning
+
+The pre-existing native no-default compile blocker is outside this PR and is not claimed as a pass. The relevant guard for this slice is dependency-tree isolation: `semantic-core-quad` is absent from the no-default tree and present in the `wgpu-backend` tree.
+
+## Acceptance mapping for #1417
+
+- Core/visual memory boundary documented -> module rustdoc and this closeout
+- `QuadTile128` alignment decision explicit -> retained static layout assertions
+- No WGPU dependency added to `semantic-core-quad` -> Cargo boundary unchanged
+- No bytemuck dependency added to `semantic-core-quad` -> derive remains visual/backend-owned
+- GPU-facing layout uses `[u32; 4]` -> `GpuQuadTile128` fields and WGSL mirror
+- Byte-casting permitted only after layout tests -> Pod/Zeroable and byte-boundary tests
+- Static layout assertions exist -> size, alignment, and field-offset assertions retained
+- Conversion helpers deterministic and tested -> split/join and core/transport tests retained
+- Existing tile/bank behavior remains intact -> no core or runtime behavior changes
+
+This PR closes #1417. It does not claim production renderer readiness or a complete WGPU upload pipeline.
+
+## Explicit non-claims
+
+This closeout does not claim GPU buffer creation, upload submission, shader compilation, render integration, runtime behavior changes, semantic authority, or cross-platform byte-endianness beyond typed `u32` word order.
+
+## Remaining work
+
+The remaining tracked work is the #1404 umbrella closeout. No additional renderer or runtime work is included here.


### PR DESCRIPTION
## Summary

- qualify `GpuQuadTile128` for Pod/Zeroable byte exposure in the visual backend layer;
- add a read-only byte-slice helper for already-converted GPU transport tiles;
- add a WGSL mirror contract for the transport shape;
- close the core/visual GPU tile upload boundary tracked by #1417.

## Boundary

`QuadTile128` remains canonical semantic storage in `semantic-core-quad`.

`GpuQuadTile128` remains a visual transport type in `prom-ui-backend-native`.

The byte helper does not create GPU buffers, submit uploads, compile shaders, render frames, or grant renderer semantic authority.

## Verification

Passing local verification:

- dependency-tree isolation for no-default and `wgpu-backend`;
- pinned fmt and workspace/transport clippy;
- GPU tile transport tests (12 passed);
- native backend wgpu feature tests and all-features check;
- core quad, core capsule, legacy guards, and root all-target tests;
- diff check and `scripts/harness-check.ps1`.

The pre-existing native no-default compile blocker outside this PR was not run or claimed as a pass. CI remains to be observed for the published head.

Closes #1417
Refs #1404