### PR TITLE
feat(ui): add projection patch contract foundation

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -61,6 +61,7 @@ pub mod prepared_effect;
 pub mod prepared_effect_result;
 pub mod projection;
 pub(crate) mod projection_compile;
+pub(crate) mod projection_patch;
 pub(crate) mod projection_source;
 pub mod raw_event;
 pub mod renderer;
@@ -81,6 +82,8 @@ pub mod validation;
 mod ui_dna2_wp2_qualification_tests;
 #[cfg(test)]
 mod ui_dna2_wp3_qualification_tests;
+#[cfg(test)]
+mod ui_dna2_wp4_qualification_tests;
 
 pub use action_admission::{
     describe_interaction_action_admission, InteractionActionAdmissionCapabilityRequirement,

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -478,12 +478,8 @@ fn validate_patch(
         }
 
         match operation {
-            ProjectionPatchOperation::CollectionInsert {
-                key, before, ..
-            }
-            | ProjectionPatchOperation::CollectionMove {
-                key, before, ..
-            } => {
+            ProjectionPatchOperation::CollectionInsert { key, before, .. }
+            | ProjectionPatchOperation::CollectionMove { key, before, .. } => {
                 if before == &Some(*key) {
                     diagnostics.push(ProjectionPatchDiagnostic::new(
                         ProjectionPatchDiagnosticKind::CollectionBeforeSelf,
@@ -562,18 +558,18 @@ fn validate_patch_set(patches: &[ProjectionPatch]) -> ProjectionPatchDiagnostics
                 {
                     core::cmp::Ordering::Equal => {
                         diagnostics.push(ProjectionPatchDiagnostic::new(
-                    ProjectionPatchDiagnosticKind::DuplicateSequence,
-                    current.envelope().patch_id().raw(),
-                    current.envelope().sequence().raw(),
-                ));
+                            ProjectionPatchDiagnosticKind::DuplicateSequence,
+                            current.envelope().patch_id().raw(),
+                            current.envelope().sequence().raw(),
+                        ));
                         sequence_chain_valid = false;
                     }
                     core::cmp::Ordering::Less => {
                         diagnostics.push(ProjectionPatchDiagnostic::new(
-                    ProjectionPatchDiagnosticKind::OutOfOrderSequence,
-                    current.envelope().patch_id().raw(),
-                    current.envelope().sequence().raw(),
-                ));
+                            ProjectionPatchDiagnosticKind::OutOfOrderSequence,
+                            current.envelope().patch_id().raw(),
+                            current.envelope().sequence().raw(),
+                        ));
                         sequence_chain_valid = false;
                     }
                     core::cmp::Ordering::Greater if current.envelope().sequence() != expected => {
@@ -627,13 +623,13 @@ fn mutation_target(operation: &ProjectionPatchOperation) -> Option<MutationTarge
             collection: *collection,
             key: *key,
         }),
-        ProjectionPatchOperation::CollectionRemove { collection, key } => Some(
-            MutationTarget::CollectionItem {
+        ProjectionPatchOperation::CollectionRemove { collection, key } => {
+            Some(MutationTarget::CollectionItem {
                 kind: CollectionOperationKind::Remove,
                 collection: *collection,
                 key: *key,
-            },
-        ),
+            })
+        }
         ProjectionPatchOperation::CollectionMove {
             collection, key, ..
         } => Some(MutationTarget::CollectionItem {

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -413,9 +413,18 @@ enum MutationTarget {
         node: StaticNodeId,
     },
     CollectionItem {
+        kind: CollectionOperationKind,
         collection: StaticNodeId,
         key: CollectionKey,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum CollectionOperationKind {
+    Insert,
+    Update,
+    Remove,
+    Move,
 }
 
 fn validate_patch(
@@ -606,14 +615,29 @@ fn mutation_target(operation: &ProjectionPatchOperation) -> Option<MutationTarge
         }
         ProjectionPatchOperation::CollectionInsert {
             collection, key, ..
-        }
-        | ProjectionPatchOperation::CollectionUpdate {
-            collection, key, ..
-        }
-        | ProjectionPatchOperation::CollectionRemove { collection, key }
-        | ProjectionPatchOperation::CollectionMove {
+        } => Some(MutationTarget::CollectionItem {
+            kind: CollectionOperationKind::Insert,
+            collection: *collection,
+            key: *key,
+        }),
+        ProjectionPatchOperation::CollectionUpdate {
             collection, key, ..
         } => Some(MutationTarget::CollectionItem {
+            kind: CollectionOperationKind::Update,
+            collection: *collection,
+            key: *key,
+        }),
+        ProjectionPatchOperation::CollectionRemove { collection, key } => Some(
+            MutationTarget::CollectionItem {
+                kind: CollectionOperationKind::Remove,
+                collection: *collection,
+                key: *key,
+            },
+        ),
+        ProjectionPatchOperation::CollectionMove {
+            collection, key, ..
+        } => Some(MutationTarget::CollectionItem {
+            kind: CollectionOperationKind::Move,
             collection: *collection,
             key: *key,
         }),

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -87,6 +87,7 @@ pub(crate) struct ProjectionPatchEnvelope {
 }
 
 impl ProjectionPatchEnvelope {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) const fn new(
         patch_id: ProjectionPatchId,
         stream_id: ProjectionPatchStreamId,

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -645,9 +645,7 @@ fn sort_and_dedup_diagnostics(
     mut diagnostics: ProjectionPatchDiagnostics,
 ) -> ProjectionPatchDiagnostics {
     diagnostics.sort();
-    diagnostics.dedup_by(|right, left| {
-        right.coordinate().code().as_str() == left.coordinate().code().as_str()
-    });
+    diagnostics.dedup();
     diagnostics
 }
 

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -1,0 +1,715 @@
+//! UI DNA v2 projection patch contract foundation.
+//!
+//! This module defines inert, deterministic projection patch values and
+//! structural validation only. It does not own Semantic truth, admission,
+//! dispatch, runtime execution, shell mutation, or renderer commands.
+#![allow(dead_code)]
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::binding_graph::BindingTarget;
+use crate::contract_primitives::{
+    CollectionKey, DiagnosticCode, DiagnosticCoordinate, Epoch, Revision, StaticDocumentId,
+    StaticNodeId, StaticSurfaceId,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionPatchId(u64);
+
+impl ProjectionPatchId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ProjectionPatchIdentityError> {
+        if raw == 0 {
+            Err(ProjectionPatchIdentityError::ZeroPatchId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionPatchStreamId(u64);
+
+impl ProjectionPatchStreamId {
+    pub(crate) const fn new(raw: u64) -> Result<Self, ProjectionPatchIdentityError> {
+        if raw == 0 {
+            Err(ProjectionPatchIdentityError::ZeroStreamId)
+        } else {
+            Ok(Self(raw))
+        }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionPatchSequence(u64);
+
+impl ProjectionPatchSequence {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.0
+    }
+
+    const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectionPatchIdentityError {
+    ZeroPatchId,
+    ZeroStreamId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionPatchEnvelope {
+    patch_id: ProjectionPatchId,
+    stream_id: ProjectionPatchStreamId,
+    document_id: StaticDocumentId,
+    surface_id: Option<StaticSurfaceId>,
+    previous_projection_revision: Revision,
+    projection_revision: Revision,
+    epoch: Epoch,
+    sequence: ProjectionPatchSequence,
+}
+
+impl ProjectionPatchEnvelope {
+    pub(crate) const fn new(
+        patch_id: ProjectionPatchId,
+        stream_id: ProjectionPatchStreamId,
+        document_id: StaticDocumentId,
+        surface_id: Option<StaticSurfaceId>,
+        previous_projection_revision: Revision,
+        projection_revision: Revision,
+        epoch: Epoch,
+        sequence: ProjectionPatchSequence,
+    ) -> Self {
+        Self {
+            patch_id,
+            stream_id,
+            document_id,
+            surface_id,
+            previous_projection_revision,
+            projection_revision,
+            epoch,
+            sequence,
+        }
+    }
+
+    pub(crate) const fn patch_id(self) -> ProjectionPatchId {
+        self.patch_id
+    }
+
+    pub(crate) const fn stream_id(self) -> ProjectionPatchStreamId {
+        self.stream_id
+    }
+
+    pub(crate) const fn document_id(self) -> StaticDocumentId {
+        self.document_id
+    }
+
+    pub(crate) const fn surface_id(self) -> Option<StaticSurfaceId> {
+        self.surface_id
+    }
+
+    pub(crate) const fn previous_projection_revision(self) -> Revision {
+        self.previous_projection_revision
+    }
+
+    pub(crate) const fn projection_revision(self) -> Revision {
+        self.projection_revision
+    }
+
+    pub(crate) const fn epoch(self) -> Epoch {
+        self.epoch
+    }
+
+    pub(crate) const fn sequence(self) -> ProjectionPatchSequence {
+        self.sequence
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionQuadState {
+    N,
+    F,
+    T,
+    S,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionPatchValue {
+    Quad(ProjectionQuadState),
+    SignedScalar(i64),
+    Text(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionNodeAvailability {
+    Available,
+    Unavailable,
+    Hidden,
+    Pending,
+    Stale,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionPatchOperation {
+    SetBindingValue {
+        target: BindingTarget,
+        value: ProjectionPatchValue,
+    },
+    SetNodeAvailability {
+        node: StaticNodeId,
+        availability: ProjectionNodeAvailability,
+    },
+    CollectionInsert {
+        collection: StaticNodeId,
+        key: CollectionKey,
+        before: Option<CollectionKey>,
+        value: ProjectionPatchValue,
+    },
+    CollectionUpdate {
+        collection: StaticNodeId,
+        key: CollectionKey,
+        value: ProjectionPatchValue,
+    },
+    CollectionRemove {
+        collection: StaticNodeId,
+        key: CollectionKey,
+    },
+    CollectionMove {
+        collection: StaticNodeId,
+        key: CollectionKey,
+        before: Option<CollectionKey>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectionPatch {
+    envelope: ProjectionPatchEnvelope,
+    operations: Vec<ProjectionPatchOperation>,
+}
+
+impl ProjectionPatch {
+    pub(crate) fn new(
+        envelope: ProjectionPatchEnvelope,
+        operations: Vec<ProjectionPatchOperation>,
+    ) -> Result<Self, ProjectionPatchDiagnostics> {
+        let diagnostics = validate_patch(envelope, &operations);
+        if diagnostics.is_empty() {
+            Ok(Self {
+                envelope,
+                operations,
+            })
+        } else {
+            Err(diagnostics)
+        }
+    }
+
+    pub(crate) const fn envelope(&self) -> ProjectionPatchEnvelope {
+        self.envelope
+    }
+
+    pub(crate) fn operations(&self) -> &[ProjectionPatchOperation] {
+        &self.operations
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectionPatchSet {
+    patches: Vec<ProjectionPatch>,
+}
+
+impl ProjectionPatchSet {
+    pub(crate) fn new(patches: Vec<ProjectionPatch>) -> Result<Self, ProjectionPatchDiagnostics> {
+        let diagnostics = validate_patch_set(&patches);
+        if diagnostics.is_empty() {
+            Ok(Self { patches })
+        } else {
+            Err(diagnostics)
+        }
+    }
+
+    pub(crate) fn patches(&self) -> &[ProjectionPatch] {
+        &self.patches
+    }
+
+    /// Internal deterministic qualification encoding only.
+    ///
+    /// This is not a public serialization format, bundle artifact, ABI,
+    /// cryptographic digest, signature, or compatibility promise.
+    pub(crate) fn canonical_bytes(&self) -> Result<Vec<u8>, ProjectionPatchEncodingError> {
+        let mut bytes = Vec::new();
+        push_bytes(&mut bytes, b"UI_DNA2_PROJECTION_PATCH_V1")?;
+        push_len(&mut bytes, self.patches.len())?;
+        for patch in &self.patches {
+            let envelope = patch.envelope();
+            push_u64(&mut bytes, envelope.patch_id().raw());
+            push_u64(&mut bytes, envelope.stream_id().raw());
+            push_u64(&mut bytes, envelope.document_id().raw());
+            push_optional_u64(&mut bytes, envelope.surface_id().map(StaticSurfaceId::raw));
+            push_u64(&mut bytes, envelope.previous_projection_revision().raw());
+            push_u64(&mut bytes, envelope.projection_revision().raw());
+            push_u64(&mut bytes, envelope.epoch().raw());
+            push_u64(&mut bytes, envelope.sequence().raw());
+            push_len(&mut bytes, patch.operations().len())?;
+            for operation in patch.operations() {
+                match operation {
+                    ProjectionPatchOperation::SetBindingValue { target, value } => {
+                        push_u8(&mut bytes, 1);
+                        push_u64(&mut bytes, target.node.raw());
+                        push_u32(&mut bytes, target.slot.0);
+                        push_value(&mut bytes, value)?;
+                    }
+                    ProjectionPatchOperation::SetNodeAvailability { node, availability } => {
+                        push_u8(&mut bytes, 2);
+                        push_u64(&mut bytes, node.raw());
+                        push_u8(&mut bytes, availability_tag(*availability));
+                    }
+                    ProjectionPatchOperation::CollectionInsert {
+                        collection,
+                        key,
+                        before,
+                        value,
+                    } => {
+                        push_u8(&mut bytes, 3);
+                        push_u64(&mut bytes, collection.raw());
+                        push_u64(&mut bytes, key.raw());
+                        push_optional_u64(&mut bytes, before.map(CollectionKey::raw));
+                        push_value(&mut bytes, value)?;
+                    }
+                    ProjectionPatchOperation::CollectionUpdate {
+                        collection,
+                        key,
+                        value,
+                    } => {
+                        push_u8(&mut bytes, 4);
+                        push_u64(&mut bytes, collection.raw());
+                        push_u64(&mut bytes, key.raw());
+                        push_value(&mut bytes, value)?;
+                    }
+                    ProjectionPatchOperation::CollectionRemove { collection, key } => {
+                        push_u8(&mut bytes, 5);
+                        push_u64(&mut bytes, collection.raw());
+                        push_u64(&mut bytes, key.raw());
+                    }
+                    ProjectionPatchOperation::CollectionMove {
+                        collection,
+                        key,
+                        before,
+                    } => {
+                        push_u8(&mut bytes, 6);
+                        push_u64(&mut bytes, collection.raw());
+                        push_u64(&mut bytes, key.raw());
+                        push_optional_u64(&mut bytes, before.map(CollectionKey::raw));
+                    }
+                }
+            }
+        }
+        Ok(bytes)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProjectionPatchDiagnosticKind {
+    ZeroPatchId,
+    ZeroStreamId,
+    EmptyOperations,
+    DuplicatePatchId,
+    MixedStream,
+    MixedDocument,
+    MixedEpoch,
+    NonIncreasingRevision,
+    BrokenRevisionChain,
+    DuplicateSequence,
+    OutOfOrderSequence,
+    SequenceOverflow,
+    DuplicateMutationTarget,
+    CollectionBeforeSelf,
+}
+
+impl ProjectionPatchDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::ZeroPatchId => DiagnosticCode::new("PP_ZERO_PATCH_ID"),
+            Self::ZeroStreamId => DiagnosticCode::new("PP_ZERO_STREAM_ID"),
+            Self::EmptyOperations => DiagnosticCode::new("PP_EMPTY_OPERATIONS"),
+            Self::DuplicatePatchId => DiagnosticCode::new("PP_DUP_PATCH_ID"),
+            Self::MixedStream => DiagnosticCode::new("PP_MIXED_STREAM"),
+            Self::MixedDocument => DiagnosticCode::new("PP_MIXED_DOCUMENT"),
+            Self::MixedEpoch => DiagnosticCode::new("PP_MIXED_EPOCH"),
+            Self::NonIncreasingRevision => DiagnosticCode::new("PP_NON_INCREASING_REVISION"),
+            Self::BrokenRevisionChain => DiagnosticCode::new("PP_BROKEN_REVISION_CHAIN"),
+            Self::DuplicateSequence => DiagnosticCode::new("PP_DUP_SEQUENCE"),
+            Self::OutOfOrderSequence => DiagnosticCode::new("PP_OUT_OF_ORDER_SEQUENCE"),
+            Self::SequenceOverflow => DiagnosticCode::new("PP_SEQUENCE_OVERFLOW"),
+            Self::DuplicateMutationTarget => DiagnosticCode::new("PP_DUP_MUTATION_TARGET"),
+            Self::CollectionBeforeSelf => DiagnosticCode::new("PP_COLLECTION_BEFORE_SELF"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionPatchDiagnostic {
+    coordinate: DiagnosticCoordinate,
+}
+
+impl ProjectionPatchDiagnostic {
+    pub(crate) const fn new(
+        code: ProjectionPatchDiagnosticKind,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(None, code.code(), domain, secondary),
+        }
+    }
+
+    pub(crate) const fn coordinate(&self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+}
+
+impl Ord for ProjectionPatchDiagnostic {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.coordinate.cmp(&other.coordinate)
+    }
+}
+
+impl PartialOrd for ProjectionPatchDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub(crate) type ProjectionPatchDiagnostics = Vec<ProjectionPatchDiagnostic>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectionPatchEncodingError {
+    LengthOverflow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum MutationTarget {
+    Binding {
+        node: StaticNodeId,
+        slot: u32,
+    },
+    NodeAvailability {
+        node: StaticNodeId,
+    },
+    CollectionItem {
+        collection: StaticNodeId,
+        key: CollectionKey,
+    },
+}
+
+fn validate_patch(
+    envelope: ProjectionPatchEnvelope,
+    operations: &[ProjectionPatchOperation],
+) -> ProjectionPatchDiagnostics {
+    let mut diagnostics = Vec::new();
+
+    if envelope.patch_id().raw() == 0 {
+        diagnostics.push(ProjectionPatchDiagnostic::new(
+            ProjectionPatchDiagnosticKind::ZeroPatchId,
+            envelope.patch_id().raw(),
+            0,
+        ));
+    }
+    if envelope.stream_id().raw() == 0 {
+        diagnostics.push(ProjectionPatchDiagnostic::new(
+            ProjectionPatchDiagnosticKind::ZeroStreamId,
+            envelope.patch_id().raw(),
+            0,
+        ));
+    }
+    if envelope.projection_revision().raw() <= envelope.previous_projection_revision().raw() {
+        diagnostics.push(ProjectionPatchDiagnostic::new(
+            ProjectionPatchDiagnosticKind::NonIncreasingRevision,
+            envelope.patch_id().raw(),
+            0,
+        ));
+    }
+    if operations.is_empty() {
+        diagnostics.push(ProjectionPatchDiagnostic::new(
+            ProjectionPatchDiagnosticKind::EmptyOperations,
+            envelope.patch_id().raw(),
+            0,
+        ));
+    }
+
+    let mut seen_targets = Vec::new();
+    for (index, operation) in operations.iter().enumerate() {
+        let op_index = u64::try_from(index).unwrap_or(u64::MAX);
+        if let Some(target) = mutation_target(operation) {
+            if seen_targets.contains(&target) {
+                diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::DuplicateMutationTarget,
+                    envelope.patch_id().raw(),
+                    op_index,
+                ));
+            } else {
+                seen_targets.push(target);
+            }
+        }
+
+        match operation {
+            ProjectionPatchOperation::CollectionInsert {
+                key, before, ..
+            }
+            | ProjectionPatchOperation::CollectionMove {
+                key, before, ..
+            } => {
+                if before == &Some(*key) {
+                    diagnostics.push(ProjectionPatchDiagnostic::new(
+                        ProjectionPatchDiagnosticKind::CollectionBeforeSelf,
+                        envelope.patch_id().raw(),
+                        op_index,
+                    ));
+                }
+            }
+            ProjectionPatchOperation::SetBindingValue { .. }
+            | ProjectionPatchOperation::SetNodeAvailability { .. }
+            | ProjectionPatchOperation::CollectionUpdate { .. }
+            | ProjectionPatchOperation::CollectionRemove { .. } => {}
+        }
+    }
+
+    sort_and_dedup_diagnostics(diagnostics)
+}
+
+fn validate_patch_set(patches: &[ProjectionPatch]) -> ProjectionPatchDiagnostics {
+    let mut diagnostics = Vec::new();
+
+    for (index, patch) in patches.iter().enumerate() {
+        if patches[..index]
+            .iter()
+            .any(|previous| previous.envelope().patch_id() == patch.envelope().patch_id())
+        {
+            diagnostics.push(ProjectionPatchDiagnostic::new(
+                ProjectionPatchDiagnosticKind::DuplicatePatchId,
+                patch.envelope().patch_id().raw(),
+                patch.envelope().sequence().raw(),
+            ));
+        }
+
+        if index > 0 {
+            let previous = &patches[index - 1];
+            let current = patch;
+            let mut sequence_chain_valid = true;
+
+            if current.envelope().stream_id() != previous.envelope().stream_id() {
+                diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::MixedStream,
+                    current.envelope().patch_id().raw(),
+                    previous.envelope().patch_id().raw(),
+                ));
+            }
+
+            if current.envelope().document_id() != previous.envelope().document_id() {
+                diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::MixedDocument,
+                    current.envelope().patch_id().raw(),
+                    previous.envelope().patch_id().raw(),
+                ));
+            }
+
+            if current.envelope().epoch() != previous.envelope().epoch() {
+                diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::MixedEpoch,
+                    current.envelope().patch_id().raw(),
+                    previous.envelope().patch_id().raw(),
+                ));
+            }
+
+            match previous.envelope().sequence().checked_next() {
+                None => {
+                    diagnostics.push(ProjectionPatchDiagnostic::new(
+                        ProjectionPatchDiagnosticKind::SequenceOverflow,
+                        previous.envelope().patch_id().raw(),
+                        previous.envelope().sequence().raw(),
+                    ));
+                    sequence_chain_valid = false;
+                }
+                Some(expected) => match current
+                    .envelope()
+                    .sequence()
+                    .cmp(&previous.envelope().sequence())
+                {
+                    core::cmp::Ordering::Equal => {
+                        diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::DuplicateSequence,
+                    current.envelope().patch_id().raw(),
+                    current.envelope().sequence().raw(),
+                ));
+                        sequence_chain_valid = false;
+                    }
+                    core::cmp::Ordering::Less => {
+                        diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::OutOfOrderSequence,
+                    current.envelope().patch_id().raw(),
+                    current.envelope().sequence().raw(),
+                ));
+                        sequence_chain_valid = false;
+                    }
+                    core::cmp::Ordering::Greater if current.envelope().sequence() != expected => {
+                        diagnostics.push(ProjectionPatchDiagnostic::new(
+                            ProjectionPatchDiagnosticKind::OutOfOrderSequence,
+                            current.envelope().patch_id().raw(),
+                            current.envelope().sequence().raw(),
+                        ));
+                        sequence_chain_valid = false;
+                    }
+                    core::cmp::Ordering::Greater => {}
+                },
+            }
+
+            if sequence_chain_valid
+                && current.envelope().previous_projection_revision()
+                    != previous.envelope().projection_revision()
+            {
+                diagnostics.push(ProjectionPatchDiagnostic::new(
+                    ProjectionPatchDiagnosticKind::BrokenRevisionChain,
+                    current.envelope().patch_id().raw(),
+                    previous.envelope().patch_id().raw(),
+                ));
+            }
+        }
+    }
+
+    sort_and_dedup_diagnostics(diagnostics)
+}
+
+fn mutation_target(operation: &ProjectionPatchOperation) -> Option<MutationTarget> {
+    match operation {
+        ProjectionPatchOperation::SetBindingValue { target, .. } => Some(MutationTarget::Binding {
+            node: target.node,
+            slot: target.slot.0,
+        }),
+        ProjectionPatchOperation::SetNodeAvailability { node, .. } => {
+            Some(MutationTarget::NodeAvailability { node: *node })
+        }
+        ProjectionPatchOperation::CollectionInsert {
+            collection, key, ..
+        }
+        | ProjectionPatchOperation::CollectionUpdate {
+            collection, key, ..
+        }
+        | ProjectionPatchOperation::CollectionRemove { collection, key }
+        | ProjectionPatchOperation::CollectionMove {
+            collection, key, ..
+        } => Some(MutationTarget::CollectionItem {
+            collection: *collection,
+            key: *key,
+        }),
+    }
+}
+
+fn sort_and_dedup_diagnostics(
+    mut diagnostics: ProjectionPatchDiagnostics,
+) -> ProjectionPatchDiagnostics {
+    diagnostics.sort();
+    diagnostics.dedup_by(|right, left| {
+        right.coordinate().code().as_str() == left.coordinate().code().as_str()
+    });
+    diagnostics
+}
+
+fn push_value(
+    bytes: &mut Vec<u8>,
+    value: &ProjectionPatchValue,
+) -> Result<(), ProjectionPatchEncodingError> {
+    match value {
+        ProjectionPatchValue::Quad(state) => {
+            push_u8(bytes, 1);
+            push_u8(bytes, quad_state_tag(*state));
+        }
+        ProjectionPatchValue::SignedScalar(value) => {
+            push_u8(bytes, 2);
+            push_i64(bytes, *value);
+        }
+        ProjectionPatchValue::Text(value) => {
+            push_u8(bytes, 3);
+            push_string(bytes, value)?;
+        }
+    }
+    Ok(())
+}
+
+const fn quad_state_tag(state: ProjectionQuadState) -> u8 {
+    match state {
+        ProjectionQuadState::N => 0,
+        ProjectionQuadState::F => 1,
+        ProjectionQuadState::T => 2,
+        ProjectionQuadState::S => 3,
+    }
+}
+
+const fn availability_tag(state: ProjectionNodeAvailability) -> u8 {
+    match state {
+        ProjectionNodeAvailability::Available => 0,
+        ProjectionNodeAvailability::Unavailable => 1,
+        ProjectionNodeAvailability::Hidden => 2,
+        ProjectionNodeAvailability::Pending => 3,
+        ProjectionNodeAvailability::Stale => 4,
+    }
+}
+
+fn push_bytes(bytes: &mut Vec<u8>, value: &[u8]) -> Result<(), ProjectionPatchEncodingError> {
+    push_len(bytes, value.len())?;
+    bytes.extend_from_slice(value);
+    Ok(())
+}
+
+fn push_string(bytes: &mut Vec<u8>, value: &str) -> Result<(), ProjectionPatchEncodingError> {
+    push_len(bytes, value.len())?;
+    bytes.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn push_len(bytes: &mut Vec<u8>, len: usize) -> Result<(), ProjectionPatchEncodingError> {
+    let len = u32::try_from(len).map_err(|_| ProjectionPatchEncodingError::LengthOverflow)?;
+    push_u32(bytes, len);
+    Ok(())
+}
+
+fn push_optional_u64(bytes: &mut Vec<u8>, value: Option<u64>) {
+    match value {
+        Some(value) => {
+            push_u8(bytes, 1);
+            push_u64(bytes, value);
+        }
+        None => push_u8(bytes, 0),
+    }
+}
+
+fn push_u8(bytes: &mut Vec<u8>, value: u8) {
+    bytes.push(value);
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_i64(bytes: &mut Vec<u8>, value: i64) {
+    bytes.extend_from_slice(&value.to_le_bytes());
+}

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -1,0 +1,682 @@
+//! WP4 Contract Qualification Tests
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::binding_graph::{BindingSlot, BindingTarget};
+use crate::contract_primitives::{
+    CollectionKey, DiagnosticCode, Epoch, Revision, StaticDocumentId, StaticNodeId,
+    StaticSurfaceId,
+};
+use crate::projection_patch::{
+    ProjectionNodeAvailability, ProjectionPatch, ProjectionPatchEnvelope,
+    ProjectionPatchId, ProjectionPatchOperation, ProjectionPatchSequence, ProjectionPatchSet,
+    ProjectionPatchStreamId, ProjectionPatchValue, ProjectionQuadState,
+};
+
+fn patch_id(raw: u64) -> ProjectionPatchId {
+    ProjectionPatchId::new(raw).expect("patch id")
+}
+
+fn stream_id(raw: u64) -> ProjectionPatchStreamId {
+    ProjectionPatchStreamId::new(raw).expect("stream id")
+}
+
+fn document_id(raw: u64) -> StaticDocumentId {
+    StaticDocumentId::new(raw).expect("document id")
+}
+
+fn surface_id(raw: u64) -> StaticSurfaceId {
+    StaticSurfaceId::new(raw).expect("surface id")
+}
+
+fn node_id(raw: u64) -> StaticNodeId {
+    StaticNodeId::new(raw).expect("node id")
+}
+
+fn key(raw: u64) -> CollectionKey {
+    CollectionKey::new(raw).expect("key")
+}
+
+fn envelope(
+    patch: u64,
+    stream: u64,
+    document: u64,
+    surface: Option<u64>,
+    previous_revision: u64,
+    revision: u64,
+    epoch: u64,
+    sequence: u64,
+) -> ProjectionPatchEnvelope {
+    ProjectionPatchEnvelope::new(
+        patch_id(patch),
+        stream_id(stream),
+        document_id(document),
+        surface.map(surface_id),
+        Revision::new(previous_revision),
+        Revision::new(revision),
+        Epoch::new(epoch),
+        ProjectionPatchSequence::new(sequence),
+    )
+}
+
+fn binding_target(node: u64, slot: u32) -> BindingTarget {
+    BindingTarget {
+        node: node_id(node),
+        slot: BindingSlot(slot),
+    }
+}
+
+fn binding_update_patch(patch: u64, sequence: u64, revision: u64) -> ProjectionPatch {
+    ProjectionPatch::new(
+        envelope(patch, 1, 1, Some(1), revision.saturating_sub(1), revision, 1, sequence),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::T),
+        }],
+    )
+    .expect("valid binding update patch")
+}
+
+fn quad_patch(state: ProjectionQuadState) -> ProjectionPatch {
+    ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 5),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::Quad(state),
+        }],
+    )
+    .expect("valid quad patch")
+}
+
+fn patch_with_operation(operation: ProjectionPatchOperation) -> ProjectionPatch {
+    ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![operation],
+    )
+    .expect("valid patch")
+}
+
+fn diagnostic_codes(diagnostics: &[crate::projection_patch::ProjectionPatchDiagnostic]) -> Vec<&'static str> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.coordinate().code().as_str())
+        .collect()
+}
+
+#[test]
+fn ui_dna2_wp4_reject_zero_patch_id() {
+    assert!(ProjectionPatchId::new(0).is_err());
+}
+
+#[test]
+fn ui_dna2_wp4_reject_zero_stream_id() {
+    assert!(ProjectionPatchStreamId::new(0).is_err());
+}
+
+#[test]
+fn ui_dna2_wp4_preserve_exact_envelope_values() {
+    let envelope = envelope(7, 8, 9, Some(10), 11, 12, 13, 14);
+
+    assert_eq!(envelope.patch_id().raw(), 7);
+    assert_eq!(envelope.stream_id().raw(), 8);
+    assert_eq!(envelope.document_id().raw(), 9);
+    assert_eq!(envelope.surface_id().expect("surface").raw(), 10);
+    assert_eq!(envelope.previous_projection_revision().raw(), 11);
+    assert_eq!(envelope.projection_revision().raw(), 12);
+    assert_eq!(envelope.epoch().raw(), 13);
+    assert_eq!(envelope.sequence().raw(), 14);
+}
+
+#[test]
+fn ui_dna2_wp4_patch_and_stream_identity_are_nominally_distinct() {
+    fn takes_patch_id(value: ProjectionPatchId) -> u64 {
+        value.raw()
+    }
+
+    fn takes_stream_id(value: ProjectionPatchStreamId) -> u64 {
+        value.raw()
+    }
+
+    assert_eq!(takes_patch_id(patch_id(1)), 1);
+    assert_eq!(takes_stream_id(stream_id(2)), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_quad_states_remain_four_distinct_values() {
+    use core::mem::discriminant;
+
+    assert_ne!(discriminant(&ProjectionQuadState::N), discriminant(&ProjectionQuadState::F));
+    assert_ne!(discriminant(&ProjectionQuadState::F), discriminant(&ProjectionQuadState::T));
+    assert_ne!(discriminant(&ProjectionQuadState::T), discriminant(&ProjectionQuadState::S));
+    assert_ne!(discriminant(&ProjectionQuadState::N), discriminant(&ProjectionQuadState::S));
+}
+
+#[test]
+fn ui_dna2_wp4_canonical_encoding_distinguishes_all_quad_states() {
+    let n = ProjectionPatchSet::new(alloc::vec![quad_patch(ProjectionQuadState::N)])
+        .expect("n set")
+        .canonical_bytes()
+        .expect("n bytes");
+    let f = ProjectionPatchSet::new(alloc::vec![quad_patch(ProjectionQuadState::F)])
+        .expect("f set")
+        .canonical_bytes()
+        .expect("f bytes");
+    let t = ProjectionPatchSet::new(alloc::vec![quad_patch(ProjectionQuadState::T)])
+        .expect("t set")
+        .canonical_bytes()
+        .expect("t bytes");
+    let s = ProjectionPatchSet::new(alloc::vec![quad_patch(ProjectionQuadState::S)])
+        .expect("s set")
+        .canonical_bytes()
+        .expect("s bytes");
+
+    assert_ne!(n, f);
+    assert_ne!(n, t);
+    assert_ne!(n, s);
+    assert_ne!(f, t);
+    assert_ne!(f, s);
+    assert_ne!(t, s);
+}
+
+#[test]
+fn ui_dna2_wp4_unknown_is_not_represented_as_false() {
+    assert_ne!(
+        ProjectionPatchValue::Quad(ProjectionQuadState::N),
+        ProjectionPatchValue::Quad(ProjectionQuadState::F)
+    );
+}
+
+#[test]
+fn ui_dna2_wp4_conflict_is_not_represented_as_error() {
+    assert_ne!(
+        ProjectionPatchValue::Quad(ProjectionQuadState::S),
+        ProjectionPatchValue::Quad(ProjectionQuadState::T)
+    );
+}
+
+#[test]
+fn ui_dna2_wp4_accept_one_valid_patch() {
+    let patch = binding_update_patch(1, 0, 1);
+    let set = ProjectionPatchSet::new(alloc::vec![patch]).expect("valid set");
+    assert_eq!(set.patches().len(), 1);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_valid_multi_patch_chain() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetNodeAvailability {
+            node: node_id(10),
+            availability: ProjectionNodeAvailability::Available,
+        }],
+    )
+    .expect("second patch");
+
+    let set = ProjectionPatchSet::new(alloc::vec![first, second]).expect("chain");
+    assert_eq!(set.patches().len(), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_non_zero_initial_previous_revision() {
+    let patch = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 10, 11, 1, 7),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(41),
+        }],
+    )
+    .expect("valid patch");
+
+    assert_eq!(patch.envelope().previous_projection_revision().raw(), 10);
+}
+
+#[test]
+fn ui_dna2_wp4_preserve_operation_order() {
+    let patch = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::SetNodeAvailability {
+                node: node_id(10),
+                availability: ProjectionNodeAvailability::Pending,
+            },
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 1),
+                value: ProjectionPatchValue::SignedScalar(9),
+            },
+        ],
+    )
+    .expect("patch");
+
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::SetNodeAvailability { .. }
+    ));
+    assert!(matches!(
+        &patch.operations()[1],
+        ProjectionPatchOperation::SetBindingValue { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_preserve_patch_order() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        }],
+    )
+    .expect("patch");
+    let set = ProjectionPatchSet::new(alloc::vec![first, second]).expect("set");
+
+    assert_eq!(set.patches()[0].envelope().patch_id().raw(), 1);
+    assert_eq!(set.patches()[1].envelope().patch_id().raw(), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_non_increasing_revision() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 5, 5, 1, 0),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        }],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_NON_INCREASING_REVISION"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_broken_adjacent_revision_chain() {
+    let first = binding_update_patch(1, 0, 2);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 99, 100, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        }],
+    )
+    .expect("patch");
+
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_BROKEN_REVISION_CHAIN"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_duplicate_sequence() {
+    let first = binding_update_patch(1, 1, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_SEQUENCE"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_descending_sequence() {
+    let first = binding_update_patch(1, 3, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 2),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_sequence_gaps() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 2),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_sequence_overflow_where_applicable() {
+    let first = binding_update_patch(1, u64::MAX, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 0),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_SEQUENCE_OVERFLOW"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_mixed_epochs() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 2, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_MIXED_EPOCH"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_mixed_streams() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 2, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_MIXED_STREAM"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_mixed_documents() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 2, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_MIXED_DOCUMENT"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_duplicate_patch_id() {
+    let first = binding_update_patch(1, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(3),
+        }],
+    )
+    .expect("patch");
+    let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_PATCH_ID"]);
+}
+
+#[test]
+fn ui_dna2_wp4_report_duplicate_patch_id_deterministically() {
+    let first = binding_update_patch(7, 0, 1);
+    let second = ProjectionPatch::new(
+        envelope(7, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(4),
+        }],
+    )
+    .expect("patch");
+
+    let error_a = ProjectionPatchSet::new(alloc::vec![first.clone(), second.clone()]).unwrap_err();
+    let error_b = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
+    assert_eq!(error_a, error_b);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_empty_operation_list() {
+    let error = ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 1, 1, 0), Vec::new())
+        .unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_EMPTY_OPERATIONS"]);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_binding_value_update() {
+    let patch = patch_with_operation(ProjectionPatchOperation::SetBindingValue {
+        target: binding_target(10, 1),
+        value: ProjectionPatchValue::Text(String::from("hello")),
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::SetBindingValue { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_node_availability_update() {
+    let patch = patch_with_operation(ProjectionPatchOperation::SetNodeAvailability {
+        node: node_id(10),
+        availability: ProjectionNodeAvailability::Hidden,
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::SetNodeAvailability { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_keyed_collection_insert() {
+    let patch = patch_with_operation(ProjectionPatchOperation::CollectionInsert {
+        collection: node_id(20),
+        key: key(1),
+        before: Some(key(2)),
+        value: ProjectionPatchValue::SignedScalar(1),
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::CollectionInsert { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_keyed_collection_update() {
+    let patch = patch_with_operation(ProjectionPatchOperation::CollectionUpdate {
+        collection: node_id(20),
+        key: key(1),
+        value: ProjectionPatchValue::SignedScalar(2),
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::CollectionUpdate { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_keyed_collection_remove() {
+    let patch = patch_with_operation(ProjectionPatchOperation::CollectionRemove {
+        collection: node_id(20),
+        key: key(1),
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::CollectionRemove { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_keyed_collection_move() {
+    let patch = patch_with_operation(ProjectionPatchOperation::CollectionMove {
+        collection: node_id(20),
+        key: key(1),
+        before: Some(key(2)),
+    });
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::CollectionMove { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_reject_move_before_self() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![ProjectionPatchOperation::CollectionMove {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(1)),
+        }],
+    )
+    .unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_COLLECTION_BEFORE_SELF"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_insert_before_self() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(1)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        }],
+    )
+    .unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_COLLECTION_BEFORE_SELF"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_ambiguous_duplicate_mutation_target() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 1),
+                value: ProjectionPatchValue::SignedScalar(1),
+            },
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 1),
+                value: ProjectionPatchValue::SignedScalar(2),
+            },
+        ],
+    )
+    .unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_same_valid_input_produces_identical_canonical_bytes() {
+    let first = ProjectionPatchSet::new(alloc::vec![binding_update_patch(1, 0, 1)]).expect("set");
+    let second = ProjectionPatchSet::new(alloc::vec![binding_update_patch(1, 0, 1)]).expect("set");
+
+    assert_eq!(
+        first.canonical_bytes().expect("bytes"),
+        second.canonical_bytes().expect("bytes")
+    );
+}
+
+#[test]
+fn ui_dna2_wp4_same_invalid_input_produces_identical_ordered_diagnostics() {
+    let invalid = || {
+        ProjectionPatch::new(
+            envelope(1, 1, 1, Some(1), 0, 0, 1, 0),
+            alloc::vec![],
+        )
+        .unwrap_err()
+    };
+
+    assert_eq!(invalid(), invalid());
+}
+
+#[test]
+fn ui_dna2_wp4_different_operation_order_produces_different_canonical_bytes() {
+    let patch_a = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::SetNodeAvailability {
+                node: node_id(10),
+                availability: ProjectionNodeAvailability::Available,
+            },
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 1),
+                value: ProjectionPatchValue::SignedScalar(2),
+            },
+        ],
+    )
+    .expect("patch a");
+    let patch_b = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 1),
+                value: ProjectionPatchValue::SignedScalar(2),
+            },
+            ProjectionPatchOperation::SetNodeAvailability {
+                node: node_id(10),
+                availability: ProjectionNodeAvailability::Available,
+            },
+        ],
+    )
+    .expect("patch b");
+
+    let bytes_a = ProjectionPatchSet::new(alloc::vec![patch_a])
+        .expect("set a")
+        .canonical_bytes()
+        .expect("bytes a");
+    let bytes_b = ProjectionPatchSet::new(alloc::vec![patch_b])
+        .expect("set b")
+        .canonical_bytes()
+        .expect("bytes b");
+
+    assert_ne!(bytes_a, bytes_b);
+}
+
+#[test]
+fn ui_dna2_wp4_out_of_order_patches_are_rejected_rather_than_silently_sorted() {
+    let later = binding_update_patch(2, 1, 2);
+    let earlier = binding_update_patch(1, 0, 1);
+
+    let error = ProjectionPatchSet::new(alloc::vec![later, earlier]).unwrap_err();
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+}
+
+#[test]
+fn ui_dna2_wp4_diagnostics_are_sorted_and_deduplicated() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 2, 2, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::CollectionMove {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(1)),
+            },
+            ProjectionPatchOperation::CollectionMove {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(1)),
+            },
+        ],
+    )
+    .unwrap_err();
+
+    let codes = diagnostic_codes(&error);
+    assert_eq!(
+        codes,
+        alloc::vec![
+            "PP_COLLECTION_BEFORE_SELF",
+            "PP_DUP_MUTATION_TARGET",
+            "PP_NON_INCREASING_REVISION"
+        ]
+    );
+    assert_eq!(codes[0], DiagnosticCode::new("PP_COLLECTION_BEFORE_SELF").as_str());
+}

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -5,13 +5,12 @@ use alloc::vec::Vec;
 
 use crate::binding_graph::{BindingSlot, BindingTarget};
 use crate::contract_primitives::{
-    CollectionKey, DiagnosticCode, Epoch, Revision, StaticDocumentId, StaticNodeId,
-    StaticSurfaceId,
+    CollectionKey, DiagnosticCode, Epoch, Revision, StaticDocumentId, StaticNodeId, StaticSurfaceId,
 };
 use crate::projection_patch::{
-    ProjectionNodeAvailability, ProjectionPatch, ProjectionPatchEnvelope,
-    ProjectionPatchId, ProjectionPatchOperation, ProjectionPatchSequence, ProjectionPatchSet,
-    ProjectionPatchStreamId, ProjectionPatchValue, ProjectionQuadState,
+    ProjectionNodeAvailability, ProjectionPatch, ProjectionPatchEnvelope, ProjectionPatchId,
+    ProjectionPatchOperation, ProjectionPatchSequence, ProjectionPatchSet, ProjectionPatchStreamId,
+    ProjectionPatchValue, ProjectionQuadState,
 };
 
 fn patch_id(raw: u64) -> ProjectionPatchId {
@@ -69,7 +68,16 @@ fn binding_target(node: u64, slot: u32) -> BindingTarget {
 
 fn binding_update_patch(patch: u64, sequence: u64, revision: u64) -> ProjectionPatch {
     ProjectionPatch::new(
-        envelope(patch, 1, 1, Some(1), revision.saturating_sub(1), revision, 1, sequence),
+        envelope(
+            patch,
+            1,
+            1,
+            Some(1),
+            revision.saturating_sub(1),
+            revision,
+            1,
+            sequence,
+        ),
         alloc::vec![ProjectionPatchOperation::SetBindingValue {
             target: binding_target(10, 1),
             value: ProjectionPatchValue::Quad(ProjectionQuadState::T),
@@ -101,7 +109,9 @@ fn patch_with_operations(operations: Vec<ProjectionPatchOperation>) -> Projectio
     ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 1, 1, 0), operations).expect("valid patch")
 }
 
-fn diagnostic_codes(diagnostics: &[crate::projection_patch::ProjectionPatchDiagnostic]) -> Vec<&'static str> {
+fn diagnostic_codes(
+    diagnostics: &[crate::projection_patch::ProjectionPatchDiagnostic],
+) -> Vec<&'static str> {
     diagnostics
         .iter()
         .map(|diagnostic| diagnostic.coordinate().code().as_str())
@@ -150,10 +160,22 @@ fn ui_dna2_wp4_patch_and_stream_identity_are_nominally_distinct() {
 fn ui_dna2_wp4_quad_states_remain_four_distinct_values() {
     use core::mem::discriminant;
 
-    assert_ne!(discriminant(&ProjectionQuadState::N), discriminant(&ProjectionQuadState::F));
-    assert_ne!(discriminant(&ProjectionQuadState::F), discriminant(&ProjectionQuadState::T));
-    assert_ne!(discriminant(&ProjectionQuadState::T), discriminant(&ProjectionQuadState::S));
-    assert_ne!(discriminant(&ProjectionQuadState::N), discriminant(&ProjectionQuadState::S));
+    assert_ne!(
+        discriminant(&ProjectionQuadState::N),
+        discriminant(&ProjectionQuadState::F)
+    );
+    assert_ne!(
+        discriminant(&ProjectionQuadState::F),
+        discriminant(&ProjectionQuadState::T)
+    );
+    assert_ne!(
+        discriminant(&ProjectionQuadState::T),
+        discriminant(&ProjectionQuadState::S)
+    );
+    assert_ne!(
+        discriminant(&ProjectionQuadState::N),
+        discriminant(&ProjectionQuadState::S)
+    );
 }
 
 #[test]
@@ -291,7 +313,10 @@ fn ui_dna2_wp4_reject_non_increasing_revision() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_NON_INCREASING_REVISION"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_NON_INCREASING_REVISION"]
+    );
 }
 
 #[test]
@@ -307,7 +332,10 @@ fn ui_dna2_wp4_reject_broken_adjacent_revision_chain() {
     .expect("patch");
 
     let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_BROKEN_REVISION_CHAIN"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_BROKEN_REVISION_CHAIN"]
+    );
 }
 
 #[test]
