### PR TITLE
feat(ui): add UI DNA v2 binding and action contracts

### DIFF
--- a/crates/prom-ui/src/action_intent_map.rs
+++ b/crates/prom-ui/src/action_intent_map.rs
@@ -1,0 +1,67 @@
+//! Deterministic mapping of UI actions to transport intents.
+#![allow(dead_code)]
+
+use crate::action_ir::ActionRoute;
+use crate::admission_contract::{ActionIntent, ActionIntentDiagnostic, ActionInvocationContext};
+use crate::contract_primitives::{DiagnosticCode, DiagnosticCoordinate};
+
+pub(crate) fn map_action_intent(
+    route: &ActionRoute,
+    context: &ActionInvocationContext,
+) -> Result<ActionIntent, ActionIntentDiagnostic> {
+    if route.context_reqs.requires_actor && context.actor.is_none() {
+        return Err(ActionIntentDiagnostic {
+            coordinate: DiagnosticCoordinate::new(None, DiagnosticCode::new("MISSING_ACTOR"), 0, 0),
+        });
+    }
+    if route.context_reqs.requires_session && context.session.is_none() {
+        return Err(ActionIntentDiagnostic {
+            coordinate: DiagnosticCoordinate::new(
+                None,
+                DiagnosticCode::new("MISSING_SESSION"),
+                0,
+                0,
+            ),
+        });
+    }
+    if route.context_reqs.requires_client && context.client.is_none() {
+        return Err(ActionIntentDiagnostic {
+            coordinate: DiagnosticCoordinate::new(
+                None,
+                DiagnosticCode::new("MISSING_CLIENT"),
+                0,
+                0,
+            ),
+        });
+    }
+    if route.context_reqs.required_revision.is_some() && context.observed_revision.is_none() {
+        return Err(ActionIntentDiagnostic {
+            coordinate: DiagnosticCoordinate::new(
+                None,
+                DiagnosticCode::new("MISSING_REVISION"),
+                0,
+                0,
+            ),
+        });
+    }
+    if route.context_reqs.required_epoch.is_some() && context.observed_epoch.is_none() {
+        return Err(ActionIntentDiagnostic {
+            coordinate: DiagnosticCoordinate::new(None, DiagnosticCode::new("MISSING_EPOCH"), 0, 0),
+        });
+    }
+
+    Ok(ActionIntent {
+        route_id: route.id,
+        semantic_action: route.semantic_action,
+        source_node: context.source_node,
+        target_node: context.target_node,
+        actor: context.actor,
+        session: context.session,
+        client: context.client,
+        observed_revision: context.observed_revision,
+        observed_epoch: context.observed_epoch,
+        route_required_revision: route.context_reqs.required_revision,
+        route_required_epoch: route.context_reqs.required_epoch,
+        capability: route.capability,
+    })
+}

