### PR TITLE
feat(ui): add projection patch replay-order model

### DIFF
--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -228,6 +228,25 @@ impl ProjectionPatch {
     pub(crate) fn operations(&self) -> &[ProjectionPatchOperation] {
         &self.operations
     }
+
+    pub(crate) fn replay_trace(
+        &self,
+    ) -> Result<ProjectionPatchReplayTrace<'_>, ProjectionPatchReplayError> {
+        let mut steps = Vec::new();
+        for (op_idx, operation) in self.operations().iter().enumerate() {
+            let operation_ordinal =
+                u64::try_from(op_idx).map_err(|_| ProjectionPatchReplayError::IndexOverflow)?;
+            steps.push(ProjectionPatchReplayStep {
+                coordinate: ProjectionPatchReplayCoordinate {
+                    patch_ordinal: 0,
+                    operation_ordinal,
+                },
+                envelope: self.envelope(),
+                operation,
+            });
+        }
+        Ok(ProjectionPatchReplayTrace { steps })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -247,6 +266,29 @@ impl ProjectionPatchSet {
 
     pub(crate) fn patches(&self) -> &[ProjectionPatch] {
         &self.patches
+    }
+
+    pub(crate) fn replay_trace(
+        &self,
+    ) -> Result<ProjectionPatchReplayTrace<'_>, ProjectionPatchReplayError> {
+        let mut steps = Vec::new();
+        for (patch_idx, patch) in self.patches().iter().enumerate() {
+            let patch_ordinal =
+                u64::try_from(patch_idx).map_err(|_| ProjectionPatchReplayError::IndexOverflow)?;
+            for (op_idx, operation) in patch.operations().iter().enumerate() {
+                let operation_ordinal =
+                    u64::try_from(op_idx).map_err(|_| ProjectionPatchReplayError::IndexOverflow)?;
+                steps.push(ProjectionPatchReplayStep {
+                    coordinate: ProjectionPatchReplayCoordinate {
+                        patch_ordinal,
+                        operation_ordinal,
+                    },
+                    envelope: patch.envelope(),
+                    operation,
+                });
+            }
+        }
+        Ok(ProjectionPatchReplayTrace { steps })
     }
 
     /// Internal deterministic qualification encoding only.
@@ -731,4 +773,57 @@ fn push_u64(bytes: &mut Vec<u8>, value: u64) {
 
 fn push_i64(bytes: &mut Vec<u8>, value: i64) {
     bytes.extend_from_slice(&value.to_le_bytes());
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionPatchReplayCoordinate {
+    patch_ordinal: u64,
+    operation_ordinal: u64,
+}
+
+impl ProjectionPatchReplayCoordinate {
+    pub(crate) const fn patch_ordinal(&self) -> u64 {
+        self.patch_ordinal
+    }
+
+    pub(crate) const fn operation_ordinal(&self) -> u64 {
+        self.operation_ordinal
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectionPatchReplayStep<'a> {
+    coordinate: ProjectionPatchReplayCoordinate,
+    envelope: ProjectionPatchEnvelope,
+    operation: &'a ProjectionPatchOperation,
+}
+
+impl<'a> ProjectionPatchReplayStep<'a> {
+    pub(crate) const fn coordinate(&self) -> ProjectionPatchReplayCoordinate {
+        self.coordinate
+    }
+
+    pub(crate) const fn envelope(&self) -> ProjectionPatchEnvelope {
+        self.envelope
+    }
+
+    pub(crate) const fn operation(&self) -> &'a ProjectionPatchOperation {
+        self.operation
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectionPatchReplayTrace<'a> {
+    steps: Vec<ProjectionPatchReplayStep<'a>>,
+}
+
+impl<'a> ProjectionPatchReplayTrace<'a> {
+    pub(crate) fn steps(&self) -> &[ProjectionPatchReplayStep<'a>] {
+        &self.steps
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectionPatchReplayError {
+    IndexOverflow,
 }

--- a/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs
@@ -1031,3 +1031,309 @@ fn ui_dna2_wp4_same_code_diagnostics_with_distinct_coordinates_are_preserved() {
     assert_eq!(error[1].coordinate().domain(), 3);
     assert_eq!(error[1].coordinate().secondary(), 2);
 }
+
+#[test]
+fn ui_dna2_wp4b_single_patch_trace_preserves_operation_order() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::SetNodeAvailability {
+            node: node_id(10),
+            availability: ProjectionNodeAvailability::Available,
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+    ]);
+
+    let trace = patch.replay_trace().expect("trace");
+    assert_eq!(trace.steps().len(), 2);
+
+    let step0 = &trace.steps()[0];
+    assert_eq!(step0.coordinate().patch_ordinal(), 0);
+    assert_eq!(step0.coordinate().operation_ordinal(), 0);
+    assert!(matches!(
+        step0.operation(),
+        ProjectionPatchOperation::SetNodeAvailability { .. }
+    ));
+
+    let step1 = &trace.steps()[1];
+    assert_eq!(step1.coordinate().patch_ordinal(), 0);
+    assert_eq!(step1.coordinate().operation_ordinal(), 1);
+    assert!(matches!(
+        step1.operation(),
+        ProjectionPatchOperation::SetBindingValue { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4b_patch_set_trace_preserves_nested_order() {
+    let first = patch_with_operation(ProjectionPatchOperation::SetBindingValue {
+        target: binding_target(10, 1),
+        value: ProjectionPatchValue::SignedScalar(1),
+    });
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        }],
+    )
+    .expect("patch");
+
+    let set = ProjectionPatchSet::new(alloc::vec![first, second]).expect("set");
+    let trace = set.replay_trace().expect("trace");
+
+    assert_eq!(trace.steps().len(), 2);
+
+    assert_eq!(trace.steps()[0].coordinate().patch_ordinal(), 0);
+    assert_eq!(trace.steps()[0].coordinate().operation_ordinal(), 0);
+
+    assert_eq!(trace.steps()[1].coordinate().patch_ordinal(), 1);
+    assert_eq!(trace.steps()[1].coordinate().operation_ordinal(), 0);
+}
+
+#[test]
+fn ui_dna2_wp4b_same_input_produces_equal_trace() {
+    let patch = binding_update_patch(1, 0, 1);
+    let trace_a = patch.replay_trace().expect("trace");
+    let trace_b = patch.replay_trace().expect("trace");
+
+    assert_eq!(trace_a, trace_b);
+}
+
+#[test]
+fn ui_dna2_wp4b_single_patch_matches_singleton_set_trace() {
+    let patch = binding_update_patch(1, 0, 1);
+    let set = ProjectionPatchSet::new(alloc::vec![patch.clone()]).expect("set");
+
+    let trace_patch = patch.replay_trace().expect("trace");
+    let trace_set = set.replay_trace().expect("trace");
+
+    assert_eq!(trace_patch, trace_set);
+}
+
+#[test]
+fn ui_dna2_wp4b_reversed_operation_order_changes_trace() {
+    let patch_a = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::SetNodeAvailability {
+            node: node_id(10),
+            availability: ProjectionNodeAvailability::Available,
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+    ]);
+
+    let patch_b = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::SetNodeAvailability {
+            node: node_id(10),
+            availability: ProjectionNodeAvailability::Available,
+        },
+    ]);
+
+    let trace_a = patch_a.replay_trace().expect("trace a");
+    let trace_b = patch_b.replay_trace().expect("trace b");
+
+    assert_ne!(trace_a, trace_b);
+}
+
+#[test]
+fn ui_dna2_wp4b_patch_order_remains_observable() {
+    let a_first = binding_update_patch(1, 0, 1);
+    let a_second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        }],
+    )
+    .expect("patch");
+    let set_a = ProjectionPatchSet::new(alloc::vec![a_first, a_second]).expect("set a");
+
+    let b_first = binding_update_patch(2, 0, 1);
+    let b_second = ProjectionPatch::new(
+        envelope(1, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        }],
+    )
+    .expect("patch");
+    let set_b = ProjectionPatchSet::new(alloc::vec![b_first, b_second]).expect("set b");
+
+    let trace_a = set_a.replay_trace().expect("trace a");
+    let trace_b = set_b.replay_trace().expect("trace b");
+
+    assert_ne!(trace_a, trace_b);
+}
+
+#[test]
+fn ui_dna2_wp4b_cross_kind_same_key_order_is_preserved() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::CollectionInsert {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(2)),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::CollectionUpdate {
+            collection: node_id(20),
+            key: key(1),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+        ProjectionPatchOperation::CollectionMove {
+            collection: node_id(20),
+            key: key(1),
+            before: Some(key(3)),
+        },
+        ProjectionPatchOperation::CollectionRemove {
+            collection: node_id(20),
+            key: key(1),
+        },
+    ]);
+
+    let trace = patch.replay_trace().expect("trace");
+    assert_eq!(trace.steps().len(), 4);
+
+    assert!(matches!(
+        trace.steps()[0].operation(),
+        ProjectionPatchOperation::CollectionInsert { .. }
+    ));
+    assert!(matches!(
+        trace.steps()[1].operation(),
+        ProjectionPatchOperation::CollectionUpdate { .. }
+    ));
+    assert!(matches!(
+        trace.steps()[2].operation(),
+        ProjectionPatchOperation::CollectionMove { .. }
+    ));
+    assert!(matches!(
+        trace.steps()[3].operation(),
+        ProjectionPatchOperation::CollectionRemove { .. }
+    ));
+}
+
+#[test]
+fn ui_dna2_wp4b_trace_borrows_exact_operations() {
+    let patch = binding_update_patch(1, 0, 1);
+    let trace = patch.replay_trace().expect("trace");
+
+    let borrowed_operation: *const ProjectionPatchOperation = trace.steps()[0].operation();
+    let original_operation: *const ProjectionPatchOperation = &patch.operations()[0];
+
+    assert_eq!(borrowed_operation, original_operation);
+}
+
+#[test]
+fn ui_dna2_wp4b_trace_preserves_envelope_coordinates() {
+    let patch = ProjectionPatch::new(
+        envelope(7, 8, 9, Some(10), 11, 12, 13, 14),
+        alloc::vec![ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(42),
+        }],
+    )
+    .expect("patch");
+
+    let trace = patch.replay_trace().expect("trace");
+    let trace_envelope = trace.steps()[0].envelope();
+
+    assert_eq!(trace_envelope.patch_id().raw(), 7);
+    assert_eq!(trace_envelope.stream_id().raw(), 8);
+    assert_eq!(trace_envelope.document_id().raw(), 9);
+    assert_eq!(trace_envelope.surface_id().expect("surface").raw(), 10);
+    assert_eq!(trace_envelope.previous_projection_revision().raw(), 11);
+    assert_eq!(trace_envelope.projection_revision().raw(), 12);
+    assert_eq!(trace_envelope.epoch().raw(), 13);
+    assert_eq!(trace_envelope.sequence().raw(), 14);
+}
+
+#[test]
+fn ui_dna2_wp4b_trace_preserves_all_quad_states() {
+    let patch = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::N),
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::F),
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 3),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::T),
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 4),
+            value: ProjectionPatchValue::Quad(ProjectionQuadState::S),
+        },
+    ]);
+
+    let trace = patch.replay_trace().expect("trace");
+
+    let mut found_n = false;
+    let mut found_f = false;
+    let mut found_t = false;
+    let mut found_s = false;
+
+    for step in trace.steps() {
+        if let ProjectionPatchOperation::SetBindingValue {
+            value: ProjectionPatchValue::Quad(state),
+            ..
+        } = step.operation()
+        {
+            match state {
+                ProjectionQuadState::N => found_n = true,
+                ProjectionQuadState::F => found_f = true,
+                ProjectionQuadState::T => found_t = true,
+                ProjectionQuadState::S => found_s = true,
+            }
+        }
+    }
+
+    assert!(found_n && found_f && found_t && found_s);
+}
+
+#[test]
+fn ui_dna2_wp4b_trace_step_count_matches_operation_count() {
+    let first = patch_with_operations(alloc::vec![
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 1),
+            value: ProjectionPatchValue::SignedScalar(1),
+        },
+        ProjectionPatchOperation::SetBindingValue {
+            target: binding_target(10, 2),
+            value: ProjectionPatchValue::SignedScalar(2),
+        },
+    ]);
+    let second = ProjectionPatch::new(
+        envelope(2, 1, 1, Some(1), 1, 2, 1, 1),
+        alloc::vec![
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 3),
+                value: ProjectionPatchValue::SignedScalar(3),
+            },
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 4),
+                value: ProjectionPatchValue::SignedScalar(4),
+            },
+            ProjectionPatchOperation::SetBindingValue {
+                target: binding_target(10, 5),
+                value: ProjectionPatchValue::SignedScalar(5),
+            },
+        ],
+    )
+    .expect("patch");
+
+    let sum_operations = first.operations().len() + second.operations().len();
+
+    let set = ProjectionPatchSet::new(alloc::vec![first, second]).expect("set");
+    let trace = set.replay_trace().expect("trace");
+
+    assert_eq!(trace.steps().len(), sum_operations);
+}

