### PR TITLE
feat(cap): add exact capability reference lookup

### DIFF
--- a/crates/prom-cap/Cargo.toml
+++ b/crates/prom-cap/Cargo.toml
@@ -12,3 +12,4 @@ std = ["prom-abi/std"]
 
 [dependencies]
 prom-abi = { path = "../prom-abi", default-features = false }
+prom-refs = { path = "../prom-refs", default-features = false }

--- a/crates/prom-cap/src/lib.rs
+++ b/crates/prom-cap/src/lib.rs
@@ -7,6 +7,7 @@ pub mod hello_observation_capability;
 use alloc::collections::BTreeSet;
 use alloc::string::String;
 use prom_abi::HostCallId;
+use prom_refs::CapabilityRef;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CapabilityKind {
@@ -18,6 +19,118 @@ pub enum CapabilityKind {
     StateUpdate,
     EventPost,
     ClockRead,
+}
+
+/// A non-authoritative lookup record for one exact capability reference.
+///
+/// Successful lookup of this entry does not grant authority and does not
+/// perform admission, dispatch, or effect execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityLookupEntry {
+    reference: CapabilityRef,
+    kind: CapabilityKind,
+}
+
+impl CapabilityLookupEntry {
+    /// Creates a non-authoritative capability lookup entry from an exact
+    /// reference and its taxonomy-only capability kind.
+    pub const fn new(reference: CapabilityRef, kind: CapabilityKind) -> Self {
+        Self { reference, kind }
+    }
+
+    /// Returns the exact stored capability reference.
+    pub const fn reference(&self) -> CapabilityRef {
+        self.reference
+    }
+
+    /// Returns the taxonomy-only capability kind associated with the reference.
+    pub const fn kind(&self) -> CapabilityKind {
+        self.kind
+    }
+}
+
+/// An immutable borrowed view over a validated, strictly sorted slice of
+/// non-authoritative capability lookup entries.
+///
+/// Construction rejects duplicate and descending adjacent full-reference keys.
+/// The operation itself is allocation-free and does not claim whole-crate
+/// `no_std` qualification.
+#[derive(Debug, Clone, Copy)]
+pub struct CapabilityLookupView<'a> {
+    entries: &'a [CapabilityLookupEntry],
+}
+
+impl<'a> CapabilityLookupView<'a> {
+    /// Borrows a validated, strictly sorted entry slice without copying,
+    /// mutating, or allocating.
+    pub fn try_new(
+        entries: &'a [CapabilityLookupEntry],
+    ) -> Result<Self, CapabilityLookupBuildError> {
+        validate_lookup_entries(entries)?;
+        Ok(Self { entries })
+    }
+
+    /// Performs exact full-reference matching and returns the borrowed stored
+    /// entry on success.
+    ///
+    /// Successful lookup does not grant authority. `UnknownReference` is a
+    /// lookup miss and is not `CapabilityDenied`.
+    pub fn lookup(
+        &self,
+        reference: CapabilityRef,
+    ) -> Result<&CapabilityLookupEntry, CapabilityLookupError> {
+        self.entries
+            .iter()
+            .find(|entry| entry.reference() == reference)
+            .ok_or(CapabilityLookupError::UnknownReference)
+    }
+}
+
+/// Public miss result for exact capability-reference lookup.
+///
+/// This error reports only that the supplied full reference was not present in
+/// the borrowed lookup view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityLookupError {
+    UnknownReference,
+}
+
+/// Public construction error for borrowed capability lookup views.
+///
+/// Validation is deterministic, adjacent-pair based, and allocation-free.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityLookupBuildError {
+    DuplicateReference,
+    UnsortedEntries,
+}
+
+fn compare_capability_refs(left: CapabilityRef, right: CapabilityRef) -> core::cmp::Ordering {
+    let left = left.token();
+    let right = right.token();
+
+    left.issuer()
+        .cmp(&right.issuer())
+        .then_with(|| left.namespace().cmp(&right.namespace()))
+        .then_with(|| left.generation().cmp(&right.generation()))
+        .then_with(|| left.value().cmp(&right.value()))
+}
+
+fn validate_lookup_entries(
+    entries: &[CapabilityLookupEntry],
+) -> Result<(), CapabilityLookupBuildError> {
+    for pair in entries.windows(2) {
+        match compare_capability_refs(pair[0].reference(), pair[1].reference()) {
+            core::cmp::Ordering::Less => {}
+            core::cmp::Ordering::Equal => {
+                return Err(CapabilityLookupBuildError::DuplicateReference);
+            }
+            core::cmp::Ordering::Greater => {
+                return Err(CapabilityLookupBuildError::UnsortedEntries);
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub const fn required_capability_for_call(call: HostCallId) -> CapabilityKind {

--- a/crates/prom-cap/tests/capability_lookup.rs
+++ b/crates/prom-cap/tests/capability_lookup.rs
@@ -1,0 +1,343 @@
+use prom_cap::{
+    CapabilityKind, CapabilityLookupBuildError, CapabilityLookupEntry, CapabilityLookupError,
+    CapabilityLookupView,
+};
+use prom_refs::{CapabilityRef, ReferenceToken};
+
+fn reference(issuer: u64, namespace: u32, generation: u32, value: u64) -> CapabilityRef {
+    CapabilityRef::new(ReferenceToken::new(issuer, namespace, generation, value))
+}
+
+fn entry(
+    issuer: u64,
+    namespace: u32,
+    generation: u32,
+    value: u64,
+    kind: CapabilityKind,
+) -> CapabilityLookupEntry {
+    CapabilityLookupEntry::new(reference(issuer, namespace, generation, value), kind)
+}
+
+#[test]
+fn lookup_view_try_new_accepts_empty_slice() {
+    let entries: [CapabilityLookupEntry; 0] = [];
+    let view = CapabilityLookupView::try_new(&entries).expect("empty slice must be valid");
+    assert_eq!(
+        view.lookup(reference(1, 0, 0, 0)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_view_try_new_accepts_single_entry() {
+    let entries = [entry(1, 0, 0, 1, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("single entry must be valid");
+    assert_eq!(
+        view.lookup(reference(1, 0, 0, 1))
+            .expect("exact hit must succeed")
+            .kind(),
+        CapabilityKind::GateRead
+    );
+}
+
+#[test]
+fn lookup_view_try_new_accepts_strictly_sorted_entries() {
+    let entries = [
+        entry(1, 0, 0, 1, CapabilityKind::GateRead),
+        entry(2, 0, 0, 0, CapabilityKind::GateWrite),
+        entry(2, 1, 0, 0, CapabilityKind::PulseEmit),
+        entry(2, 1, 1, 0, CapabilityKind::StateQuery),
+        entry(2, 1, 1, 1, CapabilityKind::StateUpdate),
+    ];
+
+    CapabilityLookupView::try_new(&entries).expect("strict full-key ordering must be valid");
+}
+
+#[test]
+fn lookup_view_try_new_rejects_duplicate_full_key() {
+    let entries = [
+        entry(1, 0, 0, 1, CapabilityKind::GateRead),
+        entry(1, 0, 0, 1, CapabilityKind::GateWrite),
+    ];
+
+    assert!(matches!(
+        CapabilityLookupView::try_new(&entries),
+        Err(CapabilityLookupBuildError::DuplicateReference)
+    ));
+}
+
+#[test]
+fn lookup_view_try_new_rejects_descending_full_key() {
+    let entries = [
+        entry(2, 0, 0, 0, CapabilityKind::GateWrite),
+        entry(1, 9, 9, 9, CapabilityKind::GateRead),
+    ];
+
+    assert!(matches!(
+        CapabilityLookupView::try_new(&entries),
+        Err(CapabilityLookupBuildError::UnsortedEntries)
+    ));
+}
+
+#[test]
+fn lookup_view_try_new_reports_first_invalid_adjacent_pair() {
+    let entries = [
+        entry(2, 0, 0, 0, CapabilityKind::GateWrite),
+        entry(1, 0, 0, 0, CapabilityKind::GateRead),
+        entry(1, 0, 0, 0, CapabilityKind::PulseEmit),
+    ];
+
+    assert!(matches!(
+        CapabilityLookupView::try_new(&entries),
+        Err(CapabilityLookupBuildError::UnsortedEntries)
+    ));
+}
+
+#[test]
+fn lookup_view_try_new_classifies_equal_pair_as_duplicate() {
+    let entries = [
+        entry(1, 0, 0, 0, CapabilityKind::GateRead),
+        entry(1, 0, 0, 0, CapabilityKind::PulseEmit),
+        entry(2, 0, 0, 0, CapabilityKind::GateWrite),
+    ];
+
+    assert!(matches!(
+        CapabilityLookupView::try_new(&entries),
+        Err(CapabilityLookupBuildError::DuplicateReference)
+    ));
+}
+
+#[test]
+fn lookup_view_try_new_ignores_later_invalid_pairs_after_first() {
+    let entries = [
+        entry(1, 0, 0, 0, CapabilityKind::GateRead),
+        entry(1, 0, 0, 0, CapabilityKind::GateWrite),
+        entry(0, 9, 9, 9, CapabilityKind::PulseEmit),
+    ];
+
+    assert!(matches!(
+        CapabilityLookupView::try_new(&entries),
+        Err(CapabilityLookupBuildError::DuplicateReference)
+    ));
+}
+
+#[test]
+fn lookup_returns_exact_full_key_hit() {
+    let entries = [
+        entry(1, 0, 0, 1, CapabilityKind::GateRead),
+        entry(1, 0, 0, 2, CapabilityKind::GateWrite),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(1, 0, 0, 2))
+            .expect("exact hit must succeed")
+            .kind(),
+        CapabilityKind::GateWrite
+    );
+}
+
+#[test]
+fn lookup_rejects_unknown_issuer() {
+    let entries = [entry(1, 7, 8, 9, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(2, 7, 8, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_rejects_unknown_namespace() {
+    let entries = [entry(1, 7, 8, 9, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(1, 8, 8, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_rejects_unknown_generation() {
+    let entries = [entry(1, 7, 8, 9, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(1, 7, 9, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_rejects_unknown_value() {
+    let entries = [entry(1, 7, 8, 9, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(1, 7, 8, 10)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_same_value_different_issuer_does_not_alias() {
+    let entries = [
+        entry(1, 7, 8, 9, CapabilityKind::GateRead),
+        entry(2, 7, 8, 9, CapabilityKind::GateWrite),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(2, 7, 8, 9))
+            .expect("exact issuer match must succeed")
+            .kind(),
+        CapabilityKind::GateWrite
+    );
+    assert_eq!(
+        view.lookup(reference(3, 7, 8, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_same_value_different_namespace_does_not_alias() {
+    let entries = [
+        entry(2, 7, 8, 9, CapabilityKind::GateRead),
+        entry(2, 8, 8, 9, CapabilityKind::GateWrite),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(2, 8, 8, 9))
+            .expect("exact namespace match must succeed")
+            .kind(),
+        CapabilityKind::GateWrite
+    );
+    assert_eq!(
+        view.lookup(reference(2, 9, 8, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_same_value_different_generation_does_not_fallback() {
+    let entries = [
+        entry(2, 8, 7, 9, CapabilityKind::GateRead),
+        entry(2, 8, 8, 9, CapabilityKind::GateWrite),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+
+    assert_eq!(
+        view.lookup(reference(2, 8, 8, 9))
+            .expect("exact generation match must succeed")
+            .kind(),
+        CapabilityKind::GateWrite
+    );
+    assert_eq!(
+        view.lookup(reference(2, 8, 9, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_returns_entry_with_exact_reference_and_kind() {
+    let expected = reference(5, 6, 7, 8);
+    let entries = [
+        entry(1, 0, 0, 1, CapabilityKind::GateRead),
+        CapabilityLookupEntry::new(expected, CapabilityKind::StateUpdate),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+    let hit = view.lookup(expected).expect("exact hit must succeed");
+
+    assert_eq!(hit.reference(), expected);
+    assert_eq!(hit.kind(), CapabilityKind::StateUpdate);
+}
+
+#[test]
+fn lookup_repeated_hit_is_deterministic() {
+    let expected = reference(5, 6, 7, 8);
+    let entries = [
+        entry(1, 0, 0, 1, CapabilityKind::GateRead),
+        CapabilityLookupEntry::new(expected, CapabilityKind::StateUpdate),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+    let first = view.lookup(expected).expect("first hit must succeed");
+    let second = view.lookup(expected).expect("second hit must succeed");
+
+    assert_eq!(first.reference(), second.reference());
+    assert_eq!(first.kind(), second.kind());
+    assert!(core::ptr::eq(first, second));
+}
+
+#[test]
+fn lookup_repeated_miss_is_deterministic() {
+    let entries = [entry(1, 0, 0, 1, CapabilityKind::GateRead)];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+    let missing = reference(9, 9, 9, 9);
+
+    assert_eq!(
+        view.lookup(missing),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+    assert_eq!(
+        view.lookup(missing),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+}
+
+#[test]
+fn lookup_result_is_non_authoritative_entry_only() {
+    let expected = reference(5, 6, 7, 8);
+    let entries = [CapabilityLookupEntry::new(
+        expected,
+        CapabilityKind::ControlledObservationSink,
+    )];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+    let hit = view.lookup(expected).expect("exact hit must succeed");
+
+    let borrowed: &CapabilityLookupEntry = hit;
+    assert_eq!(borrowed.reference(), expected);
+    assert_eq!(borrowed.kind(), CapabilityKind::ControlledObservationSink);
+}
+
+#[test]
+fn capability_lookup_public_api_contract_compiles() {
+    let entries = [
+        CapabilityLookupEntry::new(reference(1, 0, 0, 1), CapabilityKind::GateRead),
+        CapabilityLookupEntry::new(reference(1, 0, 0, 2), CapabilityKind::GateWrite),
+    ];
+    let view = CapabilityLookupView::try_new(&entries).expect("view must build");
+    let hit = view
+        .lookup(reference(1, 0, 0, 1))
+        .expect("approved public lookup API must compile");
+
+    assert_eq!(hit.reference(), reference(1, 0, 0, 1));
+    assert_eq!(hit.kind(), CapabilityKind::GateRead);
+    assert_eq!(
+        view.lookup(reference(9, 9, 9, 9)),
+        Err(CapabilityLookupError::UnknownReference)
+    );
+    assert_eq!(
+        CapabilityLookupBuildError::DuplicateReference,
+        CapabilityLookupBuildError::DuplicateReference
+    );
+    assert_eq!(
+        CapabilityLookupBuildError::UnsortedEntries,
+        CapabilityLookupBuildError::UnsortedEntries
+    );
+}
+
+#[test]
+fn capability_lookup_entry_const_construction_compiles() {
+    const TOKEN: ReferenceToken = ReferenceToken::new(7, 8, 9, 10);
+    const REFERENCE: CapabilityRef = CapabilityRef::new(TOKEN);
+    const ENTRY: CapabilityLookupEntry =
+        CapabilityLookupEntry::new(REFERENCE, CapabilityKind::GateRead);
+    const ENTRY_REFERENCE: CapabilityRef = ENTRY.reference();
+    const ENTRY_KIND: CapabilityKind = ENTRY.kind();
+
+    assert_eq!(ENTRY_REFERENCE, REFERENCE);
+    assert_eq!(ENTRY_KIND, CapabilityKind::GateRead);
+}

--- a/tests/golden_snapshots/public_api/prom_cap_lib.txt
+++ b/tests/golden_snapshots/public_api/prom_cap_lib.txt
@@ -2,6 +2,19 @@ source: crates/prom-cap/src/lib.rs
 pub mod hello_observation_capability;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CapabilityKind {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityLookupEntry {
+pub const fn new(reference: CapabilityRef, kind: CapabilityKind) -> Self {
+pub const fn reference(&self) -> CapabilityRef {
+pub const fn kind(&self) -> CapabilityKind {
+#[derive(Debug, Clone, Copy)]
+pub struct CapabilityLookupView<'a> {
+pub fn try_new( entries: &'a [CapabilityLookupEntry], ) -> Result<Self, CapabilityLookupBuildError> {
+pub fn lookup( &self, reference: CapabilityRef, ) -> Result<&CapabilityLookupEntry, CapabilityLookupError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityLookupError {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityLookupBuildError {
 pub const fn required_capability_for_call(call: HostCallId) -> CapabilityKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilitySurfaceClass {

--- a/tests/trust_boundary_guards.rs
+++ b/tests/trust_boundary_guards.rs
@@ -25,12 +25,12 @@ fn prom_cap_dependency_boundaries() {
         "prom-cap MUST NOT depend on prom-ui"
     );
 
-    // prom-cap must depend only on prom-abi among prom-* crates unless explicitly allowed
+    // prom-cap may depend only on prom-abi and prom-refs among prom-* crates.
     for line in tree.lines() {
         if line.contains("prom-") && !line.contains("prom-cap") {
             assert!(
-                line.contains("prom-abi"),
-                "prom-cap is only allowed to depend on prom-abi among prom-* crates, but found: {}",
+                line.contains("prom-abi") || line.contains("prom-refs"),
+                "prom-cap is only allowed to depend on prom-abi and prom-refs among prom-* crates, but found: {}",
                 line
             );
         }


### PR DESCRIPTION
## Summary

Implements the reviewed minimal D0E capability-reference lookup contract in
`prom-cap`.

### Implementation

- adds the single permitted dependency edge `prom-cap -> prom-refs`;
- adds `CapabilityLookupEntry`;
- adds immutable borrowed `CapabilityLookupView<'a>`;
- adds deterministic adjacent-pair construction validation;
- adds exact allocation-free linear lookup;
- collapses all misses to `CapabilityLookupError::UnknownReference`;
- keeps duplicate and unsorted construction failures separate;
- returns the exact stored non-authoritative entry;
- introduces no mutable registry or generic resolver.

### Tests and guards

- adds 22 focused capability lookup tests;
- updates the `prom-cap` dependency allow-list to exactly `prom-abi` and
  `prom-refs`;
- updates the `prom-cap` public API snapshot;
- preserves the authority separation between lookup, grant, admission,
  dispatch, and effects.

### Repository CI

GitHub CI passed on the current PR head:

- `boundary-enforcement`
- `check-no-std`
- `pcc-qualification-7hell`
- `pr-ready`
- `public-api-guard`
- `release-bundle-process`
- `runtime-release-gates`
- `test-std`

The repository's tracked CI and release scripts run Cargo without `--locked`.
The root `Cargo.lock` is intentionally ignored by the committed repository
policy and has never been tracked.

### Additional local validation

After Cargo generated the repository-ignored local root `Cargo.lock`, the
following additional local checks passed:

- `cargo metadata --locked --format-version 1`
- `cargo test --locked -p prom-cap` — 30 passed
- `cargo test --locked -p prom-refs` — 11 passed
- `cargo test --locked --test trust_boundary_guards`
- `cargo test --locked --test public_api_contracts`
- `cargo test --locked --workspace`
- `cargo +1.93.1 fmt --all --check`
- `cargo +1.93.1 clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check`

These `--locked` results are local-environment evidence. They are not a claim
that a clean checkout can run `--locked` before Cargo generates its ignored
local lockfile.

A clean tracked checkout of both the accepted base and this candidate initially
rejects `cargo metadata --locked` because the repository intentionally contains
no tracked root lockfile. Tracking the root lockfile would be a separate
repository-wide policy change and is outside this bounded D0E slice.

Known baseline defect, unchanged and outside this slice:

- with the generated ignored local lockfile,
  `cargo check --locked -p prom-cap --no-default-features` fails only on the
  existing missing `alloc::format` import in `crates/prom-cap/src/lib.rs`;
- no D0E-originated no-default-features failure was introduced.

### Boundaries

- lookup is non-authoritative;
- possession or successful lookup grants no capability;
- no `CapabilityDenied` reuse;
- no `ResolvedCapability`;
- no generic resolver;
- no mutation, revocation, persistence, synchronization, runtime, UI,
  admission, dispatch, or effect integration;
- no whole-crate `no_std` qualification claim;
- no root `Cargo.lock` policy change.

### Gates

- D0E minimal implementation candidate: independently reviewed
- Cargo.lock policy audit: complete
- Gate D activation/integration: closed
- mutable registry: unauthorized
- generic resolver: unauthorized
- runtime integration: unauthorized
- UI integration: unauthorized
- other reference-domain resolution: unauthorized