--- a/crates/prom-ui/src/action_ir.rs
+++ b/crates/prom-ui/src/action_ir.rs
@@ -1,0 +1,177 @@
+//! Action IR contract foundation.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+use crate::contract_primitives::{DiagnosticCode, DiagnosticCoordinate, SourceRef, StaticNodeId};
+use crate::semantic_refs::{CapabilityRef, EpochRef, RevisionRef, SemanticActionRef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionRouteId(pub(crate) u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionRouteOrder(pub(crate) u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionTargetSlot(pub(crate) u32);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionTarget {
+    pub(crate) node: StaticNodeId,
+    pub(crate) slot: ActionTargetSlot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionContextRequirements {
+    pub(crate) requires_actor: bool,
+    pub(crate) requires_session: bool,
+    pub(crate) requires_client: bool,
+    pub(crate) required_revision: Option<RevisionRef>,
+    pub(crate) required_epoch: Option<EpochRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionRoute {
+    pub(crate) target: ActionTarget,
+    pub(crate) order: ActionRouteOrder,
+    pub(crate) id: ActionRouteId,
+    pub(crate) semantic_action: SemanticActionRef,
+    pub(crate) source_ref: Option<SourceRef>,
+    pub(crate) context_reqs: ActionContextRequirements,
+    pub(crate) capability: Option<CapabilityRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ActionIrDiagnosticKind {
+    DuplicateActionRouteId,
+    MissingTargetNode,
+    DuplicateRouteSlot,
+    DuplicateRouteOrder,
+    ZeroSemanticActionRef,
+    InvalidContextRequirements,
+}
+
+impl ActionIrDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::DuplicateActionRouteId => DiagnosticCode::new("AIR_DUP_ROUTE_ID"),
+            Self::MissingTargetNode => DiagnosticCode::new("AIR_MISSING_TARGET"),
+            Self::DuplicateRouteSlot => DiagnosticCode::new("AIR_DUP_ROUTE_SLOT"),
+            Self::DuplicateRouteOrder => DiagnosticCode::new("AIR_DUP_ROUTE_ORDER"),
+            Self::ZeroSemanticActionRef => DiagnosticCode::new("AIR_ZERO_ACTION_REF"),
+            Self::InvalidContextRequirements => DiagnosticCode::new("AIR_INVALID_CTX_REQ"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ActionIrDiagnostic {
+    pub(crate) coordinate: DiagnosticCoordinate,
+}
+
+impl ActionIrDiagnostic {
+    pub(crate) fn new(
+        source: Option<SourceRef>,
+        kind: ActionIrDiagnosticKind,
+        primary_id: u64,
+        secondary_id: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(source, kind.code(), primary_id, secondary_id),
+        }
+    }
+}
+
+impl Ord for ActionIrDiagnostic {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.coordinate.cmp(&other.coordinate)
+    }
+}
+
+impl PartialOrd for ActionIrDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ActionIrDocument {
+    pub(crate) routes: Vec<ActionRoute>,
+}
+
+impl ActionIrDocument {
+    pub(crate) fn build(
+        mut routes: Vec<ActionRoute>,
+        target_document: &crate::static_ir::StaticUiDocument,
+    ) -> Result<Self, Vec<ActionIrDiagnostic>> {
+        routes.sort();
+        let mut diagnostics = Vec::new();
+
+        for (i, r) in routes.iter().enumerate() {
+            // Check missing target
+            if !target_document
+                .nodes()
+                .iter()
+                .any(|n| n.id() == r.target.node)
+            {
+                diagnostics.push(ActionIrDiagnostic::new(
+                    r.source_ref,
+                    ActionIrDiagnosticKind::MissingTargetNode,
+                    r.id.0,
+                    r.target.node.raw(),
+                ));
+            }
+
+            // Check duplicate ID
+            if routes[..i].iter().any(|prev| prev.id == r.id) {
+                diagnostics.push(ActionIrDiagnostic::new(
+                    r.source_ref,
+                    ActionIrDiagnosticKind::DuplicateActionRouteId,
+                    r.id.0,
+                    0,
+                ));
+            }
+
+            // Canonical duplicate key: target + slot + order
+            if routes[..i]
+                .iter()
+                .any(|prev| prev.target == r.target && prev.order == r.order)
+            {
+                diagnostics.push(ActionIrDiagnostic::new(
+                    r.source_ref,
+                    ActionIrDiagnosticKind::DuplicateRouteOrder,
+                    r.id.0,
+                    0,
+                ));
+            }
+
+            // Check Zero Semantic Action Ref
+            if r.semantic_action.raw() == 0 {
+                diagnostics.push(ActionIrDiagnostic::new(
+                    r.source_ref,
+                    ActionIrDiagnosticKind::ZeroSemanticActionRef,
+                    r.id.0,
+                    0,
+                ));
+            }
+        }
+
+        if !diagnostics.is_empty() {
+            diagnostics.sort();
+            diagnostics.dedup();
+            return Err(diagnostics);
+        }
+
+        // Normalization must be idempotent, stable, storage-permutation invariant,
+        // and differentiate on ActionRouteOrder. We sort routes by the target, slot, order, and id.
+        routes.sort_by(|a, b| {
+            a.target
+                .cmp(&b.target)
+                .then(a.order.cmp(&b.order))
+                .then(a.id.cmp(&b.id))
+        });
+
+        Ok(Self { routes })
+    }
+}

--- a/crates/prom-ui/src/admission_contract.rs
+++ b/crates/prom-ui/src/admission_contract.rs
@@ -1,0 +1,55 @@
+//! Action admission transport structures.
+#![allow(dead_code)]
+
+use core::cmp::Ordering;
+
+use crate::action_ir::ActionRouteId;
+use crate::contract_primitives::DiagnosticCoordinate;
+use crate::contract_primitives::StaticNodeId;
+use crate::semantic_refs::{
+    ActorRef, CapabilityRef, ClientRef, EpochRef, RevisionRef, SemanticActionRef, SessionRef,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionInvocationContext {
+    pub(crate) source_node: StaticNodeId,
+    pub(crate) target_node: StaticNodeId,
+    pub(crate) actor: Option<ActorRef>,
+    pub(crate) session: Option<SessionRef>,
+    pub(crate) client: Option<ClientRef>,
+    pub(crate) observed_revision: Option<RevisionRef>,
+    pub(crate) observed_epoch: Option<EpochRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActionIntent {
+    pub(crate) route_id: ActionRouteId,
+    pub(crate) semantic_action: SemanticActionRef,
+    pub(crate) source_node: StaticNodeId,
+    pub(crate) target_node: StaticNodeId,
+    pub(crate) actor: Option<ActorRef>,
+    pub(crate) session: Option<SessionRef>,
+    pub(crate) client: Option<ClientRef>,
+    pub(crate) observed_revision: Option<RevisionRef>,
+    pub(crate) observed_epoch: Option<EpochRef>,
+    pub(crate) route_required_revision: Option<RevisionRef>,
+    pub(crate) route_required_epoch: Option<EpochRef>,
+    pub(crate) capability: Option<CapabilityRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ActionIntentDiagnostic {
+    pub(crate) coordinate: DiagnosticCoordinate,
+}
+
+impl Ord for ActionIntentDiagnostic {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.coordinate.cmp(&other.coordinate)
+    }
+}
+
+impl PartialOrd for ActionIntentDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/crates/prom-ui/src/binding_graph.rs
+++ b/crates/prom-ui/src/binding_graph.rs
@@ -1,0 +1,262 @@
+//! Binding Graph contract foundation.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+use crate::contract_primitives::{DiagnosticCode, DiagnosticCoordinate, SourceRef, StaticNodeId};
+use crate::semantic_refs::SemanticValueRef;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct BindingId(pub(crate) u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum BindingValueDomain {
+    Quad,
+    Scalar,
+    Text,
+    Evidence,
+    Collection,
+    Task,
+    Connectivity,
+    ActionAvailability,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct BindingSlot(pub(crate) u32);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct BindingTarget {
+    pub(crate) node: StaticNodeId,
+    pub(crate) slot: BindingSlot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct BindingDependency {
+    pub(crate) target_binding: BindingId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct BindingDeclaration {
+    pub(crate) id: BindingId,
+    pub(crate) target: BindingTarget,
+    pub(crate) domain: BindingValueDomain,
+    pub(crate) dependencies: Vec<BindingDependency>,
+    pub(crate) collection_key: Option<u64>,
+    pub(crate) semantic_value: Option<SemanticValueRef>,
+    pub(crate) source_ref: Option<SourceRef>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum BindingDiagnosticKind {
+    DuplicateBindingId,
+    MissingTargetNode,
+    DuplicateTargetSlot,
+    DanglingDependency,
+    DuplicateDependency,
+    SelfDependency,
+    Cycle,
+    MissingCollectionKey,
+    InvalidCollectionKey,
+    ZeroSemanticRef,
+    InvalidDomainSlot,
+}
+
+impl BindingDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::DuplicateBindingId => DiagnosticCode::new("BG_DUP_BINDING_ID"),
+            Self::MissingTargetNode => DiagnosticCode::new("BG_MISSING_TARGET"),
+            Self::DuplicateTargetSlot => DiagnosticCode::new("BG_DUP_TARGET_SLOT"),
+            Self::DanglingDependency => DiagnosticCode::new("BG_DANGLING_DEP"),
+            Self::DuplicateDependency => DiagnosticCode::new("BG_DUP_DEP"),
+            Self::SelfDependency => DiagnosticCode::new("BG_SELF_DEP"),
+            Self::Cycle => DiagnosticCode::new("BG_CYCLE"),
+            Self::MissingCollectionKey => DiagnosticCode::new("BG_MISSING_COLL_KEY"),
+            Self::InvalidCollectionKey => DiagnosticCode::new("BG_INVALID_COLL_KEY"),
+            Self::ZeroSemanticRef => DiagnosticCode::new("BG_ZERO_SEM_REF"),
+            Self::InvalidDomainSlot => DiagnosticCode::new("BG_INVALID_DOMAIN_SLOT"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BindingDiagnostic {
+    pub(crate) coordinate: DiagnosticCoordinate,
+}
+
+impl BindingDiagnostic {
+    pub(crate) fn new(
+        source: Option<SourceRef>,
+        kind: BindingDiagnosticKind,
+        primary_id: u64,
+        secondary_id: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(source, kind.code(), primary_id, secondary_id),
+        }
+    }
+}
+
+impl Ord for BindingDiagnostic {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.coordinate.cmp(&other.coordinate)
+    }
+}
+
+impl PartialOrd for BindingDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BindingGraphDocument {
+    pub(crate) bindings: Vec<BindingDeclaration>,
+}
+
+impl BindingGraphDocument {
+    pub(crate) fn build(
+        mut bindings: Vec<BindingDeclaration>,
+        target_document: &crate::static_ir::StaticUiDocument,
+    ) -> Result<Self, Vec<BindingDiagnostic>> {
+        bindings.sort();
+        let mut diagnostics = Vec::new();
+
+        // 1. Initial independent structural validation
+        for (i, b) in bindings.iter().enumerate() {
+            // Check MissingTargetNode
+            if !target_document
+                .nodes()
+                .iter()
+                .any(|n| n.id() == b.target.node)
+            {
+                diagnostics.push(BindingDiagnostic::new(
+                    b.source_ref,
+                    BindingDiagnosticKind::MissingTargetNode,
+                    b.id.0,
+                    b.target.node.raw(),
+                ));
+            }
+
+            // Check duplicate BindingId
+            if bindings[..i].iter().any(|prev| prev.id == b.id) {
+                diagnostics.push(BindingDiagnostic::new(
+                    b.source_ref,
+                    BindingDiagnosticKind::DuplicateBindingId,
+                    b.id.0,
+                    0,
+                ));
+            }
+
+            // Check duplicate Target Slot
+            if bindings[..i].iter().any(|prev| prev.target == b.target) {
+                diagnostics.push(BindingDiagnostic::new(
+                    b.source_ref,
+                    BindingDiagnosticKind::DuplicateTargetSlot,
+                    b.id.0,
+                    0,
+                ));
+            }
+
+            // Semantic ref checks
+            if let Some(s) = b.semantic_value {
+                if s.raw() == 0 {
+                    diagnostics.push(BindingDiagnostic::new(
+                        b.source_ref,
+                        BindingDiagnosticKind::ZeroSemanticRef,
+                        b.id.0,
+                        0,
+                    ));
+                }
+            }
+
+            // Collection key checks
+            if b.domain == BindingValueDomain::Collection && b.collection_key.is_none() {
+                diagnostics.push(BindingDiagnostic::new(
+                    b.source_ref,
+                    BindingDiagnosticKind::MissingCollectionKey,
+                    b.id.0,
+                    0,
+                ));
+            } else if b.domain != BindingValueDomain::Collection && b.collection_key.is_some() {
+                diagnostics.push(BindingDiagnostic::new(
+                    b.source_ref,
+                    BindingDiagnosticKind::InvalidCollectionKey,
+                    b.id.0,
+                    0,
+                ));
+            }
+
+            // Dependency checks
+            for (j, dep) in b.dependencies.iter().enumerate() {
+                if b.dependencies[..j].contains(dep) {
+                    diagnostics.push(BindingDiagnostic::new(
+                        b.source_ref,
+                        BindingDiagnosticKind::DuplicateDependency,
+                        b.id.0,
+                        dep.target_binding.0,
+                    ));
+                }
+                if dep.target_binding == b.id {
+                    diagnostics.push(BindingDiagnostic::new(
+                        b.source_ref,
+                        BindingDiagnosticKind::SelfDependency,
+                        b.id.0,
+                        dep.target_binding.0,
+                    ));
+                }
+                if !bindings.iter().any(|cand| cand.id == dep.target_binding) {
+                    diagnostics.push(BindingDiagnostic::new(
+                        b.source_ref,
+                        BindingDiagnosticKind::DanglingDependency,
+                        b.id.0,
+                        dep.target_binding.0,
+                    ));
+                }
+            }
+        }
+
+        // 2. Cycle detection (iterative)
+        for b in &bindings {
+            let mut visited = alloc::vec::Vec::new();
+            let mut stack = alloc::vec::Vec::new();
+            stack.push(b.id);
+            visited.push(b.id);
+
+            while let Some(current_id) = stack.pop() {
+                if let Some(current) = bindings.iter().find(|cand| cand.id == current_id) {
+                    for dep in &current.dependencies {
+                        if dep.target_binding == b.id {
+                            diagnostics.push(BindingDiagnostic::new(
+                                b.source_ref,
+                                BindingDiagnosticKind::Cycle,
+                                b.id.0,
+                                dep.target_binding.0,
+                            ));
+                            break; // Avoid infinite loops on this path, log once for root
+                        } else if !visited.contains(&dep.target_binding) {
+                            visited.push(dep.target_binding);
+                            stack.push(dep.target_binding);
+                        }
+                    }
+                }
+            }
+        }
+
+        if !diagnostics.is_empty() {
+            diagnostics.sort();
+            diagnostics.dedup();
+            return Err(diagnostics);
+        }
+
+        // Canonical normalization
+        for binding in &mut bindings {
+            binding.dependencies.sort();
+            binding.dependencies.dedup();
+        }
+        bindings.sort();
+
+        Ok(Self { bindings })
+    }
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -31,8 +31,12 @@ pub mod action_dispatch_record;
 pub mod action_dispatch_route;
 pub mod action_dispatch_summary;
 pub mod action_dispatch_trace;
+pub(crate) mod action_intent_map;
+pub(crate) mod action_ir;
 pub mod action_mapping;
+pub(crate) mod admission_contract;
 pub mod admitted_action;
+pub(crate) mod binding_graph;
 pub mod commit_boundary;
 pub mod commit_boundary_result;
 pub mod committed_effect;
@@ -63,6 +67,7 @@ pub mod renderer;
 pub(crate) mod role_dictionary;
 pub mod runtime_capability_mapping;
 pub mod runtime_capability_mapping_result;
+pub(crate) mod semantic_refs;
 pub(crate) mod static_ir;
 pub mod trace;
 pub mod tree_bridge;
@@ -74,6 +79,8 @@ pub mod validation;
 
 #[cfg(test)]
 mod ui_dna2_wp2_qualification_tests;
+#[cfg(test)]
+mod ui_dna2_wp3_qualification_tests;
 
 pub use action_admission::{
     describe_interaction_action_admission, InteractionActionAdmissionCapabilityRequirement,

--- a/crates/prom-ui/src/semantic_refs.rs
+++ b/crates/prom-ui/src/semantic_refs.rs
@@ -1,0 +1,110 @@
+//! Opaque, non-authoritative references to external Semantic-owned entities.
+#![allow(dead_code)]
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SemanticValueRef(u64);
+
+impl SemanticValueRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SemanticActionRef(u64);
+
+impl SemanticActionRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SemanticEvidenceRef(u64);
+
+impl SemanticEvidenceRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RevisionRef(u64);
+
+impl RevisionRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct EpochRef(u64);
+
+impl EpochRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ActorRef(u64);
+
+impl ActorRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct SessionRef(u64);
+
+impl SessionRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ClientRef(u64);
+
+impl ClientRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct CapabilityRef(u64);
+
+impl CapabilityRef {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}

--- a/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
@@ -1,5 +1,4 @@
 //! WP3 Contract Qualification Tests
-#![cfg(test)]
 #![allow(dead_code, unused_imports)]
 
 use crate::action_intent_map::*;

--- a/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
@@ -1,0 +1,558 @@
+//! WP3 Contract Qualification Tests
+#![cfg(test)]
+#![allow(dead_code, unused_imports)]
+
+use crate::action_intent_map::*;
+use crate::action_ir::*;
+use crate::admission_contract::*;
+use crate::binding_graph::*;
+use crate::contract_primitives::{DiagnosticCode, DiagnosticCoordinate, SourceRef, StaticNodeId};
+use crate::semantic_refs::*;
+use crate::static_ir::*;
+use alloc::vec::Vec;
+
+fn dummy_static_doc() -> StaticUiDocument {
+    let mut doc = StaticUiDocument::new(
+        crate::contract_primitives::StaticDocumentId::new(1).unwrap(),
+        crate::contract_primitives::Revision::new(1),
+        crate::contract_primitives::Epoch::new(1),
+    );
+    doc.push_node(StaticUiNode::new(
+        StaticNodeId::new(1).unwrap(),
+        crate::role_dictionary::RoleId::new("test"),
+        crate::contract_primitives::CollectionKey::new(1).unwrap(),
+        None,
+    ));
+    doc.push_node(StaticUiNode::new(
+        StaticNodeId::new(2).unwrap(),
+        crate::role_dictionary::RoleId::new("test2"),
+        crate::contract_primitives::CollectionKey::new(2).unwrap(),
+        None,
+    ));
+    doc
+}
+
+// ============================================================================
+// Semantic Refs
+// ============================================================================
+#[test]
+fn test_semantic_refs_width() {
+    assert_eq!(core::mem::size_of::<SemanticValueRef>(), 8);
+    assert_eq!(core::mem::size_of::<SemanticActionRef>(), 8);
+    assert_eq!(core::mem::size_of::<SemanticEvidenceRef>(), 8);
+    assert_eq!(core::mem::size_of::<RevisionRef>(), 8);
+    assert_eq!(core::mem::size_of::<EpochRef>(), 8);
+    assert_eq!(core::mem::size_of::<ActorRef>(), 8);
+    assert_eq!(core::mem::size_of::<SessionRef>(), 8);
+    assert_eq!(core::mem::size_of::<ClientRef>(), 8);
+    assert_eq!(core::mem::size_of::<CapabilityRef>(), 8);
+}
+
+#[test]
+fn test_semantic_refs_deterministic_ordering() {
+    let a = SemanticValueRef::new(1);
+    let b = SemanticValueRef::new(2);
+    assert!(a < b);
+    assert_eq!(a, SemanticValueRef::new(1));
+}
+
+// ============================================================================
+// Binding Graph Tests
+// ============================================================================
+
+fn make_bg_decl(id: u64, node: u64, deps: Vec<u64>) -> BindingDeclaration {
+    BindingDeclaration {
+        id: BindingId(id),
+        target: BindingTarget {
+            node: StaticNodeId::new(node).unwrap_or(StaticNodeId::new(1).unwrap()),
+            slot: BindingSlot(1),
+        },
+        domain: BindingValueDomain::Scalar,
+        dependencies: deps
+            .into_iter()
+            .map(|d| BindingDependency {
+                target_binding: BindingId(d),
+            })
+            .collect(),
+        collection_key: None,
+        semantic_value: Some(SemanticValueRef::new(id)),
+        source_ref: None,
+    }
+}
+
+#[test]
+fn test_bg_valid_graph_accepted() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let b2 = make_bg_decl(2, 2, alloc::vec![1]);
+    let bg = BindingGraphDocument::build(alloc::vec![b1, b2], &doc);
+    assert!(bg.is_ok());
+}
+
+#[test]
+fn test_bg_duplicate_binding_id_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let b2 = make_bg_decl(1, 2, alloc::vec![]); // Dup ID
+    let bg = BindingGraphDocument::build(alloc::vec![b1, b2], &doc);
+    assert!(bg.is_err());
+    let errs = bg.unwrap_err();
+    assert!(errs
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_DUP_BINDING_ID"));
+}
+
+#[test]
+fn test_bg_missing_target_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 999, alloc::vec![]); // 999 not in doc
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_MISSING_TARGET"));
+}
+
+#[test]
+fn test_bg_duplicate_target_slot_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let b2 = make_bg_decl(2, 1, alloc::vec![]); // Same target node/slot
+    let bg = BindingGraphDocument::build(alloc::vec![b1, b2], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_DUP_TARGET_SLOT"));
+}
+
+#[test]
+fn test_bg_dangling_dependency_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![99]);
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_DANGLING_DEP"));
+}
+
+#[test]
+fn test_bg_duplicate_dependency_rejected() {
+    let doc = dummy_static_doc();
+    let b2 = make_bg_decl(2, 2, alloc::vec![]);
+    let b1 = make_bg_decl(1, 1, alloc::vec![2, 2]);
+    let bg = BindingGraphDocument::build(alloc::vec![b1, b2], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_DUP_DEP"));
+}
+
+#[test]
+fn test_bg_self_dependency_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![1]);
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_SELF_DEP"));
+}
+
+#[test]
+fn test_bg_multi_node_cycle_rejected() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![2]);
+    let mut b2 = make_bg_decl(2, 2, alloc::vec![1]);
+    b2.target.slot = BindingSlot(2);
+    let bg = BindingGraphDocument::build(alloc::vec![b1, b2], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_CYCLE"));
+}
+
+#[test]
+fn test_bg_missing_collection_key_rejected() {
+    let doc = dummy_static_doc();
+    let mut b1 = make_bg_decl(1, 1, alloc::vec![]);
+    b1.domain = BindingValueDomain::Collection;
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_MISSING_COLL_KEY"));
+}
+
+#[test]
+fn test_bg_invalid_collection_key_rejected() {
+    let doc = dummy_static_doc();
+    let mut b1 = make_bg_decl(1, 1, alloc::vec![]);
+    b1.domain = BindingValueDomain::Scalar;
+    b1.collection_key = Some(42);
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_INVALID_COLL_KEY"));
+}
+
+#[test]
+fn test_bg_invalid_zero_semantic_ref_rejected() {
+    let doc = dummy_static_doc();
+    let mut b1 = make_bg_decl(1, 1, alloc::vec![]);
+    b1.semantic_value = Some(SemanticValueRef::new(0));
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc);
+    assert!(bg.is_err());
+    assert!(bg
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "BG_ZERO_SEM_REF"));
+}
+
+#[test]
+fn test_bg_storage_permutation_invariance() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let mut b2 = make_bg_decl(2, 2, alloc::vec![1]);
+    b2.target.slot = BindingSlot(2);
+
+    let bg_a = BindingGraphDocument::build(alloc::vec![b1.clone(), b2.clone()], &doc).unwrap();
+    let bg_b = BindingGraphDocument::build(alloc::vec![b2.clone(), b1.clone()], &doc).unwrap();
+
+    assert_eq!(bg_a.bindings, bg_b.bindings);
+}
+
+#[test]
+fn test_bg_dependency_permutation_invariance() {
+    let doc = dummy_static_doc();
+    let b2 = make_bg_decl(2, 2, alloc::vec![]);
+    let mut b3 = make_bg_decl(3, 1, alloc::vec![]);
+    b3.target.slot = BindingSlot(2);
+
+    let b1a = make_bg_decl(1, 1, alloc::vec![2, 3]);
+    let b1b = make_bg_decl(1, 1, alloc::vec![3, 2]);
+
+    let bg_a = BindingGraphDocument::build(alloc::vec![b2.clone(), b3.clone(), b1a], &doc).unwrap();
+    let bg_b = BindingGraphDocument::build(alloc::vec![b2.clone(), b3.clone(), b1b], &doc).unwrap();
+
+    assert_eq!(bg_a.bindings, bg_b.bindings);
+}
+
+#[test]
+fn test_bg_normalization_idempotence() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let bg = BindingGraphDocument::build(alloc::vec![b1], &doc).unwrap();
+    let bg_again = BindingGraphDocument::build(bg.bindings.clone(), &doc).unwrap();
+    assert_eq!(bg.bindings, bg_again.bindings);
+}
+
+#[test]
+fn test_bg_changed_semantics_distinction() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 1, alloc::vec![]);
+    let mut b2 = make_bg_decl(1, 1, alloc::vec![]);
+    b2.semantic_value = Some(SemanticValueRef::new(99)); // Diff semantics
+
+    let bg_a = BindingGraphDocument::build(alloc::vec![b1], &doc).unwrap();
+    let bg_b = BindingGraphDocument::build(alloc::vec![b2], &doc).unwrap();
+    assert_ne!(bg_a.bindings, bg_b.bindings);
+}
+
+#[test]
+fn test_bg_deep_graph_traversal_safety() {
+    let doc = dummy_static_doc();
+    let mut doc_large = doc.clone();
+    for i in 1..=512 {
+        doc_large.push_node(StaticUiNode::new(
+            StaticNodeId::new(i).unwrap(),
+            crate::role_dictionary::RoleId::new("test"),
+            crate::contract_primitives::CollectionKey::new(i).unwrap(),
+            None,
+        ));
+    }
+
+    let mut bindings = alloc::vec::Vec::new();
+    for i in 1..=512 {
+        let deps = if i > 1 {
+            alloc::vec![i - 1]
+        } else {
+            alloc::vec![]
+        };
+        bindings.push(make_bg_decl(i, i, deps));
+    }
+
+    let bg = BindingGraphDocument::build(bindings, &doc_large);
+    assert!(bg.is_ok());
+}
+
+#[test]
+fn test_bg_diagnostic_order_invariant() {
+    let doc = dummy_static_doc();
+    let b1 = make_bg_decl(1, 999, alloc::vec![]); // missing target
+    let b2 = make_bg_decl(1, 1, alloc::vec![]); // dup id
+    let b3 = make_bg_decl(2, 999, alloc::vec![99]); // missing target + dangling dep
+
+    let errs1 = BindingGraphDocument::build(alloc::vec![b1.clone(), b2.clone(), b3.clone()], &doc)
+        .unwrap_err();
+    let errs2 = BindingGraphDocument::build(alloc::vec![b3.clone(), b1.clone(), b2.clone()], &doc)
+        .unwrap_err();
+    assert_eq!(errs1, errs2);
+}
+
+// ============================================================================
+// Action IR Tests
+// ============================================================================
+
+fn make_air_route(id: u64, node: u64, order: u32) -> ActionRoute {
+    ActionRoute {
+        target: ActionTarget {
+            node: StaticNodeId::new(node).unwrap_or(StaticNodeId::new(1).unwrap()),
+            slot: ActionTargetSlot(1),
+        },
+        order: ActionRouteOrder(order),
+        id: ActionRouteId(id),
+        semantic_action: SemanticActionRef::new(id),
+        source_ref: None,
+        context_reqs: ActionContextRequirements {
+            requires_actor: false,
+            requires_session: false,
+            requires_client: false,
+            required_revision: None,
+            required_epoch: None,
+        },
+        capability: None,
+    }
+}
+
+#[test]
+fn test_air_valid_route_accepted() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let r2 = make_air_route(2, 2, 1);
+    let air = ActionIrDocument::build(alloc::vec![r1, r2], &doc);
+    assert!(air.is_ok());
+}
+
+#[test]
+fn test_air_duplicate_route_id_rejected() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let r2 = make_air_route(1, 2, 1); // Dup ID
+    let air = ActionIrDocument::build(alloc::vec![r1, r2], &doc);
+    assert!(air.is_err());
+    assert!(air
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "AIR_DUP_ROUTE_ID"));
+}
+
+#[test]
+fn test_air_missing_target_rejected() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 999, 1);
+    let air = ActionIrDocument::build(alloc::vec![r1], &doc);
+    assert!(air.is_err());
+    assert!(air
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "AIR_MISSING_TARGET"));
+}
+
+#[test]
+fn test_air_duplicate_route_order_same_target_slot_rejected() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let r2 = make_air_route(2, 1, 1); // Same node, slot, and order!
+    let air = ActionIrDocument::build(alloc::vec![r1, r2], &doc);
+    assert!(air.is_err());
+    assert!(air
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "AIR_DUP_ROUTE_ORDER"));
+}
+
+#[test]
+fn test_air_invalid_zero_semantic_action_ref_rejected() {
+    let doc = dummy_static_doc();
+    let mut r1 = make_air_route(1, 1, 1);
+    r1.semantic_action = SemanticActionRef::new(0);
+    let air = ActionIrDocument::build(alloc::vec![r1], &doc);
+    assert!(air.is_err());
+    assert!(air
+        .unwrap_err()
+        .iter()
+        .any(|d| d.coordinate.code().as_str() == "AIR_ZERO_ACTION_REF"));
+}
+
+#[test]
+fn test_air_storage_permutation_invariance() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let r2 = make_air_route(2, 2, 2);
+
+    let a = ActionIrDocument::build(alloc::vec![r1.clone(), r2.clone()], &doc).unwrap();
+    let b = ActionIrDocument::build(alloc::vec![r2.clone(), r1.clone()], &doc).unwrap();
+    assert_eq!(a.routes, b.routes);
+}
+
+#[test]
+fn test_air_route_order_semantic_distinction() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let r2 = make_air_route(1, 1, 2);
+
+    let a = ActionIrDocument::build(alloc::vec![r1], &doc).unwrap();
+    let b = ActionIrDocument::build(alloc::vec![r2], &doc).unwrap();
+    assert_ne!(a.routes, b.routes);
+}
+
+#[test]
+fn test_air_normalization_idempotence() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 1, 1);
+    let a = ActionIrDocument::build(alloc::vec![r1], &doc).unwrap();
+    let b = ActionIrDocument::build(a.routes.clone(), &doc).unwrap();
+    assert_eq!(a.routes, b.routes);
+}
+
+#[test]
+fn test_air_diagnostic_order_invariant() {
+    let doc = dummy_static_doc();
+    let r1 = make_air_route(1, 999, 1); // missing target
+    let r2 = make_air_route(1, 1, 1); // dup id
+    let r3 = make_air_route(2, 999, 1); // missing target
+
+    let errs1 =
+        ActionIrDocument::build(alloc::vec![r1.clone(), r2.clone(), r3.clone()], &doc).unwrap_err();
+    let errs2 =
+        ActionIrDocument::build(alloc::vec![r3.clone(), r1.clone(), r2.clone()], &doc).unwrap_err();
+    assert_eq!(errs1, errs2);
+}
+
+// ============================================================================
+// ActionIntent Mapper Tests
+// ============================================================================
+
+fn make_test_context() -> ActionInvocationContext {
+    ActionInvocationContext {
+        source_node: StaticNodeId::new(1).unwrap(),
+        target_node: StaticNodeId::new(2).unwrap(),
+        actor: Some(ActorRef::new(1)),
+        session: Some(SessionRef::new(1)),
+        client: Some(ClientRef::new(1)),
+        observed_revision: Some(RevisionRef::new(1)),
+        observed_epoch: Some(EpochRef::new(1)),
+    }
+}
+
+#[test]
+fn test_mapper_valid_complete_context() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_actor = true;
+    let ctx = make_test_context();
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_ok());
+}
+
+#[test]
+fn test_mapper_missing_actor() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_actor = true;
+    let mut ctx = make_test_context();
+    ctx.actor = None;
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_err());
+    assert_eq!(
+        intent.unwrap_err().coordinate.code().as_str(),
+        "MISSING_ACTOR"
+    );
+}
+
+#[test]
+fn test_mapper_missing_session() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_session = true;
+    let mut ctx = make_test_context();
+    ctx.session = None;
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_err());
+    assert_eq!(
+        intent.unwrap_err().coordinate.code().as_str(),
+        "MISSING_SESSION"
+    );
+}
+
+#[test]
+fn test_mapper_missing_client() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_client = true;
+    let mut ctx = make_test_context();
+    ctx.client = None;
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_err());
+    assert_eq!(
+        intent.unwrap_err().coordinate.code().as_str(),
+        "MISSING_CLIENT"
+    );
+}
+
+#[test]
+fn test_mapper_missing_revision() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.required_revision = Some(RevisionRef::new(1));
+    let mut ctx = make_test_context();
+    ctx.observed_revision = None;
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_err());
+    assert_eq!(
+        intent.unwrap_err().coordinate.code().as_str(),
+        "MISSING_REVISION"
+    );
+}
+
+#[test]
+fn test_mapper_missing_epoch() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.required_epoch = Some(EpochRef::new(1));
+    let mut ctx = make_test_context();
+    ctx.observed_epoch = None;
+    let intent = map_action_intent(&r, &ctx);
+    assert!(intent.is_err());
+    assert_eq!(
+        intent.unwrap_err().coordinate.code().as_str(),
+        "MISSING_EPOCH"
+    );
+}
+
+#[test]
+fn test_mapper_deterministic_mapping() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_actor = true;
+    let ctx = make_test_context();
+    let intent1 = map_action_intent(&r, &ctx).unwrap();
+    let intent2 = map_action_intent(&r, &ctx).unwrap();
+    assert_eq!(intent1.route_id, intent2.route_id);
+    assert_eq!(intent1.semantic_action, intent2.semantic_action);
+    assert_eq!(intent1.actor, intent2.actor);
+}
+
+#[test]
+fn test_mapper_deterministic_diagnostic() {
+    let mut r = make_air_route(1, 1, 1);
+    r.context_reqs.requires_actor = true;
+    let mut ctx = make_test_context();
+    ctx.actor = None;
+    let err1 = map_action_intent(&r, &ctx).unwrap_err();
+    let err2 = map_action_intent(&r, &ctx).unwrap_err();
+    assert_eq!(err1.coordinate, err2.coordinate);
+}


