### PR TITLE
feat(ui): add UI DNA v2 projection foundation

### DIFF
--- a/crates/prom-ui/src/contract_primitives.rs
+++ b/crates/prom-ui/src/contract_primitives.rs
@@ -1,0 +1,388 @@
+//! UI DNA v2 contract primitives.
+//!
+//! This module is a neutral leaf provider. It must not import projection,
+//! static IR, runtime, renderer, backend, or admission consumers.
+#![allow(dead_code)]
+
+use core::cmp::Ordering;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SchemaVersion(u32);
+
+impl SchemaVersion {
+    pub(crate) const CURRENT: Self = Self(1);
+
+    pub(crate) const fn new(raw: u32) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroVersion)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ContractVersion(u32);
+
+impl ContractVersion {
+    pub(crate) const CURRENT: Self = Self(1);
+
+    pub(crate) const fn new(raw: u32) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroVersion)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SourceId(u64);
+
+impl SourceId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SourceSpan {
+    start: u32,
+    end: u32,
+}
+
+impl SourceSpan {
+    pub(crate) const fn new(start: u32, end: u32) -> Result<Self, ContractPrimitiveError> {
+        if start > end {
+            Err(ContractPrimitiveError::InvalidSourceSpan)
+        } else {
+            Ok(Self { start, end })
+        }
+    }
+
+    pub(crate) const fn start(self) -> u32 {
+        self.start
+    }
+
+    pub(crate) const fn end(self) -> u32 {
+        self.end
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SourceRef {
+    source: SourceId,
+    span: SourceSpan,
+}
+
+impl SourceRef {
+    pub(crate) const fn new(source: SourceId, span: SourceSpan) -> Self {
+        Self { source, span }
+    }
+
+    pub(crate) const fn source(self) -> SourceId {
+        self.source
+    }
+
+    pub(crate) const fn span(self) -> SourceSpan {
+        self.span
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Revision(u64);
+
+impl Revision {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Epoch(u64);
+
+impl Epoch {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionSourceSurfaceId(u64);
+
+impl ProjectionSourceSurfaceId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionSourceNodeId(u64);
+
+impl ProjectionSourceNodeId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct StaticDocumentId(u64);
+
+impl StaticDocumentId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct StaticSurfaceId(u64);
+
+impl StaticSurfaceId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct StaticNodeId(u64);
+
+impl StaticNodeId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct CollectionKey(u64);
+
+impl CollectionKey {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ContractPrimitiveError> {
+        if raw == 0 {
+            Err(ContractPrimitiveError::ZeroId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// Explicit semantic position of a child within one parent's ordered edge set.
+/// It is deliberately separate from node identity and storage position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ChildOrder(u32);
+
+impl ChildOrder {
+    pub(crate) const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct DiagnosticCode(&'static str);
+
+impl DiagnosticCode {
+    pub(crate) const fn new(code: &'static str) -> Self {
+        Self(code)
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct DiagnosticCoordinate {
+    source: Option<SourceRef>,
+    code: DiagnosticCode,
+    domain: u64,
+    secondary: u64,
+}
+
+impl DiagnosticCoordinate {
+    pub(crate) const fn new(
+        source: Option<SourceRef>,
+        code: DiagnosticCode,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self {
+            source,
+            code,
+            domain,
+            secondary,
+        }
+    }
+
+    pub(crate) const fn source(self) -> Option<SourceRef> {
+        self.source
+    }
+
+    pub(crate) const fn code(self) -> DiagnosticCode {
+        self.code
+    }
+
+    pub(crate) const fn domain(self) -> u64 {
+        self.domain
+    }
+
+    pub(crate) const fn secondary(self) -> u64 {
+        self.secondary
+    }
+}
+
+impl Ord for DiagnosticCoordinate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.source, self.code, self.domain, self.secondary).cmp(&(
+            other.source,
+            other.code,
+            other.domain,
+            other.secondary,
+        ))
+    }
+}
+
+impl PartialOrd for DiagnosticCoordinate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ContractPrimitiveError {
+    ZeroVersion,
+    ZeroId,
+    InvalidSourceSpan,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_primitives_source_span_accepts_ordered_bounds() {
+        let span = SourceSpan::new(2, 5).expect("valid span");
+        assert_eq!(span.start(), 2);
+        assert_eq!(span.end(), 5);
+    }
+
+    #[test]
+    fn contract_primitives_source_span_rejects_inverted_bounds() {
+        assert_eq!(
+            SourceSpan::new(5, 2),
+            Err(ContractPrimitiveError::InvalidSourceSpan)
+        );
+    }
+
+    #[test]
+    fn contract_primitives_versions_are_non_zero() {
+        assert_eq!(
+            SchemaVersion::new(0),
+            Err(ContractPrimitiveError::ZeroVersion)
+        );
+        assert_eq!(
+            ContractVersion::new(0),
+            Err(ContractPrimitiveError::ZeroVersion)
+        );
+        assert_eq!(SchemaVersion::CURRENT.raw(), 1);
+        assert_eq!(ContractVersion::CURRENT.raw(), 1);
+    }
+
+    #[test]
+    fn contract_primitives_domain_ids_do_not_cross_compare() {
+        let source = ProjectionSourceNodeId::new(7).expect("source node id");
+        let static_node = StaticNodeId::new(7).expect("static node id");
+
+        assert_eq!(source.raw(), static_node.raw());
+    }
+
+    #[test]
+    fn contract_primitives_order_diagnostic_coordinates_deterministically() {
+        let source = SourceId::new(1).expect("source id");
+        let first = DiagnosticCoordinate::new(
+            Some(SourceRef::new(source, SourceSpan::new(0, 1).expect("span"))),
+            DiagnosticCode::new("B"),
+            1,
+            0,
+        );
+        let second = DiagnosticCoordinate::new(
+            Some(SourceRef::new(source, SourceSpan::new(0, 1).expect("span"))),
+            DiagnosticCode::new("C"),
+            1,
+            0,
+        );
+
+        assert!(first < second);
+        assert_eq!(first.code.as_str(), "B");
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -37,6 +37,7 @@ pub mod commit_boundary;
 pub mod commit_boundary_result;
 pub mod committed_effect;
 pub mod committed_effect_record;
+pub(crate) mod contract_primitives;
 pub mod effect_request;
 pub mod effect_request_summary;
 pub mod effect_request_trace;
@@ -55,10 +56,14 @@ pub mod model;
 pub mod prepared_effect;
 pub mod prepared_effect_result;
 pub mod projection;
+pub(crate) mod projection_compile;
+pub(crate) mod projection_source;
 pub mod raw_event;
 pub mod renderer;
+pub(crate) mod role_dictionary;
 pub mod runtime_capability_mapping;
 pub mod runtime_capability_mapping_result;
+pub(crate) mod static_ir;
 pub mod trace;
 pub mod tree_bridge;
 pub mod tree_slot_intent;
@@ -66,6 +71,9 @@ pub mod ui_capability_admission;
 pub mod ui_capability_admission_result;
 pub mod ui_capability_denial_trace;
 pub mod validation;
+
+#[cfg(test)]
+mod ui_dna2_wp2_qualification_tests;
 
 pub use action_admission::{
     describe_interaction_action_admission, InteractionActionAdmissionCapabilityRequirement,

--- a/crates/prom-ui/src/projection_compile.rs
+++ b/crates/prom-ui/src/projection_compile.rs
@@ -1,0 +1,475 @@
+//! Deterministic UI DNA v2 Projection Source to Static UI IR lowering.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+use crate::contract_primitives::{
+    ChildOrder, DiagnosticCode, DiagnosticCoordinate, StaticDocumentId, StaticNodeId,
+    StaticSurfaceId,
+};
+use crate::projection_source::{
+    ProjectionSourceDiagnosticKind, ProjectionSourceDiagnostics, ProjectionSourceDocument,
+};
+use crate::role_dictionary::RoleDictionary;
+use crate::static_ir::{
+    StaticUiChild, StaticUiDocument, StaticUiIrDiagnosticKind, StaticUiIrDiagnostics, StaticUiNode,
+    StaticUiSurface,
+};
+
+pub(crate) fn compile_projection_source_to_static_ir(
+    document_id: StaticDocumentId,
+    source: &ProjectionSourceDocument,
+    dictionary: RoleDictionary,
+) -> Result<StaticUiDocument, ProjectionCompileDiagnostics> {
+    let normalized = source
+        .normalized(dictionary)
+        .map_err(ProjectionCompileDiagnostics::from_source)?;
+    let mut document = StaticUiDocument::new(document_id, source.revision(), source.epoch());
+
+    for source_node in normalized.nodes() {
+        let mut static_node = StaticUiNode::new(
+            static_node_id(source_node.id().raw())?,
+            source_node.role(),
+            source_node.key(),
+            Some(source_node.source()),
+        );
+        for child in source_node.children() {
+            static_node.push_child(StaticUiChild::new(
+                static_node_id(child.child().raw())?,
+                ChildOrder::new(child.order().raw()),
+            ));
+        }
+        document.push_node(static_node);
+    }
+
+    for surface in normalized.surfaces() {
+        document.push_surface(StaticUiSurface::new(
+            static_surface_id(surface.id().raw())?,
+            static_node_id(surface.root().raw())?,
+            surface.key(),
+            Some(surface.source()),
+        ));
+    }
+
+    document
+        .canonicalized(dictionary)
+        .map_err(ProjectionCompileDiagnostics::from_static_ir)
+}
+
+fn static_node_id(raw: u64) -> Result<StaticNodeId, ProjectionCompileDiagnostics> {
+    StaticNodeId::new(raw).map_err(|_| {
+        ProjectionCompileDiagnostics::from_compile_kind(
+            ProjectionCompileDiagnosticKind::InvalidLoweredIdentity,
+            raw,
+            0,
+        )
+    })
+}
+
+fn static_surface_id(raw: u64) -> Result<StaticSurfaceId, ProjectionCompileDiagnostics> {
+    StaticSurfaceId::new(raw).map_err(|_| {
+        ProjectionCompileDiagnostics::from_compile_kind(
+            ProjectionCompileDiagnosticKind::InvalidLoweredIdentity,
+            raw,
+            1,
+        )
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionCompileDiagnosticKind {
+    Source(ProjectionSourceDiagnosticKind),
+    StaticIr(StaticUiIrDiagnosticKind),
+    InvalidLoweredIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionCompileDiagnostic {
+    kind: ProjectionCompileDiagnosticKind,
+    stage: ProjectionCompileStage,
+    coordinate: DiagnosticCoordinate,
+}
+
+impl ProjectionCompileDiagnostic {
+    const fn new(
+        kind: ProjectionCompileDiagnosticKind,
+        stage: ProjectionCompileStage,
+        coordinate: DiagnosticCoordinate,
+    ) -> Self {
+        Self {
+            kind,
+            stage,
+            coordinate,
+        }
+    }
+
+    pub(crate) const fn kind(self) -> ProjectionCompileDiagnosticKind {
+        self.kind
+    }
+
+    pub(crate) const fn stage(self) -> ProjectionCompileStage {
+        self.stage
+    }
+
+    pub(crate) const fn coordinate(self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionCompileStage {
+    Source,
+    Lowering,
+    StaticIr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionCompileDiagnostics {
+    diagnostics: Vec<ProjectionCompileDiagnostic>,
+}
+
+impl ProjectionCompileDiagnostics {
+    fn from_compile_kind(
+        kind: ProjectionCompileDiagnosticKind,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self::new(Vec::from([ProjectionCompileDiagnostic::new(
+            kind,
+            ProjectionCompileStage::Lowering,
+            DiagnosticCoordinate::new(
+                None,
+                DiagnosticCode::new("PC_INVALID_LOWERED_IDENTITY"),
+                domain,
+                secondary,
+            ),
+        )]))
+    }
+
+    fn from_source(source: ProjectionSourceDiagnostics) -> Self {
+        Self::new(
+            source
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| {
+                    ProjectionCompileDiagnostic::new(
+                        ProjectionCompileDiagnosticKind::Source(diagnostic.kind()),
+                        ProjectionCompileStage::Source,
+                        diagnostic.coordinate(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn from_static_ir(static_ir: StaticUiIrDiagnostics) -> Self {
+        Self::new(
+            static_ir
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| {
+                    ProjectionCompileDiagnostic::new(
+                        ProjectionCompileDiagnosticKind::StaticIr(diagnostic.kind()),
+                        ProjectionCompileStage::StaticIr,
+                        diagnostic.coordinate(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn new(mut diagnostics: Vec<ProjectionCompileDiagnostic>) -> Self {
+        diagnostics.sort();
+        diagnostics.dedup();
+        Self { diagnostics }
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[ProjectionCompileDiagnostic] {
+        &self.diagnostics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract_primitives::{
+        ChildOrder, CollectionKey, Epoch, ProjectionSourceNodeId, ProjectionSourceSurfaceId,
+        Revision, SourceId, SourceRef, SourceSpan,
+    };
+    use crate::projection_source::{
+        ProjectionSourceChild, ProjectionSourceNode, ProjectionSourceSurface,
+    };
+    use crate::role_dictionary::RoleId;
+
+    fn source_ref(start: u32, end: u32) -> SourceRef {
+        SourceRef::new(
+            SourceId::new(1).expect("source id"),
+            SourceSpan::new(start, end).expect("source span"),
+        )
+    }
+
+    fn source_node_id(raw: u64) -> ProjectionSourceNodeId {
+        ProjectionSourceNodeId::new(raw).expect("source node id")
+    }
+
+    fn source_surface_id(raw: u64) -> ProjectionSourceSurfaceId {
+        ProjectionSourceSurfaceId::new(raw).expect("source surface id")
+    }
+
+    fn static_doc_id(raw: u64) -> StaticDocumentId {
+        StaticDocumentId::new(raw).expect("static document id")
+    }
+
+    fn key(raw: u64) -> CollectionKey {
+        CollectionKey::new(raw).expect("key")
+    }
+
+    fn minimal_source() -> ProjectionSourceDocument {
+        let mut source = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        source.push_node(ProjectionSourceNode::new(
+            source_node_id(10),
+            RoleId::new("root"),
+            key(10),
+            source_ref(0, 1),
+        ));
+        source.push_surface(ProjectionSourceSurface::new(
+            source_surface_id(1),
+            source_node_id(10),
+            key(1),
+            source_ref(0, 1),
+        ));
+        source
+    }
+
+    #[test]
+    fn projection_compile_lowers_minimal_source() {
+        let document = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &minimal_source(),
+            RoleDictionary::current(),
+        )
+        .expect("compiled");
+
+        assert_eq!(document.surfaces().len(), 1);
+        assert_eq!(document.nodes().len(), 1);
+    }
+
+    #[test]
+    fn projection_compile_repeated_lowering_is_equal() {
+        let source = minimal_source();
+
+        let first = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &source,
+            RoleDictionary::current(),
+        )
+        .expect("first");
+        let second = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &source,
+            RoleDictionary::current(),
+        )
+        .expect("second");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .canonical_bytes(RoleDictionary::current())
+                .expect("first bytes"),
+            second
+                .canonical_bytes(RoleDictionary::current())
+                .expect("second bytes")
+        );
+    }
+
+    #[test]
+    fn projection_compile_reports_source_diagnostics() {
+        let mut source = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        let mut root = ProjectionSourceNode::new(
+            source_node_id(10),
+            RoleId::new("root"),
+            key(10),
+            source_ref(0, 1),
+        );
+        root.push_child(ProjectionSourceChild::new(
+            source_node_id(11),
+            ChildOrder::new(0),
+        ));
+        source.push_node(root);
+        source.push_node(ProjectionSourceNode::new(
+            source_node_id(11),
+            RoleId::new("renderer_button"),
+            key(11),
+            source_ref(2, 3),
+        ));
+        source.push_surface(ProjectionSourceSurface::new(
+            source_surface_id(1),
+            source_node_id(10),
+            key(1),
+            source_ref(0, 1),
+        ));
+
+        let diagnostics = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &source,
+            RoleDictionary::current(),
+        )
+        .expect_err("source diagnostic");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            ProjectionCompileDiagnosticKind::Source(ProjectionSourceDiagnosticKind::UnknownRole)
+        );
+        assert_eq!(
+            diagnostics.diagnostics()[0].stage(),
+            ProjectionCompileStage::Source
+        );
+        assert_eq!(
+            diagnostics.diagnostics()[0]
+                .coordinate()
+                .source()
+                .expect("source coordinate")
+                .span()
+                .start(),
+            2
+        );
+        assert_eq!(
+            diagnostics.diagnostics()[0].coordinate().code(),
+            DiagnosticCode::new("PS_UNKNOWN_ROLE")
+        );
+        assert_eq!(diagnostics.diagnostics()[0].coordinate().domain(), 11);
+        assert_eq!(diagnostics.diagnostics()[0].coordinate().secondary(), 0);
+    }
+
+    #[test]
+    fn projection_compile_stage_wrappers_preserve_diagnostic_identity() {
+        let lowering = ProjectionCompileDiagnostics::from_compile_kind(
+            ProjectionCompileDiagnosticKind::InvalidLoweredIdentity,
+            41,
+            7,
+        );
+        let lowering_diagnostic = lowering.diagnostics()[0];
+        assert_eq!(
+            lowering_diagnostic.stage(),
+            ProjectionCompileStage::Lowering
+        );
+        assert_eq!(
+            lowering_diagnostic.kind(),
+            ProjectionCompileDiagnosticKind::InvalidLoweredIdentity
+        );
+        assert_eq!(lowering_diagnostic.coordinate().source(), None);
+        assert_eq!(
+            lowering_diagnostic.coordinate().code(),
+            DiagnosticCode::new("PC_INVALID_LOWERED_IDENTITY")
+        );
+        assert_eq!(lowering_diagnostic.coordinate().domain(), 41);
+        assert_eq!(lowering_diagnostic.coordinate().secondary(), 7);
+
+        let static_ir =
+            ProjectionCompileDiagnostics::new(Vec::from([ProjectionCompileDiagnostic::new(
+                ProjectionCompileDiagnosticKind::StaticIr(StaticUiIrDiagnosticKind::MissingRoot),
+                ProjectionCompileStage::StaticIr,
+                DiagnosticCoordinate::new(
+                    Some(source_ref(3, 4)),
+                    DiagnosticCode::new("SIR_MISSING_ROOT"),
+                    51,
+                    9,
+                ),
+            )]));
+        let static_ir_diagnostic = static_ir.diagnostics()[0];
+        assert_eq!(
+            static_ir_diagnostic.stage(),
+            ProjectionCompileStage::StaticIr
+        );
+        assert_eq!(
+            static_ir_diagnostic.kind(),
+            ProjectionCompileDiagnosticKind::StaticIr(StaticUiIrDiagnosticKind::MissingRoot)
+        );
+        assert_eq!(
+            static_ir_diagnostic
+                .coordinate()
+                .source()
+                .expect("static IR coordinate")
+                .span()
+                .start(),
+            3
+        );
+        assert_eq!(static_ir_diagnostic.coordinate().domain(), 51);
+        assert_eq!(static_ir_diagnostic.coordinate().secondary(), 9);
+    }
+
+    #[test]
+    fn projection_compile_cross_stage_order_is_deterministic() {
+        let first = ProjectionCompileDiagnostics::new(Vec::from([
+            ProjectionCompileDiagnostic::new(
+                ProjectionCompileDiagnosticKind::InvalidLoweredIdentity,
+                ProjectionCompileStage::Lowering,
+                DiagnosticCoordinate::new(
+                    None,
+                    DiagnosticCode::new("PC_INVALID_LOWERED_IDENTITY"),
+                    2,
+                    0,
+                ),
+            ),
+            ProjectionCompileDiagnostic::new(
+                ProjectionCompileDiagnosticKind::StaticIr(StaticUiIrDiagnosticKind::MissingRoot),
+                ProjectionCompileStage::StaticIr,
+                DiagnosticCoordinate::new(None, DiagnosticCode::new("SIR_MISSING_ROOT"), 1, 0),
+            ),
+        ]));
+        let second = ProjectionCompileDiagnostics::new(Vec::from([
+            first.diagnostics()[1],
+            first.diagnostics()[0],
+        ]));
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn projection_compile_diagnostic_order_uses_coordinate_not_message_text() {
+        let mut source = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        source.push_node(ProjectionSourceNode::new(
+            source_node_id(10),
+            RoleId::new("renderer_button"),
+            key(10),
+            source_ref(10, 11),
+        ));
+        source.push_surface(ProjectionSourceSurface::new(
+            source_surface_id(1),
+            source_node_id(10),
+            key(1),
+            source_ref(0, 1),
+        ));
+
+        let first = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &source,
+            RoleDictionary::current(),
+        )
+        .expect_err("diagnostics");
+        let second = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &source,
+            RoleDictionary::current(),
+        )
+        .expect_err("diagnostics");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first.diagnostics()[0].kind(),
+            ProjectionCompileDiagnosticKind::Source(ProjectionSourceDiagnosticKind::UnknownRole)
+        );
+    }
+}

--- a/crates/prom-ui/src/projection_source.rs
+++ b/crates/prom-ui/src/projection_source.rs
@@ -1,0 +1,1024 @@
+//! UI DNA v2 Projection Source contracts.
+//!
+//! This is a programmatically constructible source-facing AST and validation
+//! surface. It is not a textual `.proj.sm` parser and it is not an alias for
+//! the legacy `UiAst` substrate.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+use crate::contract_primitives::{
+    ChildOrder, CollectionKey, DiagnosticCode, DiagnosticCoordinate, Epoch, ProjectionSourceNodeId,
+    ProjectionSourceSurfaceId, Revision, SourceId, SourceRef,
+};
+use crate::role_dictionary::{RoleDictionary, RoleId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionSourceTokenKind {
+    Surface,
+    Node,
+    Role,
+    Key,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceToken {
+    kind: ProjectionSourceTokenKind,
+    source: SourceRef,
+}
+
+impl ProjectionSourceToken {
+    pub(crate) const fn new(kind: ProjectionSourceTokenKind, source: SourceRef) -> Self {
+        Self { kind, source }
+    }
+
+    pub(crate) const fn kind(self) -> ProjectionSourceTokenKind {
+        self.kind
+    }
+
+    pub(crate) const fn source(self) -> SourceRef {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceSurface {
+    id: ProjectionSourceSurfaceId,
+    root: ProjectionSourceNodeId,
+    key: CollectionKey,
+    source: SourceRef,
+}
+
+impl ProjectionSourceSurface {
+    pub(crate) const fn new(
+        id: ProjectionSourceSurfaceId,
+        root: ProjectionSourceNodeId,
+        key: CollectionKey,
+        source: SourceRef,
+    ) -> Self {
+        Self {
+            id,
+            root,
+            key,
+            source,
+        }
+    }
+
+    pub(crate) const fn id(&self) -> ProjectionSourceSurfaceId {
+        self.id
+    }
+
+    pub(crate) const fn root(&self) -> ProjectionSourceNodeId {
+        self.root
+    }
+
+    pub(crate) const fn key(&self) -> CollectionKey {
+        self.key
+    }
+
+    pub(crate) const fn source(&self) -> SourceRef {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceNode {
+    id: ProjectionSourceNodeId,
+    role: RoleId,
+    key: CollectionKey,
+    source: SourceRef,
+    children: Vec<ProjectionSourceChild>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceChild {
+    child: ProjectionSourceNodeId,
+    order: ChildOrder,
+}
+
+impl ProjectionSourceChild {
+    pub(crate) const fn new(child: ProjectionSourceNodeId, order: ChildOrder) -> Self {
+        Self { child, order }
+    }
+
+    pub(crate) const fn child(self) -> ProjectionSourceNodeId {
+        self.child
+    }
+
+    pub(crate) const fn order(self) -> ChildOrder {
+        self.order
+    }
+}
+
+impl ProjectionSourceNode {
+    pub(crate) fn new(
+        id: ProjectionSourceNodeId,
+        role: RoleId,
+        key: CollectionKey,
+        source: SourceRef,
+    ) -> Self {
+        Self {
+            id,
+            role,
+            key,
+            source,
+            children: Vec::new(),
+        }
+    }
+
+    pub(crate) const fn id(&self) -> ProjectionSourceNodeId {
+        self.id
+    }
+
+    pub(crate) const fn role(&self) -> RoleId {
+        self.role
+    }
+
+    pub(crate) const fn key(&self) -> CollectionKey {
+        self.key
+    }
+
+    pub(crate) const fn source(&self) -> SourceRef {
+        self.source
+    }
+
+    pub(crate) fn children(&self) -> &[ProjectionSourceChild] {
+        &self.children
+    }
+
+    pub(crate) fn push_child(&mut self, child: ProjectionSourceChild) {
+        self.children.push(child);
+    }
+
+    fn normalize(&mut self) {
+        self.children.sort_by_key(|edge| edge.order);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceDocument {
+    source_id: SourceId,
+    revision: Revision,
+    epoch: Epoch,
+    surfaces: Vec<ProjectionSourceSurface>,
+    nodes: Vec<ProjectionSourceNode>,
+}
+
+impl ProjectionSourceDocument {
+    pub(crate) fn new(source_id: SourceId, revision: Revision, epoch: Epoch) -> Self {
+        Self {
+            source_id,
+            revision,
+            epoch,
+            surfaces: Vec::new(),
+            nodes: Vec::new(),
+        }
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub(crate) const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    pub(crate) fn surfaces(&self) -> &[ProjectionSourceSurface] {
+        &self.surfaces
+    }
+
+    pub(crate) fn nodes(&self) -> &[ProjectionSourceNode] {
+        &self.nodes
+    }
+
+    pub(crate) fn push_surface(&mut self, surface: ProjectionSourceSurface) {
+        self.surfaces.push(surface);
+    }
+
+    pub(crate) fn push_node(&mut self, node: ProjectionSourceNode) {
+        self.nodes.push(node);
+    }
+
+    pub(crate) fn validate(
+        &self,
+        dictionary: RoleDictionary,
+    ) -> Result<(), ProjectionSourceDiagnostics> {
+        let diagnostics = validate_source(self, dictionary);
+        if diagnostics.is_empty() {
+            Ok(())
+        } else {
+            Err(diagnostics)
+        }
+    }
+
+    pub(crate) fn normalized(
+        &self,
+        dictionary: RoleDictionary,
+    ) -> Result<Self, ProjectionSourceDiagnostics> {
+        self.validate(dictionary)?;
+        let mut normalized = self.clone();
+        normalized
+            .surfaces
+            .sort_by_key(|surface| (surface.key, surface.id));
+        normalized.nodes.sort_by_key(|node| (node.key, node.id));
+        for node in &mut normalized.nodes {
+            node.normalize();
+        }
+        Ok(normalized)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionSourceDiagnosticKind {
+    DuplicateSurfaceId,
+    DuplicateSurfaceKey,
+    DuplicateNodeId,
+    DuplicateNodeKey,
+    MissingRootNode,
+    MissingChild,
+    DuplicateChild,
+    DuplicateChildOrder,
+    DuplicateSurfaceRoot,
+    RootUsedAsChild,
+    MultipleParents,
+    Cycle,
+    UnreachableNode,
+    SharedAcrossSurfaces,
+    UnknownRole,
+}
+
+impl ProjectionSourceDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::DuplicateSurfaceId => DiagnosticCode::new("PS_DUP_SURFACE_ID"),
+            Self::DuplicateSurfaceKey => DiagnosticCode::new("PS_DUP_SURFACE_KEY"),
+            Self::DuplicateNodeId => DiagnosticCode::new("PS_DUP_NODE_ID"),
+            Self::DuplicateNodeKey => DiagnosticCode::new("PS_DUP_NODE_KEY"),
+            Self::MissingRootNode => DiagnosticCode::new("PS_MISSING_ROOT"),
+            Self::MissingChild => DiagnosticCode::new("PS_MISSING_CHILD"),
+            Self::DuplicateChild => DiagnosticCode::new("PS_DUP_CHILD"),
+            Self::DuplicateChildOrder => DiagnosticCode::new("PS_DUP_CHILD_ORDER"),
+            Self::DuplicateSurfaceRoot => DiagnosticCode::new("PS_DUP_SURFACE_ROOT"),
+            Self::RootUsedAsChild => DiagnosticCode::new("PS_ROOT_USED_AS_CHILD"),
+            Self::MultipleParents => DiagnosticCode::new("PS_MULTIPLE_PARENTS"),
+            Self::Cycle => DiagnosticCode::new("PS_CYCLE"),
+            Self::UnreachableNode => DiagnosticCode::new("PS_UNREACHABLE_NODE"),
+            Self::SharedAcrossSurfaces => DiagnosticCode::new("PS_SHARED_ACROSS_SURFACES"),
+            Self::UnknownRole => DiagnosticCode::new("PS_UNKNOWN_ROLE"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceDiagnostic {
+    coordinate: DiagnosticCoordinate,
+    kind: ProjectionSourceDiagnosticKind,
+}
+
+impl ProjectionSourceDiagnostic {
+    fn new(
+        source: Option<SourceRef>,
+        kind: ProjectionSourceDiagnosticKind,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(source, kind.code(), domain, secondary),
+            kind,
+        }
+    }
+
+    pub(crate) const fn kind(self) -> ProjectionSourceDiagnosticKind {
+        self.kind
+    }
+
+    pub(crate) const fn coordinate(self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+}
+
+impl Ord for ProjectionSourceDiagnostic {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        (self.coordinate, self.kind).cmp(&(other.coordinate, other.kind))
+    }
+}
+
+impl PartialOrd for ProjectionSourceDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceDiagnostics {
+    diagnostics: Vec<ProjectionSourceDiagnostic>,
+}
+
+impl ProjectionSourceDiagnostics {
+    fn new(mut diagnostics: Vec<ProjectionSourceDiagnostic>) -> Self {
+        diagnostics.sort();
+        diagnostics.dedup();
+        Self { diagnostics }
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[ProjectionSourceDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
+fn validate_source(
+    document: &ProjectionSourceDocument,
+    dictionary: RoleDictionary,
+) -> ProjectionSourceDiagnostics {
+    let mut diagnostics = Vec::new();
+
+    for (index, surface) in document.surfaces.iter().enumerate() {
+        if document.surfaces[..index]
+            .iter()
+            .any(|previous| previous.id == surface.id)
+        {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(surface.source),
+                ProjectionSourceDiagnosticKind::DuplicateSurfaceId,
+                surface.id.raw(),
+                0,
+            ));
+        }
+        if document.surfaces[..index]
+            .iter()
+            .any(|previous| previous.key == surface.key)
+        {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(surface.source),
+                ProjectionSourceDiagnosticKind::DuplicateSurfaceKey,
+                surface.key.raw(),
+                0,
+            ));
+        }
+        if !document.nodes.iter().any(|node| node.id == surface.root) {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(surface.source),
+                ProjectionSourceDiagnosticKind::MissingRootNode,
+                surface.root.raw(),
+                0,
+            ));
+        }
+    }
+
+    for (index, node) in document.nodes.iter().enumerate() {
+        if document.nodes[..index]
+            .iter()
+            .any(|previous| previous.id == node.id)
+        {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::DuplicateNodeId,
+                node.id.raw(),
+                0,
+            ));
+        }
+        if document.nodes[..index]
+            .iter()
+            .any(|previous| previous.key == node.key)
+        {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::DuplicateNodeKey,
+                node.key.raw(),
+                0,
+            ));
+        }
+        if dictionary.validate(node.role).is_err() {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::UnknownRole,
+                node.key.raw(),
+                0,
+            ));
+        }
+        for (child_index, child) in node.children.iter().enumerate() {
+            if !document
+                .nodes
+                .iter()
+                .any(|candidate| candidate.id == child.child)
+            {
+                diagnostics.push(ProjectionSourceDiagnostic::new(
+                    Some(node.source),
+                    ProjectionSourceDiagnosticKind::MissingChild,
+                    node.id.raw(),
+                    child.child.raw(),
+                ));
+            }
+            if node.children[..child_index]
+                .iter()
+                .any(|previous| previous.child == child.child)
+            {
+                diagnostics.push(ProjectionSourceDiagnostic::new(
+                    Some(node.source),
+                    ProjectionSourceDiagnosticKind::DuplicateChild,
+                    node.id.raw(),
+                    child.child.raw(),
+                ));
+            }
+            if node.children[..child_index]
+                .iter()
+                .any(|previous| previous.order == child.order)
+            {
+                diagnostics.push(ProjectionSourceDiagnostic::new(
+                    Some(node.source),
+                    ProjectionSourceDiagnosticKind::DuplicateChildOrder,
+                    node.id.raw(),
+                    u64::from(child.order.raw()),
+                ));
+            }
+        }
+    }
+
+    validate_source_forest(document, &mut diagnostics);
+
+    ProjectionSourceDiagnostics::new(diagnostics)
+}
+
+fn validate_source_forest(
+    document: &ProjectionSourceDocument,
+    diagnostics: &mut Vec<ProjectionSourceDiagnostic>,
+) {
+    if document.surfaces.is_empty() {
+        diagnostics.push(ProjectionSourceDiagnostic::new(
+            None,
+            ProjectionSourceDiagnosticKind::MissingRootNode,
+            0,
+            0,
+        ));
+        return;
+    }
+
+    let mut root_indices = Vec::new();
+    let mut owner: Vec<Option<usize>> = alloc::vec![None; document.nodes.len()];
+    let mut parent_count: Vec<u32> = alloc::vec![0; document.nodes.len()];
+    let mut visiting: Vec<bool> = alloc::vec![false; document.nodes.len()];
+    let mut complete: Vec<bool> = alloc::vec![false; document.nodes.len()];
+
+    for (surface_index, surface) in document.surfaces.iter().enumerate() {
+        let Some(root_index) = node_index(document, surface.root) else {
+            continue;
+        };
+        if root_indices.contains(&root_index) {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(surface.source),
+                ProjectionSourceDiagnosticKind::DuplicateSurfaceRoot,
+                surface.root.raw(),
+                surface.id.raw(),
+            ));
+        }
+        root_indices.push(root_index);
+        walk_source_forest(
+            document,
+            surface_index,
+            root_index,
+            &mut owner,
+            &mut parent_count,
+            &mut visiting,
+            &mut complete,
+            diagnostics,
+        );
+    }
+
+    for (index, node) in document.nodes.iter().enumerate() {
+        let is_root = root_indices.contains(&index);
+        if is_root && parent_count[index] != 0 {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::RootUsedAsChild,
+                node.id.raw(),
+                0,
+            ));
+        }
+        if !is_root && parent_count[index] > 1 {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::MultipleParents,
+                node.id.raw(),
+                u64::from(parent_count[index]),
+            ));
+        }
+        if !is_root && parent_count[index] == 0 {
+            diagnostics.push(ProjectionSourceDiagnostic::new(
+                Some(node.source),
+                ProjectionSourceDiagnosticKind::UnreachableNode,
+                node.id.raw(),
+                0,
+            ));
+        }
+    }
+}
+
+struct SourceTraversalFrame {
+    node_index: usize,
+    parent: Option<usize>,
+    next_child: usize,
+    entered: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_source_forest(
+    document: &ProjectionSourceDocument,
+    surface_index: usize,
+    root_index: usize,
+    owner: &mut [Option<usize>],
+    parent_count: &mut [u32],
+    visiting: &mut [bool],
+    complete: &mut [bool],
+    diagnostics: &mut Vec<ProjectionSourceDiagnostic>,
+) {
+    let mut stack = Vec::from([SourceTraversalFrame {
+        node_index: root_index,
+        parent: None,
+        next_child: 0,
+        entered: false,
+    }]);
+
+    while let Some(mut frame) = stack.pop() {
+        let current_index = frame.node_index;
+        if !frame.entered {
+            frame.entered = true;
+            let node = &document.nodes[current_index];
+            if let Some(parent) = frame.parent {
+                parent_count[current_index] = parent_count[current_index].saturating_add(1);
+                if parent == current_index {
+                    diagnostics.push(ProjectionSourceDiagnostic::new(
+                        Some(node.source),
+                        ProjectionSourceDiagnosticKind::Cycle,
+                        node.id.raw(),
+                        node.id.raw(),
+                    ));
+                    continue;
+                }
+            }
+
+            match owner[current_index] {
+                Some(previous) if previous != surface_index => {
+                    diagnostics.push(ProjectionSourceDiagnostic::new(
+                        Some(node.source),
+                        ProjectionSourceDiagnosticKind::SharedAcrossSurfaces,
+                        node.id.raw(),
+                        surface_index as u64,
+                    ));
+                }
+                None => owner[current_index] = Some(surface_index),
+                _ => {}
+            }
+
+            if visiting[current_index] {
+                diagnostics.push(ProjectionSourceDiagnostic::new(
+                    Some(node.source),
+                    ProjectionSourceDiagnosticKind::Cycle,
+                    node.id.raw(),
+                    0,
+                ));
+                continue;
+            }
+            if complete[current_index] {
+                continue;
+            }
+            visiting[current_index] = true;
+        }
+
+        let next_child = frame.next_child;
+        let next = document.nodes[current_index]
+            .children
+            .get(next_child)
+            .copied();
+        if let Some(child) = next {
+            frame.next_child += 1;
+            stack.push(frame);
+            if let Some(child_index) = node_index(document, child.child) {
+                stack.push(SourceTraversalFrame {
+                    node_index: child_index,
+                    parent: Some(current_index),
+                    next_child: 0,
+                    entered: false,
+                });
+            }
+        } else {
+            visiting[current_index] = false;
+            complete[current_index] = true;
+        }
+    }
+}
+
+fn node_index(document: &ProjectionSourceDocument, id: ProjectionSourceNodeId) -> Option<usize> {
+    document.nodes.iter().position(|node| node.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract_primitives::{ChildOrder, CollectionKey, SourceSpan};
+    use crate::model::UiAst;
+
+    fn source_ref(start: u32, end: u32) -> SourceRef {
+        SourceRef::new(
+            SourceId::new(1).expect("source id"),
+            SourceSpan::new(start, end).expect("source span"),
+        )
+    }
+
+    fn node_id(raw: u64) -> ProjectionSourceNodeId {
+        ProjectionSourceNodeId::new(raw).expect("node id")
+    }
+
+    fn surface_id(raw: u64) -> ProjectionSourceSurfaceId {
+        ProjectionSourceSurfaceId::new(raw).expect("surface id")
+    }
+
+    fn key(raw: u64) -> CollectionKey {
+        CollectionKey::new(raw).expect("collection key")
+    }
+
+    fn minimal_source() -> ProjectionSourceDocument {
+        let mut document = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        document.push_node(ProjectionSourceNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            source_ref(0, 4),
+        ));
+        document.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            source_ref(0, 4),
+        ));
+        document
+    }
+
+    fn source_with_ordered_children(order_a: u32, order_b: u32) -> ProjectionSourceDocument {
+        let mut document = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        let mut root =
+            ProjectionSourceNode::new(node_id(10), RoleId::new("root"), key(10), source_ref(0, 4));
+        root.push_child(ProjectionSourceChild::new(
+            node_id(20),
+            ChildOrder::new(order_a),
+        ));
+        root.push_child(ProjectionSourceChild::new(
+            node_id(30),
+            ChildOrder::new(order_b),
+        ));
+        document.push_node(root);
+        document.push_node(ProjectionSourceNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            source_ref(10, 11),
+        ));
+        document.push_node(ProjectionSourceNode::new(
+            node_id(30),
+            RoleId::new("text"),
+            key(30),
+            source_ref(12, 13),
+        ));
+        document.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            source_ref(0, 4),
+        ));
+        document
+    }
+
+    #[test]
+    fn projection_source_minimal_ast_validates() {
+        assert!(minimal_source().validate(RoleDictionary::current()).is_ok());
+    }
+
+    #[test]
+    fn projection_source_rejects_unknown_role() {
+        let mut document = minimal_source();
+        document.push_node(ProjectionSourceNode::new(
+            node_id(11),
+            RoleId::new("renderer_button"),
+            key(11),
+            source_ref(5, 9),
+        ));
+
+        let diagnostics = document
+            .validate(RoleDictionary::current())
+            .expect_err("unknown role");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            ProjectionSourceDiagnosticKind::UnknownRole
+        );
+    }
+
+    #[test]
+    fn projection_source_normalization_is_insertion_order_independent() {
+        let mut first = minimal_source();
+        first
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
+        first.push_node(ProjectionSourceNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            source_ref(10, 11),
+        ));
+
+        let mut second = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        second.push_node(ProjectionSourceNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            source_ref(10, 11),
+        ));
+        second.push_node(ProjectionSourceNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            source_ref(0, 4),
+        ));
+        second
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
+        second.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            source_ref(0, 4),
+        ));
+
+        assert_eq!(
+            first.normalized(RoleDictionary::current()).expect("first"),
+            second
+                .normalized(RoleDictionary::current())
+                .expect("second")
+        );
+    }
+
+    #[test]
+    fn projection_source_storage_permutation_preserves_explicit_child_order() {
+        let first = source_with_ordered_children(0, 1);
+        let mut second = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        second.push_node(ProjectionSourceNode::new(
+            node_id(30),
+            RoleId::new("text"),
+            key(30),
+            source_ref(12, 13),
+        ));
+        let mut root =
+            ProjectionSourceNode::new(node_id(10), RoleId::new("root"), key(10), source_ref(0, 4));
+        root.push_child(ProjectionSourceChild::new(node_id(30), ChildOrder::new(1)));
+        root.push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
+        second.push_node(root);
+        second.push_node(ProjectionSourceNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            source_ref(10, 11),
+        ));
+        second.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            source_ref(0, 4),
+        ));
+
+        assert_eq!(
+            first.normalized(RoleDictionary::current()).expect("first"),
+            second
+                .normalized(RoleDictionary::current())
+                .expect("second")
+        );
+    }
+
+    #[test]
+    fn projection_source_semantic_child_order_changes_normalized_source() {
+        let first = source_with_ordered_children(0, 1);
+        let second = source_with_ordered_children(1, 0);
+
+        assert_ne!(
+            first.normalized(RoleDictionary::current()).expect("first"),
+            second
+                .normalized(RoleDictionary::current())
+                .expect("second")
+        );
+    }
+
+    #[test]
+    fn projection_source_rejects_duplicate_child_and_order() {
+        let mut document = source_with_ordered_children(0, 0);
+        document
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(2)));
+
+        let diagnostics = document
+            .validate(RoleDictionary::current())
+            .expect_err("duplicates");
+
+        assert!(diagnostics
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == ProjectionSourceDiagnosticKind::DuplicateChild));
+        assert!(diagnostics
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind()
+                == ProjectionSourceDiagnosticKind::DuplicateChildOrder));
+    }
+
+    #[test]
+    fn projection_source_rejects_ordered_forest_violations() {
+        let mut cycle = minimal_source();
+        cycle
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(ProjectionSourceChild::new(node_id(10), ChildOrder::new(0)));
+        assert!(cycle
+            .validate(RoleDictionary::current())
+            .expect_err("cycle")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == ProjectionSourceDiagnosticKind::Cycle));
+
+        let mut orphan = minimal_source();
+        orphan.push_node(ProjectionSourceNode::new(
+            node_id(40),
+            RoleId::new("text"),
+            key(40),
+            source_ref(20, 21),
+        ));
+        assert!(
+            orphan
+                .validate(RoleDictionary::current())
+                .expect_err("orphan")
+                .diagnostics()
+                .iter()
+                .any(|diagnostic| diagnostic.kind()
+                    == ProjectionSourceDiagnosticKind::UnreachableNode)
+        );
+    }
+
+    #[test]
+    fn projection_source_diagnostics_are_deterministically_ordered() {
+        let mut document = minimal_source();
+        document.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(99),
+            key(1),
+            source_ref(20, 21),
+        ));
+
+        let diagnostics = document
+            .validate(RoleDictionary::current())
+            .expect_err("duplicates");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            ProjectionSourceDiagnosticKind::DuplicateSurfaceId
+        );
+        assert_eq!(
+            diagnostics.diagnostics()[1].kind(),
+            ProjectionSourceDiagnosticKind::DuplicateSurfaceKey
+        );
+    }
+
+    #[test]
+    fn projection_source_is_not_legacy_ui_ast_alias() {
+        let source = minimal_source();
+        let legacy = UiAst::new();
+
+        assert_eq!(source.nodes().len(), 1);
+        assert!(legacy.nodes().is_empty());
+    }
+
+    #[test]
+    fn projection_source_token_preserves_source_reference() {
+        let token = ProjectionSourceToken::new(ProjectionSourceTokenKind::Role, source_ref(1, 2));
+
+        assert_eq!(token.kind(), ProjectionSourceTokenKind::Role);
+        assert_eq!(token.source().span().start(), 1);
+    }
+
+    #[test]
+    fn projection_source_validates_deep_forest_without_recursive_traversal() {
+        const DEPTH: u64 = 512;
+        let mut document = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        for raw in 1..=DEPTH {
+            let mut node = ProjectionSourceNode::new(
+                node_id(raw),
+                if raw == 1 {
+                    RoleId::new("root")
+                } else {
+                    RoleId::new("text")
+                },
+                key(raw),
+                source_ref(raw as u32, raw as u32 + 1),
+            );
+            if raw < DEPTH {
+                node.push_child(ProjectionSourceChild::new(
+                    node_id(raw + 1),
+                    ChildOrder::new(0),
+                ));
+            }
+            document.push_node(node);
+        }
+        document.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(1),
+            key(1),
+            source_ref(0, 1),
+        ));
+
+        assert!(document.validate(RoleDictionary::current()).is_ok());
+    }
+
+    #[test]
+    fn projection_source_reports_deep_cycle_deterministically() {
+        const DEPTH: u64 = 512;
+        let mut document = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        for raw in 1..=DEPTH {
+            let mut node = ProjectionSourceNode::new(
+                node_id(raw),
+                if raw == 1 {
+                    RoleId::new("root")
+                } else {
+                    RoleId::new("text")
+                },
+                key(raw),
+                source_ref(raw as u32, raw as u32 + 1),
+            );
+            let child = (raw < DEPTH)
+                .then_some(raw + 1)
+                .or((raw == DEPTH).then_some(1));
+            if let Some(child) = child {
+                node.push_child(ProjectionSourceChild::new(
+                    node_id(child),
+                    ChildOrder::new(0),
+                ));
+            }
+            document.push_node(node);
+        }
+        document.push_surface(ProjectionSourceSurface::new(
+            surface_id(1),
+            node_id(1),
+            key(1),
+            source_ref(0, 1),
+        ));
+
+        let first = document
+            .validate(RoleDictionary::current())
+            .expect_err("cycle");
+        let second = document
+            .validate(RoleDictionary::current())
+            .expect_err("cycle");
+        assert_eq!(first, second);
+        assert!(first
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == ProjectionSourceDiagnosticKind::Cycle));
+    }
+}

