### PR TITLE
test(refs): guard prom-refs public API contract

### DIFF
--- a/crates/prom-refs/tests/public_api_contract.rs
+++ b/crates/prom-refs/tests/public_api_contract.rs
@@ -1,0 +1,58 @@
+use prom_refs::*;
+
+fn assert_value_traits<T>()
+where
+    T: core::fmt::Debug + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + core::hash::Hash,
+{
+}
+
+#[test]
+fn prom_refs_public_value_contract_compiles() {
+    assert_value_traits::<ReferenceToken>();
+    assert_value_traits::<CapabilityRef>();
+    assert_value_traits::<ActorRef>();
+    assert_value_traits::<SessionRef>();
+    assert_value_traits::<ClientRef>();
+    assert_value_traits::<RevisionRef>();
+    assert_value_traits::<EpochRef>();
+}
+
+const TOKEN: ReferenceToken = ReferenceToken::new(1, 2, 3, 4);
+
+const ISSUER: u64 = TOKEN.issuer();
+const NAMESPACE: u32 = TOKEN.namespace();
+const GENERATION: u32 = TOKEN.generation();
+const VALUE: u64 = TOKEN.value();
+
+const CAPABILITY: CapabilityRef = CapabilityRef::new(TOKEN);
+const CAPABILITY_TOKEN: ReferenceToken = CAPABILITY.token();
+
+const ACTOR: ActorRef = ActorRef::new(TOKEN);
+const ACTOR_TOKEN: ReferenceToken = ACTOR.token();
+
+const SESSION: SessionRef = SessionRef::new(TOKEN);
+const SESSION_TOKEN: ReferenceToken = SESSION.token();
+
+const CLIENT: ClientRef = ClientRef::new(TOKEN);
+const CLIENT_TOKEN: ReferenceToken = CLIENT.token();
+
+const REVISION: RevisionRef = RevisionRef::new(TOKEN);
+const REVISION_TOKEN: ReferenceToken = REVISION.token();
+
+const EPOCH: EpochRef = EpochRef::new(TOKEN);
+const EPOCH_TOKEN: ReferenceToken = EPOCH.token();
+
+#[test]
+fn runtime_assertions_for_prom_refs_constants() {
+    assert_eq!(ISSUER, 1);
+    assert_eq!(NAMESPACE, 2);
+    assert_eq!(GENERATION, 3);
+    assert_eq!(VALUE, 4);
+
+    assert_eq!(CAPABILITY_TOKEN, TOKEN);
+    assert_eq!(ACTOR_TOKEN, TOKEN);
+    assert_eq!(SESSION_TOKEN, TOKEN);
+    assert_eq!(CLIENT_TOKEN, TOKEN);
+    assert_eq!(REVISION_TOKEN, TOKEN);
+    assert_eq!(EPOCH_TOKEN, TOKEN);
+}