@@ -337,7 +365,10 @@ fn ui_dna2_wp4_reject_descending_sequence() {
     )
     .expect("patch");
     let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]
+    );
 }
 
 #[test]
@@ -352,7 +383,10 @@ fn ui_dna2_wp4_reject_sequence_gaps() {
     )
     .expect("patch");
     let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]
+    );
 }
 
 #[test]
@@ -367,7 +401,10 @@ fn ui_dna2_wp4_reject_sequence_overflow_where_applicable() {
     )
     .expect("patch");
     let error = ProjectionPatchSet::new(alloc::vec![first, second]).unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_SEQUENCE_OVERFLOW"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_SEQUENCE_OVERFLOW"]
+    );
 }
 
 #[test]
@@ -449,8 +486,8 @@ fn ui_dna2_wp4_report_duplicate_patch_id_deterministically() {
 
 #[test]
 fn ui_dna2_wp4_reject_empty_operation_list() {
-    let error = ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 1, 1, 0), Vec::new())
-        .unwrap_err();
+    let error =
+        ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 1, 1, 0), Vec::new()).unwrap_err();
     assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_EMPTY_OPERATIONS"]);
 }
 
@@ -541,7 +578,10 @@ fn ui_dna2_wp4_reject_move_before_self() {
         }],
     )
     .unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_COLLECTION_BEFORE_SELF"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_COLLECTION_BEFORE_SELF"]