### PR DESCRIPTION
## Summary

Adds the accepted UI DNA v2 Binding Graph and Action IR contract foundation
as crate-internal `prom-ui` structures.

This PR introduces:

- opaque, non-authoritative Semantic identity references;
- deterministic read-side Binding Graph declarations;
- deterministic static Action IR route declarations;
- transport-only `ActionIntent` and invocation context contracts;
- a pure structural Action Route → ActionIntent mapper;
- deterministic structural diagnostics;
- iterative Binding Graph cycle validation;
- 36 WP3 qualification tests.

## Authority boundaries

The implementation preserves:

- bindings observe and do not mutate;
- Binding Graph stores declarations and references, not live Semantic values;
- Quad is represented only as an expected value domain;
- `prom-ui` does not store or evaluate live `N/F/T/S` values;
- Action IR declares static routes, not dynamic `ActionOffer` availability;
- Action IR does not admit, authorize, dispatch or execute actions;
- `ActionIntent` is transport only and contains no verdict;
- the mapper performs structural assembly only;
- revision freshness, epoch validity, capability and admission policy remain external;
- no legacy `SemanticIntent` integration is introduced;
- runtime and renderer integration remain outside this PR.

All new WP3 modules and symbols remain crate-internal.

## Validation

- `cargo test -p prom-ui --lib ui_dna2_wp3` — 36 passed
- `cargo test -p prom-ui` — 448 passed
- `cargo check -p prom-ui --all-features`
- `cargo clippy -p prom-ui --all-targets -- -D warnings`
- `cargo fmt --check`
- `scripts/harness-check.ps1`
- `git diff --check`

The crate-wide `--no-default-features` check remains blocked by previously
known legacy `prom-ui` files outside this change. WP3 production paths
introduce zero no-default diagnostics.

## Gates

- Gate A: approved
- Gate B: approved
- Gate C: approved
- Gate D runtime/admission integration: not granted
- production promotion: not authorized

Follow-up to #1490.
Refs #1489.