--- a/docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
+++ b/docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
@@ -1,28 +1,56 @@
 # UI-DNA2 implementation roadmap
 
-Status: ACTIVE EXECUTION ROADMAP
+Status: DIRECTIONAL RESEARCH ROADMAP
 Repository baseline: `f28d8d37417301c04058bd13909a9b18b7460c2a`
 Live tracker: `#1489`
 
-This document is the durable repository mirror of issue `#1489`.
+## Document role
 
-Issue `#1489` is the live execution ledger.
+This document is a directional research roadmap for UI DNA v2.
 
-`ui_dna2_implementation_roadmap.md` is the durable repository mirror.
+It is not a canonical source of repository truth, architectural authority,
+implementation authorization, release posture, or production readiness.
 
-Neither replaces the other.
+It records the current research direction, working phase decomposition,
+landed evidence, unresolved hypotheses, and likely sequencing.
 
-This document records landed evidence and remaining gated execution contours.
+Because UI DNA v2 is partly an exploratory engineering programme, this
+roadmap may be revised, reordered, split, collapsed, or rewritten when
+implementation and qualification evidence changes the model.
 
-It does not authorize implementation by itself.
+Canonical ownership and forbidden-boundary decisions remain in the accepted
+ownership and compatibility documents.
 
-## 1. Current execution baseline
+Actual implementation evidence is established by landed code, tests,
+qualification artifacts, and merged pull requests.
 