+    );
 }
 
 #[test]
@@ -556,7 +596,10 @@ fn ui_dna2_wp4_reject_insert_before_self() {
         }],
     )
     .unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_COLLECTION_BEFORE_SELF"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_COLLECTION_BEFORE_SELF"]
+    );
 }
 
 #[test]
@@ -575,7 +618,10 @@ fn ui_dna2_wp4_reject_ambiguous_duplicate_mutation_target() {
         ],
     )
     .unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -661,7 +707,10 @@ fn ui_dna2_wp4_reject_same_key_insert_then_insert() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -683,7 +732,10 @@ fn ui_dna2_wp4_reject_same_key_update_then_update() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -703,7 +755,10 @@ fn ui_dna2_wp4_reject_same_key_remove_then_remove() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -725,7 +780,10 @@ fn ui_dna2_wp4_reject_same_key_move_then_move() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -745,7 +803,10 @@ fn ui_dna2_wp4_reject_duplicate_node_availability_target() {
     )
     .unwrap_err();
 
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_DUP_MUTATION_TARGET"]
+    );
 }
 
 #[test]
@@ -842,13 +903,8 @@ fn ui_dna2_wp4_same_valid_input_produces_identical_canonical_bytes() {
 
 #[test]
 fn ui_dna2_wp4_same_invalid_input_produces_identical_ordered_diagnostics() {
-    let invalid = || {
-        ProjectionPatch::new(
-            envelope(1, 1, 1, Some(1), 0, 0, 1, 0),
-            alloc::vec![],
-        )
-        .unwrap_err()
-    };
+    let invalid =
+        || ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 0, 1, 0), alloc::vec![]).unwrap_err();
 
     assert_eq!(invalid(), invalid());
 }