--- a/crates/prom-ui/src/role_dictionary.rs
+++ b/crates/prom-ui/src/role_dictionary.rs
@@ -1,0 +1,158 @@
+//! Minimal UI DNA v2 Role Dictionary.
+//!
+//! This module is independent from Projection Source, Static UI IR, runtime,
+//! renderer, backend, and admission layers.
+#![allow(dead_code)]
+
+use crate::contract_primitives::{ContractVersion, SchemaVersion};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RoleId(&'static str);
+
+impl RoleId {
+    pub(crate) const fn new(raw: &'static str) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum BuiltInRole {
+    Root,
+    Surface,
+    NumericReadout,
+    DangerAction,
+    EvidencePanel,
+    RecoveryOutlet,
+    Text,
+    Fragment,
+}
+
+impl BuiltInRole {
+    pub(crate) const fn id(self) -> RoleId {
+        match self {
+            Self::Root => RoleId::new("root"),
+            Self::Surface => RoleId::new("surface"),
+            Self::NumericReadout => RoleId::new("numeric_readout"),
+            Self::DangerAction => RoleId::new("danger_action"),
+            Self::EvidencePanel => RoleId::new("evidence_panel"),
+            Self::RecoveryOutlet => RoleId::new("recovery_outlet"),
+            Self::Text => RoleId::new("text"),
+            Self::Fragment => RoleId::new("fragment"),
+        }
+    }
+}
+
+const BUILT_IN_ROLES: [BuiltInRole; 8] = [
+    BuiltInRole::DangerAction,
+    BuiltInRole::EvidencePanel,
+    BuiltInRole::Fragment,
+    BuiltInRole::NumericReadout,
+    BuiltInRole::RecoveryOutlet,
+    BuiltInRole::Root,
+    BuiltInRole::Surface,
+    BuiltInRole::Text,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct RoleDictionary {
+    schema_version: SchemaVersion,
+    contract_version: ContractVersion,
+    roles: &'static [BuiltInRole],
+}
+
+impl RoleDictionary {
+    pub(crate) const fn current() -> Self {
+        Self {
+            schema_version: SchemaVersion::CURRENT,
+            contract_version: ContractVersion::CURRENT,
+            roles: &BUILT_IN_ROLES,
+        }
+    }
+
+    pub(crate) const fn schema_version(self) -> SchemaVersion {
+        self.schema_version
+    }
+
+    pub(crate) const fn contract_version(self) -> ContractVersion {
+        self.contract_version
+    }
+
+    pub(crate) const fn roles(self) -> &'static [BuiltInRole] {
+        self.roles
+    }
+
+    pub(crate) fn validate(self, role: RoleId) -> Result<BuiltInRole, RoleDictionaryError> {
+        for built_in in self.roles {
+            if built_in.id() == role {
+                return Ok(*built_in);
+            }
+        }
+        Err(RoleDictionaryError::UnknownRole(role))
+    }
+
+    pub(crate) fn contains(self, role: RoleId) -> bool {
+        self.validate(role).is_ok()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RoleDictionaryError {
+    UnknownRole(RoleId),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_dictionary_validates_built_in_roles() {
+        let dictionary = RoleDictionary::current();
+
+        assert_eq!(
+            dictionary.validate(RoleId::new("numeric_readout")),
+            Ok(BuiltInRole::NumericReadout)
+        );
+        assert!(dictionary.contains(RoleId::new("danger_action")));
+    }
+
+    #[test]
+    fn role_dictionary_rejects_unknown_roles() {
+        let dictionary = RoleDictionary::current();
+
+        assert_eq!(
+            dictionary.validate(RoleId::new("renderer_button")),
+            Err(RoleDictionaryError::UnknownRole(RoleId::new(
+                "renderer_button"
+            )))
+        );
+    }
+
+    #[test]
+    fn role_dictionary_versions_are_stable() {
+        let dictionary = RoleDictionary::current();
+
+        assert_eq!(dictionary.schema_version().raw(), 1);
+        assert_eq!(dictionary.contract_version().raw(), 1);
+    }
+
+    #[test]
+    fn role_dictionary_roles_are_canonically_ordered() {
+        let roles = RoleDictionary::current().roles();
+
+        for pair in roles.windows(2) {
+            assert!(pair[0].id() < pair[1].id());
+        }
+    }
+
+    #[test]
+    fn role_dictionary_does_not_import_renderer_taxonomy() {
+        let dictionary = RoleDictionary::current();
+
+        assert!(!dictionary.contains(RoleId::new("button")));
+        assert!(!dictionary.contains(RoleId::new("wgpu_surface")));
+    }
+}

--- a/crates/prom-ui/src/static_ir.rs
+++ b/crates/prom-ui/src/static_ir.rs
@@ -1,0 +1,1732 @@
+//! UI DNA v2 Static UI IR document wrapper.
+//!
+//! `UiIr` remains the legacy structural substrate. This module owns the
+//! versioned v2 Static UI IR contract and bounded legacy adaptation.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+use crate::contract_primitives::{
+    ChildOrder, CollectionKey, ContractVersion, DiagnosticCode, DiagnosticCoordinate, Epoch,
+    Revision, SchemaVersion, SourceRef, StaticDocumentId, StaticNodeId, StaticSurfaceId,
+};
+use crate::model::{UiAstNodeId, UiIr, UiIrNodeKind};
+use crate::role_dictionary::{RoleDictionary, RoleId};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiDocument {
+    schema_version: SchemaVersion,
+    contract_version: ContractVersion,
+    id: StaticDocumentId,
+    revision: Revision,
+    epoch: Epoch,
+    surfaces: Vec<StaticUiSurface>,
+    nodes: Vec<StaticUiNode>,
+}
+
+impl StaticUiDocument {
+    pub(crate) fn new(id: StaticDocumentId, revision: Revision, epoch: Epoch) -> Self {
+        Self {
+            schema_version: SchemaVersion::CURRENT,
+            contract_version: ContractVersion::CURRENT,
+            id,
+            revision,
+            epoch,
+            surfaces: Vec::new(),
+            nodes: Vec::new(),
+        }
+    }
+
+    pub(crate) const fn schema_version(&self) -> SchemaVersion {
+        self.schema_version
+    }
+
+    pub(crate) const fn contract_version(&self) -> ContractVersion {
+        self.contract_version
+    }
+
+    pub(crate) const fn id(&self) -> StaticDocumentId {
+        self.id
+    }
+
+    pub(crate) const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub(crate) const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    pub(crate) fn surfaces(&self) -> &[StaticUiSurface] {
+        &self.surfaces
+    }
+
+    pub(crate) fn nodes(&self) -> &[StaticUiNode] {
+        &self.nodes
+    }
+
+    pub(crate) fn push_surface(&mut self, surface: StaticUiSurface) {
+        self.surfaces.push(surface);
+    }
+
+    pub(crate) fn push_node(&mut self, node: StaticUiNode) {
+        self.nodes.push(node);
+    }
+
+    pub(crate) fn validate(&self, dictionary: RoleDictionary) -> Result<(), StaticUiIrDiagnostics> {
+        let diagnostics = validate_static_ir(self, dictionary);
+        if diagnostics.is_empty() {
+            Ok(())
+        } else {
+            Err(diagnostics)
+        }
+    }
+
+    pub(crate) fn canonicalized(
+        &self,
+        dictionary: RoleDictionary,
+    ) -> Result<Self, StaticUiIrDiagnostics> {
+        self.validate(dictionary)?;
+        let mut canonical = self.clone();
+        canonical
+            .surfaces
+            .sort_by_key(|surface| (surface.key, surface.id));
+        canonical.nodes.sort_by_key(|node| (node.key, node.id));
+        for node in &mut canonical.nodes {
+            node.normalize();
+        }
+        Ok(canonical)
+    }
+
+    // Internal deterministic qualification encoding; not a public artifact,
+    // cryptographic digest, signature, integrity guarantee, or compatibility promise.
+    pub(crate) fn canonical_bytes(
+        &self,
+        dictionary: RoleDictionary,
+    ) -> Result<Vec<u8>, CanonicalEncodingError> {
+        let canonical = self.canonicalized(dictionary)?;
+        let mut bytes = Vec::new();
+        push_bytes(&mut bytes, b"UI_DNA2_STATIC_IR_V1")?;
+        push_u32(&mut bytes, canonical.schema_version.raw());
+        push_u32(&mut bytes, canonical.contract_version.raw());
+        push_u64(&mut bytes, canonical.id.raw());
+        push_u64(&mut bytes, canonical.revision.raw());
+        push_u64(&mut bytes, canonical.epoch.raw());
+        push_len(&mut bytes, canonical.surfaces.len())?;
+        for surface in &canonical.surfaces {
+            push_u64(&mut bytes, surface.id.raw());
+            push_u64(&mut bytes, surface.root.raw());
+            push_u64(&mut bytes, surface.key.raw());
+            push_optional_source(&mut bytes, surface.source);
+        }
+        push_len(&mut bytes, canonical.nodes.len())?;
+        for node in &canonical.nodes {
+            push_u64(&mut bytes, node.id.raw());
+            push_str(&mut bytes, node.role.as_str())?;
+            push_u64(&mut bytes, node.key.raw());
+            push_optional_source(&mut bytes, node.source);
+            push_len(&mut bytes, node.children.len())?;
+            for child in &node.children {
+                push_u32(&mut bytes, child.order.raw());
+                push_u64(&mut bytes, child.child.raw());
+            }
+            push_optional_u64(&mut bytes, node.accessibility_ref.map(StaticNodeId::raw));
+        }
+        Ok(bytes)
+    }
+
+    pub(crate) fn from_legacy_ui_ir(
+        context: LegacyUiIrAdapterContext<'_>,
+        ir: &UiIr,
+    ) -> Result<Self, StaticUiIrDiagnostics> {
+        validate_legacy_parent_evidence(ir)?;
+        let mut document = Self::new(context.document_id, context.revision, context.epoch);
+        let mut root: Option<StaticNodeId> = None;
+        let mut root_count = 0_u32;
+
+        for node in ir.nodes() {
+            let static_id = StaticNodeId::new(node.id().raw()).map_err(|_| {
+                StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                    None,
+                    StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                    node.id().raw(),
+                    0,
+                ))
+            })?;
+            let role = match node.kind() {
+                UiIrNodeKind::Root => {
+                    root_count += 1;
+                    root = Some(static_id);
+                    RoleId::new("root")
+                }
+                UiIrNodeKind::Element => RoleId::new("evidence_panel"),
+                UiIrNodeKind::Text => RoleId::new("text"),
+                UiIrNodeKind::Fragment => RoleId::new("fragment"),
+                UiIrNodeKind::Property | UiIrNodeKind::Action | UiIrNodeKind::EffectBoundary => {
+                    return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                        None,
+                        StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                        node.id().raw(),
+                        0,
+                    )));
+                }
+            };
+            let Some(source_ast_node_id) = node.source_ast_node_id() else {
+                return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                    None,
+                    StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                    node.id().raw(),
+                    4,
+                )));
+            };
+            let Some(source_ref) = context.source_ref(source_ast_node_id) else {
+                return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                    None,
+                    StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                    node.id().raw(),
+                    source_ast_node_id.raw(),
+                )));
+            };
+            let key = CollectionKey::new(node.id().raw()).map_err(|_| {
+                StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                    None,
+                    StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                    node.id().raw(),
+                    1,
+                ))
+            })?;
+            let mut static_node = StaticUiNode::new(static_id, role, key, Some(source_ref));
+            for (order, child) in node.children().iter().enumerate() {
+                let order = u32::try_from(order).map_err(|_| {
+                    StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                        None,
+                        StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                        node.id().raw(),
+                        2,
+                    ))
+                })?;
+                let child = StaticNodeId::new(child.raw()).map_err(|_| {
+                    StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                        None,
+                        StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                        node.id().raw(),
+                        3,
+                    ))
+                })?;
+                static_node.push_child(StaticUiChild::new(child, ChildOrder::new(order)));
+            }
+            document.push_node(static_node);
+        }
+
+        if root_count != 1 {
+            return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                None,
+                StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                context.document_id.raw(),
+                u64::from(root_count),
+            )));
+        };
+        let Some(root) = root else {
+            return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                None,
+                StaticUiIrDiagnosticKind::MissingRoot,
+                context.document_id.raw(),
+                0,
+            )));
+        };
+        document.push_surface(StaticUiSurface::new(
+            context.surface_id,
+            root,
+            context.surface_key,
+            context.surface_source,
+        ));
+        document.canonicalized(RoleDictionary::current())
+    }
+}
+
+fn validate_legacy_parent_evidence(ir: &UiIr) -> Result<(), StaticUiIrDiagnostics> {
+    let roots: Vec<usize> = ir
+        .nodes()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, node)| (node.kind() == UiIrNodeKind::Root).then_some(index))
+        .collect();
+    if roots.len() != 1 {
+        return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+            None,
+            StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+            0,
+            u64::try_from(roots.len()).unwrap_or(u64::MAX),
+        )));
+    }
+
+    let root_index = roots[0];
+    let mut expected_parent: Vec<Option<crate::model::UiIrNodeId>> =
+        alloc::vec![None; ir.nodes().len()];
+    for parent in ir.nodes() {
+        for child in parent.children() {
+            let Some(child_index) = ir.nodes().iter().position(|node| node.id() == *child) else {
+                return Err(StaticUiIrDiagnostics::single(StaticUiIrDiagnostic::new(
+                    None,
+                    StaticUiIrDiagnosticKind::InvalidLegacyMapping,
+                    parent.id().raw(),
+                    child.raw(),
+                )));
+            };
+            if let Some(previous) = expected_parent[child_index] {
+                return Err(StaticUiIrDiagnostics::single(
+                    StaticUiIrDiagnostic::legacy_parent(
+                        StaticUiIrDiagnosticKind::LegacyMultipleParents,
+                        child.raw(),
+                        Some(previous.raw()),
+                        Some(parent.id().raw()),
+                    ),
+                ));
+            }
+            expected_parent[child_index] = Some(parent.id());
+        }
+    }
+
+    for (index, node) in ir.nodes().iter().enumerate() {
+        let actual = node.parent();
+        if index == root_index {
+            if let Some(actual) = actual {
+                return Err(StaticUiIrDiagnostics::single(
+                    StaticUiIrDiagnostic::legacy_parent(
+                        StaticUiIrDiagnosticKind::RootHasLegacyParent,
+                        node.id().raw(),
+                        None,
+                        Some(actual.raw()),
+                    ),
+                ));
+            }
+            if let Some(expected) = expected_parent[index] {
+                return Err(StaticUiIrDiagnostics::single(
+                    StaticUiIrDiagnostic::legacy_parent(
+                        StaticUiIrDiagnosticKind::LegacyParentMismatch,
+                        node.id().raw(),
+                        Some(expected.raw()),
+                        None,
+                    ),
+                ));
+            }
+            continue;
+        }
+
+        let Some(expected) = expected_parent[index] else {
+            return Err(StaticUiIrDiagnostics::single(
+                StaticUiIrDiagnostic::legacy_parent(
+                    StaticUiIrDiagnosticKind::MissingLegacyParent,
+                    node.id().raw(),
+                    None,
+                    actual.map(crate::model::UiIrNodeId::raw),
+                ),
+            ));
+        };
+        let Some(actual) = actual else {
+            return Err(StaticUiIrDiagnostics::single(
+                StaticUiIrDiagnostic::legacy_parent(
+                    StaticUiIrDiagnosticKind::MissingLegacyParent,
+                    node.id().raw(),
+                    Some(expected.raw()),
+                    None,
+                ),
+            ));
+        };
+        if !ir.nodes().iter().any(|candidate| candidate.id() == actual) {
+            return Err(StaticUiIrDiagnostics::single(
+                StaticUiIrDiagnostic::legacy_parent(
+                    StaticUiIrDiagnosticKind::DanglingLegacyParent,
+                    node.id().raw(),
+                    Some(expected.raw()),
+                    Some(actual.raw()),
+                ),
+            ));
+        }
+        if actual != expected {
+            return Err(StaticUiIrDiagnostics::single(
+                StaticUiIrDiagnostic::legacy_parent(
+                    StaticUiIrDiagnosticKind::LegacyParentMismatch,
+                    node.id().raw(),
+                    Some(expected.raw()),
+                    Some(actual.raw()),
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) struct LegacyUiIrAdapterContext<'a> {
+    document_id: StaticDocumentId,
+    surface_id: StaticSurfaceId,
+    surface_key: CollectionKey,
+    surface_source: Option<SourceRef>,
+    revision: Revision,
+    epoch: Epoch,
+    source_refs: &'a [(UiAstNodeId, SourceRef)],
+}
+
+impl<'a> LegacyUiIrAdapterContext<'a> {
+    pub(crate) const fn new(
+        document_id: StaticDocumentId,
+        surface_id: StaticSurfaceId,
+        surface_key: CollectionKey,
+        surface_source: Option<SourceRef>,
+        revision: Revision,
+        epoch: Epoch,
+        source_refs: &'a [(UiAstNodeId, SourceRef)],
+    ) -> Self {
+        Self {
+            document_id,
+            surface_id,
+            surface_key,
+            surface_source,
+            revision,
+            epoch,
+            source_refs,
+        }
+    }
+
+    fn source_ref(&self, id: UiAstNodeId) -> Option<SourceRef> {
+        self.source_refs
+            .iter()
+            .find_map(|(candidate, source)| (*candidate == id).then_some(*source))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiSurface {
+    id: StaticSurfaceId,
+    root: StaticNodeId,
+    key: CollectionKey,
+    source: Option<SourceRef>,
+}
+
+impl StaticUiSurface {
+    pub(crate) const fn new(
+        id: StaticSurfaceId,
+        root: StaticNodeId,
+        key: CollectionKey,
+        source: Option<SourceRef>,
+    ) -> Self {
+        Self {
+            id,
+            root,
+            key,
+            source,
+        }
+    }
+
+    pub(crate) const fn id(&self) -> StaticSurfaceId {
+        self.id
+    }
+
+    pub(crate) const fn root(&self) -> StaticNodeId {
+        self.root
+    }
+
+    pub(crate) const fn key(&self) -> CollectionKey {
+        self.key
+    }
+
+    pub(crate) const fn source(&self) -> Option<SourceRef> {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiNode {
+    id: StaticNodeId,
+    role: RoleId,
+    key: CollectionKey,
+    source: Option<SourceRef>,
+    children: Vec<StaticUiChild>,
+    accessibility_ref: Option<StaticNodeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiChild {
+    child: StaticNodeId,
+    order: ChildOrder,
+}
+impl StaticUiChild {
+    pub(crate) const fn new(child: StaticNodeId, order: ChildOrder) -> Self {
+        Self { child, order }
+    }
+
+    pub(crate) const fn child(self) -> StaticNodeId {
+        self.child
+    }
+
+    pub(crate) const fn order(self) -> ChildOrder {
+        self.order
+    }
+}
+
+impl StaticUiNode {
+    pub(crate) fn new(
+        id: StaticNodeId,
+        role: RoleId,
+        key: CollectionKey,
+        source: Option<SourceRef>,
+    ) -> Self {
+        Self {
+            id,
+            role,
+            key,
+            source,
+            children: Vec::new(),
+            accessibility_ref: None,
+        }
+    }
+
+    pub(crate) const fn id(&self) -> StaticNodeId {
+        self.id
+    }
+
+    pub(crate) const fn role(&self) -> RoleId {
+        self.role
+    }
+
+    pub(crate) const fn key(&self) -> CollectionKey {
+        self.key
+    }
+
+    pub(crate) const fn source(&self) -> Option<SourceRef> {
+        self.source
+    }
+
+    pub(crate) fn children(&self) -> &[StaticUiChild] {
+        &self.children
+    }
+
+    pub(crate) fn push_child(&mut self, child: StaticUiChild) {
+        self.children.push(child);
+    }
+
+    pub(crate) fn set_accessibility_ref(&mut self, target: StaticNodeId) {
+        self.accessibility_ref = Some(target);
+    }
+
+    fn normalize(&mut self) {
+        self.children.sort_by_key(|edge| edge.order);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum StaticUiIrDiagnosticKind {
+    DuplicateSurfaceId,
+    DuplicateSurfaceKey,
+    DuplicateNodeId,
+    DuplicateNodeKey,
+    MissingRoot,
+    MissingChild,
+    DuplicateChild,
+    DuplicateChildOrder,
+    DuplicateSurfaceRoot,
+    RootUsedAsChild,
+    MultipleParents,
+    Cycle,
+    UnreachableNode,
+    SharedAcrossSurfaces,
+    InvalidAccessibilityReference,
+    UnknownRole,
+    InvalidLegacyMapping,
+    RootHasLegacyParent,
+    MissingLegacyParent,
+    LegacyParentMismatch,
+    DanglingLegacyParent,
+    LegacyMultipleParents,
+}
+
+impl StaticUiIrDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::DuplicateSurfaceId => DiagnosticCode::new("SIR_DUP_SURFACE_ID"),
+            Self::DuplicateSurfaceKey => DiagnosticCode::new("SIR_DUP_SURFACE_KEY"),
+            Self::DuplicateNodeId => DiagnosticCode::new("SIR_DUP_NODE_ID"),
+            Self::DuplicateNodeKey => DiagnosticCode::new("SIR_DUP_NODE_KEY"),
+            Self::MissingRoot => DiagnosticCode::new("SIR_MISSING_ROOT"),
+            Self::MissingChild => DiagnosticCode::new("SIR_MISSING_CHILD"),
+            Self::DuplicateChild => DiagnosticCode::new("SIR_DUP_CHILD"),
+            Self::DuplicateChildOrder => DiagnosticCode::new("SIR_DUP_CHILD_ORDER"),
+            Self::DuplicateSurfaceRoot => DiagnosticCode::new("SIR_DUP_SURFACE_ROOT"),
+            Self::RootUsedAsChild => DiagnosticCode::new("SIR_ROOT_USED_AS_CHILD"),
+            Self::MultipleParents => DiagnosticCode::new("SIR_MULTIPLE_PARENTS"),
+            Self::Cycle => DiagnosticCode::new("SIR_CYCLE"),
+            Self::UnreachableNode => DiagnosticCode::new("SIR_UNREACHABLE_NODE"),
+            Self::SharedAcrossSurfaces => DiagnosticCode::new("SIR_SHARED_ACROSS_SURFACES"),
+            Self::InvalidAccessibilityReference => DiagnosticCode::new("SIR_BAD_A11Y_REF"),
+            Self::UnknownRole => DiagnosticCode::new("SIR_UNKNOWN_ROLE"),
+            Self::InvalidLegacyMapping => DiagnosticCode::new("SIR_INVALID_LEGACY"),
+            Self::RootHasLegacyParent => DiagnosticCode::new("SIR_LEGACY_ROOT_PARENT"),
+            Self::MissingLegacyParent => DiagnosticCode::new("SIR_LEGACY_MISSING_PARENT"),
+            Self::LegacyParentMismatch => DiagnosticCode::new("SIR_LEGACY_PARENT_MISMATCH"),
+            Self::DanglingLegacyParent => DiagnosticCode::new("SIR_LEGACY_DANGLING_PARENT"),
+            Self::LegacyMultipleParents => DiagnosticCode::new("SIR_LEGACY_MULTI_PARENT"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct LegacyParentEvidence {
+    node: u64,
+    expected: Option<u64>,
+    actual: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiIrDiagnostic {
+    coordinate: DiagnosticCoordinate,
+    kind: StaticUiIrDiagnosticKind,
+    legacy_parent: Option<LegacyParentEvidence>,
+}
+
+impl StaticUiIrDiagnostic {
+    fn new(
+        source: Option<SourceRef>,
+        kind: StaticUiIrDiagnosticKind,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(source, kind.code(), domain, secondary),
+            kind,
+            legacy_parent: None,
+        }
+    }
+
+    fn legacy_parent(
+        kind: StaticUiIrDiagnosticKind,
+        node: u64,
+        expected: Option<u64>,
+        actual: Option<u64>,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(
+                None,
+                kind.code(),
+                node,
+                actual.or(expected).unwrap_or(0),
+            ),
+            kind,
+            legacy_parent: Some(LegacyParentEvidence {
+                node,
+                expected,
+                actual,
+            }),
+        }
+    }
+
+    pub(crate) const fn kind(self) -> StaticUiIrDiagnosticKind {
+        self.kind
+    }
+
+    pub(crate) const fn coordinate(self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+}
+
+impl Ord for StaticUiIrDiagnostic {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        (self.coordinate, self.kind, self.legacy_parent).cmp(&(
+            other.coordinate,
+            other.kind,
+            other.legacy_parent,
+        ))
+    }
+}
+
+impl PartialOrd for StaticUiIrDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct StaticUiIrDiagnostics {
+    diagnostics: Vec<StaticUiIrDiagnostic>,
+}
+
+impl StaticUiIrDiagnostics {
+    fn single(diagnostic: StaticUiIrDiagnostic) -> Self {
+        Self::new(Vec::from([diagnostic]))
+    }
+
+    fn new(mut diagnostics: Vec<StaticUiIrDiagnostic>) -> Self {
+        diagnostics.sort();
+        diagnostics.dedup();
+        Self { diagnostics }
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[StaticUiIrDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
+fn validate_static_ir(
+    document: &StaticUiDocument,
+    dictionary: RoleDictionary,
+) -> StaticUiIrDiagnostics {
+    let mut diagnostics = Vec::new();
+
+    for (index, surface) in document.surfaces.iter().enumerate() {
+        if document.surfaces[..index]
+            .iter()
+            .any(|previous| previous.id == surface.id)
+        {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                surface.source,
+                StaticUiIrDiagnosticKind::DuplicateSurfaceId,
+                surface.id.raw(),
+                0,
+            ));
+        }
+        if document.surfaces[..index]
+            .iter()
+            .any(|previous| previous.key == surface.key)
+        {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                surface.source,
+                StaticUiIrDiagnosticKind::DuplicateSurfaceKey,
+                surface.key.raw(),
+                0,
+            ));
+        }
+        if !document.nodes.iter().any(|node| node.id == surface.root) {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                surface.source,
+                StaticUiIrDiagnosticKind::MissingRoot,
+                surface.root.raw(),
+                0,
+            ));
+        }
+    }
+
+    for (index, node) in document.nodes.iter().enumerate() {
+        if document.nodes[..index]
+            .iter()
+            .any(|previous| previous.id == node.id)
+        {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::DuplicateNodeId,
+                node.id.raw(),
+                0,
+            ));
+        }
+        if document.nodes[..index]
+            .iter()
+            .any(|previous| previous.key == node.key)
+        {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::DuplicateNodeKey,
+                node.key.raw(),
+                0,
+            ));
+        }
+        if dictionary.validate(node.role).is_err() {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::UnknownRole,
+                node.key.raw(),
+                0,
+            ));
+        }
+        if let Some(target) = node.accessibility_ref {
+            if target == node.id
+                || !document
+                    .nodes
+                    .iter()
+                    .any(|candidate| candidate.id == target)
+            {
+                diagnostics.push(StaticUiIrDiagnostic::new(
+                    node.source,
+                    StaticUiIrDiagnosticKind::InvalidAccessibilityReference,
+                    node.id.raw(),
+                    target.raw(),
+                ));
+            }
+        }
+        for (child_index, child) in node.children.iter().enumerate() {
+            if !document
+                .nodes
+                .iter()
+                .any(|candidate| candidate.id == child.child)
+            {
+                diagnostics.push(StaticUiIrDiagnostic::new(
+                    node.source,
+                    StaticUiIrDiagnosticKind::MissingChild,
+                    node.id.raw(),
+                    child.child.raw(),
+                ));
+            }
+            if node.children[..child_index]
+                .iter()
+                .any(|previous| previous.child == child.child)
+            {
+                diagnostics.push(StaticUiIrDiagnostic::new(
+                    node.source,
+                    StaticUiIrDiagnosticKind::DuplicateChild,
+                    node.id.raw(),
+                    child.child.raw(),
+                ));
+            }
+            if node.children[..child_index]
+                .iter()
+                .any(|previous| previous.order == child.order)
+            {
+                diagnostics.push(StaticUiIrDiagnostic::new(
+                    node.source,
+                    StaticUiIrDiagnosticKind::DuplicateChildOrder,
+                    node.id.raw(),
+                    u64::from(child.order.raw()),
+                ));
+            }
+        }
+    }
+
+    validate_static_forest(document, &mut diagnostics);
+
+    StaticUiIrDiagnostics::new(diagnostics)
+}
+
+fn validate_static_forest(
+    document: &StaticUiDocument,
+    diagnostics: &mut Vec<StaticUiIrDiagnostic>,
+) {
+    if document.surfaces.is_empty() {
+        diagnostics.push(StaticUiIrDiagnostic::new(
+            None,
+            StaticUiIrDiagnosticKind::MissingRoot,
+            document.id.raw(),
+            0,
+        ));
+        return;
+    }
+
+    let mut root_indices = Vec::new();
+    for surface in &document.surfaces {
+        let Some(root_index) = static_node_index(document, surface.root) else {
+            continue;
+        };
+        if root_indices.contains(&root_index) {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                surface.source,
+                StaticUiIrDiagnosticKind::DuplicateSurfaceRoot,
+                surface.root.raw(),
+                surface.id.raw(),
+            ));
+        }
+        root_indices.push(root_index);
+    }
+
+    let mut owner: Vec<Option<usize>> = alloc::vec![None; document.nodes.len()];
+    let mut parent_count: Vec<u32> = alloc::vec![0; document.nodes.len()];
+    let mut visiting: Vec<bool> = alloc::vec![false; document.nodes.len()];
+    let mut complete: Vec<bool> = alloc::vec![false; document.nodes.len()];
+
+    for (surface_index, surface) in document.surfaces.iter().enumerate() {
+        if let Some(root_index) = static_node_index(document, surface.root) {
+            walk_static_forest(
+                document,
+                surface_index,
+                root_index,
+                &mut owner,
+                &mut parent_count,
+                &mut visiting,
+                &mut complete,
+                diagnostics,
+            );
+        }
+    }
+
+    for (index, node) in document.nodes.iter().enumerate() {
+        let is_root = root_indices.contains(&index);
+        if is_root && parent_count[index] != 0 {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::RootUsedAsChild,
+                node.id.raw(),
+                0,
+            ));
+        }
+        if !is_root && parent_count[index] == 0 {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::UnreachableNode,
+                node.id.raw(),
+                0,
+            ));
+        }
+        if !is_root && parent_count[index] > 1 {
+            diagnostics.push(StaticUiIrDiagnostic::new(
+                node.source,
+                StaticUiIrDiagnosticKind::MultipleParents,
+                node.id.raw(),
+                u64::from(parent_count[index]),
+            ));
+        }
+    }
+}
+
+struct StaticTraversalFrame {
+    node_index: usize,
+    parent: Option<usize>,
+    next_child: usize,
+    entered: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_static_forest(
+    document: &StaticUiDocument,
+    surface_index: usize,
+    root_index: usize,
+    owner: &mut [Option<usize>],
+    parent_count: &mut [u32],
+    visiting: &mut [bool],
+    complete: &mut [bool],
+    diagnostics: &mut Vec<StaticUiIrDiagnostic>,
+) {
+    let mut stack = Vec::from([StaticTraversalFrame {
+        node_index: root_index,
+        parent: None,
+        next_child: 0,
+        entered: false,
+    }]);
+
+    while let Some(mut frame) = stack.pop() {
+        let node_index = frame.node_index;
+        if !frame.entered {
+            frame.entered = true;
+            let node = &document.nodes[node_index];
+            if frame.parent.is_some() {
+                parent_count[node_index] = parent_count[node_index].saturating_add(1);
+            }
+
+            match owner[node_index] {
+                Some(previous) if previous != surface_index => {
+                    diagnostics.push(StaticUiIrDiagnostic::new(
+                        node.source,
+                        StaticUiIrDiagnosticKind::SharedAcrossSurfaces,
+                        node.id.raw(),
+                        surface_index as u64,
+                    ));
+                }
+                None => owner[node_index] = Some(surface_index),
+                _ => {}
+            }
+
+            if visiting[node_index] {
+                diagnostics.push(StaticUiIrDiagnostic::new(
+                    node.source,
+                    StaticUiIrDiagnosticKind::Cycle,
+                    node.id.raw(),
+                    0,
+                ));
+                continue;
+            }
+            if complete[node_index] {
+                continue;
+            }
+            visiting[node_index] = true;
+        }
+
+        let next_child = frame.next_child;
+        let next = document.nodes[node_index].children.get(next_child).copied();
+        if let Some(child) = next {
+            frame.next_child += 1;
+            stack.push(frame);
+            if let Some(child_index) = static_node_index(document, child.child) {
+                stack.push(StaticTraversalFrame {
+                    node_index: child_index,
+                    parent: Some(node_index),
+                    next_child: 0,
+                    entered: false,
+                });
+            }
+        } else {
+            visiting[node_index] = false;
+            complete[node_index] = true;
+        }
+    }
+}
+
+fn static_node_index(document: &StaticUiDocument, id: StaticNodeId) -> Option<usize> {
+    document.nodes.iter().position(|node| node.id == id)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum CanonicalEncodingError {
+    InvalidDocument(StaticUiIrDiagnostics),
+    LengthOverflow,
+}
+
+impl From<StaticUiIrDiagnostics> for CanonicalEncodingError {
+    fn from(value: StaticUiIrDiagnostics) -> Self {
+        Self::InvalidDocument(value)
+    }
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn checked_len(value: usize) -> Result<u32, CanonicalEncodingError> {
+    u32::try_from(value).map_err(|_| CanonicalEncodingError::LengthOverflow)
+}
+
+fn push_len(bytes: &mut Vec<u8>, value: usize) -> Result<(), CanonicalEncodingError> {
+    push_u32(bytes, checked_len(value)?);
+    Ok(())
+}
+
+fn push_bytes(bytes: &mut Vec<u8>, value: &[u8]) -> Result<(), CanonicalEncodingError> {
+    push_len(bytes, value.len())?;
+    bytes.extend_from_slice(value);
+    Ok(())
+}
+
+fn push_str(bytes: &mut Vec<u8>, value: &str) -> Result<(), CanonicalEncodingError> {
+    push_bytes(bytes, value.as_bytes())
+}
+
+fn push_optional_u64(bytes: &mut Vec<u8>, value: Option<u64>) {
+    match value {
+        Some(value) => {
+            bytes.push(1);
+            push_u64(bytes, value);
+        }
+        None => bytes.push(0),
+    }
+}
+
+fn push_optional_source(bytes: &mut Vec<u8>, source: Option<SourceRef>) {
+    match source {
+        Some(source) => {
+            bytes.push(1);
+            push_u64(bytes, source.source().raw());
+            push_u32(bytes, source.span().start());
+            push_u32(bytes, source.span().end());
+        }
+        None => bytes.push(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract_primitives::{SourceId, SourceSpan};
+    use crate::model::{UiAstNodeId, UiIrNode, UiIrNodeId};
+
+    fn doc_id(raw: u64) -> StaticDocumentId {
+        StaticDocumentId::new(raw).expect("document id")
+    }
+
+    fn node_id(raw: u64) -> StaticNodeId {
+        StaticNodeId::new(raw).expect("node id")
+    }
+
+    fn surface_id(raw: u64) -> StaticSurfaceId {
+        StaticSurfaceId::new(raw).expect("surface id")
+    }
+
+    fn key(raw: u64) -> CollectionKey {
+        CollectionKey::new(raw).expect("collection key")
+    }
+
+    fn source_ref(start: u32, end: u32) -> SourceRef {
+        SourceRef::new(
+            SourceId::new(1).expect("source id"),
+            SourceSpan::new(start, end).expect("source span"),
+        )
+    }
+
+    fn legacy_context<'a>(
+        source_refs: &'a [(UiAstNodeId, SourceRef)],
+    ) -> LegacyUiIrAdapterContext<'a> {
+        LegacyUiIrAdapterContext::new(
+            doc_id(1),
+            surface_id(1),
+            key(1),
+            Some(source_ref(0, 1)),
+            Revision::new(0),
+            Epoch::new(0),
+            source_refs,
+        )
+    }
+
+    fn legacy_node(
+        id: u64,
+        kind: UiIrNodeKind,
+        source_ast_id: u64,
+        parent: Option<u64>,
+        children: &[u64],
+    ) -> UiIrNode {
+        let mut node = match parent {
+            Some(parent) => {
+                UiIrNode::with_parent(UiIrNodeId::new(id), kind, UiIrNodeId::new(parent))
+            }
+            None => UiIrNode::new(UiIrNodeId::new(id), kind),
+        };
+        node.set_source_ast_node_id(Some(UiAstNodeId::new(source_ast_id)));
+        for child in children {
+            node.push_child(UiIrNodeId::new(*child));
+        }
+        node
+    }
+
+    fn minimal_document() -> StaticUiDocument {
+        let mut document = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        document.push_node(StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        ));
+        document.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+        document
+    }
+
+    fn document_with_ordered_children(order_a: u32, order_b: u32) -> StaticUiDocument {
+        let mut document = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        let mut root = StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        );
+        root.push_child(StaticUiChild::new(node_id(20), ChildOrder::new(order_a)));
+        root.push_child(StaticUiChild::new(node_id(30), ChildOrder::new(order_b)));
+        document.push_node(root);
+        document.push_node(StaticUiNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            Some(source_ref(2, 3)),
+        ));
+        document.push_node(StaticUiNode::new(
+            node_id(30),
+            RoleId::new("text"),
+            key(30),
+            Some(source_ref(4, 5)),
+        ));
+        document.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+        document
+    }
+
+    #[test]
+    fn static_ir_minimal_document_validates() {
+        assert!(minimal_document()
+            .validate(RoleDictionary::current())
+            .is_ok());
+    }
+
+    #[test]
+    fn static_ir_rejects_duplicate_ids_and_keys() {
+        let mut document = minimal_document();
+        document.push_node(StaticUiNode::new(
+            node_id(10),
+            RoleId::new("text"),
+            key(10),
+            Some(source_ref(2, 3)),
+        ));
+
+        let diagnostics = document
+            .validate(RoleDictionary::current())
+            .expect_err("duplicate");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            StaticUiIrDiagnosticKind::DuplicateNodeId
+        );
+        assert_eq!(
+            diagnostics.diagnostics()[1].kind(),
+            StaticUiIrDiagnosticKind::DuplicateNodeKey
+        );
+    }
+
+    #[test]
+    fn static_ir_rejects_dangling_references() {
+        let mut document = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        document.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(99),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+
+        let diagnostics = document
+            .validate(RoleDictionary::current())
+            .expect_err("missing root");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            StaticUiIrDiagnosticKind::MissingRoot
+        );
+    }
+
+    #[test]
+    fn static_ir_canonical_bytes_are_insertion_order_independent() {
+        let mut first = minimal_document();
+        first
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(StaticUiChild::new(node_id(20), ChildOrder::new(0)));
+        first.push_node(StaticUiNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            Some(source_ref(2, 3)),
+        ));
+
+        let mut second = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        second.push_node(StaticUiNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            Some(source_ref(2, 3)),
+        ));
+        second.push_node(StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        ));
+        second
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(StaticUiChild::new(node_id(20), ChildOrder::new(0)));
+        second.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+
+        assert_eq!(
+            first
+                .canonical_bytes(RoleDictionary::current())
+                .expect("first"),
+            second
+                .canonical_bytes(RoleDictionary::current())
+                .expect("second")
+        );
+    }
+
+    #[test]
+    fn static_ir_storage_permutation_preserves_semantic_order_bytes() {
+        let first = document_with_ordered_children(0, 1);
+        let mut second = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        second.push_node(StaticUiNode::new(
+            node_id(30),
+            RoleId::new("text"),
+            key(30),
+            Some(source_ref(4, 5)),
+        ));
+        let mut root = StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        );
+        root.push_child(StaticUiChild::new(node_id(30), ChildOrder::new(1)));
+        root.push_child(StaticUiChild::new(node_id(20), ChildOrder::new(0)));
+        second.push_node(root);
+        second.push_node(StaticUiNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            Some(source_ref(2, 3)),
+        ));
+        second.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+
+        assert_eq!(
+            first
+                .canonical_bytes(RoleDictionary::current())
+                .expect("first bytes"),
+            second
+                .canonical_bytes(RoleDictionary::current())
+                .expect("second bytes")
+        );
+    }
+
+    #[test]
+    fn static_ir_semantic_child_order_changes_bytes() {
+        let first = document_with_ordered_children(0, 1);
+        let second = document_with_ordered_children(1, 0);
+
+        assert_ne!(
+            first
+                .canonical_bytes(RoleDictionary::current())
+                .expect("first bytes"),
+            second
+                .canonical_bytes(RoleDictionary::current())
+                .expect("second bytes")
+        );
+    }
+
+    #[test]
+    fn static_ir_rejects_ordered_forest_violations() {
+        let duplicate_order = document_with_ordered_children(0, 0);
+        assert!(duplicate_order
+            .validate(RoleDictionary::current())
+            .expect_err("duplicate order")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::DuplicateChildOrder));
+
+        let mut cycle = minimal_document();
+        cycle
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(StaticUiChild::new(node_id(10), ChildOrder::new(0)));
+        assert!(cycle
+            .validate(RoleDictionary::current())
+            .expect_err("cycle")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::Cycle));
+
+        let mut multi_parent = document_with_ordered_children(0, 1);
+        multi_parent
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(20))
+            .expect("child")
+            .push_child(StaticUiChild::new(node_id(30), ChildOrder::new(0)));
+        assert!(multi_parent
+            .validate(RoleDictionary::current())
+            .expect_err("multiple parents")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::MultipleParents));
+
+        let mut orphan = minimal_document();
+        orphan.push_node(StaticUiNode::new(
+            node_id(40),
+            RoleId::new("text"),
+            key(40),
+            Some(source_ref(6, 7)),
+        ));
+        assert!(orphan
+            .validate(RoleDictionary::current())
+            .expect_err("orphan")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::UnreachableNode));
+
+        let mut duplicate_child = document_with_ordered_children(0, 1);
+        duplicate_child
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(StaticUiChild::new(node_id(20), ChildOrder::new(2)));
+        assert!(duplicate_child
+            .validate(RoleDictionary::current())
+            .expect_err("duplicate child")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::DuplicateChild));
+
+        let mut dangling_child = minimal_document();
+        dangling_child
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .push_child(StaticUiChild::new(node_id(99), ChildOrder::new(0)));
+        assert!(dangling_child
+            .validate(RoleDictionary::current())
+            .expect_err("dangling child")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::MissingChild));
+
+        let mut shared = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        let mut first_root = StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        );
+        first_root.push_child(StaticUiChild::new(node_id(30), ChildOrder::new(0)));
+        let mut second_root = StaticUiNode::new(
+            node_id(20),
+            RoleId::new("root"),
+            key(20),
+            Some(source_ref(2, 3)),
+        );
+        second_root.push_child(StaticUiChild::new(node_id(30), ChildOrder::new(0)));
+        shared.push_node(first_root);
+        shared.push_node(second_root);
+        shared.push_node(StaticUiNode::new(
+            node_id(30),
+            RoleId::new("text"),
+            key(30),
+            Some(source_ref(4, 5)),
+        ));
+        shared.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+        shared.push_surface(StaticUiSurface::new(
+            surface_id(2),
+            node_id(20),
+            key(2),
+            Some(source_ref(2, 3)),
+        ));
+        let shared_diagnostics = shared
+            .validate(RoleDictionary::current())
+            .expect_err("shared node");
+        assert!(shared_diagnostics
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::SharedAcrossSurfaces));
+
+        let mut multi_node_cycle =
+            StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        let mut root = StaticUiNode::new(
+            node_id(10),
+            RoleId::new("root"),
+            key(10),
+            Some(source_ref(0, 1)),
+        );
+        root.push_child(StaticUiChild::new(node_id(20), ChildOrder::new(0)));
+        let mut child = StaticUiNode::new(
+            node_id(20),
+            RoleId::new("text"),
+            key(20),
+            Some(source_ref(2, 3)),
+        );
+        child.push_child(StaticUiChild::new(node_id(10), ChildOrder::new(0)));
+        multi_node_cycle.push_node(root);
+        multi_node_cycle.push_node(child);
+        multi_node_cycle.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(10),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+        assert!(multi_node_cycle
+            .validate(RoleDictionary::current())
+            .expect_err("multi-node cycle")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::Cycle));
+    }
+
+    #[test]
+    fn static_ir_rejects_invalid_accessibility_reference() {
+        let mut document = minimal_document();
+        document
+            .nodes
+            .iter_mut()
+            .find(|node| node.id() == node_id(10))
+            .expect("root")
+            .set_accessibility_ref(node_id(99));
+
+        assert!(document
+            .validate(RoleDictionary::current())
+            .expect_err("bad accessibility ref")
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind()
+                == StaticUiIrDiagnosticKind::InvalidAccessibilityReference));
+    }
+
+    #[test]
+    fn static_ir_adapts_legacy_ui_ir_without_widening_authority() {
+        let mut ir = UiIr::new();
+        let mut root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+        root.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+        root.push_child(UiIrNodeId::new(2));
+        ir.push_node(root);
+        let mut child =
+            UiIrNode::with_parent(UiIrNodeId::new(2), UiIrNodeKind::Text, UiIrNodeId::new(1));
+        child.set_source_ast_node_id(Some(UiAstNodeId::new(102)));
+        ir.push_node(child);
+        let source_refs = [
+            (UiAstNodeId::new(101), source_ref(0, 1)),
+            (UiAstNodeId::new(102), source_ref(2, 3)),
+        ];
+
+        let document = StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+            .expect("legacy adapter");
+
+        assert_eq!(document.nodes().len(), 2);
+        assert_eq!(document.surfaces()[0].root(), node_id(1));
+    }
+
+    #[test]
+    fn static_ir_legacy_adapter_rejects_missing_source_mapping() {
+        let mut ir = UiIr::new();
+        let mut root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+        root.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+        ir.push_node(root);
+
+        let diagnostics = StaticUiDocument::from_legacy_ui_ir(legacy_context(&[]), &ir)
+            .expect_err("missing source mapping");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            StaticUiIrDiagnosticKind::InvalidLegacyMapping
+        );
+    }
+
+    #[test]
+    fn static_ir_legacy_adapter_rejects_multiple_roots() {
+        let mut ir = UiIr::new();
+        let mut first = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+        first.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+        let mut second = UiIrNode::new(UiIrNodeId::new(2), UiIrNodeKind::Root);
+        second.set_source_ast_node_id(Some(UiAstNodeId::new(102)));
+        ir.push_node(first);
+        ir.push_node(second);
+        let source_refs = [
+            (UiAstNodeId::new(101), source_ref(0, 1)),
+            (UiAstNodeId::new(102), source_ref(2, 3)),
+        ];
+
+        let diagnostics = StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+            .expect_err("multiple roots");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            StaticUiIrDiagnosticKind::InvalidLegacyMapping
+        );
+    }
+
+    #[test]
+    fn static_ir_checked_encoding_length_boundaries() {
+        assert_eq!(checked_len(u32::MAX as usize), Ok(u32::MAX));
+        if usize::BITS > u32::BITS {
+            assert_eq!(
+                checked_len((u32::MAX as usize) + 1),
+                Err(CanonicalEncodingError::LengthOverflow)
+            );
+        }
+    }
+
+    #[test]
+    fn static_ir_rejects_legacy_action_as_v2_static_ir() {
+        let mut ir = UiIr::new();
+        let mut action = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Action);
+        action.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+        ir.push_node(action);
+        let source_refs = [(UiAstNodeId::new(101), source_ref(0, 1))];
+
+        let diagnostics = StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+            .expect_err("legacy action rejected");
+
+        assert_eq!(
+            diagnostics.diagnostics()[0].kind(),
+            StaticUiIrDiagnosticKind::InvalidLegacyMapping
+        );
+    }
+
+    #[test]
+    fn static_ir_validates_deep_forest_without_recursive_traversal() {
+        const DEPTH: u64 = 512;
+        let mut document = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        for raw in 1..=DEPTH {
+            let mut node = StaticUiNode::new(
+                node_id(raw),
+                if raw == 1 {
+                    RoleId::new("root")
+                } else {
+                    RoleId::new("text")
+                },
+                key(raw),
+                Some(source_ref(raw as u32, raw as u32 + 1)),
+            );
+            if raw < DEPTH {
+                node.push_child(StaticUiChild::new(node_id(raw + 1), ChildOrder::new(0)));
+            }
+            document.push_node(node);
+        }
+        document.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(1),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+
+        assert!(document.validate(RoleDictionary::current()).is_ok());
+    }
+
+    #[test]
+    fn static_ir_reports_deep_cycle_deterministically() {
+        const DEPTH: u64 = 512;
+        let mut document = StaticUiDocument::new(doc_id(1), Revision::new(0), Epoch::new(0));
+        for raw in 1..=DEPTH {
+            let mut node = StaticUiNode::new(
+                node_id(raw),
+                if raw == 1 {
+                    RoleId::new("root")
+                } else {
+                    RoleId::new("text")
+                },
+                key(raw),
+                Some(source_ref(raw as u32, raw as u32 + 1)),
+            );
+            let child = (raw < DEPTH)
+                .then_some(raw + 1)
+                .or((raw == DEPTH).then_some(1));
+            if let Some(child) = child {
+                node.push_child(StaticUiChild::new(node_id(child), ChildOrder::new(0)));
+            }
+            document.push_node(node);
+        }
+        document.push_surface(StaticUiSurface::new(
+            surface_id(1),
+            node_id(1),
+            key(1),
+            Some(source_ref(0, 1)),
+        ));
+
+        let first = document
+            .validate(RoleDictionary::current())
+            .expect_err("cycle");
+        let second = document
+            .validate(RoleDictionary::current())
+            .expect_err("cycle");
+        assert_eq!(first, second);
+        assert!(first
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.kind() == StaticUiIrDiagnosticKind::Cycle));
+    }
+
+    #[test]
+    fn static_ir_legacy_adapter_validates_parent_evidence() {
+        let source_refs = [
+            (UiAstNodeId::new(101), source_ref(0, 1)),
+            (UiAstNodeId::new(102), source_ref(2, 3)),
+            (UiAstNodeId::new(103), source_ref(4, 5)),
+        ];
+
+        let mut valid = UiIr::new();
+        valid.push_node(legacy_node(1, UiIrNodeKind::Root, 101, None, &[2]));
+        valid.push_node(legacy_node(2, UiIrNodeKind::Text, 102, Some(1), &[]));
+        assert!(StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &valid).is_ok());
+
+        let mut root_with_parent = UiIr::new();
+        root_with_parent.push_node(legacy_node(1, UiIrNodeKind::Root, 101, Some(2), &[2]));
+        root_with_parent.push_node(legacy_node(2, UiIrNodeKind::Text, 102, Some(1), &[]));
+        assert_eq!(
+            StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &root_with_parent)
+                .expect_err("root parent")
+                .diagnostics()[0]
+                .kind(),
+            StaticUiIrDiagnosticKind::RootHasLegacyParent
+        );
+
+        let mut missing_parent = UiIr::new();
+        missing_parent.push_node(legacy_node(1, UiIrNodeKind::Root, 101, None, &[2]));
+        missing_parent.push_node(legacy_node(2, UiIrNodeKind::Text, 102, None, &[]));
+        assert_eq!(
+            StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &missing_parent)
+                .expect_err("missing parent")
+                .diagnostics()[0]
+                .kind(),
+            StaticUiIrDiagnosticKind::MissingLegacyParent
+        );
+
+        let mut wrong_parent = UiIr::new();
+        wrong_parent.push_node(legacy_node(1, UiIrNodeKind::Root, 101, None, &[2, 3]));
+        wrong_parent.push_node(legacy_node(2, UiIrNodeKind::Text, 102, Some(3), &[]));
+        wrong_parent.push_node(legacy_node(3, UiIrNodeKind::Text, 103, Some(1), &[]));
+        assert_eq!(
+            StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &wrong_parent)
+                .expect_err("wrong parent")
+                .diagnostics()[0]
+                .kind(),
+            StaticUiIrDiagnosticKind::LegacyParentMismatch
+        );
+
+        let mut dangling_parent = UiIr::new();
+        dangling_parent.push_node(legacy_node(1, UiIrNodeKind::Root, 101, None, &[2]));
+        dangling_parent.push_node(legacy_node(2, UiIrNodeKind::Text, 102, Some(99), &[]));
+        assert_eq!(
+            StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &dangling_parent)
+                .expect_err("dangling parent")
+                .diagnostics()[0]
+                .kind(),
+            StaticUiIrDiagnosticKind::DanglingLegacyParent
+        );
+    }
+
+    #[test]
+    fn static_ir_legacy_adapter_rejects_child_derived_multiple_parents() {
+        let source_refs = [
+            (UiAstNodeId::new(101), source_ref(0, 1)),
+            (UiAstNodeId::new(102), source_ref(2, 3)),
+            (UiAstNodeId::new(103), source_ref(4, 5)),
+            (UiAstNodeId::new(104), source_ref(6, 7)),
+        ];
+        let mut ir = UiIr::new();
+        let mut root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+        root.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+        root.push_child(UiIrNodeId::new(2));
+        root.push_child(UiIrNodeId::new(3));
+        ir.push_node(root);
+        let mut first =
+            UiIrNode::with_parent(UiIrNodeId::new(2), UiIrNodeKind::Text, UiIrNodeId::new(1));
+        first.set_source_ast_node_id(Some(UiAstNodeId::new(102)));
+        first.push_child(UiIrNodeId::new(4));
+        ir.push_node(first);
+        let mut second =
+            UiIrNode::with_parent(UiIrNodeId::new(3), UiIrNodeKind::Text, UiIrNodeId::new(1));
+        second.set_source_ast_node_id(Some(UiAstNodeId::new(103)));
+        second.push_child(UiIrNodeId::new(4));
+        ir.push_node(second);
+        let mut child =
+            UiIrNode::with_parent(UiIrNodeId::new(4), UiIrNodeKind::Text, UiIrNodeId::new(2));
+        child.set_source_ast_node_id(Some(UiAstNodeId::new(104)));
+        ir.push_node(child);
+
+        assert_eq!(
+            StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+                .expect_err("multiple parents")
+                .diagnostics()[0]
+                .kind(),
+            StaticUiIrDiagnosticKind::LegacyMultipleParents
+        );
+    }
+}