-Current main baseline:
+The active issue ledger records current coordination state, but roadmap
+position alone never authorizes a task.
 
 ```text
-f28d8d37417301c04058bd13909a9b18b7460c2a
-feat(ui): add projection patch contract foundation (#1497)
+roadmap direction != canonical truth
+roadmap phase != automatic authorization
+roadmap ordering != immutable architecture
+implementation evidence != production promotion
+landed code != stable promise
+qualification != shell integration
+```
+
+Issue #1489 is the active coordination ledger.
+
+This roadmap is the durable directional research map.
+
+The issue and roadmap may be synchronized for clarity, but neither overrides
+accepted ownership boundaries, landed code, qualification evidence, or
+explicit promotion decisions.
+
+## 1. WP4B observation baseline
+
+WP4B accepted starting baseline:
+
+```text
+5f9549690505968743f111851a7ae3b087433e9e
+docs(ui): add UI DNA v2 implementation roadmap (#1498)
 ```
 
 Current governing rule:
@@ -80,6 +108,7 @@ Renderer owns pixels.
 | #1495 | `56df8ab37ae4bea23ced24bced6c28555319f7cf` | Exact capability-reference lookup specification owned by `prom-cap` |
 | #1496 | `5bbda87455f0bdc65cd6f6013df8cbad799eae15` | Immutable borrowed exact capability-reference lookup implementation and qualification |
 | #1497 | `f28d8d37417301c04058bd13909a9b18b7460c2a` | Crate-internal Projection Patch contract foundation, deterministic validation, exact diagnostic coordinate preservation, WP4A qualification |