@@ -902,7 +958,10 @@ fn ui_dna2_wp4_out_of_order_patches_are_rejected_rather_than_silently_sorted() {
     let earlier = binding_update_patch(1, 0, 1);
 
     let error = ProjectionPatchSet::new(alloc::vec![later, earlier]).unwrap_err();
-    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]);
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_OUT_OF_ORDER_SEQUENCE"]
+    );
 }
 
 #[test]
@@ -933,5 +992,8 @@ fn ui_dna2_wp4_diagnostics_are_sorted_and_deduplicated() {
             "PP_NON_INCREASING_REVISION"
         ]
     );
-    assert_eq!(codes[0], DiagnosticCode::new("PP_COLLECTION_BEFORE_SELF").as_str());
+    assert_eq!(
+        codes[0],
+        DiagnosticCode::new("PP_COLLECTION_BEFORE_SELF").as_str()
+    );
 }

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -37,6 +37,7 @@ fn key(raw: u64) -> CollectionKey {
     CollectionKey::new(raw).expect("key")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn envelope(
     patch: u64,
     stream: u64,

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -97,6 +97,10 @@ fn patch_with_operation(operation: ProjectionPatchOperation) -> ProjectionPatch 
     .expect("valid patch")
 }
 
+fn patch_with_operations(operations: Vec<ProjectionPatchOperation>) -> ProjectionPatch {
+    ProjectionPatch::new(envelope(1, 1, 1, Some(1), 0, 1, 1, 0), operations).expect("valid patch")
+}
+
 fn diagnostic_codes(diagnostics: &[crate::projection_patch::ProjectionPatchDiagnostic]) -> Vec<&'static str> {
     diagnostics
         .iter()
@@ -572,6 +576,257 @@ fn ui_dna2_wp4_reject_ambiguous_duplicate_mutation_target() {
     )
     .unwrap_err();
     assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_same_key_insert_then_update() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(2)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+    ]);