--- a/crates/prom-ui/src/ui_dna2_wp2_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp2_qualification_tests.rs
@@ -1,0 +1,234 @@
+use crate::contract_primitives::{
+    CollectionKey, Epoch, ProjectionSourceNodeId, ProjectionSourceSurfaceId, Revision, SourceId,
+    SourceRef, SourceSpan, StaticDocumentId, StaticSurfaceId,
+};
+use crate::model::{UiAstNodeId, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind};
+use crate::projection_compile::compile_projection_source_to_static_ir;
+use crate::projection_source::{
+    ProjectionSourceDocument, ProjectionSourceNode, ProjectionSourceSurface,
+};
+use crate::role_dictionary::{RoleDictionary, RoleId};
+use crate::static_ir::{LegacyUiIrAdapterContext, StaticUiDocument};
+
+fn source_ref(start: u32, end: u32) -> SourceRef {
+    SourceRef::new(
+        SourceId::new(1).expect("source id"),
+        SourceSpan::new(start, end).expect("source span"),
+    )
+}
+
+fn source_node_id(raw: u64) -> ProjectionSourceNodeId {
+    ProjectionSourceNodeId::new(raw).expect("source node id")
+}
+
+fn source_surface_id(raw: u64) -> ProjectionSourceSurfaceId {
+    ProjectionSourceSurfaceId::new(raw).expect("source surface id")
+}
+
+fn static_doc_id(raw: u64) -> StaticDocumentId {
+    StaticDocumentId::new(raw).expect("static document id")
+}
+
+fn static_surface_id(raw: u64) -> StaticSurfaceId {
+    StaticSurfaceId::new(raw).expect("static surface id")
+}
+
+fn key(raw: u64) -> CollectionKey {
+    CollectionKey::new(raw).expect("key")
+}
+
+fn legacy_context<'a>(source_refs: &'a [(UiAstNodeId, SourceRef)]) -> LegacyUiIrAdapterContext<'a> {
+    LegacyUiIrAdapterContext::new(
+        static_doc_id(1),
+        static_surface_id(1),
+        key(1),
+        Some(source_ref(0, 1)),
+        Revision::new(0),
+        Epoch::new(0),
+        source_refs,
+    )
+}
+
+fn minimal_source() -> ProjectionSourceDocument {
+    let mut source = ProjectionSourceDocument::new(
+        SourceId::new(1).expect("source id"),
+        Revision::new(0),
+        Epoch::new(0),
+    );
+    source.push_node(ProjectionSourceNode::new(
+        source_node_id(10),
+        RoleId::new("root"),
+        key(10),
+        source_ref(0, 1),
+    ));
+    source.push_surface(ProjectionSourceSurface::new(
+        source_surface_id(1),
+        source_node_id(10),
+        key(1),
+        source_ref(0, 1),
+    ));
+    source
+}
+
+fn multi_surface_source(order: &[u64]) -> ProjectionSourceDocument {
+    let mut source = ProjectionSourceDocument::new(
+        SourceId::new(1).expect("source id"),
+        Revision::new(0),
+        Epoch::new(0),
+    );
+    for raw in order {
+        let role = if *raw == 10 {
+            RoleId::new("root")
+        } else {
+            RoleId::new("text")
+        };
+        source.push_node(ProjectionSourceNode::new(
+            source_node_id(*raw),
+            role,
+            key(*raw),
+            source_ref(*raw as u32, *raw as u32 + 1),
+        ));
+    }
+    for raw in order {
+        source.push_surface(ProjectionSourceSurface::new(
+            source_surface_id(*raw),
+            source_node_id(*raw),
+            key(*raw),
+            source_ref(*raw as u32, *raw as u32 + 1),
+        ));
+    }
+    source
+}
+
+#[test]
+fn ui_dna2_wp2_minimal_valid_projection_has_stable_bytes() {
+    let source = minimal_source();
+    let first = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect("compile");
+    let second = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect("compile again");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .canonical_bytes(RoleDictionary::current())
+            .expect("bytes"),
+        second
+            .canonical_bytes(RoleDictionary::current())
+            .expect("bytes again")
+    );
+}
+
+#[test]
+fn ui_dna2_wp2_multi_surface_projection_is_deterministic() {
+    let first = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &multi_surface_source(&[10, 20]),
+        RoleDictionary::current(),
+    )
+    .expect("first");
+    let second = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &multi_surface_source(&[20, 10]),
+        RoleDictionary::current(),
+    )
+    .expect("second");
+
+    assert_eq!(
+        first
+            .canonical_bytes(RoleDictionary::current())
+            .expect("first bytes"),
+        second
+            .canonical_bytes(RoleDictionary::current())
+            .expect("second bytes")
+    );
+}
+
+#[test]
+fn ui_dna2_wp2_invalid_projection_diagnostics_are_stable() {
+    let mut source = minimal_source();
+    source.push_node(ProjectionSourceNode::new(
+        source_node_id(20),
+        RoleId::new("renderer_button"),
+        key(20),
+        source_ref(20, 21),
+    ));
+
+    let first = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect_err("first diagnostics");
+    let second = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect_err("second diagnostics");
+
+    assert_eq!(first, second);
+}
+
+#[test]
+fn ui_dna2_wp2_legacy_ui_ir_adaptation_is_stable_and_bounded() {
+    let mut ir = UiIr::new();
+    let mut root = UiIrNode::new(UiIrNodeId::new(1), UiIrNodeKind::Root);
+    root.set_source_ast_node_id(Some(UiAstNodeId::new(101)));
+    root.push_child(UiIrNodeId::new(2));
+    ir.push_node(root);
+    let mut child =
+        UiIrNode::with_parent(UiIrNodeId::new(2), UiIrNodeKind::Text, UiIrNodeId::new(1));
+    child.set_source_ast_node_id(Some(UiAstNodeId::new(102)));
+    ir.push_node(child);
+    let source_refs = [
+        (UiAstNodeId::new(101), source_ref(0, 1)),
+        (UiAstNodeId::new(102), source_ref(2, 3)),
+    ];
+
+    let first = StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+        .expect("first adapter");
+    let second = StaticUiDocument::from_legacy_ui_ir(legacy_context(&source_refs), &ir)
+        .expect("second adapter");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .canonical_bytes(RoleDictionary::current())
+            .expect("first bytes"),
+        second
+            .canonical_bytes(RoleDictionary::current())
+            .expect("second bytes")
+    );
+}
+
+#[test]
+fn ui_dna2_wp2_stable_keyed_collection_vector_is_order_independent() {
+    let first = multi_surface_source(&[10, 20, 30]);
+    let second = multi_surface_source(&[30, 10, 20]);
+
+    assert_eq!(
+        first
+            .normalized(RoleDictionary::current())
+            .expect("first")
+            .nodes()
+            .iter()
+            .map(|node| node.key().raw())
+            .collect::<alloc::vec::Vec<_>>(),
+        second
+            .normalized(RoleDictionary::current())
+            .expect("second")
+            .nodes()
+            .iter()
+            .map(|node| node.key().raw())
+            .collect::<alloc::vec::Vec<_>>()
+    );
+}