+| #1498 | `5f9549690505968743f111851a7ae3b087433e9e` | Directional UI DNA v2 implementation roadmap, WP4B ownership-boundary correction, Gate D closure preserved |
 
 ## 4. Current landed contract state
 
@@ -147,7 +176,10 @@ Workbench or Semantic Studio work
 production promotion
 ```
 
-## 5. Rebaselined phase matrix
+## 5. Current research checkpoint matrix
+
+This matrix is a working decomposition, not an immutable architecture.
+Future evidence may split, combine, reorder, or retire phases.
 
 | Phase | Current status | Landed evidence | Remaining closure work |
 | --- | --- | --- | --- |
@@ -157,7 +189,7 @@ production promotion
 | UI-DNA2-3 — Canonical Static UI IR | **FOUNDATION LANDED** | versioned wrapper, stable structure, semantic child ordering, lowering, qualification bytes, #1490 | Final canonical artifact/serialization policy, compatibility surface and full invalid-artifact matrix |
 | UI-DNA2-4 — Binding Graph | **CONTRACT FOUNDATION LANDED** | deterministic declarations, cycle validation, diagnostics, #1491 | Approved Semantic source adapters, revision/epoch observation rules, dirty-propagation integration and Quad preservation evidence |
 | UI-DNA2-5 — Action IR integration | **CONTRACT FOUNDATION LANDED** | static routes, `ActionIntent`, invocation context, structural mapper, #1491 | Explicit adapter to existing admission boundary, accepted/denied traces, stale revision, idempotency and capability evidence; Gate D required |
-| UI-DNA2-6 — Projection patch model and runtime | **WP4A CONTRACT FOUNDATION LANDED** | `#1497`, crate-internal Projection Patch contract foundation and qualification | WP4B deterministic replay-order model and qualification; actual patch application remains deferred to the separately gated UI-DNA2-9 shell-player contour |
+| UI-DNA2-6 — Projection patch model and runtime | **WP4A FOUNDATION + WP4B REPLAY-ORDER CHECKPOINT COMPLETE** | #1497 — Projection Patch contract foundation<br>#1499 — deterministic replay-order model and qualification | actual patch application remains deferred to the separately gated UI-DNA2-9 prom-ui-runtime::shell_player contour |
 | UI-DNA2-7 — Denial, recovery, task and freshness projection | **NOT STARTED** | specifications only | Bounded contracts and evidence after deterministic patch replay-order qualification |
 | UI-DNA2-8 — ProjectionBundle qualification | **NOT STARTED** | fixture and draft-tool evidence only | Parser, validators, verifier, inert loader and activation separation |
 | UI-DNA2-9 — Shell player integration | **NOT STARTED** | experimental `ui-shell-kit` evidence only | Separate promotion audit and bounded shell-player implementation |