+
+    assert!(matches!(
+        &patch.operations()[0],
+        ProjectionPatchOperation::CollectionInsert { .. }
+    ));
+    assert!(matches!(
+        &patch.operations()[1],
+        ProjectionPatchOperation::CollectionUpdate { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4_accept_same_key_insert_then_move() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(2)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::CollectionMove {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(3)),
+        },
+    ]);
+
+    assert_eq!(patch.operations().len(), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_same_key_update_then_remove() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+        ProjectionPatchOperation::CollectionRemove {
+            collection: node_id(20),
+            key: key(1),
+        },
+    ]);
+
+    assert_eq!(patch.operations().len(), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_same_key_insert_then_insert() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::CollectionInsert {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(2)),
+                value: ProjectionPatchValue::SignedScalar(1),
+            },
+            ProjectionPatchOperation::CollectionInsert {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(3)),
+                value: ProjectionPatchValue::SignedScalar(2),
+            },
+        ],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_same_key_update_then_update() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::CollectionUpdate {
+                collection: node_id(20),
+                key: key(1),
+                value: ProjectionPatchValue::SignedScalar(1),
+            },
+            ProjectionPatchOperation::CollectionUpdate {
+                collection: node_id(20),
+                key: key(1),
+                value: ProjectionPatchValue::SignedScalar(2),
+            },
+        ],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_same_key_remove_then_remove() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::CollectionRemove {
+                collection: node_id(20),
+                key: key(1),
+            },
+            ProjectionPatchOperation::CollectionRemove {
+                collection: node_id(20),
+                key: key(1),
+            },
+        ],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_same_key_move_then_move() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::CollectionMove {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(2)),
+            },
+            ProjectionPatchOperation::CollectionMove {
+                collection: node_id(20),
+                key: key(1),
+                before: Some(key(3)),
+            },
+        ],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_reject_duplicate_node_availability_target() {
+    let error = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+        alloc::vec![
+            ProjectionPatchOperation::SetNodeAvailability {
+                node: node_id(10),
+                availability: ProjectionNodeAvailability::Pending,
+            },
+            ProjectionPatchOperation::SetNodeAvailability {
+                node: node_id(10),
+                availability: ProjectionNodeAvailability::Available,
+            },
+        ],
+    )
+    .unwrap_err();
+
+    assert_eq!(diagnostic_codes(&error), alloc::vec!["PP_DUP_MUTATION_TARGET"]);
+}
+
+#[test]
+fn ui_dna2_wp4_accept_same_kind_collection_ops_for_distinct_keys() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+    ]);
+
+    assert_eq!(patch.operations().len(), 2);
+}
+
+#[test]
+fn ui_dna2_wp4_same_key_cross_kind_order_remains_observable_in_bytes() {
+    let insert_then_update = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(2)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+    ]);
+    let update_then_insert = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+        ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(2)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+    ]);
+
+    let bytes_a = ProjectionPatchSet::new(alloc::vec![insert_then_update])
+        .expect("set a")
+        .canonical_bytes()
+        .expect("bytes a");
+    let bytes_b = ProjectionPatchSet::new(alloc::vec![update_then_insert])
+        .expect("set b")
+        .canonical_bytes()
+        .expect("bytes b");
+
+    assert_ne!(bytes_a, bytes_b);
+}
+
+#[test]
+fn ui_dna2_wp4_same_kind_duplicate_diagnostics_are_deterministic() {
+    let invalid = || {
+        ProjectionPatch::new(
+            envelope(1, 1, 1, Some(1), 0, 1, 1, 0),
+            alloc::vec![
+                ProjectionPatchOperation::CollectionRemove {
+                    collection: node_id(20),
+                    key: key(1),
+                },
+                ProjectionPatchOperation::CollectionRemove {
+                    collection: node_id(20),
+                    key: key(1),
+                },
+            ],
+        )
+        .unwrap_err()
+    };
+
+    assert_eq!(invalid(), invalid());
 }
 
 #[test]

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -989,6 +989,7 @@ fn ui_dna2_wp4_diagnostics_are_sorted_and_deduplicated() {
         codes,
         alloc::vec![
             "PP_COLLECTION_BEFORE_SELF",
+            "PP_COLLECTION_BEFORE_SELF",
             "PP_DUP_MUTATION_TARGET",
             "PP_NON_INCREASING_REVISION"
         ]
@@ -997,4 +998,36 @@ fn ui_dna2_wp4_diagnostics_are_sorted_and_deduplicated() {
         codes[0],
         DiagnosticCode::new("PP_COLLECTION_BEFORE_SELF").as_str()
     );
+}
+
+#[test]
+fn ui_dna2_wp4_same_code_diagnostics_with_distinct_coordinates_are_preserved() {
+    let patch_a = binding_update_patch(1, 0, 1);
+    let patch_b = ProjectionPatch::new(
+        envelope(2, 2, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::T),
+        }],
+    )
+    .expect("patch b");
+    let patch_c = ProjectionPatch::new(
+        envelope(3, 3, 1, Some(1), 2, 3, 1, 2),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::T),
+        }],
+    )
+    .expect("patch c");
+
+    let error = ProjectionPatchSet::new(alloc::vec![patch_a, patch_b, patch_c]).unwrap_err();
+
+    assert_eq!(
+        diagnostic_codes(&error),
+        alloc::vec!["PP_MIXED_STREAM", "PP_MIXED_STREAM"]
+    );
+    assert_eq!(error[0].coordinate().domain(), 2);
+    assert_eq!(error[0].coordinate().secondary(), 1);
+    assert_eq!(error[1].coordinate().domain(), 3);
+    assert_eq!(error[1].coordinate().secondary(), 2);
 }


