### PR TITLE
feat(refs): add authority-free reference value contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/sm-vm",
     "crates/smc-cli",
     "crates/prom-abi",
+    "crates/prom-refs",
     "crates/prom-cap",
     "crates/prom-gates",
     "crates/prom-runtime",

--- a/crates/prom-refs/Cargo.toml
+++ b/crates/prom-refs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "prom-refs"
+version = "0.1.0"
+edition = "2021"
+authors = ["Said Kulmakov"]
+license = "Apache-2.0"
+publish = false
+
+[dependencies]

--- a/crates/prom-refs/src/lib.rs
+++ b/crates/prom-refs/src/lib.rs
@@ -1,0 +1,158 @@
+//! This crate owns authority-free reference values.
+//! References are untrusted claims; possession grants no authority.
+//! Trusted domain owners issue and resolve canonical references.
+//! Resolution, admission, capability checks, and execution are outside this crate.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+/// An explicit four-part composite reference token.
+/// It provides deterministic provenance coordinates, not authentication.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReferenceToken {
+    issuer: u64,
+    namespace: u32,
+    generation: u32,
+    value: u64,
+}
+
+impl ReferenceToken {
+    /// Construct a new `ReferenceToken` from explicit components.
+    pub const fn new(issuer: u64, namespace: u32, generation: u32, value: u64) -> Self {
+        Self {
+            issuer,
+            namespace,
+            generation,
+            value,
+        }
+    }
+
+    /// Returns the issuer of the token.
+    pub const fn issuer(&self) -> u64 {
+        self.issuer
+    }
+
+    /// Returns the namespace of the token.
+    pub const fn namespace(&self) -> u32 {
+        self.namespace
+    }
+
+    /// Returns the generation of the token.
+    pub const fn generation(&self) -> u32 {
+        self.generation
+    }
+
+    /// Returns the value of the token.
+    pub const fn value(&self) -> u64 {
+        self.value
+    }
+}
+
+macro_rules! define_ref_wrapper {
+    ($name:ident, $doc:expr) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name {
+            token: ReferenceToken,
+        }
+
+        impl $name {
+            /// Construct from a ReferenceToken.
+            pub const fn new(token: ReferenceToken) -> Self {
+                Self { token }
+            }
+
+            /// Retrieve the underlying ReferenceToken.
+            pub const fn token(&self) -> ReferenceToken {
+                self.token
+            }
+        }
+    };
+}
+
+define_ref_wrapper!(CapabilityRef, "Capability Candidate Reference");
+define_ref_wrapper!(ActorRef, "Authority-Scoped Correlation Handle for Actor");
+define_ref_wrapper!(SessionRef, "Session-Scoped Handle");
+define_ref_wrapper!(ClientRef, "Session-Scoped Correlation Handle for Client");
+define_ref_wrapper!(RevisionRef, "Versioned State Token for Revision");
+define_ref_wrapper!(EpochRef, "Versioned Execution Token for Epoch");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_token_preserves_all_four_components() {
+        let token = ReferenceToken::new(1, 2, 3, 4);
+        assert_eq!(token.issuer(), 1);
+        assert_eq!(token.namespace(), 2);
+        assert_eq!(token.generation(), 3);
+        assert_eq!(token.value(), 4);
+    }
+
+    #[test]
+    fn reference_token_equality_uses_all_components() {
+        let a = ReferenceToken::new(1, 2, 3, 4);
+        let b = ReferenceToken::new(1, 2, 3, 4);
+        let c = ReferenceToken::new(9, 2, 3, 4);
+        let d = ReferenceToken::new(1, 9, 3, 4);
+        let e = ReferenceToken::new(1, 2, 9, 4);
+        let f = ReferenceToken::new(1, 2, 3, 9);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+        assert_ne!(a, e);
+        assert_ne!(a, f);
+    }
+
+    #[test]
+    fn reference_token_ordering_is_deterministic() {
+        let a = ReferenceToken::new(1, 2, 3, 4);
+        let b = ReferenceToken::new(1, 2, 3, 5);
+        let c = ReferenceToken::new(2, 0, 0, 0);
+        assert!(a < b);
+        assert!(a < c);
+    }
+
+    #[test]
+    fn capability_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = CapabilityRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+
+    #[test]
+    fn actor_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = ActorRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+
+    #[test]
+    fn session_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = SessionRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+
+    #[test]
+    fn client_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = ClientRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+
+    #[test]
+    fn revision_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = RevisionRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+
+    #[test]
+    fn epoch_ref_preserves_its_token() {
+        let t = ReferenceToken::new(1, 2, 3, 4);
+        let r = EpochRef::new(t);
+        assert_eq!(r.token(), t);
+    }
+}