--- a/docs/roadmap/post_ui/ui_dna2_ownership_and_compatibility_freeze.md
+++ b/docs/roadmap/post_ui/ui_dna2_ownership_and_compatibility_freeze.md
@@ -1,0 +1,694 @@
+# UI DNA v2 Ownership and Compatibility Freeze
+
+Status: proposed Gate A ownership freeze
+Milestone: UI-DNA2-WP1
+Task: UI-DNA2-WP1-FINAL-CLOSEOUT
+Issue context: #1488 / #1489
+Reconciliation evidence: `docs/roadmap/post_ui/ui_dna2_prom_ui_reconciliation.md`
+
+This document is the canonical UI DNA v2 ownership authority for Gate A review.
+It freezes target owners, compatibility posture, dependency direction, activation gates, and implementation package boundaries.
+
+This document does not authorize implementation.
+
+## 1. Status and baseline
+
+| Field | Value |
+| --- | --- |
+| Repository | `skulmakov-oss/Semantic` |
+| Required working directory | `C:\Users\said3\Desktop\EXOcode\Semantic_phase1_prom_ui` |
+| Baseline branch | `main` |
+| Baseline HEAD | `928d260fdcf18afdac54636badeaeca56e376610` |
+| Scope | docs-only ownership freeze |
+| Canonical doctrine anchor | `docs/dna/SEMANTIC_UI_DNA_v2.md` |
+| Evidence ledger | `docs/roadmap/post_ui/ui_dna2_prom_ui_reconciliation.md` |
+
+UI DNA v2 remains governed by the doctrine ordering:
+
+```text
+Meaning first.
+Intent projection second.
+UI IR third.
+Rendering last.
+```
+
+The ownership chain remains:
+
+```text
+Semantic owns meaning.
+Projection owns presentation intent.
+UI IR owns structure.
+Shell owns rendering.
+Renderer owns pixels.
+```
+
+The safety rule remains:
+
+```text
+One meaning.
+Many projections.
+Truth does not move into UI.
+```
+
+## 2. Approved decisions D01-D11
+
+| Decision | Status | Binding result |
+| --- | --- | --- |
+| D01 | APPROVED | Existing `UiIr` remains a structural substrate behind a separate versioned Static UI IR document contract. |
+| D02 | APPROVED | Projection Source AST is dedicated and must not alias `UiAst`. |
+| D03 | APPROVED | `ActionIntent` is a new boundary contract. `SemanticIntent` compatibility requires an explicit adapter. Action IR owns no admission authority. |
+| D04 | APPROVED | `ProjectionBundle` progresses through separate claim levels. |
+| D05 | APPROVED WITH RESTRICTION | `ui-shell-kit` remains experimental and cannot be promoted implicitly. |
+| D06 | APPROVED | R12/Aldente evidence may be reused selectively, but its authority model is superseded. |
+| D07 | APPROVED | A dedicated `projection_compile` owner performs deterministic lowering from Projection Source AST into Static UI IR. |
+| D08 | APPROVED | `contract_primitives` is a neutral leaf owner for shared identifiers, source coordinates, revisions, epochs, and schema/version primitives. |
+| D09 | APPROVED | `semantic_refs` owns opaque UI-side references to external Semantic facts. A reference never owns the referenced truth. |
+| D10 | APPROVED | `admission_contract` owns UI-side transport envelopes only. External Semantic authority retains policy, capability evaluation, acceptance, denial, and revision validity. |
+| D11 | APPROVED | The canonical ownership matrix contains target contracts, existing substrates, and exact interface boundaries only. Compatibility, experimental evidence, and superseded authority are registries inside this document. |
+
+D01-D11 are not reopened here.
+
+## 3. Normative ownership principles
+
+- UI DNA v2 ownership is a contract boundary, not permission for crate-wide edits.
+- Crate-level ownership never authorizes future work outside exact task `allowed_paths`.
+- Compatibility evidence is not ownership.
+- Experimental evidence is not ownership.
+- Superseded authority is not ownership.
+- External Semantic policy authority is not a UI compile/import node.
+- Static UI IR must be usable without Projection Source AST availability.
+- Projection Source AST types must not appear as fields in the canonical serialized Static UI IR document.
+- Provenance must cross the source-to-IR boundary through neutral `SourceRef`-style contracts.
+- `reference != referenced truth`.
+- Action IR describes routes; it does not admit actions.
+- `ActionIntent` carries a request; it does not represent acceptance.
+- `AdmissionPort` forwards requests and transports results; it does not own policy.
+- Dispatcher consumes admitted actions only; it cannot admit retroactively.
+- Shell owns local interaction state and projection playback; it owns no Semantic truth.
+- Renderer/backend evidence is backend-local evidence, not Semantic truth.
+- Implementation activation remains unauthorized until a separate Gate B decision.
+
+## 4. Canonical ownership matrix
+
+The matrix contains target implementation contracts, existing substrates, and exact interface boundaries only.
+
+| ID | Contract or substrate | Canonical owner | Kind | Status | Owns | Must not own | Compatibility posture |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| O01 | Contract primitives | `crates/prom-ui::contract_primitives` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | `SchemaVersion`, `ContractVersion`, `SourceSpan`, `SourceRef`, `Revision`, `Epoch`, stable opaque IDs, deterministic diagnostic coordinates | projection, IR, binding, action, runtime, Semantic internals, shell, renderer, backend, admission policy | new neutral leaf |
+| O02 | Role Dictionary | `crates/prom-ui::role_dictionary` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | projection roles, role IDs, role version identifiers, role compatibility metadata | source AST, Static UI IR authority, renderer behavior, Semantic meaning | new provider contract |
+| O03 | Projection Source | `crates/prom-ui::projection_source` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | `.proj.sm` tokens, source AST, source refs, source diagnostics, source normalization | Static UI IR document authority, renderer layout, Semantic meaning, admission | dedicated owner; not `UiAst` |
+| O04 | Projection lowering | `crates/prom-ui::projection_compile` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | deterministic Projection Source AST to Static UI IR lowering, lowering order, provenance transfer, source-to-IR diagnostics | source language ownership, Static UI IR serialization authority, runtime activation | D07 owner |
+| O05 | Static UI IR document | `crates/prom-ui::static_ir` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | versioned renderer-independent projected structure, canonical ordering, IR digest, document wrapper | Projection Source AST fields, Semantic truth, renderer/backend behavior | may adapt existing `UiIr` substrate |
+| O06 | Opaque Semantic references | `crates/prom-ui::semantic_refs` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | `SemanticStateRef`, `EvidenceRef`, `ActionOfferRef`, `TaskRecordRef`, `ConnectivityFactRef`, `ActorRef`, `SessionRef`, `ClientRef` | referenced truth, Semantic internals, runtime policy, renderer/backend behavior | D09 owner |
+| O07 | Binding Graph | `crates/prom-ui::binding_graph` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | read-side relationships between structure, roles, semantic refs, action surfaces, evidence anchors | patch stream, denial/recovery, task/control semantics, runtime effects, admission | may adapt slot-intent carrier evidence |
+| O08 | Action IR | `crates/prom-ui::action_ir` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | compiled route declarations, route identity, route lookup contracts | request envelope, actor/session/client context, admission authority, capability policy | new route contract |
+| O09 | ActionIntent | `crates/prom-ui::action_intent` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | request envelope, route reference, actor/session/client attribution, source revision and epoch, idempotency, freshness evidence, requested action representation | route table ownership, acceptance, denial, policy, capability evaluation | new boundary contract |
+| O10 | SemanticIntent compatibility adapter | `crates/prom-ui::compat` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | explicit mapping between legacy carrier and `ActionIntent` without context erasure | implicit `From`/`Into`, admission authority, historical authority revival | adapter only |
+| O11 | Admission transport contract | `crates/prom-ui::admission_contract` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | `AdmissionRequestId`, `AdmissionOutcome`, `AdmittedAction`, `AdmissionDenied`, correlation metadata, revision/freshness evidence | policy, capability evaluation, acceptance logic, denial logic, revision validity, Semantic truth | D10 owner |
+| O12 | AdmissionPort adapter boundary | `crates/prom-ui-runtime::intent_admission` | runtime module owning a port contract | PROPOSED LOGICAL LOCATION - no implementation exists yet | `AdmissionPort`, request forwarding, result transport, trace correlation, mapping to `admission_contract` envelopes | Semantic policy, capability evaluation, acceptance, denial, revision validity | exact UI-facing port owned by this module |
+| O13 | Admitted-action dispatcher | `crates/prom-ui-runtime::intent_dispatch` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | dispatch of `admission_contract::AdmittedAction` after admission | retroactive admission, policy, capability checks | consumes admitted action only |
+| O14 | Projection Patch | `crates/prom-ui::projection_patch` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | deterministic patch vocabulary and replay order over Static UI IR and Binding Graph outputs | Binding Graph authority, Semantic truth, runtime effects | patch stream contract |
+| O15 | Denial/recovery projection | `crates/prom-ui::denial_recovery` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | denial projection, recovery outlets, local/session denial distinction, acknowledgement/retry/resume/cancel-suffix presentation contracts | admission policy, invented recovery behavior, Semantic truth | consumes admission outcomes and graph anchors |
+| O16 | Task projection | `crates/prom-ui::task_projection` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | `TaskRecord` projection, progress presentation, task control projection, task-scope visibility | task truth, task engine, capability policy | consumes opaque refs and patches |
+| O17 | Connectivity/freshness projection | `crates/prom-ui::connectivity_projection` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | Fresh/stale/offline projection, observation-only and cache-only presentation, `PendingUnknown`, `Resyncing` projection | connection truth, control authority, offline critical action queue | consumes opaque refs and patches |
+| O18 | Backend-neutral interaction contracts | `crates/prom-ui::interaction` | existing or proposed module boundary | PARTIAL EXISTING SUBSTRATE | raw UI event normalization contracts and interaction intent surface before action routing | shell local state, runtime sessions, native event loop, admission | backend-neutral provider |
+| O19 | Bundle manifest | `crates/prom-ui-runtime::bundle::manifest` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | manifest metadata, schema IDs, artifact IDs, role dictionary version IDs, digest references | parser, validation, verification, loading, activation | claim-level owner |
+| O20 | Bundle parser | `crates/prom-ui-runtime::bundle::parser` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | deterministic parse from approved artifact format into parsed bundle structure | structural compatibility, integrity verification, loading, activation | claim-level owner |
+| O21 | Bundle structural validator | `crates/prom-ui-runtime::bundle::validate::structural` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | structural acceptance/rejection of parsed bundle | compatibility validation, integrity verification, loading, activation | claim-level owner |
+| O22 | Bundle compatibility validator | `crates/prom-ui-runtime::bundle::validate::compatibility` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | role, renderer profile, schema, and version compatibility checks | integrity verification, loading, activation | claim-level owner |
+| O23 | Bundle verifier | `crates/prom-ui-runtime::bundle::verify` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | hash/signature/trust material verification for bundles | Semantic admission authority, activation, production promotion | claim-level owner |
+| O24 | Bundle inert loader | `crates/prom-ui-runtime::bundle::loader` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | loading verified bundle into inert runtime representation | activation, runtime side effects, production rollout | claim-level owner |
+| O25 | Bundle activation boundary | `crates/prom-ui-runtime::bundle_activation` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | safe activation boundary, rollback/quarantine contract | production promotion, Semantic authority | claim-level owner |
+| O26 | Shell player | `crates/prom-ui-runtime::shell_player` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | local focus, hit testing, accessibility realization, patch application, draw-command production | Semantic truth, admission policy, renderer pixel authority, backend event loop | may consume experimental shell evidence after approval |
+| O27 | Runtime draw/session seam | `crates/prom-ui-runtime::draw_seam` | target module | PROPOSED LOGICAL LOCATION - no implementation exists yet | backend-neutral draw/session boundary consumed by native backends | native backend implementation, pixels, Semantic truth | runtime-owned seam |
+| O28 | Native backend boundary | `crates/prom-ui-backend-native` | crate boundary | EXISTING SUBSTRATE | native facade, platform event bridge, backend-local rendering evidence | UI model authority, Semantic truth, runtime policy, Static UI IR authority | backend provider only |
+| O29 | Existing `UiIr` structural substrate | existing `crates/prom-ui` `UiIr` owner | existing substrate | EXISTING SUBSTRATE | inert structural patterns and typed IDs usable behind v2 wrapper | complete UI DNA v2 document authority | ADAPTER |
+| O30 | Existing `UiAst` substrate patterns | existing `crates/prom-ui` `UiAst` owner | existing substrate | EXISTING SUBSTRATE | reusable AST implementation patterns and diagnostics style | canonical Projection Source AST identity | ADAPTER |
+| O31 | Existing `SemanticIntent` carrier | `crates/prom-ui::action_mapping` | existing substrate | EXISTING SUBSTRATE | legacy/minimal carrier type available to explicit compatibility mapper | `ActionIntent` replacement, admission authority, hidden context erasure | ADAPTER through `compat` |
+| O32 | Existing UI model substrate | `crates/prom-ui::model` | existing substrate | EXISTING SUBSTRATE | neutral UI model identifiers and existing model vocabulary usable by Static UI IR through narrow contracts | Projection Source AST, lowering, renderer behavior, Semantic meaning | substrate only |
+
+## 5. Logical module map
+
+```text
+crates/prom-ui
+  contract_primitives
+  role_dictionary
+  model
+  projection_source
+  projection_compile
+  static_ir
+  semantic_refs
+  binding_graph
+  action_ir
+  action_intent
+  compat
+  admission_contract
+  projection_patch
+  denial_recovery
+  task_projection
+  connectivity_projection
+  interaction
+
+crates/prom-ui-runtime
+  intent_admission::AdmissionPort
+  intent_admission
+  intent_dispatch
+  bundle::manifest
+  bundle::parser
+  bundle::validate::structural
+  bundle::validate::compatibility
+  bundle::verify
+  bundle::loader
+  bundle_activation
+  shell_player
+  draw_seam
+
+crates/prom-ui-backend-native
+  native backend boundary
+```
+
+Required projection boundary:
+
+```text
+projection_source
+  owns tokens, source AST, source references, source diagnostics
+
+projection_compile
+  consumes projection_source
+  emits static_ir
+
+static_ir
+  owns versioned renderer-independent projected structure
+  does not import projection_source
+```
+
+Required action boundary:
+
+```text
+action_ir
+  owns compiled route declarations, route identity, route lookup contracts
+
+action_intent
+  owns request envelope, route reference, actor/session/client attribution,
+  revision, epoch, idempotency, freshness, and requested-action representation
+
+admission_contract
+  owns UI-side transport envelopes only
+
+intent_admission::AdmissionPort
+  owns adapter interface and result transport only
+
+intent_dispatch
+  consumes admitted actions only
+```
+
+Required runtime/backend direction:
+
+```text
+prom-ui-backend-native
+  -> prom-ui-runtime
+  -> prom-ui
+```
+
+Required interaction/shell direction:
+
+```text
+crates/prom-ui::interaction
+  owns backend-neutral raw-event and interaction contracts
+
+crates/prom-ui-runtime::shell_player
+  consumes interaction contracts
+  owns local shell state and projection playback
+```
+
+## 6. Compile/import dependency model
+
+Arrow semantics:
+
+```text
+Consumer -> Provider
+```
+
+Only independently owned logical modules or contract modules may appear as nodes.
+Container crate nodes are represented separately in the crate dependency table.
+Nested trait/type contracts remain owned by their module unless they have independent logical ownership.
+External Semantic policy authority is not a compile/import node.
+
+### Compile node registry
+
+| Node | Classification | Exact logical owner/path | Importable contract description | Status |
+| --- | --- | --- | --- | --- |
+| N01 | MODULE | `crates/prom-ui::contract_primitives` | shared schema/version/source/revision/epoch/ID primitives | proposed |
+| N02 | MODULE | `crates/prom-ui::role_dictionary` | role definitions and role version identifiers | proposed |
+| N03 | MODULE | `crates/prom-ui::model` | neutral existing UI model substrate contracts | existing |
+| N04 | MODULE | `crates/prom-ui::projection_source` | Projection Source tokens, AST, source refs, diagnostics | proposed |
+| N05 | MODULE | `crates/prom-ui::projection_compile` | deterministic lowering boundary from Projection Source to Static UI IR | proposed |
+| N06 | MODULE | `crates/prom-ui::static_ir` | versioned renderer-independent Static UI IR document contract | proposed |
+| N07 | MODULE | `crates/prom-ui::semantic_refs` | opaque non-authoritative references to external Semantic facts | proposed |
+| N08 | MODULE | `crates/prom-ui::binding_graph` | read-side binding relationship graph | proposed |
+| N09 | MODULE | `crates/prom-ui::action_ir` | action route declarations and route lookup contracts | proposed |
+| N10 | MODULE | `crates/prom-ui::action_intent` | structured action request envelope | proposed |
+| N11 | MODULE | `crates/prom-ui::compat` | explicit compatibility adapters | proposed |
+| N12 | MODULE | `crates/prom-ui::action_mapping` | existing `SemanticIntent` carrier provider | existing |
+| N13 | MODULE | `crates/prom-ui::admission_contract` | UI-side admission request/outcome transport envelopes | proposed |
+| N14 | MODULE | `crates/prom-ui::projection_patch` | deterministic projection patch vocabulary and replay contract | proposed |
+| N15 | MODULE | `crates/prom-ui::denial_recovery` | denial and recovery projection contracts | proposed |
+| N16 | MODULE | `crates/prom-ui::task_projection` | task projection and task-control presentation contracts | proposed |
+| N17 | MODULE | `crates/prom-ui::connectivity_projection` | connectivity/freshness projection contracts | proposed |
+| N18 | MODULE | `crates/prom-ui::interaction` | backend-neutral interaction contracts | existing/proposed |
+| N19 | MODULE | `crates/prom-ui-runtime::intent_admission` | admission adapter implementation boundary owning `AdmissionPort` | proposed |
+| N20 | MODULE | `crates/prom-ui-runtime::intent_dispatch` | admitted-action dispatch boundary | proposed |
+| N21 | MODULE | `crates/prom-ui-runtime::bundle::manifest` | bundle manifest contract | proposed |
+| N22 | MODULE | `crates/prom-ui-runtime::bundle::parser` | bundle parser contract | proposed |
+| N23 | MODULE | `crates/prom-ui-runtime::bundle::validate::structural` | structural validation contract | proposed |
+| N24 | MODULE | `crates/prom-ui-runtime::bundle::validate::compatibility` | compatibility validation contract | proposed |
+| N25 | MODULE | `crates/prom-ui-runtime::bundle::verify` | integrity/signature verification contract | proposed |
+| N26 | MODULE | `crates/prom-ui-runtime::bundle::loader` | inert bundle loading contract | proposed |
+| N27 | MODULE | `crates/prom-ui-runtime::bundle_activation` | safe activation boundary contract | proposed |
+| N28 | MODULE | `crates/prom-ui-runtime::shell_player` | shell playback, focus, hit-test, accessibility, patch application, draw-command production | proposed |
+| N29 | MODULE | `crates/prom-ui-runtime::draw_seam` | backend-neutral draw/session seam | proposed |
+
+### Compile/import edge table
+
+| Consumer | Provider | Reason |
+| --- | --- | --- |
+| `crates/prom-ui::role_dictionary` | `crates/prom-ui::contract_primitives` | role versions use neutral version/ID primitives |
+| `crates/prom-ui::projection_source` | `crates/prom-ui::contract_primitives` | source refs and diagnostics use neutral source coordinates |
+| `crates/prom-ui::projection_source` | `crates/prom-ui::role_dictionary` | source projection roles use role dictionary contracts |
+| `crates/prom-ui::static_ir` | `crates/prom-ui::contract_primitives` | IR IDs, schema versions, source refs, revisions, and digests use neutral primitives |
+| `crates/prom-ui::static_ir` | `crates/prom-ui::role_dictionary` | Static UI IR references role dictionary contracts |
+| `crates/prom-ui::static_ir` | `crates/prom-ui::model` | Static UI IR may reuse neutral existing UI model substrate contracts |
+| `crates/prom-ui::projection_compile` | `crates/prom-ui::projection_source` | lowering consumes Projection Source AST |
+| `crates/prom-ui::projection_compile` | `crates/prom-ui::static_ir` | lowering emits Static UI IR |
+| `crates/prom-ui::projection_compile` | `crates/prom-ui::contract_primitives` | lowering transfers neutral source provenance and diagnostics |
+| `crates/prom-ui::projection_compile` | `crates/prom-ui::role_dictionary` | lowering resolves approved projection roles |
+| `crates/prom-ui::semantic_refs` | `crates/prom-ui::contract_primitives` | opaque refs use stable IDs, epochs, revisions, and coordinates |
+| `crates/prom-ui::binding_graph` | `crates/prom-ui::static_ir` | graph binds projected structure |
+| `crates/prom-ui::binding_graph` | `crates/prom-ui::semantic_refs` | graph stores opaque references to external facts |
+| `crates/prom-ui::binding_graph` | `crates/prom-ui::role_dictionary` | graph binds role identities |
+| `crates/prom-ui::binding_graph` | `crates/prom-ui::contract_primitives` | graph uses stable IDs and revisions |
+| `crates/prom-ui::action_ir` | `crates/prom-ui::static_ir` | routes attach to projected structure |
+| `crates/prom-ui::action_ir` | `crates/prom-ui::binding_graph` | routes reference graph anchors |
+| `crates/prom-ui::action_ir` | `crates/prom-ui::role_dictionary` | routes reference approved role contracts |
+| `crates/prom-ui::action_ir` | `crates/prom-ui::contract_primitives` | route IDs and versions use neutral primitives |
+| `crates/prom-ui::action_intent` | `crates/prom-ui::action_ir` | request envelope references action routes |
+| `crates/prom-ui::action_intent` | `crates/prom-ui::semantic_refs` | request envelope carries actor/session/client and evidence refs |
+| `crates/prom-ui::action_intent` | `crates/prom-ui::contract_primitives` | request envelope carries revision, epoch, idempotency, and freshness IDs |
+| `crates/prom-ui::compat` | `crates/prom-ui::action_mapping` | explicit SemanticIntent adapter imports the exact legacy carrier provider |
+| `crates/prom-ui::compat` | `crates/prom-ui::action_intent` | compatibility mapper produces or consumes ActionIntent explicitly |
+| `crates/prom-ui::compat` | `crates/prom-ui::contract_primitives` | compatibility mapping preserves revision/epoch/source primitives |
+| `crates/prom-ui::admission_contract` | `crates/prom-ui::contract_primitives` | request IDs, revisions, epochs, and freshness evidence use neutral primitives |
+| `crates/prom-ui::admission_contract` | `crates/prom-ui::semantic_refs` | outcomes carry opaque fact/evidence/action-offer refs |
+| `crates/prom-ui::admission_contract` | `crates/prom-ui::action_intent` | admission transport envelopes carry or reference requested action intent |
+| `crates/prom-ui::projection_patch` | `crates/prom-ui::static_ir` | patches target Static UI IR structures |
+| `crates/prom-ui::projection_patch` | `crates/prom-ui::binding_graph` | patches reference graph outputs |
+| `crates/prom-ui::projection_patch` | `crates/prom-ui::contract_primitives` | patch IDs and replay order use neutral primitives |
+| `crates/prom-ui::denial_recovery` | `crates/prom-ui::projection_patch` | denial/recovery emits projection patches |
+| `crates/prom-ui::denial_recovery` | `crates/prom-ui::binding_graph` | denial/recovery anchors to graph outputs |
+| `crates/prom-ui::denial_recovery` | `crates/prom-ui::semantic_refs` | denial/recovery carries opaque evidence/action refs |
+| `crates/prom-ui::denial_recovery` | `crates/prom-ui::admission_contract` | denial/recovery consumes admission outcomes |
+| `crates/prom-ui::task_projection` | `crates/prom-ui::projection_patch` | task progress emits projection patches |
+| `crates/prom-ui::task_projection` | `crates/prom-ui::binding_graph` | task projection anchors to graph outputs |
+| `crates/prom-ui::task_projection` | `crates/prom-ui::semantic_refs` | task projection carries opaque task/action-offer refs |
+| `crates/prom-ui::connectivity_projection` | `crates/prom-ui::projection_patch` | freshness and connectivity emit projection patches |
+| `crates/prom-ui::connectivity_projection` | `crates/prom-ui::binding_graph` | connectivity projection anchors to graph outputs |
+| `crates/prom-ui::connectivity_projection` | `crates/prom-ui::semantic_refs` | connectivity projection carries opaque connectivity refs |
+| `crates/prom-ui::interaction` | `crates/prom-ui::contract_primitives` | interaction contracts use stable source/session IDs where required |
+| `crates/prom-ui-runtime::intent_admission` | `crates/prom-ui::admission_contract` | adapter maps results to admission envelopes |
+| `crates/prom-ui-runtime::intent_admission` | `crates/prom-ui::action_intent` | adapter forwards structured requests |
+| `crates/prom-ui-runtime::intent_admission` | `crates/prom-ui::semantic_refs` | adapter preserves opaque external references |
+| `crates/prom-ui-runtime::intent_admission` | `crates/prom-ui::contract_primitives` | adapter preserves correlation, revision, and freshness primitives |
+| `crates/prom-ui-runtime::intent_dispatch` | `crates/prom-ui::admission_contract` | dispatcher consumes only admitted actions |
+| `crates/prom-ui-runtime::bundle::manifest` | `crates/prom-ui::contract_primitives` | manifest uses schema/version/digest identifiers |
+| `crates/prom-ui-runtime::bundle::manifest` | `crates/prom-ui::static_ir` | manifest references Static UI IR artifact/schema identifiers |
+| `crates/prom-ui-runtime::bundle::manifest` | `crates/prom-ui::role_dictionary` | manifest references Role Dictionary version identifiers |
+| `crates/prom-ui-runtime::bundle::parser` | `crates/prom-ui-runtime::bundle::manifest` | parser reads manifest contract |
+| `crates/prom-ui-runtime::bundle::validate::structural` | `crates/prom-ui-runtime::bundle::parser` | structural validator consumes parsed bundle structure |
+| `crates/prom-ui-runtime::bundle::validate::structural` | `crates/prom-ui-runtime::bundle::manifest` | structural validator checks manifest-declared structure |
+| `crates/prom-ui-runtime::bundle::validate::structural` | `crates/prom-ui::static_ir` | structural validator checks Static UI IR structure |
+| `crates/prom-ui-runtime::bundle::validate::compatibility` | `crates/prom-ui-runtime::bundle::parser` | compatibility validator consumes parsed bundle structure |
+| `crates/prom-ui-runtime::bundle::validate::compatibility` | `crates/prom-ui-runtime::bundle::manifest` | compatibility validator checks manifest-declared compatibility inputs |
+| `crates/prom-ui-runtime::bundle::validate::compatibility` | `crates/prom-ui::role_dictionary` | compatibility validator checks role compatibility |
+| `crates/prom-ui-runtime::bundle::verify` | `crates/prom-ui-runtime::bundle::manifest` | verifier checks manifest-declared trust material |
+| `crates/prom-ui-runtime::bundle::verify` | `crates/prom-ui::contract_primitives` | verifier uses digest/version identifiers |
+| `crates/prom-ui-runtime::bundle::loader` | `crates/prom-ui-runtime::bundle::parser` | inert loader consumes parsed bundle representation |
+| `crates/prom-ui-runtime::bundle::loader` | `crates/prom-ui-runtime::bundle::validate::structural` | inert loader requires structural validation |
+| `crates/prom-ui-runtime::bundle::loader` | `crates/prom-ui-runtime::bundle::validate::compatibility` | inert loader requires compatibility validation |
+| `crates/prom-ui-runtime::bundle::loader` | `crates/prom-ui-runtime::bundle::verify` | inert loader requires integrity/signature verification |
+| `crates/prom-ui-runtime::bundle_activation` | `crates/prom-ui-runtime::bundle::loader` | activation consumes inert loaded bundle |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui::interaction` | shell consumes normalized interaction contracts |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui-runtime::bundle::loader` | shell consumes inert loaded bundle representation |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui::projection_patch` | shell applies projection patches |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui::action_ir` | shell performs local route lookup |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui::action_intent` | shell creates structured requests |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui::static_ir` | shell reads static projected structure |
+| `crates/prom-ui-runtime::shell_player` | `crates/prom-ui-runtime::draw_seam` | shell emits draw/session material through the backend-neutral draw seam |
+| `crates/prom-ui-runtime::draw_seam` | `crates/prom-ui::contract_primitives` | draw/session seam may carry stable opaque IDs |
+
+### Crate dependency table
+
+| Consumer crate | Provider crate | Purpose |
+| --- | --- | --- |
+| `prom-ui-runtime` | `prom-ui` | runtime consumes UI contract modules without moving authority into runtime |
+| `prom-ui-backend-native` | `prom-ui-runtime` | native backend consumes backend-neutral runtime seams |
+| `prom-ui-backend-native` | `prom-ui` | native backend may consume stable UI transport/event contracts without owning UI semantics |
+
+Forbidden crate dependencies:
+
+```text
+prom-ui -> prom-ui-runtime
+prom-ui-runtime -> prom-ui-backend-native
+prom-ui -> prom-ui-backend-native
+```
+
+Forbidden compile/import edges:
+
+```text
+static_ir -> projection_source
+projection_source -> static_ir
+binding_graph -> projection_patch
+interaction -> shell_player
+prom-ui -> prom-ui-runtime
+prom-ui-runtime -> prom-ui-backend-native
+any UI compile node -> external Semantic policy authority
+```
+
+## 7. Runtime/data flow
+
+Arrow semantics:
+
+```text
+data or request moves from A to B
+```
+
+Canonical runtime/data flow:
+
+```text
+RawUiEvent
+  -> interaction normalization
+  -> Action IR route lookup
+  -> ActionIntent
+  -> AdmissionPort adapter
+  -> external Semantic admission authority
+  -> AdmissionOutcome
+  -> admitted dispatcher or denial projection
+  -> ProjectionPatch
+  -> shell player
+  -> runtime draw seam
+  -> native backend
+```
+
+Expanded runtime notes:
+
+- Raw events are local until normalized into backend-neutral interaction contracts.
+- Action IR lookup selects a route; it does not admit.
+- `ActionIntent` carries request context; it does not represent acceptance.
+- `AdmissionPort` forwards the request to external Semantic admission authority and transports the result.
+- External Semantic admission authority may accept, deny, reject for freshness, or return evidence.
+- Admitted results flow to `intent_dispatch`.
+- Denied results flow to `denial_recovery`.
+- Projection changes flow through `projection_patch`.
+- Shell player applies patches and produces draw commands.
+- Native backend receives backend-local draw/session material only.
+
+## 8. Authority flow
+
+Arrow semantics:
+
+```text
+decision authority remains with the named owner
+```
+
+Canonical authority flow:
+
+```text
+Semantic owns meaning.
+External Semantic admission authority owns policy and acceptance.
+Projection owns presentation intent.
+Static UI IR owns structure.
+Binding Graph owns read-side dependencies.
+Action IR owns routes.
+ActionIntent carries requests.
+AdmissionContract carries outcomes.
+Shell owns local interaction state.
+Renderer/backend owns pixels.
+```
+
+Authority non-transfer rules:
+
+- Projection Source does not own Semantic meaning.
+- Static UI IR does not own Semantic meaning.
+- Binding Graph does not own Semantic truth.
+- Action IR does not own admission.
+- `ActionIntent` does not own acceptance.
+- `admission_contract` does not own policy.
+- `intent_admission` does not own capability evaluation or revision validity.
+- Shell does not own Semantic truth.
+- Renderer/backend does not own projection authority or Semantic truth.
+- Snapshot evidence is not Semantic truth.
+
+External Semantic admission authority is recorded only in runtime/data flow and authority flow.
+It is intentionally absent from the compile/import graph.
+
+## 9. Public/internal contract policy
+
+Default posture:
+
+| Contract | Default visibility | Promotion requirements |
+| --- | --- | --- |
+| `contract_primitives` | internal first; selected primitive types may become public only by explicit approval | versioning, public API guard, compatibility policy |
+| `projection_source` | internal | parser/source diagnostics tests, no `.proj.sm` public claim before approval |
+| `projection_compile` | internal | deterministic lowering tests, source-to-IR provenance tests |
+| `static_ir` | internal document contract first | serialization/digest tests, compatibility wrapper, public API guard |
+| `semantic_refs` | boundary-visible where required | opacity tests and no Semantic internals exposure |
+| `binding_graph` | internal | deterministic construction tests and negative cycle/missing-key tests |
+| `action_ir` | internal | route lookup tests and admission non-authority tests |
+| `action_intent` | boundary type where required | context-preservation tests and explicit compatibility mapping |
+| `admission_contract` | boundary type where required | acceptance/denial envelope tests and no policy ownership |
+| `intent_admission::AdmissionPort` | runtime boundary | adapter-only tests and trace-correlation tests |
+| `ProjectionBundle` stages | internal first by claim level | parser/validator/verifier/loader separation evidence |
+| `shell_player` | experimental/internal first | deterministic shell evidence and no authority widening |
+| native backend | existing boundary | backend-local tests only |
+
+A contract may become public only after stable ownership, deterministic behavior where relevant, positive and negative tests, versioning, compatibility policy, public API guard, and explicit architect approval.
+
+## 10. Compatibility Registry
+
+| Entity | Classification | Permitted compatibility | Forbidden compatibility | Required seam |
+| --- | --- | --- | --- | --- |
+| `UiIr` | ADAPTER | structural substrate behind v2 Static UI IR wrapper/lowering | treating legacy `UiIr` as complete v2 document authority | `crates/prom-ui::static_ir` |
+| `UiAst` patterns | ADAPTER | implementation patterns and diagnostics style | aliasing `UiAst` as Projection Source AST | `crates/prom-ui::projection_source` |
+| `SemanticIntent` | ADAPTER | explicit mapper to/from `ActionIntent` preserving actor/session/client/revision/epoch/idempotency/freshness | implicit context-erasing `From`/`Into`; admission authority | `crates/prom-ui::compat` importing `crates/prom-ui::action_mapping` |
+| slot-intent carriers | ADAPTER | metadata and carrier evidence for Binding Graph migration | Binding Graph authority | `crates/prom-ui::binding_graph` |
+| ProjectionBundle fixture reader | QUARANTINED | fixture evidence and negative-probe input | parser, validator, loader, activation authority | future `bundle::parser` tests only |
+| historical compatibility adapters | QUARANTINED | deterministic evidence where mapped to exact owner | new architecture authority | narrow removable adapters |
+
+Compatibility totals:
+
+| Classification | Count |
+| --- | ---: |
+| ADAPTER | 4 |
+| QUARANTINED | 2 |
+| SUPERSEDED | 0 |
+
+## 11. Experimental Evidence Registry
+
+| Evidence source | Status | Permitted evidence | Forbidden authority | Required prerequisites | Promotion gate |
+| --- | --- | --- | --- | --- | --- |
+| `experiments/ui-shell-kit` | QUARANTINED | reference shell ideas, deterministic calculator shell evidence, focus/hit-test/paint/snapshot evidence, possible future ProjectionBundle player seed | production dependency, app authoring framework requirement, Semantic authority, admission authority, runtime policy, renderer/backend authority | Static UI IR, Binding Graph, Action IR, ActionIntent/admission seam, patch model, bundle parser basis, deterministic shell evidence | separate explicit architect approval after Gate B/C evidence |
+
+Registry totals:
+
+| Classification | Count |
+| --- | ---: |
+| QUARANTINED | 1 |
+
+## 12. Superseded Authority Registry
+
+| Historical authority | Status | Permitted use | Forbidden use | Revival rule |
+| --- | --- | --- | --- | --- |
+| R12/Aldente authority model | SUPERSEDED | historical context and separately mapped deterministic evidence | target owner, compile dependency, default UI DNA v2 authority, revival through compatibility adapter | requires a new explicit architecture decision; not part of WP1 |
+
+Superseded authority rules:
+
+- A superseded authority has no target owner.
+- A superseded authority is not a compile dependency.
+- A superseded authority cannot be revived through a compatibility adapter.
+- Deterministic evidence associated with superseded work may be listed in the Compatibility or Experimental Evidence Registry only when mapped to an exact current owner.
+
+Registry totals:
+
+| Classification | Count |
+| --- | ---: |
+| SUPERSEDED | 1 |
+
+## 13. Migration policy
+
+| Source entity | Target owner | Migration rule | Required evidence | Stop condition |
+| --- | --- | --- | --- | --- |
+| `UiIr` | `crates/prom-ui::static_ir` | wrap or lower through an explicit v2 Static UI IR document contract | deterministic wrapper/lowering tests, serialization/digest evidence | legacy type treated as full v2 authority |
+| `UiAst` | `crates/prom-ui::projection_source` | reuse implementation patterns only; do not alias identity | source AST/source-ref/diagnostic tests | Projection Source becomes a `UiAst` rename |
+| `SemanticIntent` | `crates/prom-ui::compat` and `crates/prom-ui::action_intent` | explicit adapter preserving full context | positive and negative mapping tests | implicit context-erasing conversion |
+| slot-intent metadata | `crates/prom-ui::binding_graph` | migrate carrier evidence to graph construction where useful | graph construction tests and migration cases | slot-intent chain becomes graph authority |
+| ProjectionBundle fixtures | `crates/prom-ui-runtime::bundle::parser` | use as parser evidence only after parser basis approval | valid/invalid fixture tests | fixture reader claimed as parser/loader |
+| `ui-shell-kit` | `crates/prom-ui-runtime::shell_player` evidence only | evaluate as experimental seed after prerequisites | deterministic shell evidence | implicit promotion |
+| R12/Aldente deterministic evidence | exact current owner per case | reuse only through narrow owner-specific mapping | owner-specific regression or golden tests | authority model revived |
+
+Migration must replace obsolete authority text rather than preserve parallel authority beside the new owner model.
+
+## 14. Determinism ownership
+
+| Determinism concern | Owner |
+| --- | --- |
+| contract identifier stability | `crates/prom-ui::contract_primitives` |
+| source normalization | `crates/prom-ui::projection_source` |
+| source diagnostic ordering | `crates/prom-ui::projection_source` |
+| lowering order | `crates/prom-ui::projection_compile` |
+| Static UI IR canonical ordering | `crates/prom-ui::static_ir` |
+| Static UI IR serialization/digest | `crates/prom-ui::static_ir` |
+| Binding Graph construction order | `crates/prom-ui::binding_graph` |
+| patch replay order | `crates/prom-ui::projection_patch` |
+| bundle interpretation/digest | `bundle::manifest`, `bundle::parser`, validators, `bundle::verify`, and `bundle::loader` by stage |
+| shell snapshot determinism | `crates/prom-ui-runtime::shell_player` |
+| backend-local rendering evidence | `crates/prom-ui-backend-native` |
+
+Snapshot evidence must not be described as Semantic truth.
+End-to-end determinism must not be assigned to one undifferentiated runtime layer.
+
+## 15. ProjectionBundle claim levels
+
+| Level | Name | Permitted claim | Forbidden claim | Required evidence | Owner |
+| ---: | --- | --- | --- | --- | --- |
+| 0 | Fixture evidence | inert fixture and draft-tool evidence exists | parser, validator, loader, activation, production readiness | fixture files, negative probes, claim-boundary docs | fixture evidence only |
+| 1 | Parser basis | parser requirements and claim boundaries approved | parser implementation exists | parser-basis doc and negative fixture plan | `crates/prom-ui-runtime::bundle::parser` |
+| 2 | Parser | parser consumes approved artifact format deterministically | validation, verification, loading, activation | parser tests and diagnostics | `crates/prom-ui-runtime::bundle::parser` |
+| 3 | Structural validation | structural validator accepts/rejects parsed structure | compatibility, integrity, loading, activation | valid/invalid structural tests | `crates/prom-ui-runtime::bundle::validate::structural` |
+| 4 | Compatibility validation | role/renderer/profile compatibility is checked | integrity, loading, activation | compatibility matrix tests | `crates/prom-ui-runtime::bundle::validate::compatibility` |
+| 5 | Integrity/signature verification | bundle trust material is verified/rejected | Semantic admission authority, activation | hash/signature tests and rejection cases | `crates/prom-ui-runtime::bundle::verify` |
+| 6 | Inert loading | verified bundle loads into inert representation | activation, runtime side effects, production UI | no-side-effect loader tests | `crates/prom-ui-runtime::bundle::loader` |
+| 7 | Activation | safe activation gate is implemented | production promotion | safe update boundary and rollback/quarantine tests | `crates/prom-ui-runtime::bundle_activation` |
+| 8 | Production promotion | production use is authorized under separate gate | automatic promotion from activation | release/promotion evidence and explicit architect approval | separate production promotion authority |
+
+Parser is not validator. Validator is not verifier. Verifier is not loader. Loader is not activation. Activation is not production promotion.
+
+## 16. Implementation work packages
+
+This section defines large implementation work packages, not micro-PR sequencing.
+
+Normative execution rule:
+
+```text
+one completed work package
+  -> one final review
+  -> one PR only after explicit publication authorization
+```
+
+An internal checkpoint is not a separate PR.
+Gate B must be granted separately for every work package.
+
+| Work package | Title | Includes | Required prior gate | Explicit non-goals |
+| --- | --- | --- | --- | --- |
+| UI-DNA2-WP2 | Projection Front-End and Static IR Foundation | `contract_primitives`, Role Dictionary, Projection Source tokens/AST/source refs/diagnostics, `projection_compile`, Static UI IR document wrapper, stable IDs, stable collection keys | Gate B for WP2 | no compiler activation, no shell, no renderer, no admission |
+| UI-DNA2-WP3 | Binding, Action, and Admission Boundary | `semantic_refs`, Binding Graph, Action IR, `ActionIntent`, `admission_contract`, `SemanticIntent` compatibility mapper, `AdmissionPort` adapter, admitted-action dispatcher boundary | Gate B for WP3 after relevant WP2 contracts | no admission policy ownership, no runtime effects, no Semantic authority movement |
+| UI-DNA2-WP4 | Projection State and Control Semantics | Projection Patch, denial/recovery, task projection, freshness/connectivity projection | Gate B for WP4 after relevant WP2/WP3 contracts | no renderer command streaming, no UI-local task engine, no offline critical action queue |
+| UI-DNA2-WP5 | ProjectionBundle Qualification | parser basis, manifest, parser, structural validator, compatibility validator, integrity/signature verifier, inert loader, activation-boundary contract | Gate B for WP5 after required contracts | no live production promotion, no dynamic unchecked critical UI streaming |
+| UI-DNA2-WP6 | Shell and Backend Evidence Alignment | shell player, patch application, focus, hit testing, accessibility realization, draw-command production, native backend boundary evidence, `ui-shell-kit` experimental evaluation | Gate B for WP6 after required contracts | no Workbench/Studio product work, no production promotion, no Semantic authority |
+
+## 17. Implementation issue contract
+
+Every future UI-DNA2 task must include the exact working directory:
+
+```text
+C:\Users\said3\Desktop\EXOcode\Semantic_phase1_prom_ui
+```
+
+Required preflight:
+
+```powershell
+Set-Location 'C:\Users\said3\Desktop\EXOcode\Semantic_phase1_prom_ui'
+git rev-parse --show-toplevel
+```
+
+Root mismatch is a mandatory stop condition.
+
+Every future task must include:
+
+- work package and checkpoint ID;
+- canonical owner;
+- exact allowed files/modules;
+- forbidden paths;
+- authority impact;
+- public API impact;
+- compatibility impact;
+- determinism requirements;
+- positive tests;
+- negative tests;
+- golden evidence where relevant;
+- no_std/alloc/std posture;
+- migration rule;
+- non-goals;
+- stop conditions;
+- completion report.
+
+Crate-level ownership never authorizes crate-wide edits.
+No task may invent or widen ownership for convenience.
+
+## 18. Gates A-E
+
+| Gate | Name | Meaning | Satisfied by WP1 approval |
+| --- | --- | --- | --- |
+| Gate A | architecture ownership freeze approved | canonical owners, dependency direction, compatibility posture, and activation constraints accepted | YES |
+| Gate B | large implementation work package authorized | a bounded implementation work package is explicitly approved | NO |
+| Gate C | implementation evidence accepted | local/CI tests and evidence for a work package are accepted | NO |
+| Gate D | integration authorized | integration with adjacent layers is explicitly approved | NO |
+| Gate E | production promotion authorized | public/production use is explicitly approved | NO |
+
+UI-DNA2-WP1 approval satisfies Gate A only.
+
+Gate A does not imply Gate B.
+
+Implementation activation remains unauthorized.
+
+## 19. Required non-changes
+
+This freeze does not change:
+
+- Semantic grammar;
+- `.sm` parser;
+- `.proj.sm` parser;
+- compiler;
+- verification;
+- VM;
+- capability model;
+- admission implementation or behavior;
+- runtime implementation or behavior;
+- renderer behavior;
+- native backend behavior;
+- public Rust APIs;
+- Cargo manifests;
+- dependencies;
+- features;
+- tests;
+- fixtures;
+- CI;
+- Workbench;
+- Semantic Studio;
+- `ui-shell-kit` status;
+- ProjectionBundle implementation;
+- GitHub state.
+
+This freeze does not create:
+
+- ADR files;
+- separate compatibility registry files;
+- separate experimental registry files;
+- separate dependency graph documents;
+- separate decision logs;
+- separate Gate A reports;
+- new UI-DNA2 specifications.
+
+## 20. Final Gate A recommendation
+
+READY FOR GATE A APPROVAL
+
+Implementation activation remains unauthorized.