--- a/tests/golden_snapshots/public_api/prom_refs_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_refs_lib.txt
@@ -1,0 +1,13 @@
+source: crates/prom-refs/src/lib.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReferenceToken {
+pub const fn new(issuer: u64, namespace: u32, generation: u32, value: u64) -> Self {
+pub const fn issuer(&self) -> u64 {
+pub const fn namespace(&self) -> u32 {
+pub const fn generation(&self) -> u32 {
+pub const fn value(&self) -> u64 {
+#[doc = $doc]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct $name {
+pub const fn new(token: ReferenceToken) -> Self {
+pub const fn token(&self) -> ReferenceToken {

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -1,5 +1,14 @@
 use std::fs;
 
+const PROM_REF_WRAPPERS: &[&str] = &[
+    "CapabilityRef",
+    "ActorRef",
+    "SessionRef",
+    "ClientRef",
+    "RevisionRef",
+    "EpochRef",
+];
+
 const TARGETS: &[(&str, &str)] = &[
     (
         "crates/sm-ir/src/lib.rs",
@@ -198,14 +207,8 @@ fn prom_refs_forbidden_impl_surface_is_absent() {
         "RevisionRef",
         "EpochRef",
     ];
-    let wrappers = [
-        "CapabilityRef",
-        "ActorRef",
-        "SessionRef",
-        "ClientRef",
-        "RevisionRef",
-        "EpochRef",
-    ];
+
+    let wrappers = PROM_REF_WRAPPERS;
 
     for t in approved_types {
         let patterns = [
@@ -293,4 +296,266 @@ fn prom_refs_forbidden_impl_surface_is_absent() {
     // Note: this scan protects explicit source-level `impl` contracts only.
     // It does not constitute full semantic or compiler-level negative proof.
     // Alias-based or macro-generated implementations remain outside the textual guard’s proof boundary.
+}
+
+fn extract_define_ref_wrapper_names(source: &str) -> Result<Vec<String>, String> {
+    let mut names = Vec::new();
+    let chars: Vec<char> = source.chars().collect();
+    let mut i = 0;
+
+    let mut no_comments_or_strings = String::new();
+
+    while i < chars.len() {
+        if i + 1 < chars.len() && chars[i] == '/' && chars[i + 1] == '/' {
+            // line comment
+            i += 2;
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+        } else if i + 1 < chars.len() && chars[i] == '/' && chars[i + 1] == '*' {
+            // block comment
+            i += 2;
+            let mut depth = 1;
+            while i < chars.len() && depth > 0 {
+                if i + 1 < chars.len() && chars[i] == '/' && chars[i + 1] == '*' {
+                    depth += 1;
+                    i += 2;
+                } else if i + 1 < chars.len() && chars[i] == '*' && chars[i + 1] == '/' {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+        } else if chars[i] == '"' {
+            // string literal
+            i += 1;
+            while i < chars.len() && chars[i] != '"' {
+                if chars[i] == '\\' {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            if i < chars.len() {
+                i += 1;
+            }
+        } else if chars[i] == 'r'
+            && i + 1 < chars.len()
+            && (chars[i + 1] == '"' || chars[i + 1] == '#')
+        {
+            // raw string literal
+            i += 1;
+            let mut hash_count = 0;
+            while i < chars.len() && chars[i] == '#' {
+                hash_count += 1;
+                i += 1;
+            }
+            if i < chars.len() && chars[i] == '"' {
+                i += 1;
+                loop {
+                    if i >= chars.len() {
+                        break;
+                    }
+                    if chars[i] == '"' {
+                        let mut closing_hashes = 0;
+                        let mut j = i + 1;
+                        while j < chars.len() && chars[j] == '#' && closing_hashes < hash_count {
+                            closing_hashes += 1;
+                            j += 1;
+                        }
+                        if closing_hashes == hash_count {
+                            i = j;
+                            break;
+                        }
+                    }
+                    i += 1;
+                }
+            }
+        } else if chars[i] == '\'' {
+            // character literal or lifetime
+            no_comments_or_strings.push(chars[i]);
+            i += 1;
+            while i < chars.len() {
+                let c = chars[i];
+                if c == '\\' {
+                    no_comments_or_strings.push(chars[i]);
+                    if i + 1 < chars.len() {
+                        no_comments_or_strings.push(chars[i + 1]);
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                } else if c == '\'' {
+                    no_comments_or_strings.push(chars[i]);
+                    i += 1;
+                    break;
+                } else if !c.is_alphanumeric() && c != '_' {
+                    // if it's a lifetime, there's no closing quote, so break on non-identifier
+                    break;
+                } else {
+                    no_comments_or_strings.push(chars[i]);
+                    i += 1;
+                }
+            }
+        } else {
+            no_comments_or_strings.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    let clean_chars: Vec<char> = no_comments_or_strings.chars().collect();
+    let mut i = 0;
+    while i < clean_chars.len() {
+        if clean_chars[i].is_alphabetic() || clean_chars[i] == '_' {
+            let mut ident = String::new();
+            while i < clean_chars.len()
+                && (clean_chars[i].is_alphanumeric() || clean_chars[i] == '_')
+            {
+                ident.push(clean_chars[i]);
+                i += 1;
+            }
+            if ident == "define_ref_wrapper" {
+                let mut temp_i = i;
+                while temp_i < clean_chars.len() && clean_chars[temp_i].is_whitespace() {
+                    temp_i += 1;
+                }
+                if temp_i < clean_chars.len() && clean_chars[temp_i] == '!' {
+                    temp_i += 1;
+                    while temp_i < clean_chars.len() && clean_chars[temp_i].is_whitespace() {
+                        temp_i += 1;
+                    }
+                    if temp_i < clean_chars.len()
+                        && (clean_chars[temp_i] == '('
+                            || clean_chars[temp_i] == '['
+                            || clean_chars[temp_i] == '{')
+                    {
+                        temp_i += 1;
+                        while temp_i < clean_chars.len() && clean_chars[temp_i].is_whitespace() {
+                            temp_i += 1;
+                        }
+
+                        let mut arg = String::new();
+                        while temp_i < clean_chars.len()
+                            && (clean_chars[temp_i].is_alphanumeric() || clean_chars[temp_i] == '_')
+                        {
+                            arg.push(clean_chars[temp_i]);
+                            temp_i += 1;
+                        }
+
+                        let is_valid_ident = !arg.is_empty()
+                            && (arg.chars().next().unwrap().is_alphabetic()
+                                || arg.starts_with('_'));
+                        if !is_valid_ident {
+                            return Err(format!(
+                                "Invalid identifier in define_ref_wrapper! invocation: '{}'",
+                                arg
+                            ));
+                        }
+
+                        names.push(arg);
+                        i = temp_i;
+                    }
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(names)
+}
+
+#[test]
+fn prom_refs_wrapper_invocation_extractor_ignores_non_code_occurrences() {
+    let source = r##"
+        macro_rules! define_ref_wrapper {
+            ($name:ident, $doc:expr) => { ... }
+        }
+
+        // define_ref_wrapper!(Fake1, ...);
+        /* define_ref_wrapper!(Fake2, ...); */
+
+        let a = "define_ref_wrapper!(Fake3, ...)";
+        let b = r#"define_ref_wrapper!(Fake4, ...)"#;
+
+        let _quote = '\'';
+        let _plain = 'x';
+
+        // These must remain ignored as non-code text around literal state transitions.
+        let _text = "define_ref_wrapper!(FakeStringRef, \"fake\");";
+
+        // Synthetic cases crossing or adjacent to character literal boundaries
+        let _cross1 = 'd';efine_ref_wrapper!(FakeCross1, "...");
+        let _cross2 = define_ref_wrapper'!';(FakeCross2, "...");
+
+        define_ref_wrapper!(Real1, "doc");
+        define_ref_wrapper! {
+            Real2,
+            "doc"
+        }
+        define_ref_wrapper![
+            BracketRef,
+            "real"
+        ];
+    "##;
+
+    let names = extract_define_ref_wrapper_names(source).unwrap();
+    assert_eq!(names, vec!["Real1", "Real2", "BracketRef"]);
+}
+
+#[test]
+fn prom_refs_wrapper_invocations_match_contract() {
+    let path = "crates/prom-refs/src/lib.rs";
+    let src = fs::read_to_string(path).unwrap();
+
+    let actual_wrappers = extract_define_ref_wrapper_names(&src).unwrap();
+
+    let mut expected: Vec<String> = PROM_REF_WRAPPERS.iter().map(|s| s.to_string()).collect();
+    let mut actual = actual_wrappers.clone();
+
+    expected.sort();
+    actual.sort();
+
+    let mut actual_unique = actual.clone();
+    actual_unique.dedup();
+
+    if actual.len() != actual_unique.len() {
+        println!("expected wrappers: {:?}", expected);
+        println!("actual wrappers: {:?}", actual);
+        println!(
+            "missing wrappers: {:?}",
+            expected
+                .iter()
+                .filter(|w| !actual.contains(w))
+                .collect::<Vec<_>>()
+        );
+        println!(
+            "unexpected wrappers: {:?}",
+            actual
+                .iter()
+                .filter(|w| !expected.contains(w))
+                .collect::<Vec<_>>()
+        );
+        println!("duplicate wrappers: {:?}", actual);
+        panic!("duplicate wrappers found: {:?}", actual);
+    }
+
+    if actual != expected {
+        println!("expected wrappers: {:?}", expected);
+        println!("actual wrappers: {:?}", actual);
+
+        let missing: Vec<_> = expected.iter().filter(|w| !actual.contains(w)).collect();
+        let unexpected: Vec<_> = actual.iter().filter(|w| !expected.contains(w)).collect();
+
+        println!("missing wrappers: {:?}", missing);
+        println!("unexpected wrappers: {:?}", unexpected);
+        println!("duplicate wrappers: []");
+
+        panic!("Wrapper contract mismatch");
+    }
+
+    assert_eq!(actual.len(), 6, "actual invocation count = 6");
+    assert_eq!(actual_unique.len(), 6, "actual unique wrapper count = 6");
+    assert_eq!(expected.len(), 6, "expected wrapper count = 6");
 }

--- a/tests/public_api_contracts.rs
+++ b/tests/public_api_contracts.rs
@@ -41,6 +41,10 @@ const TARGETS: &[(&str, &str)] = &[
         "crates/smc-cli/src/lib.rs",
         "tests/golden_snapshots/public_api/smc_cli_lib.txt",
     ),
+    (
+        "crates/prom-refs/src/lib.rs",
+        "tests/golden_snapshots/public_api/prom_refs_lib.txt",
+    ),
 ];
 
 fn normalize_ws(line: &str) -> String {
@@ -120,4 +124,173 @@ fn public_api_inventory_matches_checked_in_contract_snapshots() {
             "public API inventory drifted for {source}; update snapshot only for intentional contract changes"
         );
     }
+}
+
+#[test]
+fn prom_refs_forbidden_impl_surface_is_absent() {
+    let path = "crates/prom-refs/src/lib.rs";
+    let src = std::fs::read_to_string(path).unwrap();
+
+    // 1. Remove comments
+    let mut no_comments = String::with_capacity(src.len());
+    let mut in_block_comment = false;
+    let mut in_line_comment = false;
+    let mut chars = src.chars().peekable();
+    while let Some(c) = chars.next() {
+        if in_block_comment {
+            if c == '*' && chars.peek() == Some(&'/') {
+                chars.next();
+                in_block_comment = false;
+            }
+        } else if in_line_comment {
+            if c == '\n' {
+                in_line_comment = false;
+                no_comments.push('\n');
+            }
+        } else if c == '/' && chars.peek() == Some(&'*') {
+            chars.next();
+            in_block_comment = true;
+        } else if c == '/' && chars.peek() == Some(&'/') {
+            chars.next();
+            in_line_comment = true;
+        } else {
+            no_comments.push(c);
+        }
+    }
+
+    // 2. Normalize whitespace
+    let mut normalized = no_comments
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    // 3. Canonicalize known standard trait prefixes
+    let prefixes = [
+        "::core::convert::",
+        "core::convert::",
+        "::std::convert::",
+        "std::convert::",
+        "::core::ops::",
+        "core::ops::",
+        "::std::ops::",
+        "std::ops::",
+        "::core::borrow::",
+        "core::borrow::",
+        "::std::borrow::",
+        "std::borrow::",
+        "::core::default::",
+        "core::default::",
+        "::std::default::",
+        "std::default::",
+    ];
+    for p in prefixes {
+        normalized = normalized.replace(p, "");
+    }
+
+    let approved_types = [
+        "ReferenceToken",
+        "CapabilityRef",
+        "ActorRef",
+        "SessionRef",
+        "ClientRef",
+        "RevisionRef",
+        "EpochRef",
+    ];
+    let wrappers = [
+        "CapabilityRef",
+        "ActorRef",
+        "SessionRef",
+        "ClientRef",
+        "RevisionRef",
+        "EpochRef",
+    ];
+
+    for t in approved_types {
+        let patterns = [
+            format!("impl Default for {}", t),
+            format!("impl From<u64> for {}", t),
+            format!("impl Into<u64> for {}", t),
+            format!("impl TryFrom<u64> for {}", t),
+            format!("impl TryInto<u64> for {}", t),
+            format!("impl From<{}> for u64", t),
+            format!("impl Into<{}> for u64", t),
+            format!("impl TryFrom<{}> for u64", t),
+            format!("impl TryInto<{}> for u64", t),
+            format!("impl Deref for {}", t),
+            format!("impl AsRef<u64> for {}", t),
+            format!("impl Borrow<u64> for {}", t),
+        ];
+
+        for pattern in patterns {
+            assert!(
+                !normalized.contains(&pattern),
+                "Forbidden impl pattern found: {}",
+                pattern
+            );
+        }
+    }
+
+    // Cross-domain conversions
+    let mut generated_pairs = 0;
+    let mut checked_patterns = 0;
+    for src_wrapper in wrappers {
+        for dest_wrapper in wrappers {
+            if src_wrapper != dest_wrapper {
+                generated_pairs += 1;
+                let patterns = [
+                    format!("impl From<{}> for {}", src_wrapper, dest_wrapper),
+                    format!("impl Into<{}> for {}", dest_wrapper, src_wrapper),
+                    format!("impl TryFrom<{}> for {}", src_wrapper, dest_wrapper),
+                    format!("impl TryInto<{}> for {}", dest_wrapper, src_wrapper),
+                ];
+                for pattern in patterns {
+                    checked_patterns += 1;
+                    assert!(
+                        !normalized.contains(&pattern),
+                        "Forbidden cross-domain conversion pattern found: {}",
+                        pattern
+                    );
+                }
+            }
+        }
+    }
+    assert_eq!(generated_pairs, 30, "Should generate 30 cross-domain pairs");
+    assert_eq!(checked_patterns, 120, "Should check 120 patterns");
+
+    // Forbidden inherent methods
+    let forbidden_methods = [
+        "pub fn raw",
+        "pub const fn raw",
+        "pub fn from_raw",
+        "pub const fn from_raw",
+        "pub fn resolve",
+        "pub const fn resolve",
+        "pub fn validate",
+        "pub const fn validate",
+        "pub fn verify",
+        "pub const fn verify",
+        "pub fn grant",
+        "pub const fn grant",
+        "pub fn admit",
+        "pub const fn admit",
+        "pub fn register",
+        "pub const fn register",
+        "pub fn serialize",
+        "pub const fn serialize",
+        "pub fn deserialize",
+        "pub const fn deserialize",
+    ];
+    for method in forbidden_methods {
+        assert!(
+            !normalized.contains(method),
+            "Forbidden public method declaration: {}",
+            method
+        );
+    }
+
+    // Note: this scan protects explicit source-level `impl` contracts only.
+    // It does not constitute full semantic or compiler-level negative proof.
+    // Alias-based or macro-generated implementations remain outside the textual guard’s proof boundary.
 }


### PR DESCRIPTION
## Summary

Adds bounded public API enforcement for the landed `prom-refs` value contract.

### Changes

- registers `crates/prom-refs/src/lib.rs` in the existing public API snapshot guard;
- adds the corresponding checked-in snapshot;
- adds positive compile-time coverage for the seven public value types;
- verifies required trait bounds and the `const` API;
- rejects explicit forbidden scalar conversions and authority-like inherent methods;
- rejects `From`, `Into`, `TryFrom`, and `TryInto` across all 30 directed wrapper pairs.

### Scope

Tests only.

No resolver, registry, capability lookup, identity model, revision model, epoch model, admission behavior, runtime adapter, serialization contract, or ABI promise is introduced.

The negative scan is a bounded source-level guard after canonicalization of common `core` and `std` trait paths. It is not an AST-level or cross-crate semantic proof.

## Validation

- `cargo test --locked --test public_api_contracts --quiet`
- `cargo test --locked -p prom-refs`
- `cargo test --locked -p prom-refs --test public_api_contract`
- `cargo check --locked -p prom-refs --no-default-features`
- `cargo +1.93.1 fmt --all --check`
- `cargo +1.93.1 clippy --workspace --all-targets --locked -- -D warnings`
- `scripts/harness-check.ps1`
- `git diff --check`
- `git diff --cached --check`

## Gates

- D0B value contract: merged
- D0B spec sync: merged
- D0C public API guard: implemented
- Gate D: closed
- resolver implementation: unauthorized
- capability lookup: unauthorized

Follow-up to #1492 and #1493.