--- a/crates/prom-ui/Cargo.toml
+++ b/crates/prom-ui/Cargo.toml
@@ -12,3 +12,4 @@ std = ["prom-abi/std"]
 
 [dependencies]
 prom-abi = { path = "../prom-abi", default-features = false }
+prom-refs = { path = "../prom-refs", default-features = false }

--- a/crates/prom-ui/src/semantic_refs.rs
+++ b/crates/prom-ui/src/semantic_refs.rs
@@ -1,5 +1,9 @@
 //! Opaque, non-authoritative references to external Semantic-owned entities.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
+
+pub(crate) use prom_refs::{
+    ActorRef, CapabilityRef, ClientRef, EpochRef, ReferenceToken, RevisionRef, SessionRef,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct SemanticValueRef(u64);
@@ -29,78 +33,6 @@ impl SemanticActionRef {
 pub(crate) struct SemanticEvidenceRef(u64);
 
 impl SemanticEvidenceRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct RevisionRef(u64);
-
-impl RevisionRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct EpochRef(u64);
-
-impl EpochRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct ActorRef(u64);
-
-impl ActorRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct SessionRef(u64);
-
-impl SessionRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct ClientRef(u64);
-
-impl ClientRef {
-    pub(crate) const fn new(raw: u64) -> Self {
-        Self(raw)
-    }
-    pub(crate) const fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct CapabilityRef(u64);
-
-impl CapabilityRef {
     pub(crate) const fn new(raw: u64) -> Self {
         Self(raw)
     }

--- a/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp3_qualification_tests.rs
@@ -39,12 +39,12 @@ fn test_semantic_refs_width() {
     assert_eq!(core::mem::size_of::<SemanticValueRef>(), 8);
     assert_eq!(core::mem::size_of::<SemanticActionRef>(), 8);
     assert_eq!(core::mem::size_of::<SemanticEvidenceRef>(), 8);
-    assert_eq!(core::mem::size_of::<RevisionRef>(), 8);
-    assert_eq!(core::mem::size_of::<EpochRef>(), 8);
-    assert_eq!(core::mem::size_of::<ActorRef>(), 8);
-    assert_eq!(core::mem::size_of::<SessionRef>(), 8);
-    assert_eq!(core::mem::size_of::<ClientRef>(), 8);
-    assert_eq!(core::mem::size_of::<CapabilityRef>(), 8);
+    assert_eq!(core::mem::size_of::<RevisionRef>(), 24);
+    assert_eq!(core::mem::size_of::<EpochRef>(), 24);
+    assert_eq!(core::mem::size_of::<ActorRef>(), 24);
+    assert_eq!(core::mem::size_of::<SessionRef>(), 24);
+    assert_eq!(core::mem::size_of::<ClientRef>(), 24);
+    assert_eq!(core::mem::size_of::<CapabilityRef>(), 24);
 }
 
 #[test]
@@ -446,11 +446,11 @@ fn make_test_context() -> ActionInvocationContext {
     ActionInvocationContext {
         source_node: StaticNodeId::new(1).unwrap(),
         target_node: StaticNodeId::new(2).unwrap(),
-        actor: Some(ActorRef::new(1)),
-        session: Some(SessionRef::new(1)),
-        client: Some(ClientRef::new(1)),
-        observed_revision: Some(RevisionRef::new(1)),
-        observed_epoch: Some(EpochRef::new(1)),
+        actor: Some(ActorRef::new(ReferenceToken::new(1, 1, 1, 1))),
+        session: Some(SessionRef::new(ReferenceToken::new(2, 2, 2, 2))),
+        client: Some(ClientRef::new(ReferenceToken::new(3, 3, 3, 3))),
+        observed_revision: Some(RevisionRef::new(ReferenceToken::new(4, 4, 4, 4))),
+        observed_epoch: Some(EpochRef::new(ReferenceToken::new(5, 5, 5, 5))),
     }
 }
 
@@ -508,7 +508,7 @@ fn test_mapper_missing_client() {
 #[test]
 fn test_mapper_missing_revision() {
     let mut r = make_air_route(1, 1, 1);
-    r.context_reqs.required_revision = Some(RevisionRef::new(1));
+    r.context_reqs.required_revision = Some(RevisionRef::new(ReferenceToken::new(4, 4, 4, 4)));
     let mut ctx = make_test_context();
     ctx.observed_revision = None;
     let intent = map_action_intent(&r, &ctx);
@@ -522,7 +522,7 @@ fn test_mapper_missing_revision() {
 #[test]
 fn test_mapper_missing_epoch() {
     let mut r = make_air_route(1, 1, 1);
-    r.context_reqs.required_epoch = Some(EpochRef::new(1));
+    r.context_reqs.required_epoch = Some(EpochRef::new(ReferenceToken::new(5, 5, 5, 5)));
     let mut ctx = make_test_context();
     ctx.observed_epoch = None;
     let intent = map_action_intent(&r, &ctx);


### PR DESCRIPTION
## Summary

Introduces the UI-DNA2 Gate D0B authority-free reference value contract.

This PR:

- adds the neutral `prom-refs` no_std crate;
- defines the explicit four-part `ReferenceToken`;
- defines six distinct authority-reference value types;
- migrates the corresponding WP3 references out of `prom-ui`;
- preserves the existing WP3 Action IR and Binding Graph behavior;
- preserves all 36 WP3 qualification tests.

## Reference contract

Each reference carries:

```text
issuer: u64
namespace: u32
generation: u32
value: u64
```

The values are untrusted correlation claims.

Reference possession grants no authority.

This PR introduces no:

* resolver;
* authority registry;
* capability mapping;
* identity mapping;
* revision or epoch validation;
* admission policy;
* admission verdict;
* ActionOffer;
* dispatch or execution behavior.

## Dependency boundary

```text
prom-ui -> prom-refs
```

`prom-refs` has zero dependencies and does not depend on UI, runtime, capability, audit or VM crates.

## Validation

* `cargo test --locked -p prom-refs` — 9 passed
* `cargo check --locked -p prom-refs --no-default-features`
* `cargo test --locked -p prom-ui --lib ui_dna2_wp3` — 36 passed
* `cargo test --locked -p prom-ui`
* `cargo test --locked -p prom-ui-runtime`
* `cargo check --locked -p prom-ui --all-features`
* `cargo check --locked -p prom-ui-runtime --all-features`
* `cargo +1.93.1 fmt --all --check`
* `cargo +1.93.1 clippy --workspace --all-targets --locked -- -D warnings`
* `cargo test --locked --test public_api_contracts --quiet`
* `scripts/harness-check.ps1`
* `git diff --check`

## Gates

* UI-DNA2 WP3: merged
* Gate D0B value-contract slice: implemented
* Gate D runtime/admission integration: closed
* resolver implementation: not authorized
* runtime adapter: not authorized

Follow-up to #1491.
Refs #1489.