--- a/docs/roadmap/post_ui/ui_dna2_prom_ui_reconciliation.md
+++ b/docs/roadmap/post_ui/ui_dna2_prom_ui_reconciliation.md
@@ -1,0 +1,578 @@
+# UI DNA v2 / prom-ui Reconciliation
+
+Status: Evidence baseline for architectural approval
+Milestone: UI-DNA2-0
+Parent issue: #1488
+Implementation roadmap: #1489
+
+This document records repository evidence and recommendations.
+It does not authorize implementation.
+
+## 1. Audit Baseline
+
+| Field | Value |
+| --- | --- |
+| Audit date | 2026-07-10 |
+| Repository | `skulmakov-oss/Semantic` |
+| Working directory | `C:\Users\said3\Desktop\EXOcode\Semantic_phase1_prom_ui` |
+| Branch | `main` |
+| HEAD | `928d260fdcf18afdac54636badeaeca56e376610` |
+| Tracked modifications at start | `.harness/current.task.yaml` only, approved harness activation for `UI-DNA2-0A` |
+| Staging state | empty |
+| Untracked-file posture | existing unrelated untracked files preserved; not inspected as source evidence |
+| Rust version | `rustc 1.96.1 (31fca3adb 2026-06-26)` |
+| Cargo version | `cargo 1.96.1 (356927216 2026-06-26)` |
+| Operating environment | `Microsoft Windows NT 10.0.26300.0` |
+| Codebase Memory MCP availability | unavailable in this Codex session; no `mcp_codebase-memo_*` tools were exposed |
+| Codebase Memory decision | `AGENTS.md` says Codebase Memory MCP is mandatory-first, but does not state that work must not proceed without exposed tools or that fallback is forbidden; local read-only discovery was used |
+| Scope inspected | `docs/dna`, `docs/spec/ui`, `docs/roadmap/post_ui`, `crates/prom-ui`, `crates/prom-ui-runtime`, `crates/prom-ui-backend-native`, `experiments/ui-shell-kit`, `tests/fixtures/post_ui/projection_bundle`, `tools/post_ui`, package dependency direction, related GitHub issues |
+| Inspection limitations | Codebase Memory graph unavailable; evidence is local file/search/metadata based plus read-only `gh issue view`; no implementation files were changed |
+
+## 2. Executive Conclusion
+
+The current `prom-ui` family is broadly reusable as evidence and as a partial substrate, but it is not already the canonical UI DNA v2 implementation.
+
+Substantially present layers:
+
+- Structural UI model handles: `UiTree`, `UiAst`, `UiIr`, stable local IDs, validation, tree-to-AST and AST-to-IR lowering seeds in `crates/prom-ui/src/model.rs`, `validation.rs`, `tree_bridge.rs`, and `lowering.rs`.
+- Projection artifact seed: `UiProjectionArtifact`, projected nodes, deterministic IR-to-projection helper, and source-IR traceability in `crates/prom-ui/src/projection.rs`.
+- Local interaction/action scaffolds: raw event normalization, hit testing, action binding, action admission descriptors, denial traces, dispatch traces, and runtime intent admission/dispatch surfaces across `crates/prom-ui/src/*action*`, `raw_event.rs`, `hit_test.rs`, and `crates/prom-ui-runtime/src/intent_*`.
+- Runtime/backend substrate: desktop session lifecycle, in-memory backend, draw commands, adapter boundary, native backend, Winit/WGPU feature boundaries in `prom-ui-runtime` and `prom-ui-backend-native`.
+- Experimental shell evidence: `experiments/ui-shell-kit` exposes calculator scene/controller, local event/focus/action primitives, draw snapshots, and tests.
+
+Partial layers:
+
+- Static UI IR is present only as an inert, local structural model. It lacks the v2 document shape, role dictionary, bindings, action refs, accessibility contract, source refs, deterministic serialization, versioning, and digest policy required by `docs/spec/ui/ui_ir_schema.md`.
+- Action routing exists as first-wave scaffolding but not as the v2 `Action IR` plus `ActionIntent` envelope with actor/session/client refs, source revisions, idempotency, freshness, and ActionOffer references.
+- ProjectionBundle has fixture and reader-draft evidence only. `docs/spec/ui/projection_bundle_basis.md` explicitly says there is no parser, loader, runtime, verification authority, or production UI wiring.
+
+Absent layers:
+
+- `.proj.sm` parser and projection source AST.
+- Canonical Binding Graph implementation.
+- v2 patch stream implementation and shell patch player.
+- `TaskRecord`, `TaskStatePatch`, multi-client freshness runtime, and connectivity state implementation.
+- Production ProjectionBundle parser, structural validator, compatibility validator, integrity/signature verifier, loader, and activation gate.
+
+Historical R12/Aldente material is evidence of prior UI tracks and renderer metadata work, not an authority to promote old structures into UI DNA v2. `#1152` remains historical tail unless separately revived.
+
+`ui-shell-kit` is a viable experimental shell substrate under `#1310`, but not a production shell and not a ProjectionBundle player today.
+
+The largest ownership risks are: promoting inert `prom-ui` model names as canonical v2 without adding the required contracts; letting Action IR absorb admission authority; treating ProjectionBundle fixtures as loader/activation evidence; and letting R12 renderer/layout work drive the new v2 ownership map.
+
+## 3. UI DNA v2 Requirement Ledger
+
+| ID | Requirement | Authority source | Required owner | Required evidence |
+| --- | --- | --- | --- | --- |
+| R01 | Projection source | `docs/spec/ui/projection_source_model.md` | Projection source front-end, proposed owner to approve in UI-DNA2-1 | parser/AST contract, diagnostics, forbidden layout-pollution tests |
+| R02 | Static UI IR | `docs/spec/ui/ui_ir_schema.md` | Static UI IR owner, proposed `prom-ui` or new projection model module | versioned document, surfaces, nodes, roles, source refs, serialization tests |
+| R03 | Stable node identity | `docs/spec/ui/ui_ir_schema.md` | Static UI IR | stable IDs and keyed collection tests |
+| R04 | Role dictionary | `docs/spec/ui/projection_source_model.md`, `ui_ir_schema.md` | Projection/UI IR shared role owner | versioned role dictionary and compatibility tests |
+| R05 | Bindings | `docs/spec/ui/ui_ir_schema.md`, `projection_patch_model.md` | Binding Graph | source/target graph, revision, dirty propagation tests |
+| R06 | Action references | `docs/spec/ui/ui_ir_schema.md` | Static UI IR + Action IR | ActionOffer refs, role, target node/surface, capability/freshness metadata |
+| R07 | Action IR | `docs/spec/ui/action_ir_routing.md` | Action IR owner | route contracts, safe/guarded/danger policy, repeat/idempotency tests |
+| R08 | Admission boundary | `docs/spec/ui/action_ir_routing.md`, `SEMANTIC_UI_DNA_v2.md` | Semantic admission/runtime capability boundary | admitted/denied traces; UI cannot admit itself |
+| R09 | Patches | `docs/spec/ui/projection_patch_model.md` | Projection patch model | envelope, ordering, stale/duplicate/out-of-order tests |
+| R10 | Quad-state preservation | `SEMANTIC_UI_DNA_v2.md`, `ui_ir_schema.md` | Projection/UI IR/patch model | N/F/T/S preservation tests; no bool flattening |
+| R11 | Denial | `docs/spec/ui/denial_recovery_projection.md` | Denial projection | LocalDenied vs AdmissionDenied routes and evidence |
+| R12 | Recovery | `docs/spec/ui/denial_recovery_projection.md` | Recovery projection | Dismiss/Acknowledge/Retry/Resume/CancelSuffix routes; ResumeToken rules |
+| R13 | Task projection | `docs/spec/ui/task_projection_model.md` | Task projection | TaskRecord refs, TaskStatePatch, phases, controls, locks |
+| R14 | Freshness | `docs/spec/ui/multi_client_freshness_model.md` | Connectivity/freshness projection | Fresh/Degraded/Stale/Offline/Resyncing/PendingUnknown tests |
+| R15 | Connectivity | `docs/spec/ui/multi_client_freshness_model.md` | Connectivity projection | control gating, no offline critical queue evidence |
+| R16 | Accessibility | `projection_source_model.md`, `ui_ir_schema.md` | Projection/UI IR/shell | role labels, focus intent, non-visual interpretation |
+| R17 | ProjectionBundle | `docs/spec/ui/projection_bundle_delivery.md` | Bundle package owner | manifest, artifacts, role dictionary, renderer profile |
+| R18 | Bundle parsing | `projection_bundle_delivery.md`, `projection_bundle_basis.md` | Bundle parser | parser tests beyond fixture reader |
+| R19 | Structural validation | `projection_bundle_delivery.md` | Bundle validator | valid/invalid structural bundle tests |
+| R20 | Compatibility validation | `projection_bundle_delivery.md` | Bundle compatibility validator | role/renderer/profile compatibility matrix |
+| R21 | Integrity verification | `projection_bundle_delivery.md` | Bundle trust verifier | hash/signature validation and rejection tests |
+| R22 | Loading | `projection_bundle_delivery.md` | Bundle loader | inert loader, no activation side effects |
+| R23 | Activation | `projection_bundle_delivery.md` | Activation gate | verification-before-activation and safe update boundary tests |
+| R24 | Shell interpretation | `SEMANTIC_UI_DNA_v2.md`, `ui_shell_kit_projection_alignment.md` | Shell player | patch/bundle interpretation evidence without semantic authority |
+| R25 | Renderer boundary | `SEMANTIC_UI_DNA_v2.md`, runtime/backend specs | Renderer/backend owner | renderer consumes draw/presentation, does not own meaning |
+| R26 | Deterministic serialization | `ui_ir_schema.md`, `projection_bundle_delivery.md` | UI IR/bundle owners | canonical serialization and digest stability tests |
+| R27 | Deterministic snapshots | `ui_shell_kit_projection_alignment.md`, draw snapshot policy | Shell/evidence owner | snapshot/golden fixtures and replay stability |
+
+## 4. Current Repository Inventory
+
+| ID | Current entity | Path/module | Current owner | Public/internal | Responsibility | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| E01 | UI doctrine v2 | `docs/dna/SEMANTIC_UI_DNA_v2.md` | docs/dna | public doctrine | Meaning -> intent -> UI IR -> rendering doctrine | issue #1327 closed/completed |
+| E02 | Projection source spec | `docs/spec/ui/projection_source_model.md` | docs/spec/ui | draft spec | `.proj.sm` posture, allowed/forbidden intent | explicitly says no parser grammar implementation |
+| E03 | UI IR schema spec | `docs/spec/ui/ui_ir_schema.md` | docs/spec/ui | draft spec | target deterministic UI IR shape | explicitly says no Rust types/compiler/runtime |
+| E04 | Action IR spec | `docs/spec/ui/action_ir_routing.md` | docs/spec/ui | draft spec | Action IR and future ActionIntent envelope | explicitly says no Action IR/runtime implementation |
+| E05 | Patch model spec | `docs/spec/ui/projection_patch_model.md` | docs/spec/ui | draft spec | Binding Graph and patch families | explicitly says no Binding Graph/patch runtime |
+| E06 | Denial/recovery spec | `docs/spec/ui/denial_recovery_projection.md` | docs/spec/ui | draft spec | denial/recovery/batch taxonomy | explicitly says no denial/recovery runtime |
+| E07 | Task projection spec | `docs/spec/ui/task_projection_model.md` | docs/spec/ui | draft spec | TaskRecord and TaskStatePatch model | explicitly says no task execution/projection runtime |
+| E08 | Freshness spec | `docs/spec/ui/multi_client_freshness_model.md` | docs/spec/ui | draft spec | viewer-relative control and freshness | explicitly says no networking/freshness tracking |
+| E09 | Bundle delivery spec | `docs/spec/ui/projection_bundle_delivery.md` | docs/spec/ui | draft spec | ProjectionBundle delivery and activation rules | explicitly says no loader/verification/runtime |
+| E10 | Bundle basis | `docs/spec/ui/projection_bundle_basis.md` | docs/spec/ui | claim boundary | fixture/draft claim levels | current achieved level is Level 3 baseline; Levels 4-7 not claimed |
+| E11 | `UiTree`, `UiAst`, `UiIr` | `crates/prom-ui/src/model.rs` | `prom-ui` | public exports | inert structural handles and containers | module rustdoc says no render/admission/parser/verifier/VM/runtime |
+| E12 | Validation seeds | `crates/prom-ui/src/validation.rs` | `prom-ui` | public exports | tree/AST/IR structural validation | rustdoc says no parse/verify/typecheck/effect admission/render |
+| E13 | Tree/AST/IR lowering chain | `tree_bridge.rs`, `lowering.rs`, slot-intent modules | `prom-ui` | public exports | historical model transformation and slot metadata | tests `ui_tree_to_ast_bridge.rs`, `ui_ast_ir_lowering_carriers.rs`, slot-carrier tests |
+| E14 | Projection artifact | `crates/prom-ui/src/projection.rs` | `prom-ui` | public exports | validates IR and builds inert projection artifact | `UiProjectionArtifact`, `project_ir_to_projection`, deterministic projection tests |
+| E15 | Renderer presentation/model | `crates/prom-ui/src/renderer.rs` | `prom-ui` | public exports | projection-to-render model and renderer presentation metadata | renderer tests and public API lock tests |
+| E16 | Layout models | `crates/prom-ui/src/layout/**`, `minimal_block_layout.rs`, `layout_rect.rs` | `prom-ui` | public exports | renderer/local layout evidence | layout seed/golden tests under `crates/prom-ui/tests` |
+| E17 | Raw event normalization | `crates/prom-ui/src/raw_event.rs` | `prom-ui` | public exports | raw event to interaction intent descriptor | tests in module and interaction tests |
+| E18 | Hit testing | `crates/prom-ui/src/hit_test.rs`, `layout/physical_placement.rs` | `prom-ui` | public exports | local hit-test helper/trait | `ui_hit_test_contract.rs` |
+| E19 | Action mapping | `crates/prom-ui/src/action_mapping.rs` | `prom-ui` | public exports | maps interaction to `SemanticIntent`; default inert mapper returns none | `ui_action_mapping_contract.rs` |
+| E20 | Action admission descriptor | `crates/prom-ui/src/action_admission.rs`, result/trace modules | `prom-ui` | public exports | descriptor/evidence for admission requirements | descriptor tests; rustdoc says no actual admission/execution |
+| E21 | Runtime intent admission | `crates/prom-ui-runtime/src/intent_admission.rs` | `prom-ui-runtime` | public export | evaluates `SemanticIntent` through inert capability/audit scaffolds | `runtime_intent_capability_contract.rs`, `runtime_intent_audit_contract.rs` |
+| E22 | Runtime dispatch | `crates/prom-ui-runtime/src/intent_dispatch.rs`, `state_update.rs` | `prom-ui-runtime` | public export | dispatches already admitted action into inert updater | `runtime_intent_dispatch_contract.rs` |
+| E23 | Runtime/session/draw | `crates/prom-ui-runtime/src/lib.rs` | `prom-ui-runtime` | public API | desktop session, event buffer, draw commands, in-memory backend | many runtime tests; crate rustdoc calls backend policy internal |
+| E24 | Native backend | `crates/prom-ui-backend-native/src/lib.rs`, `action_translation.rs`, `frame_sink.rs`, `draw_generation.rs`, `session_hook.rs` | `prom-ui-backend-native` | public crate API | native event/backend bridge, Winit/WGPU feature paths, draw staging | native backend tests and feature contracts |
+| E25 | GPU quad transport | `crates/prom-ui-backend-native/src/quad_tile_upload.rs` | `prom-ui-backend-native` | `wgpu-backend` gated | visual/backend transport ABI | unrelated to UI DNA v2 projection model except renderer/backend boundary evidence |
+| E26 | ui-shell-kit | `experiments/ui-shell-kit/src/lib.rs` | experimental crate | public experiment API | calculator shell, event/focus/paint/snapshot primitives | #1310 open; tests for calculator/focus/hit/motion/reference scenario |
+| E27 | ProjectionBundle fixtures | `tests/fixtures/post_ui/projection_bundle/**` | test fixtures | fixture-only | inert positive/negative/probe sketches and golden reader output | `projection_bundle_basis.md`, expected reader outputs |
+| E28 | ProjectionBundle draft tools | `tools/post_ui/projection_bundle_*_draft.rs`, `check_projection_bundle_*.ps1` | tools/post_ui | tool/fixture-only | manifest draft and fixture-facing sketch reader | basis says not parser/loader/runtime/verification |
+| E29 | Dependency direction | `cargo tree` | Cargo workspace | package graph | `prom-ui-runtime -> prom-ui`; `prom-ui-backend-native -> prom-ui + prom-ui-runtime`; `ui-shell-kit -> prom-ui + prom-ui-runtime` | no reverse dependency from `prom-ui` to runtime/backend/shell |
+
+## 5. Main Reconciliation Matrix
+
+| ID | UI DNA2 concern | Current evidence | Classification | Preserved contract | Required change | Target owner | Risk | Decision required | Phase |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| M01 | Projection source `.proj.sm` | `projection_source_model.md`; no source parser found | ABSENT | doctrine/spec only | introduce parser/AST/diagnostics after ownership freeze | PROPOSED - projection source front-end | parser could pollute `.sm` or layout | owner and grammar choice | UI-DNA2-2 |
+| M02 | Existing `UiAst` as projection source AST | `crates/prom-ui/src/model.rs::UiAst` | ADAPT | local AST handles and node kinds | cannot be canonical projection source AST without grammar/source refs/diagnostics | PROPOSED - projection source or static model owner | name similarity could overclaim | whether to adapt or create separate AST type | UI-DNA2-1/2 |
+| M03 | Static UI IR structural core | `UiIr`, `UiIrNode`, `UiIrNodeId` | ADAPT | stable local IDs, parent/child structure, inertness | add v2 document shape, surfaces, roles, bindings, action refs, source refs, versioning, serialization | PROPOSED - `prom-ui` static IR module | current type lacks required contracts | public compatibility policy | UI-DNA2-3 |
+| M04 | Role dictionary | only enum vocabularies like `UiIrNodeKind`; role specs in docs | ABSENT | none beyond draft role words | versioned role dictionary with allowed/forbidden interpretation | PROPOSED - role dictionary owner | renderer/widget role confusion | dictionary location and versioning | UI-DNA2-1/3 |
+| M05 | Stable node identity | `UiNodeId`, `UiAstNodeId`, `UiIrNodeId`, `UiProjectedNodeId` | REUSE | typed local ID wrappers and public accessors | document relationship to v2 IDs; avoid using raw equality across domains | PROPOSED - model owner keeps ID domains | raw u64 reuse across domains | ID compatibility policy | UI-DNA2-1/3 |
+| M06 | Keyed collections | spec requires stable keys; no implementation type found | ABSENT | none | add collection/key model and diagnostics | PROPOSED - Static UI IR + Binding Graph | anonymous lists would break replay | key model approval | UI-DNA2-3/4 |
+| M07 | Binding Graph | `projection_patch_model.md`; no `BindingGraph` type found | ABSENT | none | implement deterministic graph with source/target/revision/dirty propagation | PROPOSED - Binding Graph module | mutation/authority leakage | owner and dependency direction | UI-DNA2-4 |
+| M08 | Existing binding-like carriers | slot-intent modules and `UiProjectionPropertyRef` | ADAPT | traceable carrier metadata | split historical carrier metadata from canonical read-side Binding Graph | PROPOSED - Binding Graph and compatibility adapters | historical chain could become canonical by accident | migration/compat adapter decision | UI-DNA2-4 |
+| M09 | Action IR | spec exists; no `ActionIr` type found | ABSENT | none | introduce compiled action route model | PROPOSED - Action IR module | action routes may absorb admission | owner and envelope shape | UI-DNA2-5 |
+| M10 | `SemanticIntent` | `crates/prom-ui/src/action_mapping.rs` | ADAPT | abstract target + action binding ID | expand or replace with v2 `ActionIntent` envelope carrying actor/session/client/source rev/idempotency/freshness | PROPOSED - Action IR/admission seam | existing name lacks required context | compatibility vs new type | UI-DNA2-5 |
+| M11 | Runtime intent admission | `RuntimeIntentAdmission::admit_intent` | ADAPT | admission boundary separated from dispatcher | connect to v2 ActionIntent only after approved mapping; preserve capability/audit boundary | `prom-ui-runtime` | UI may bypass admission if route is flattened | admission authority contract | UI-DNA2-5 |
+| M12 | Runtime dispatcher | `RuntimeActionDispatcher` | REUSE | dispatch assumes capability evaluation already happened | no v2 authority change; only consume admitted action | `prom-ui-runtime` | low if admission remains separate | no authority expansion | UI-DNA2-5 |
+| M13 | Raw event normalization | `RawUiEvent`, `map_raw_event_to_interaction_intent` | ADAPT | raw event stays local and maps to interaction descriptor | add source projection/action context and freshness-aware routing outside raw event type | `prom-ui` / shell boundary | raw events could leak upward | route boundary approval | UI-DNA2-5 |
+| M14 | Hit testing/focus routing | `hit_test.rs`, `physical_placement::hit_test_placement`, ui-shell-kit focus tests | ADAPT | local shell targeting evidence | bind to Action IR lookup without semantic mutation | Shell/local interaction owner | shell could own semantic action | Action IR lookup contract | UI-DNA2-5/9 |
+| M15 | Patch streams | docs only; no patch types found | ABSENT | none | define patch envelope, stale/duplicate/out-of-order handling | PROPOSED - projection patch model | ad hoc UI state mutation | patch owner | UI-DNA2-6 |
+| M16 | Denial/recovery projection | docs; `action_denial_trace`, admission denial result types | ADAPT | denial trace vocabulary and result scaffolds | implement v2 taxonomy/routes/recovery tokens without UI policy invention | PROPOSED - denial projection + admission result seam | LocalDenied vs AdmissionDenied collapse | route ownership | UI-DNA2-7 |
+| M17 | Task projection | docs only; no `TaskRecord` implementation found | ABSENT | none | introduce Semantic-owned task refs and projection patches | PROPOSED - task projection owner | UI-local task engine risk | task authority owner | UI-DNA2-7 |
+| M18 | Freshness/connectivity | docs and fixture text only; no runtime tracking found | ABSENT | none | introduce freshness state and control gating evidence | PROPOSED - connectivity projection owner | connected/fresh confusion | networking vs projection boundary | UI-DNA2-7 |
+| M19 | Accessibility contract | docs; ui-shell-kit accessibility mention; runtime visual/layout tokens | ADAPT | accessibility recognized as projection contract | add v2 accessibility refs/labels/focus intent in IR and shell evidence | Projection/UI IR/shell | treating as renderer polish | minimum contract | UI-DNA2-3/9 |
+| M20 | ProjectionBundle manifest fixture | `manifest_minimal.sketch.md`, draft tool constants | REUSE | fixture evidence and negative probes | keep fixture-only until parser phase; do not treat as final serialization | Bundle evidence owner | overclaiming parser/loader | claim level discipline | UI-DNA2-8 |
+| M21 | ProjectionBundle fixture reader draft | `projection_bundle_sketch_reader_draft.rs` | ADAPT | narrow deterministic reader evidence | use as parser-test inspiration; not production parser | Bundle parser owner | fixture reader mistaken for parser | parser basis decision | UI-DNA2-8 |
+| M22 | Bundle structural validator | no production validator; probe guards only | ABSENT | none | implement validator after parser | Bundle validator | guard scripts mistaken for validation | validation scope | UI-DNA2-8 |
+| M23 | Bundle compatibility validator | no implementation found | ABSENT | none | add role/renderer/profile compatibility matrix | Bundle validator | incompatible activation | compatibility owner | UI-DNA2-8 |
+| M24 | Bundle integrity/signature verification | fixture trust fields/probes only | ABSENT | none | implement hash/signature verification separately | Bundle trust verifier | hash/signature overclaim | security boundary | UI-DNA2-8 |
+| M25 | Bundle loader | basis says no loader | ABSENT | none | introduce inert loader before activation | Bundle loader | loader becomes activation | loader/activation split | UI-DNA2-8 |
+| M26 | Bundle activation | basis says no runtime activation | ABSENT | none | activation gate with safe update boundaries | Activation gate | activation bypasses policy | activation authority | UI-DNA2-8 |
+| M27 | `ui-shell-kit` shell primitives | experiment crate, #1310, alignment doc | ADAPT | layout/input/focus/paint/snapshot evidence | keep experimental; evaluate as future player seed only | Experimental shell owner | implicit production promotion | promotion gate | UI-DNA2-9 |
+| M28 | `prom-ui-runtime` draw/session substrate | runtime crate | ADAPT | backend seam, in-memory backend, draw commands | remain runtime/backend substrate; do not own UI DNA contracts | Runtime owner | runtime-to-model leakage | shell/runtime split | UI-DNA2-9 |
+| M29 | Native backend/WGPU transport | backend-native crate | REUSE | backend-specific rendering/transport boundary stays below runtime | no v2 semantic ownership; consume draw/transport only | `prom-ui-backend-native` | renderer/backend claims meaning | boundary wording | UI-DNA2-9/11 |
+| M30 | R12 renderer/layout metadata | `docs/roadmap/post_ui/r12_*`, `prom-ui` renderer/layout tests | REPLACE | retain historical compatibility/evidence | do not make R12 chain the v2 authority model | PROPOSED - compatibility adapter only if needed | old architecture drives new contracts | historical policy | UI-DNA2-1 |
+
+## 6. Projection Source Analysis
+
+CURRENT - `docs/spec/ui/projection_source_model.md` defines `.proj.sm` as the preferred v0 working name, forbids inline projection in `.sm`, defines allowed projection intent, and says it does not implement or finalize a parser grammar. No `.proj.sm` parser, projection lexer, projection AST, or compiler entrypoint was found in `crates/`, `tools/`, or `tests/`.
+
+CURRENT - `crates/prom-ui/src/model.rs::UiAst` is an inert AST container with local `UiAstNodeId`, `UiAstNodeKind`, parent/child handles, and no parser/source references. Tests in `ui_model_seed.rs` and `ui_ast_ir_lowering_carriers.rs` prove structural behavior, not projection source language support.
+
+PROPOSED - requires architect approval: keep projection source separate from `UiAst` until UI-DNA2-1 decides whether `UiAst` becomes an adapter/substrate or remains historical foundation evidence. Projection source needs grammar ownership, source refs, role vocabulary validation, layout pollution diagnostics, accessibility declarations, and deterministic diagnostics.
+
+Classification: `.proj.sm` implementation is ABSENT. Existing `UiAst` is ADAPT, not REUSE, for projection-source responsibilities.
+
+## 7. Static UI IR Analysis
+
+CURRENT - `crates/prom-ui/src/model.rs::UiIr` and `UiIrNode` provide inert structural nodes with typed IDs, kinds, parent/child handles, and optional source AST node reference. `validation.rs` provides structural diagnostics for duplicate IDs, missing parent/child targets, self links, and multiple roots. `projection.rs` can validate an IR and project it into `UiProjectionArtifact`.
+
+CURRENT - the implementation lacks the full `docs/spec/ui/ui_ir_schema.md` top-level document shape: `ir_version`, `projection_id`, `source_refs`, `role_dictionary_version`, `surfaces`, `bindings`, `actions`, evidence/denial/recovery routes, task contracts, connectivity policy, accessibility contract, diagnostics, canonical serialization, and digest policy.
+
+PROPOSED - requires architect approval: adapt the existing `UiIr` model only if public compatibility and versioning rules are frozen first. Stable local ID wrappers are REUSE. Static UI IR document semantics are ADAPT/ABSENT depending on row: structural core ADAPT, role dictionary/bindings/accessibility document contracts ABSENT.
+
+## 8. Binding Graph Analysis
+
+CURRENT - `docs/spec/ui/projection_patch_model.md` defines Binding Graph requirements. No implementation type named `BindingGraph`, no source/target graph, no dependency edges, no dirty propagation engine, and no revision/epoch handling type was found.
+
+CURRENT - existing related evidence is carrier metadata and references: slot-intent modules (`tree_slot_intent`, `tree_slot_ast_intent`, `ast_slot_ir_intent`, `ir_slot_projection_intent`, `projection_slot_render_intent`) and projection refs (`UiProjectionPropertyRef`, `UiProjectionActionRef`, `UiProjectionEffectBoundaryRef`, `UiProjectionTraceRef`). These are not read-side state bindings and do not preserve ActionOffer/task/connectivity revisions.
+
+PROPOSED - requires architect approval: Binding Graph should be introduced as its own owner after the static IR owner is frozen. It may adapt carrier identity patterns but must not inherit historical slot-chain authority.
+
+Classification: Binding Graph implementation is ABSENT. Existing carrier metadata is ADAPT.
+
+## 9. Action IR and Admission Analysis
+
+CURRENT ownership:
+
+| Responsibility | Current owner/evidence |
+| --- | --- |
+| raw UI event normalization | `crates/prom-ui/src/raw_event.rs` maps `RawUiEvent` to `InteractionIntentDescriptor` |
+| hit testing | `crates/prom-ui/src/hit_test.rs`, `layout/physical_placement.rs`, `crates/prom-ui/tests/ui_hit_test_contract.rs` |
+| focus routing | `experiments/ui-shell-kit/src/focus.rs`, calculator focus/action trace tests |
+| Action IR lookup | ABSENT; only `action_binding.rs` and action binding traces exist |
+| ActionIntent construction | ABSENT for v2 envelope; existing `SemanticIntent` has target + action binding ID only |
+| action admission descriptor | `crates/prom-ui/src/action_admission.rs` describes requirements but does not execute admission |
+| runtime admission | `crates/prom-ui-runtime/src/intent_admission.rs::RuntimeIntentAdmission` evaluates `SemanticIntent` through capability/audit scaffolds |
+| capability checks | `crates/prom-ui-runtime/src/intent_capability.rs`, `crates/prom-ui/src/ui_capability_*` scaffolds |
+| actor/session/client attribution | ABSENT for v2 ActionIntent |
+| stale revision handling | ABSENT for v2 ActionIntent |
+| denial traces | `crates/prom-ui/src/action_denial_trace.rs` and related admission/result modules |
+| idempotency/repeat behavior | ABSENT for v2 GuardedAction/DangerAction requirements |
+
+The current flow is useful but narrower than UI DNA v2:
+
+```text
+RawUiEvent
+  -> InteractionIntentDescriptor
+  -> SemanticIntent (default mapper currently inert)
+  -> RuntimeIntentAdmission
+  -> InteractionAdmittedSemanticAction
+  -> RuntimeActionDispatcher
+```
+
+The v2 target flow remains:
+
+```text
+Raw UI event
+  -> local normalization
+  -> hit test / focus routing
+  -> Action IR route
+  -> ActionIntent
+  -> Semantic admission
+```
+
+Classification: raw event normalization ADAPT; runtime admission boundary ADAPT; dispatcher REUSE as an admitted-action consumer; Action IR and full ActionIntent envelope ABSENT.
+
+## 10. Patch Model Analysis
+
+CURRENT - `docs/spec/ui/projection_patch_model.md` defines `SemanticStatePatch`, `ProjectionPatch`, `RenderPatch`, `EvidencePatch`, `ActionOfferPatch`, `ConnectivityPatch`, and deferred `TaskStatePatch`. It explicitly says it does not implement Binding Graph, patch streams, runtime patch queues, shell patch player, Rust types, compiler behavior, or renderer backend behavior.
+
+Search did not find implementation types for `SemanticStatePatch`, `ProjectionPatch`, `EvidencePatch`, `ActionOfferPatch`, `TaskStatePatch`, or `ConnectivityPatch` in the inspected crates. Existing `prom-ui-runtime/src/state_update.rs` is a runtime state updater scaffold for admitted actions, not a projection patch player.
+
+Classification: all v2 patch families are ABSENT. Existing render presentation and draw command output are not patch streams.
+
+## 11. ProjectionBundle Analysis
+
+| Responsibility | Current evidence | Current owner | Classification | Notes |
+| --- | --- | --- | --- | --- |
+| manifest | `tests/fixtures/post_ui/projection_bundle/manifest_minimal.sketch.md`; `tools/post_ui/projection_bundle_manifest_draft.rs` | fixtures/tools | REUSE | fixture evidence only |
+| payload representation | fixture sketches and draft constants | fixtures/tools | ADAPT | needs final serialization decision |
+| fixture reader | `tools/post_ui/projection_bundle_sketch_reader_draft.rs` | tools/post_ui | ADAPT | narrow fixture reader, not parser |
+| parser | `projection_bundle_basis.md` says no parser | none | ABSENT | needs parser basis |
+| structural validator | invalid/probe fixtures and guard scripts only | fixtures/tools | ABSENT | guards are not production validator |
+| compatibility validator | spec only | none | ABSENT | needs role/renderer compatibility checks |
+| integrity verification | trust fields/probes only | none | ABSENT | no hash/signature verifier |
+| signature verification | trust fields/probes only | none | ABSENT | no crypto verification |
+| loader | basis says no loader | none | ABSENT | must remain separate from parser |
+| activation | basis says no runtime activation | none | ABSENT | must remain separate from loader |
+
+`docs/spec/ui/projection_bundle_basis.md` is the controlling evidence boundary. It states current achieved level is Level 3 baseline and that Level 4 general reader/parser behavior, Level 5 loader behavior, Level 6 runtime behavior, and Level 7 production UI behavior are not claimed.
+
+## 12. Shell and Renderer Analysis
+
+CURRENT - `prom-ui` owns structural model, validation, projection, renderer presentation metadata, and layout evidence. It does not own runtime/backend execution. The crate rustdoc says Wave 0 scaffolding, inert markers, and no published stable UI support claim.
+
+CURRENT - `prom-ui-runtime` owns runtime side of the first-wave UI boundary: session lifecycle, input event polling, frame tokens, draw command family, backend adapter contract, in-memory backend, intent admission/dispatch scaffolds. It depends on `prom-ui`, not the reverse.
+
+CURRENT - `prom-ui-backend-native` owns native backend facade, raw backend event capture/translation, frame sink, draw generation, Winit/WGPU feature contracts, and GPU transport. It depends on `prom-ui` and `prom-ui-runtime`.
+
+CURRENT - `experiments/ui-shell-kit` owns experimental calculator shell primitives: controller, scene/layout, local event/focus/action queue, paint frame, snapshots, theme. It depends on `prom-ui` and `prom-ui-runtime`.
+
+Classification: runtime/backend boundaries are REUSE as boundaries; shell-player implementation for UI DNA v2 is ADAPT/ABSENT. `ui-shell-kit` is ADAPT as an experimental substrate and must not be promoted implicitly.
+
+## 13. Denial, Recovery, Task and Freshness Analysis
+
+| Concept | Current implementation evidence | Classification | Notes |
+| --- | --- | --- | --- |
+| `LocalDenied` | docs only; local denial concepts in action/capability denial traces use different names | ABSENT | do not infer equivalence |
+| `AdmissionDenied` | admission result/denial scaffolds exist but not v2 taxonomy | ADAPT | keep boundary distinct |
+| `PartialDenied` | docs only | ABSENT | no batch result model found |
+| `NotApplied` | docs only | ABSENT | no separate state found |
+| `BatchBreak` | docs only | ABSENT | no batch patch model found |
+| `Dismiss` | docs only | ABSENT | recovery action not implemented |
+| `Acknowledge` | existing action names include `AcknowledgeError`; not v2 recovery contract | ADAPT | similar name is insufficient |
+| `Retry` | docs only | ABSENT | no v2 retry proposal |
+| `Resume` | docs only | ABSENT | no v2 resume path |
+| `CancelSuffix` | docs only | ABSENT | no partial batch suffix model |
+| `ResumeToken` | docs only | ABSENT | no token type found |
+| `TaskRecord` | docs only | ABSENT | no Semantic-owned task record type found |
+| `PendingUnknown` | docs/fixtures text only | ABSENT | no runtime state found |
+| `Fresh` | docs/fixtures text only | ABSENT | no freshness runtime found |
+| `Degraded` | docs only | ABSENT | no freshness runtime found |
+| `Stale` | docs only | ABSENT | no freshness runtime found |
+| `Offline` | docs only | ABSENT | no freshness runtime found |
+| `Resyncing` | docs only | ABSENT | no freshness runtime found |
+
+Denial/recovery/task/freshness are mostly doctrine/spec today. Existing denial trace scaffolds can be adapted, but v2 semantics should not be inferred from similar names.
+
+## 14. Determinism and Evidence Analysis
+
+CURRENT deterministic evidence:
+
+- `crates/prom-ui/src/projection.rs` has deterministic projection tests such as `test_deterministic_projection` and artifact/node ID policies.
+- `crates/prom-ui/tests/ui_layout_golden_rects.rs` records stable layout rectangle signatures and repeated-run stability.
+- `crates/prom-ui/tests/ui_render_model_stability.rs` and renderer presentation tests cover deterministic renderer-model evidence.
+- `crates/prom-ui-runtime/tests/ui_in_memory_deterministic_replay.rs` covers in-memory runtime replay.
+- `experiments/ui-shell-kit/tests/*` covers calculator reference, focus/action trace, hit-test stability, and motion phase evidence.
+- `tests/fixtures/post_ui/projection_bundle/expected/*.reader.out.txt` provides golden output for fixture-facing ProjectionBundle reader drafts.
+- `tests/public_api_contracts.rs` and crate-specific public API lock tests guard current public surfaces.
+
+Missing deterministic evidence:
+
+- canonical UI IR serialization and digest;
+- Binding Graph deterministic construction;
+- patch replay and stale/out-of-order/duplicate rejection;
+- bundle parser/validator/loader/activation golden tests;
+- v2 ActionIntent stale revision/idempotency/repeat tests;
+- v2 denial/recovery/task/freshness negative fixtures.
+
+## 15. Current Ownership Map
+
+CURRENT repository state:
+
+```mermaid
+flowchart TD
+  DNA["docs/dna + docs/spec/ui\nDoctrine and draft specs"]
+  PromUI["crates/prom-ui\nmodel, validation, projection, action scaffolds,\nrenderer/layout presentation evidence"]
+  Runtime["crates/prom-ui-runtime\nsession lifecycle, adapter boundary,\nintent admission/dispatch scaffolds, draw frame"]
+  Backend["crates/prom-ui-backend-native\nnative/Winit/WGPU backend boundary,\nevent translation, draw staging"]
+  ShellKit["experiments/ui-shell-kit\nexperimental shell evidence"]
+  Fixtures["tests/fixtures/post_ui/projection_bundle + tools/post_ui\nfixture-only bundle evidence"]
+  Workbench["Workbench / Studio\npaused by #675"]
+
+  DNA --> PromUI
+  PromUI --> Runtime
+  PromUI --> Backend
+  Runtime --> Backend
+  PromUI --> ShellKit
+  Runtime --> ShellKit
+  DNA --> Fixtures
+  Workbench -. blocked .- DNA
+```
+
+This map describes observed repository ownership. It does not describe the approved target architecture.
+
+## 16. Proposed Target Ownership Map
+
+PROPOSED — requires architect approval.
+
+| Target owner | Owned contracts | Allowed dependencies | Forbidden dependencies | Public/internal posture | Migration relationship |
+| --- | --- | --- | --- | --- | --- |
+| Projection source front-end | `.proj.sm` tokens/AST/source refs/diagnostics | docs/spec, future role dictionary | runtime/backend/shell/renderer | internal until grammar approved | may adapt `UiAst` patterns, not inherit current AST as-is |
+| Static UI IR owner | versioned IR document, surfaces, nodes, roles, action refs, accessibility refs | projection source AST, role dictionary | runtime/backend/admission/renderer authority | public only after compatibility freeze | adapt `UiIr` structural core |
+| Binding Graph owner | read-side dependency graph, revisions, dirty propagation | Static UI IR, Semantic state refs, ActionOffer refs | mutation/admission/runtime effects | internal first | new owner; adapt carrier metadata only |
+| Action IR owner | action route contract and ActionIntent envelope | Static UI IR, Binding Graph, ActionOffer refs | direct runtime mutation, capability policy ownership | internal first | adapt action binding/trace scaffolds |
+| Admission seam owner | accepts/denies ActionIntent | existing Semantic/PROMETHEUS admission/capability/audit boundary | shell/renderer authority | public contract only by explicit decision | adapt `RuntimeIntentAdmission` boundary |
+| Patch model owner | projection patch envelopes and replay rules | Binding Graph, Static UI IR | arbitrary tree streaming, renderer backend commands | internal first | new owner |
+| Bundle owner | manifest, parser, validators, verifier, loader, activation gate | Static UI IR, Binding Graph, Action IR, patch contracts | Semantic admission authority, production promotion by default | staged claim levels | adapt fixtures/tools as evidence |
+| Shell player owner | bundle/patch interpretation, local focus/hit testing/accessibility | Bundle, patches, Action IR route refs | semantic truth/admission | experimental first | evaluate `ui-shell-kit` |
+| Renderer/backend owner | pixels/backend-specific drawing | shell draw output/runtime adapter | Semantic meaning, UI IR authority | backend-specific | keep `prom-ui-backend-native` below runtime/shell |
+
+## 17. Dependency Direction Analysis
+
+CURRENT valid directions:
+
+- `prom-ui-runtime -> prom-ui`.
+- `prom-ui-backend-native -> prom-ui + prom-ui-runtime`.
+- `ui-shell-kit -> prom-ui + prom-ui-runtime`.
+- ProjectionBundle tools/fixtures are outside production crates.
+
+CURRENT suspicious pressures:
+
+- `prom-ui` contains renderer/layout presentation models; these are useful evidence but may pressure Static UI IR ownership toward renderer concerns.
+- R12 layout/renderer docs and tests can bias the new UI DNA v2 plan toward historical layout metadata rather than projection intent.
+- Existing `SemanticIntent` name may be mistaken for v2 `ActionIntent`, but it lacks the required envelope.
+
+No cycle was observed in the inspected package directions. No renderer-to-Semantic dependency was identified in the inspected UI crates. The main risk is authority inversion by interpretation, not an existing Cargo cycle.
+
+PROPOSED target direction:
+
+```text
+Projection source
+  -> Static UI IR
+  -> Binding Graph + Action IR
+  -> ProjectionBundle
+  -> Shell player
+  -> Runtime adapter
+  -> Renderer/backend
+```
+
+Admission remains adjacent authority:
+
+```text
+ActionIntent -> Semantic admission / capability / audit -> admitted or denied result -> patches/evidence
+```
+
+## 18. Historical R12 / Aldente Reconciliation
+
+| Historical structure | Classification | Evidence | Use in UI DNA v2 |
+| --- | --- | --- | --- |
+| R12 renderer/layout docs | active historical evidence | many `docs/roadmap/post_ui/r12_ui_renderer_*` docs | documentation-only or compatibility context; not v2 authority |
+| R12 renderer/layout tests | active test evidence | `crates/prom-ui/tests/renderer_*`, layout tests | can inform deterministic presentation evidence |
+| Aldente issue #1152 | historical tail | issue referenced by #1488 context; not current authority | do not use as v2 roadmap without explicit revival |
+| slot-intent vertical chain | active code/tests | slot-intent modules and tests | ADAPT as compatibility/metadata evidence |
+| Workbench/Studio notes | gated track | #675 and pause docs | blocked for implementation |
+
+Historical existence is not evidence of UI DNA v2 suitability. R12 structures are REPLACE as architectural authority and ADAPT only where a bounded compatibility adapter is approved.
+
+## 19. ui-shell-kit Assessment
+
+Under #1310, `experiments/ui-shell-kit` is a first-class experimental track, not production UI.
+
+Usable experimental substrate:
+
+- local shell primitives: `UiEvent`, `FocusRing`, `UiFrame`, `UiActionQueue`;
+- deterministic calculator reference scenario;
+- hit-test/focus/action trace/motion evidence tests;
+- snapshot output via `snapshot::frame_to_snapshot`;
+- dependency on `prom-ui` and `prom-ui-runtime`, not the reverse.
+
+Adaptable mechanisms:
+
+- local event and focus routing can inform shell-side Action IR lookup;
+- frame snapshots can inform deterministic evidence;
+- calculator reference scenario can seed an end-to-end v2 reference slice after bundle/patch contracts exist.
+
+Non-transferable application logic:
+
+- calculator controller/business behavior is example logic, not projection source or Semantic meaning authority;
+- theme/drawing helpers are renderer/shell evidence, not role dictionary or UI IR.
+
+Missing production boundaries:
+
+- no ProjectionBundle player;
+- no UI IR interpreter;
+- no Binding Graph or patch application;
+- no v2 ActionIntent route;
+- no admission integration;
+- no freshness/task/denial runtime.
+
+Promotion requirements:
+
+- separate implementation issue;
+- explicit #1310 promotion gate;
+- no Workbench/Studio bypass of #675;
+- deterministic shell-player evidence.
+
+Classification: ADAPT as experimental substrate.
+
+## 20. Architecture Decision Package
+
+1. Decision ID: D01
+   Question: Should existing `UiIr` become the canonical Static UI IR type?
+   Options: adapt existing `UiIr`; create new v2 IR document type and keep `UiIr` as legacy/compat; replace `UiIr`.
+   Repository evidence: `UiIr` is inert structural only; `ui_ir_schema.md` requires a richer document.
+   Risk per option: adapting preserves tests but may overload public API; new type avoids drift but duplicates concepts; replacement disrupts current tests.
+   Recommended option: ADAPT existing structural core behind an approved v2 document wrapper.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-3 and later.
+
+2. Decision ID: D02
+   Question: Where does projection source AST live?
+   Options: reuse `UiAst`; create dedicated projection source AST; add parser-owned AST in front-end crate.
+   Repository evidence: `UiAst` has no source refs or grammar; projection source spec is no-parser today.
+   Risk per option: reuse risks semantic mismatch; dedicated AST creates new surface; front-end ownership may blur `.sm` and `.proj.sm`.
+   Recommended option: create dedicated projection source AST after grammar approval.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-2.
+
+3. Decision ID: D03
+   Question: How should ActionIntent relate to existing `SemanticIntent`?
+   Options: expand `SemanticIntent`; introduce new `ActionIntent`; replace `SemanticIntent`.
+   Repository evidence: `SemanticIntent` has only target and action binding ID.
+   Risk per option: expanding may break compatibility; new type preserves existing API but adds mapping; replacement is disruptive.
+   Recommended option: introduce new `ActionIntent` and adapt `SemanticIntent` as legacy/minimal route if needed.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-5.
+
+4. Decision ID: D04
+   Question: What is the Bundle claim-level progression?
+   Options: jump to parser; formalize parser basis first; implement loader first.
+   Repository evidence: `projection_bundle_basis.md` caps current evidence at fixture/draft level and forbids loader/runtime claims.
+   Risk per option: jumping over parser basis overclaims; loader first collapses parser/activation; basis first is slower but auditable.
+   Recommended option: formalize parser basis first.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-8.
+
+5. Decision ID: D05
+   Question: Can `ui-shell-kit` become the first shell player seed?
+   Options: use as seed; keep as reference only; create new shell crate.
+   Repository evidence: #1310 says experimental; alignment doc says not production and not yet ProjectionBundle player.
+   Risk per option: seed risks implicit promotion; reference-only delays integration; new crate duplicates working evidence.
+   Recommended option: use as experimental seed only after bundle/patch contracts exist.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-9.
+
+6. Decision ID: D06
+   Question: What compatibility posture applies to R12 slot/render/layout chains?
+   Options: adapt selected parts; replace as v2 authority; keep entirely historical.
+   Repository evidence: R12 tests and docs exist, but #1327/#1488 define current UI DNA v2 authority.
+   Risk per option: adapting without boundaries leaks old ownership; replacing as authority contradicts v2; historical-only may discard useful evidence.
+   Recommended option: adapt selected deterministic evidence and replace R12 as authority.
+   Architect approval required: yes.
+   Blocked phases: UI-DNA2-1.
+
+## 21. Proposed Seed Backlog
+
+1. Proposed title: `UI-DNA2-1: freeze UI DNA v2 ownership and compatibility map`
+   Roadmap phase: UI-DNA2-1
+   Owner crate/module: docs/roadmap + proposed `prom-ui` ownership map
+   Goal: approve owners for projection source, Static UI IR, Binding Graph, Action IR, patches, bundle, shell, renderer.
+   Dependency: #1488 reconciliation approval.
+   Allowed conceptual scope: docs/evidence only.
+   Expected evidence: ownership table, dependency rules, public/internal policy.
+   Explicit non-goals: no Rust, no parser, no runtime.
+
+2. Proposed title: `UI-DNA2-2A: define projection source AST and diagnostics contract`
+   Roadmap phase: UI-DNA2-2
+   Owner crate/module: proposed projection source owner.
+   Goal: create smallest approved AST/diagnostic contract for `.proj.sm` or approved equivalent.
+   Dependency: UI-DNA2-1.
+   Allowed conceptual scope: spec/doc or tiny non-executing type plan, depending on approval.
+   Expected evidence: grammar decision, forbidden content diagnostics, source refs.
+   Explicit non-goals: no compiler, no shell, no renderer.
+
+3. Proposed title: `UI-DNA2-3A: introduce canonical Static UI IR document wrapper`
+   Roadmap phase: UI-DNA2-3
+   Owner crate/module: proposed `prom-ui` static IR module.
+   Goal: adapt current `UiIr` structural core into a versioned v2 document boundary.
+   Dependency: UI-DNA2-1 and D01.
+   Allowed conceptual scope: only after implementation activation.
+   Expected evidence: deterministic serialization/digest and validation tests.
+   Explicit non-goals: no Binding Graph, no runtime patching.
+
+4. Proposed title: `UI-DNA2-4A: specify Binding Graph minimal implementation contract`
+   Roadmap phase: UI-DNA2-4
+   Owner crate/module: proposed Binding Graph module.
+   Goal: freeze source/target edge, revision, and dirty propagation contract.
+   Dependency: Static UI IR owner.
+   Allowed conceptual scope: docs/spec-first.
+   Expected evidence: graph construction cases and stale/unknown diagnostics plan.
+   Explicit non-goals: no mutation, no admission, no shell player.
+
+5. Proposed title: `UI-DNA2-8A: ProjectionBundle parser basis and claim-level gate`
+   Roadmap phase: UI-DNA2-8
+   Owner crate/module: bundle parser owner.
+   Goal: move from fixture reader evidence to approved parser basis without loader/activation.
+   Dependency: Static UI IR/Bundle ownership decisions.
+   Allowed conceptual scope: parser-basis docs and negative fixture plan.
+   Expected evidence: valid/invalid parser cases and claim-level update.
+   Explicit non-goals: no loader, no signature verification, no activation.
+
+## 22. Final Gate Recommendation
+
+READY FOR UI-DNA2-1 OWNERSHIP FREEZE
+
+This is a reconciliation recommendation only. It is not implementation authorization.
+
+## 23. Required Non-Changes Statement
+
+This task did not change:
+
+- Semantic grammar;
+- `.sm` parsing;
+- verification;
+- VM behavior;
+- capability model;
+- action admission;
+- runtime behavior;
+- renderer behavior;
+- native backend behavior;
+- public Rust APIs;
+- Cargo dependencies;
+- features;
+- CI;
+- Workbench;
+- Semantic Studio;
+- ui-shell-kit promotion status.
+
+No implementation, parser, tests, fixtures, public exports, runtime, renderer, or GitHub state changed.