@@ -199,30 +231,42 @@ other reference-domain resolution
 UI wiring
 ```
 
-## 7. Next proposed execution slice
+## 7. Latest bounded research checkpoint
 
 ### UI-DNA2-WP4B — deterministic patch replay-order model and qualification
 
-This is the next proposed slice. This document does not authorize it by itself; it requires a separate bounded implementation issue and explicit activation.
+WP4B REPLAY-ORDER CHECKPOINT —
+IMPLEMENTED AND QUALIFIED IN #1499
+NOT PROMOTED
 
 Current state:
 
 ```text
 WP4A contract foundation = LANDED
-WP4B deterministic patch replay-order model and qualification = PROPOSED, NOT AUTHORIZED
-Gate D = CLOSED
-production promotion = NOT AUTHORIZED
+
+WP4B deterministic replay-order model =
+IMPLEMENTED AND QUALIFIED IN #1499
+
+WP4B scope =
+crate-internal replay-order evidence only
+
+patch application =
+NOT IMPLEMENTED
+
+shell-player integration =
+NOT AUTHORIZED
+
+Gate D =
+CLOSED
+
+production promotion =
+NOT AUTHORIZED
 ```
 
-#### Proposed narrow scope
+No next implementation slice is authorized by this roadmap.
 
-```text
-owner: crates/prom-ui::projection_patch
-input: validated ProjectionPatch / ProjectionPatchSet
-output: deterministic replay-order model,
-ordered replay trace,
-and qualification evidence
-```
+The next bounded task must be chosen separately using current evidence,
+ownership boundaries, and explicit authorization.
 
 #### Required invariants
 
@@ -243,13 +287,28 @@ no host effects
 Ownership boundary:
 
 ```text
