### PR TITLE
refactor(ui): own projection source role names

### DIFF
--- a/crates/prom-ui/src/projection_compile.rs
+++ b/crates/prom-ui/src/projection_compile.rs
@@ -27,9 +27,16 @@ pub(crate) fn compile_projection_source_to_static_ir(
     let mut document = StaticUiDocument::new(document_id, source.revision(), source.epoch());
 
     for source_node in normalized.nodes() {
+        let role = source_node
+            .resolved_role(dictionary)
+            .map_err(|diagnostic| {
+                ProjectionCompileDiagnostics::from_source(ProjectionSourceDiagnostics::single(
+                    diagnostic,
+                ))
+            })?;
         let mut static_node = StaticUiNode::new(
             static_node_id(source_node.id().raw())?,
-            source_node.role(),
+            role,
             source_node.key(),
             Some(source_node.source()),
         );
@@ -197,9 +204,10 @@ mod tests {
         Revision, SourceId, SourceRef, SourceSpan,
     };
     use crate::projection_source::{
-        ProjectionSourceChild, ProjectionSourceNode, ProjectionSourceSurface,
+        ProjectionSourceChild, ProjectionSourceNode, ProjectionSourceRoleName,
+        ProjectionSourceSurface,
     };
-    use crate::role_dictionary::RoleId;
+    use alloc::string::String;
 
     fn source_ref(start: u32, end: u32) -> SourceRef {
         SourceRef::new(
@@ -232,7 +240,28 @@ mod tests {
         );
         source.push_node(ProjectionSourceNode::new(
             source_node_id(10),
-            RoleId::new("root"),
+            ProjectionSourceRoleName::new("root"),
+            key(10),
+            source_ref(0, 1),
+        ));
+        source.push_surface(ProjectionSourceSurface::new(
+            source_surface_id(1),
+            source_node_id(10),
+            key(1),
+            source_ref(0, 1),
+        ));
+        source
+    }
+
+    fn source_with_role(role: &str) -> ProjectionSourceDocument {
+        let mut source = ProjectionSourceDocument::new(
+            SourceId::new(1).expect("source id"),
+            Revision::new(0),
+            Epoch::new(0),
+        );
+        source.push_node(ProjectionSourceNode::new(
+            source_node_id(10),
+            ProjectionSourceRoleName::new(role),
             key(10),
             source_ref(0, 1),
         ));
@@ -287,6 +316,40 @@ mod tests {
     }
 
     #[test]
+    fn projection_compile_owned_role_buffers_have_stable_output() {
+        let first_role = String::from("root");
+        let first_source = source_with_role(&first_role);
+        drop(first_role);
+
+        let second_role = String::from("root");
+        let second_source = source_with_role(&second_role);
+        drop(second_role);
+
+        let first = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &first_source,
+            RoleDictionary::current(),
+        )
+        .expect("first");
+        let second = compile_projection_source_to_static_ir(
+            static_doc_id(1),
+            &second_source,
+            RoleDictionary::current(),
+        )
+        .expect("second");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first
+                .canonical_bytes(RoleDictionary::current())
+                .expect("first bytes"),
+            second
+                .canonical_bytes(RoleDictionary::current())
+                .expect("second bytes")
+        );
+    }
+
+    #[test]
     fn projection_compile_reports_source_diagnostics() {
         let mut source = ProjectionSourceDocument::new(
             SourceId::new(1).expect("source id"),
@@ -295,7 +358,7 @@ mod tests {
         );
         let mut root = ProjectionSourceNode::new(
             source_node_id(10),
-            RoleId::new("root"),
+            ProjectionSourceRoleName::new("root"),
             key(10),
             source_ref(0, 1),
         );
@@ -306,7 +369,7 @@ mod tests {
         source.push_node(root);
         source.push_node(ProjectionSourceNode::new(
             source_node_id(11),
-            RoleId::new("renderer_button"),
+            ProjectionSourceRoleName::new("renderer_button"),
             key(11),
             source_ref(2, 3),
         ));
@@ -442,7 +505,7 @@ mod tests {
         );
         source.push_node(ProjectionSourceNode::new(
             source_node_id(10),
-            RoleId::new("renderer_button"),
+            ProjectionSourceRoleName::new("renderer_button"),
             key(10),
             source_ref(10, 11),
         ));

--- a/crates/prom-ui/src/projection_source.rs
+++ b/crates/prom-ui/src/projection_source.rs
@@ -5,7 +5,7 @@
 //! the legacy `UiAst` substrate.
 #![allow(dead_code)]
 
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 use crate::contract_primitives::{
     ChildOrder, CollectionKey, DiagnosticCode, DiagnosticCoordinate, Epoch, ProjectionSourceNodeId,
@@ -19,6 +19,19 @@ pub(crate) enum ProjectionSourceTokenKind {
     Node,
     Role,
     Key,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ProjectionSourceRoleName(Box<str>);
+
+impl ProjectionSourceRoleName {
+    pub(crate) fn new(raw: &str) -> Self {
+        Self(raw.into())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -84,7 +97,7 @@ impl ProjectionSourceSurface {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ProjectionSourceNode {
     id: ProjectionSourceNodeId,
-    role: RoleId,
+    role: ProjectionSourceRoleName,
     key: CollectionKey,
     source: SourceRef,
     children: Vec<ProjectionSourceChild>,
@@ -113,7 +126,7 @@ impl ProjectionSourceChild {
 impl ProjectionSourceNode {
     pub(crate) fn new(
         id: ProjectionSourceNodeId,
-        role: RoleId,
+        role: ProjectionSourceRoleName,
         key: CollectionKey,
         source: SourceRef,
     ) -> Self {
@@ -130,8 +143,22 @@ impl ProjectionSourceNode {
         self.id
     }
 
-    pub(crate) const fn role(&self) -> RoleId {
-        self.role
+    pub(crate) fn role(&self) -> &ProjectionSourceRoleName {
+        &self.role
+    }
+
+    pub(crate) fn resolved_role(
+        &self,
+        dictionary: RoleDictionary,
+    ) -> Result<RoleId, ProjectionSourceDiagnostic> {
+        dictionary.resolve_name(self.role.as_str()).ok_or_else(|| {
+            ProjectionSourceDiagnostic::new(
+                Some(self.source),
+                ProjectionSourceDiagnosticKind::UnknownRole,
+                self.key.raw(),
+                0,
+            )
+        })
     }
 
     pub(crate) const fn key(&self) -> CollectionKey {
@@ -319,6 +346,10 @@ pub(crate) struct ProjectionSourceDiagnostics {
 }
 
 impl ProjectionSourceDiagnostics {
+    pub(crate) fn single(diagnostic: ProjectionSourceDiagnostic) -> Self {
+        Self::new(Vec::from([diagnostic]))
+    }
+
     fn new(mut diagnostics: Vec<ProjectionSourceDiagnostic>) -> Self {
         diagnostics.sort();
         diagnostics.dedup();
@@ -396,13 +427,8 @@ fn validate_source(
                 0,
             ));
         }
-        if dictionary.validate(node.role).is_err() {
-            diagnostics.push(ProjectionSourceDiagnostic::new(
-                Some(node.source),
-                ProjectionSourceDiagnosticKind::UnknownRole,
-                node.key.raw(),
-                0,
-            ));
+        if let Err(diagnostic) = node.resolved_role(dictionary) {
+            diagnostics.push(diagnostic);
         }
         for (child_index, child) in node.children.iter().enumerate() {
             if !document
@@ -624,6 +650,7 @@ mod tests {
     use super::*;
     use crate::contract_primitives::{ChildOrder, CollectionKey, SourceSpan};
     use crate::model::UiAst;
+    use alloc::string::String;
 
     fn source_ref(start: u32, end: u32) -> SourceRef {
         SourceRef::new(
@@ -652,7 +679,7 @@ mod tests {
         );
         document.push_node(ProjectionSourceNode::new(
             node_id(10),
-            RoleId::new("root"),
+            ProjectionSourceRoleName::new("root"),
             key(10),
             source_ref(0, 4),
         ));
@@ -671,8 +698,12 @@ mod tests {
             Revision::new(0),
             Epoch::new(0),
         );
-        let mut root =
-            ProjectionSourceNode::new(node_id(10), RoleId::new("root"), key(10), source_ref(0, 4));
+        let mut root = ProjectionSourceNode::new(
+            node_id(10),
+            ProjectionSourceRoleName::new("root"),
+            key(10),
+            source_ref(0, 4),
+        );
         root.push_child(ProjectionSourceChild::new(
             node_id(20),
             ChildOrder::new(order_a),
@@ -684,13 +715,13 @@ mod tests {
         document.push_node(root);
         document.push_node(ProjectionSourceNode::new(
             node_id(20),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(20),
             source_ref(10, 11),
         ));
         document.push_node(ProjectionSourceNode::new(
             node_id(30),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(30),
             source_ref(12, 13),
         ));
@@ -709,11 +740,29 @@ mod tests {
     }
 
     #[test]
+    fn projection_source_role_name_owns_input_text() {
+        let role = {
+            let temporary = String::from("renderer_button");
+            ProjectionSourceRoleName::new(&temporary)
+        };
+
+        assert_eq!(role.as_str(), "renderer_button");
+    }
+
+    #[test]
+    fn projection_source_role_name_compares_by_text() {
+        assert_eq!(
+            ProjectionSourceRoleName::new("root"),
+            ProjectionSourceRoleName::new("root")
+        );
+    }
+
+    #[test]
     fn projection_source_rejects_unknown_role() {
         let mut document = minimal_source();
         document.push_node(ProjectionSourceNode::new(
             node_id(11),
-            RoleId::new("renderer_button"),
+            ProjectionSourceRoleName::new("renderer_button"),
             key(11),
             source_ref(5, 9),
         ));
@@ -725,6 +774,16 @@ mod tests {
         assert_eq!(
             diagnostics.diagnostics()[0].kind(),
             ProjectionSourceDiagnosticKind::UnknownRole
+        );
+        let coordinate = diagnostics.diagnostics()[0].coordinate();
+        assert_eq!(coordinate.code(), DiagnosticCode::new("PS_UNKNOWN_ROLE"));
+        assert_eq!(coordinate.source().expect("source").span().start(), 5);
+        assert_eq!(coordinate.source().expect("source").span().end(), 9);
+        assert_eq!(coordinate.domain(), 11);
+        assert_eq!(coordinate.secondary(), 0);
+        assert_eq!(
+            document.validate(RoleDictionary::current()),
+            Err(diagnostics)
         );
     }
 
@@ -739,7 +798,7 @@ mod tests {
             .push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
         first.push_node(ProjectionSourceNode::new(
             node_id(20),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(20),
             source_ref(10, 11),
         ));
@@ -751,13 +810,13 @@ mod tests {
         );
         second.push_node(ProjectionSourceNode::new(
             node_id(20),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(20),
             source_ref(10, 11),
         ));
         second.push_node(ProjectionSourceNode::new(
             node_id(10),
-            RoleId::new("root"),
+            ProjectionSourceRoleName::new("root"),
             key(10),
             source_ref(0, 4),
         ));
@@ -792,18 +851,22 @@ mod tests {
         );
         second.push_node(ProjectionSourceNode::new(
             node_id(30),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(30),
             source_ref(12, 13),
         ));
-        let mut root =
-            ProjectionSourceNode::new(node_id(10), RoleId::new("root"), key(10), source_ref(0, 4));
+        let mut root = ProjectionSourceNode::new(
+            node_id(10),
+            ProjectionSourceRoleName::new("root"),
+            key(10),
+            source_ref(0, 4),
+        );
         root.push_child(ProjectionSourceChild::new(node_id(30), ChildOrder::new(1)));
         root.push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
         second.push_node(root);
         second.push_node(ProjectionSourceNode::new(
             node_id(20),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(20),
             source_ref(10, 11),
         ));
@@ -879,7 +942,7 @@ mod tests {
         let mut orphan = minimal_source();
         orphan.push_node(ProjectionSourceNode::new(
             node_id(40),
-            RoleId::new("text"),
+            ProjectionSourceRoleName::new("text"),
             key(40),
             source_ref(20, 21),
         ));
@@ -947,9 +1010,9 @@ mod tests {
             let mut node = ProjectionSourceNode::new(
                 node_id(raw),
                 if raw == 1 {
-                    RoleId::new("root")
+                    ProjectionSourceRoleName::new("root")
                 } else {
-                    RoleId::new("text")
+                    ProjectionSourceRoleName::new("text")
                 },
                 key(raw),
                 source_ref(raw as u32, raw as u32 + 1),
@@ -984,9 +1047,9 @@ mod tests {
             let mut node = ProjectionSourceNode::new(
                 node_id(raw),
                 if raw == 1 {
-                    RoleId::new("root")
+                    ProjectionSourceRoleName::new("root")
                 } else {
-                    RoleId::new("text")
+                    ProjectionSourceRoleName::new("text")
                 },
                 key(raw),
                 source_ref(raw as u32, raw as u32 + 1),

--- a/crates/prom-ui/src/role_dictionary.rs
+++ b/crates/prom-ui/src/role_dictionary.rs
@@ -85,6 +85,13 @@ impl RoleDictionary {
         self.roles
     }
 
+    pub(crate) fn resolve_name(self, raw: &str) -> Option<RoleId> {
+        self.roles
+            .iter()
+            .map(|built_in| built_in.id())
+            .find(|role| role.as_str() == raw)
+    }
+
     pub(crate) fn validate(self, role: RoleId) -> Result<BuiltInRole, RoleDictionaryError> {
         for built_in in self.roles {
             if built_in.id() == role {
@@ -129,6 +136,22 @@ mod tests {
                 "renderer_button"
             )))
         );
+    }
+
+    #[test]
+    fn role_dictionary_resolves_borrowed_names_without_allocation() {
+        let dictionary = RoleDictionary::current();
+
+        assert_eq!(
+            dictionary.resolve_name("root"),
+            Some(BuiltInRole::Root.id())
+        );
+        assert_eq!(
+            dictionary.resolve_name("numeric_readout"),
+            Some(BuiltInRole::NumericReadout.id())
+        );
+        assert_eq!(dictionary.resolve_name("renderer_button"), None);
+        assert_eq!(dictionary.resolve_name("Root"), None);
     }
 
     #[test]

--- a/crates/prom-ui/src/ui_dna2_wp2_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp2_qualification_tests.rs
@@ -1,13 +1,16 @@
+use alloc::string::String;
+
 use crate::contract_primitives::{
-    CollectionKey, Epoch, ProjectionSourceNodeId, ProjectionSourceSurfaceId, Revision, SourceId,
-    SourceRef, SourceSpan, StaticDocumentId, StaticSurfaceId,
+    ChildOrder, CollectionKey, Epoch, ProjectionSourceNodeId, ProjectionSourceSurfaceId, Revision,
+    SourceId, SourceRef, SourceSpan, StaticDocumentId, StaticSurfaceId,
 };
 use crate::model::{UiAstNodeId, UiIr, UiIrNode, UiIrNodeId, UiIrNodeKind};
 use crate::projection_compile::compile_projection_source_to_static_ir;
 use crate::projection_source::{
-    ProjectionSourceDocument, ProjectionSourceNode, ProjectionSourceSurface,
+    ProjectionSourceChild, ProjectionSourceDocument, ProjectionSourceNode,
+    ProjectionSourceRoleName, ProjectionSourceSurface,
 };
-use crate::role_dictionary::{RoleDictionary, RoleId};
+use crate::role_dictionary::RoleDictionary;
 use crate::static_ir::{LegacyUiIrAdapterContext, StaticUiDocument};
 
 fn source_ref(start: u32, end: u32) -> SourceRef {
@@ -57,7 +60,7 @@ fn minimal_source() -> ProjectionSourceDocument {
     );
     source.push_node(ProjectionSourceNode::new(
         source_node_id(10),
-        RoleId::new("root"),
+        ProjectionSourceRoleName::new("root"),
         key(10),
         source_ref(0, 1),
     ));
@@ -78,9 +81,9 @@ fn multi_surface_source(order: &[u64]) -> ProjectionSourceDocument {
     );
     for raw in order {
         let role = if *raw == 10 {
-            RoleId::new("root")
+            ProjectionSourceRoleName::new("root")
         } else {
-            RoleId::new("text")
+            ProjectionSourceRoleName::new("text")
         };
         source.push_node(ProjectionSourceNode::new(
             source_node_id(*raw),
@@ -157,7 +160,7 @@ fn ui_dna2_wp2_invalid_projection_diagnostics_are_stable() {
     let mut source = minimal_source();
     source.push_node(ProjectionSourceNode::new(
         source_node_id(20),
-        RoleId::new("renderer_button"),
+        ProjectionSourceRoleName::new("renderer_button"),
         key(20),
         source_ref(20, 21),
     ));
@@ -176,6 +179,54 @@ fn ui_dna2_wp2_invalid_projection_diagnostics_are_stable() {
     .expect_err("second diagnostics");
 
     assert_eq!(first, second);
+}
+
+#[test]
+fn ui_dna2_wp2_owned_unknown_role_survives_source_drop() {
+    let role = String::from("renderer_button");
+    let mut source = ProjectionSourceDocument::new(
+        SourceId::new(1).expect("source id"),
+        Revision::new(0),
+        Epoch::new(0),
+    );
+    let mut root = ProjectionSourceNode::new(
+        source_node_id(10),
+        ProjectionSourceRoleName::new("root"),
+        key(10),
+        source_ref(0, 1),
+    );
+    root.push_child(ProjectionSourceChild::new(
+        source_node_id(20),
+        ChildOrder::new(0),
+    ));
+    source.push_node(root);
+    source.push_node(ProjectionSourceNode::new(
+        source_node_id(20),
+        ProjectionSourceRoleName::new(&role),
+        key(20),
+        source_ref(20, 21),
+    ));
+    source.push_surface(ProjectionSourceSurface::new(
+        source_surface_id(1),
+        source_node_id(10),
+        key(1),
+        source_ref(0, 1),
+    ));
+    drop(role);
+
+    let diagnostics = compile_projection_source_to_static_ir(
+        static_doc_id(1),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect_err("unknown role must fail semantic validation");
+
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        crate::projection_compile::ProjectionCompileDiagnosticKind::Source(
+            crate::projection_source::ProjectionSourceDiagnosticKind::UnknownRole
+        )
+    );
 }
 
 #[test]

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -26,6 +26,28 @@ projection_source_grammar_v0.md.
 
 Parser implementation remains a separate, unauthorized slice.
 
+## Source Role Representation Boundary
+
+Projection Source AST stores authored role identifiers as owned source text.
+
+RoleDictionary retains canonical static `RoleId` values.
+
+Owned source text is resolved through RoleDictionary during Projection Source
+semantic validation and lowering.
+
+A syntactically valid unknown role remains representable in the source AST and
+fails through `PS_UNKNOWN_ROLE`.
+
+Source-role storage does not grant role validity, authority, runtime behavior,
+renderer ownership, or admission.
+
+```text
+source role name != canonical RoleId
+source storage != semantic acceptance
+unknown source role != parser failure
+known role resolution != authority
+```
+
 ## 1. Purpose
 
 The projection source model exists to prevent the bad workflow:


### PR DESCRIPTION
## Summary

Introduces a bounded owned source-role representation for the programmatic
Projection Source AST.

The change:

- adds crate-private `ProjectionSourceRoleName` backed by immutable
  `Box<str>`;
- allows authored runtime role text to remain valid after the original source
  buffer is dropped;
- keeps canonical `RoleId` as static, `Copy` and allocation-free;
- adds exact allocation-free `RoleDictionary::resolve_name(&str)`;
- uses one shared source-role resolution path for validation and lowering;
- preserves unknown authored role text in the AST;
- keeps unknown-role rejection in existing `PS_UNKNOWN_ROLE` semantic
  validation;
- passes only canonical `RoleId` values into Static UI IR.

## Motivation

The landed Grammar v0 requires syntactically valid unknown role identifiers to
parse into the source AST and fail later through semantic validation.

The previous source AST stored `RoleId(&'static str)`, which could not safely
represent arbitrary role text originating from a runtime `.proj.sm` source
without leaks, unsafe lifetime extension, global interning or parser-time
semantic rejection.

This prerequisite removes that representation blocker without implementing a
parser.

## Scope

Changed repository paths:

- `crates/prom-ui/src/projection_source.rs`
- `crates/prom-ui/src/role_dictionary.rs`
- `crates/prom-ui/src/projection_compile.rs`
- `crates/prom-ui/src/ui_dna2_wp2_qualification_tests.rs`
- `docs/spec/ui/projection_source_model.md`

## Preserved boundaries

```text
source role name != canonical RoleId
source storage != semantic acceptance
unknown source role != parser failure
known role resolution != authority

The following remain unchanged:

- Static UI IR representation;
- canonical "RoleId";
- existing "PS_*" diagnostic identities;
- deterministic normalization and lowering;
- public API;
- Cargo features and dependencies.

Explicit non-goals

parser implementation = NOT INCLUDED
lexer implementation = NOT INCLUDED
PSP diagnostics = NOT INCLUDED
SourceSpan policy correction = NOT INCLUDED
grammar diagnostic correction = NOT INCLUDED
runtime activation = NOT AUTHORIZED
Gate D = CLOSED
production promotion = NOT AUTHORIZED

Validation

Passed locally:

- "scripts/harness-check.ps1"
- focused Role Dictionary tests
- focused Projection Source tests
- focused Projection Compile tests
- UI-DNA2 WP2 qualification tests
- "cargo test --test public_api_contracts --quiet"
- "cargo test --test trust_boundary_guards"
- "cargo +1.93.1 fmt --all --check"
- "cargo test --workspace"
- full committed-range "git diff --check"

"cargo check -p prom-ui --no-default-features" retains the pre-existing
unrelated baseline failures and introduces no failure in the changed
source-role files.

Review

The exact candidate received:

PASS WITH NON-BLOCKING OBSERVATIONS —
SAFE FOR PUBLICATION PREP

The publication preflight repeated the full workspace test run to successful
terminal completion.

Refs #1489