### PR DESCRIPTION
## Summary

Establishes the accepted UI DNA v2 architecture baseline and implements the
crate-internal Projection Front-End and Static UI IR foundation.

This PR publishes:

- the UI-DNA2 reconciliation and canonical ownership freeze;
- neutral contract primitives and the versioned Role Dictionary;
- a programmatically constructible Projection Source AST;
- deterministic source normalization and diagnostics;
- a versioned Static UI IR document wrapper over the legacy UiIr substrate;
- explicit semantic ChildOrder and surface-rooted ordered-forest validation;
- deterministic Projection Source → Static UI IR lowering;
- a bounded, non-lossy-or-rejecting legacy UiIr adapter;
- internal canonical qualification bytes and WP2 evidence tests.

## Authority boundaries

The implementation preserves:

- Projection Source != UiAst;
- Static UI IR != legacy UiIr;
- storage order != semantic child order;
- source and Static UI IR do not import one another;
- projection_compile owns deterministic lowering;
- renderer, runtime, backend, admission, Binding Graph, Action IR,
  Projection Patch and ProjectionBundle remain outside this change.

All new WP2 modules and symbols remain crate-internal.

## Validation

- cargo test -p prom-ui
- cargo check -p prom-ui --all-features
- cargo clippy -p prom-ui --all-targets -- -D warnings
- cargo fmt --check
- scripts/harness-check.ps1
- git diff --check

The crate-wide --no-default-features check still reports only the previously
known failures in non-WP2 legacy files. WP2 production paths introduce zero
no-default diagnostics.

## Gates

- Gate A: approved
- Gate C for UI-DNA2-WP2: approved
- Gate D integration: not authorized
- production promotion: not authorized

Closes #1488.
Refs #1489.