-prom-ui::projection_patch owns patch vocabulary and replay order.
+prom-ui::projection_patch owns:
+- patch vocabulary;
+- structural validation;
+- declared replay order;
+- inert replay trace evidence.
 
-prom-ui-runtime::shell_player owns patch application when separately
-authorized under the shell-player integration phase.
+prom-ui-runtime::shell_player owns:
+- actual patch application;
+- shell-local realization;
+- focus;
+- hit testing;
+- accessibility realization;
+- draw-command production.
+
+replay order != application
+trace != execution
+step != command
+borrowed operation != applied operation
+prom-ui model evidence != prom-ui-runtime shell mutation
+```
 
 WP4B does not implement shell application.
-```
 
 #### Explicitly forbidden in WP4B
 
@@ -269,26 +328,38 @@ public API expansion without separate review
 
 ## 8. Dependency order after rebaseline
 
+EVIDENCE LANDED OR CARRIED BY THE CURRENT CHANGE:
+
 ```text
-COMPLETE:
-0 → 1 → WP2 foundation → WP3 foundation → D0B → D0C → D0D → D0E → WP4A
-
-NEXT PROPOSED:
-WP4B deterministic patch replay-order model and qualification
-
-REMAINING:
-2 parser qualification
-3 final artifact qualification
-4 source/dirty integration
-5 admission integration behind Gate D
-7 denial/task/freshness
-8 bundle qualification
-9 shell player
-10 reference slice
-11 promotion decision
+0 → 1 → WP2 foundation → WP3 foundation
+→ D0B → D0C → D0D → D0E
+→ WP4A → WP4B replay-order checkpoint
 ```
 
-No later phase may be used to bypass an unfinished earlier authority or determinism requirement.
+CURRENTLY UNAUTHORIZED FUTURE CONTOURS:
+
+```text
+parser qualification
+final Static UI IR artifact qualification
+Binding Graph source/dirty integration
+admission integration behind Gate D
+denial/recovery/task/freshness projection
+ProjectionBundle qualification
+shell-player implementation
+end-to-end reference slice
+production-promotion decision
+```
+
+This order is directional rather than immutable.
+
+Research evidence may justify:
+- reordering;
+- splitting a phase;
+- merging phases;
+- adding a prerequisite;
+- removing an obsolete contour.
+
+No roadmap movement may bypass an accepted ownership or authority boundary.
 
 ## 9. Governance boundaries
 
@@ -337,7 +408,7 @@ reference slice != production promotion
 - [ ] Static UI IR artifact/serialization qualification is complete.
 - [ ] Binding Graph source and dirty-propagation integration is qualified.
 - [ ] Action IR admission integration is separately approved and qualified.
-- [ ] Projection Patch replay-order model and qualification are complete.
+- [x] Projection Patch replay-order model and qualification are complete in the bounded WP4B contour.
 - [ ] Patch application is separately qualified in the `prom-ui-runtime::shell_player` contour.
 - [ ] Denial/recovery/task/freshness projection is qualified.
 - [ ] ProjectionBundle parser/validator/verifier/loader sequence is qualified.
@@ -346,6 +417,17 @@ reference slice != production promotion
 - [ ] Production promotion decision is explicit.
 
 ## 11. Definition of Done
+
+This roadmap does not independently declare UI DNA v2 complete.
+
+Completion or promotion decisions require explicit evidence and governance
+outside roadmap progression, including:
+
+- landed implementation evidence;
+- qualification results;
+- accepted ownership compliance;
+- integration evidence where applicable;
+- explicit release or promotion decisions.
 
 This umbrella issue may close only when:
 