### PR DESCRIPTION
## Summary

Adds the crate-internal UI DNA v2 Projection Patch contract foundation in `prom-ui`.

The slice provides deterministic inert values and validation for:

- patch and stream identity;
- projection revisions, epochs, and strict sequence chains;
- Quad-preserving projected values (`N/F/T/S`);
- binding value and node availability operations;
- stable-key collection insert/update/remove/move operations;
- deterministic diagnostics;
- internal-only canonical qualification bytes;
- structural replay-equivalence evidence.

A follow-up correction narrows duplicate-target validation so that:

- same-kind exact mutation coordinates remain rejected;
- ordered cross-kind operations against the same collection item remain valid;
- operation order remains explicit and byte-observable.

## Scope

Changed paths:

- `crates/prom-ui/src/lib.rs`
- `crates/prom-ui/src/projection_patch.rs`
- `crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs`

No dependency, Cargo policy, public API, runtime, renderer, shell, admission, capability, or ProjectionBundle activation change is included.

## Authority boundary

```text
Patch != Semantic truth.
Patch != capability.
Patch != admission.
Patch != ActionIntent dispatch.
Patch != shell mutation.
Patch != renderer command.

Gate D remains closed.
```

## Determinism

The contract enforces:

- one stream, document, and epoch per validated patch set;
- unique patch IDs;
- strictly adjacent checked sequences;
- continuous projection revision chains;
- no silent sorting, repair, coalescing, or discard;
- deterministic diagnostic ordering;
- deterministic internal qualification bytes;
- explicit operation and patch order.

## Quad-state preservation

`N`, `F`, `T`, and `S` remain distinct.

No `bool` or `Option<bool>` flattening is introduced.

## Validation

Passed locally:

- `scripts/harness-check.ps1`
- `cargo test -p prom-ui --lib ui_dna2_wp4` — 50 passed
- `cargo test -p prom-ui`
- `cargo test -p prom-ui-runtime`
- `cargo check -p prom-ui --all-features`
- `cargo tree -p prom-ui --depth 1`
- `cargo test --test public_api_contracts --quiet`
- `cargo test --test trust_boundary_guards`
- `cargo +1.93.1 fmt --all --check`
- `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

`cargo check -p prom-ui --no-default-features` retains the known pre-existing failures in non-WP4 legacy modules. No diagnostic originates from the new Projection Patch module.

## Deferred

This PR does not implement:

- live patch application;
- patch queues or transport;
- dirty propagation runtime;
- denial/recovery patch families;
- SemanticStatePatch, EvidencePatch, ActionOfferPatch, ConnectivityPatch, or TaskStatePatch;
- ProjectionBundle loading or activation;
- shell player;
- renderer/backend integration;
- Gate D admission/runtime integration;
- production promotion.

Refs #1489