@@ -358,7 +440,6 @@ This umbrella issue may close only when:
 Until then:
 
 ```text
-Issue #1489 = OPEN ACTIVE EXECUTION UMBRELLA
 Gate D = CLOSED
 production promotion = NOT AUTHORIZED
 ```


### PR DESCRIPTION
## Summary

Adds the crate-internal UI DNA v2 Projection Patch replay-order model and qualification.

The slice provides a deterministic inert replay trace over already validated:

- `ProjectionPatch`;
- `ProjectionPatchSet`;
- declared patch order;
- declared operation order.

Each replay step preserves:

- zero-based patch and operation ordinals;
- the complete originating patch envelope;
- an exact borrowed reference to the validated patch operation.

## Scope

Changed paths:

- `crates/prom-ui/src/projection_patch.rs`
- `crates/prom-ui/src/ui_dna2_wp4_qualification_tests.rs`
- `docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md`

No dependency, Cargo policy, public API, runtime, shell-player, renderer, admission, capability or ProjectionBundle activation change is included.

## Directional roadmap synchronization

This PR also updates the UI DNA v2 roadmap as a directional research artifact.

The roadmap is not a canonical source of repository truth, architectural
authority, implementation authorization, release posture, or production
readiness.

It records the current research direction and checkpoint evidence and may be
revised as implementation and qualification evidence develops.

For this change it records:

- WP4B replay-order model and qualification as the latest bounded checkpoint;
- actual patch application as still deferred to
  `prom-ui-runtime::shell_player`;
- Gate D as closed;
- production promotion as unauthorized;
- no next implementation slice as automatically authorized.

Issue #1489 remains unchanged until merge. It can be rebaselined separately
using the actual resulting merge SHA.

## Ownership boundary

```text
prom-ui::projection_patch
    owns patch vocabulary and deterministic replay order.

prom-ui-runtime::shell_player
    owns actual patch application when separately authorized.
```

This PR does not implement patch application.

## Replay boundary

```text
replay order != application
trace != execution
step != command
borrowed operation != applied operation
```

The trace:

* follows stored patch order;
* follows stored operation order;
* does not sort;
* does not normalize;
* does not coalesce;
* does not deduplicate;
* does not mutate projected state;
* performs no host effect.

## Determinism

The qualification demonstrates:

* single-patch operation order;
* nested patch-set order;
* repeated construction equality;
* singleton patch/set equivalence;
* operation-order observability;
* patch-order observability;
* cross-kind same-key order preservation;
* exact borrowed operation identity;
* complete envelope preservation;
* Quad `N/F/T/S` preservation;
* exact replay-step count.

## Canonical compatibility

The existing WP4A canonical qualification encoding remains unchanged:

```text
UI_DNA2_PROJECTION_PATCH_V1
```

Replay coordinates are not added to canonical patch bytes.

## Validation

Passed locally:

* `scripts/harness-check.ps1`
* `cargo test -p prom-ui --lib ui_dna2_wp4b` — 11 passed
* `cargo test -p prom-ui --lib ui_dna2_wp4` — 62 passed
* `cargo test -p prom-ui`
* `cargo test -p prom-ui-runtime`
* `cargo check -p prom-ui --all-features`
* `cargo tree -p prom-ui --depth 1`
* `cargo test --test public_api_contracts --quiet`
* `cargo test --test trust_boundary_guards`
* `cargo +1.93.1 fmt --all --check`
* `cargo +1.93.1 clippy --workspace --all-targets -- -D warnings`
* `cargo test --workspace`
* `git diff --check`

`cargo check -p prom-ui --no-default-features` retains only the known pre-existing failures outside WP4B. No diagnostic originates from the replay-order model.

## Deferred

This PR does not implement:

* patch application;
* projected UI state mutation;
* shell-local state;
* dirty propagation;
* runtime queues;
* renderer or draw commands;
* ProjectionBundle loading or activation;
* admission or capability policy;
* ActionIntent dispatch;
* Gate D integration;
* production promotion.

Refs #1489