### PR TITLE
docs(ui): define projection source size policy

### DIFF
--- a/docs/spec/ui/projection_source_grammar_v0.md
+++ b/docs/spec/ui/projection_source_grammar_v0.md
@@ -154,6 +154,65 @@ Non-ASCII UTF-8 is allowed only inside line-comment text.
 
 Outside comments, non-ASCII input is rejected as PSP_UNEXPECTED_CHAR.
 
+### 5.1.1 Source-size representability
+
+The normative maximum accepted Projection Source input length is:
+
+```text
+MAX_PROJECTION_SOURCE_BYTES = u32::MAX = 4_294_967_295 bytes
+```
+
+This is a SourceSpan representability ceiling, not a recommended operational
+file size. The input length is the UTF-8 encoded byte length of the caller's
+`&str`, not a character, scalar, grapheme or line count.
+
+The boundary is inclusive:
+
+```text
+len = 0
+            -> representable
+len = u32::MAX
+            -> representable and accepted for lexical processing
+len = u32::MAX + 1
+            -> rejected before lexical processing
+```
+
+An oversized input is any input for which `source_text.len() > u32::MAX`.
+The future API classifies this input-domain failure as
+`ProjectionSourceInputError::SourceTooLarge`, carrying the caller-supplied
+`SourceId`, the actual UTF-8 byte length, and the maximum accepted length
+`4_294_967_295`. This task specifies the classification but does not
+implement the Rust type.
+
+`SourceTooLarge` is not a `DiagnosticCode`, is not a `PSP_` diagnostic, is not
+a `PS_` diagnostic, and is not a syntax or semantic-validation failure.
+Every PSP diagnostic requires a representable `SourceSpan`; an oversized
+input has no representable complete input domain or EOF position. Therefore
+oversized rejection produces no SourceSpan, tokens, AST or PS validation.
+
+The source-size check is performed before inspection of BOM, bare CR, invalid
+ASCII, forbidden non-ASCII input, identifier shape, number shape, version,
+clauses or EOF. Thus an oversized malformed source returns `SourceTooLarge`,
+not a PSP diagnostic. Parser left-to-right first-failure semantics begin only
+after this source-input preflight succeeds.
+
+Once preflight succeeds, every derived parser offset must use checked
+conversion equivalent to `u32::try_from(offset)`. Offset arithmetic for token
+lengths, UTF-8 widths, delimiters, CRLF, semicolons, braces and EOF must be
+checked; wrapping, saturating, clamping, truncating or lossy fallback is
+forbidden. A correct scanner must never derive an offset beyond the accepted
+input length.
+
+For a source of exactly `u32::MAX` bytes, the first byte index is `0`, the
+last byte index is `u32::MAX - 1`, and the EOF byte position is `u32::MAX`.
+Therefore an EOF span is `[u32::MAX, u32::MAX)`, and a token ending at EOF may
+use `[start, u32::MAX)`.
+
+An operational host or loader may impose a smaller limit for memory, quota,
+transport or sandbox reasons. Such a host resource rejection is outside this
+grammar contract and is distinct from syntax failure, PS validation failure,
+and SourceSpan representability.
+
 ## 5.5 Source span construction
 
 All SourceSpan values use UTF-8 byte offsets.
@@ -347,6 +406,12 @@ structural equivalence != PartialEq
 ## 7. Parse versus Semantic Validation
 
 ### Parser-owned failures
+
+Before parser-owned failures are considered, the future parser performs the
+source-size representability preflight defined in section 5.1.1. An oversized
+input returns the source-input error `SourceTooLarge` with no SourceSpan and
+does not enter PSP diagnostic ordering.
+
 The future parser owns:
 invalid UTF-8 input contract;
 unexpected character;

--- a/docs/spec/ui/projection_source_grammar_v0.md
+++ b/docs/spec/ui/projection_source_grammar_v0.md
@@ -177,6 +177,20 @@ len = u32::MAX + 1
             -> rejected before lexical processing
 ```
 
+`len <= u32::MAX` means only that the input byte domain and its EOF position
+can be represented by `SourceSpan` and may proceed to lexical processing. It
+does not mean that the source conforms to Grammar v0, that parsing will
+succeed, that the resulting AST will pass PS validation, or that the document
+may be loaded or executed.
+
+```text
+source-size acceptance != syntax validity
+source-size acceptance != parse success
+source-size acceptance != semantic validity
+parse success != semantic-validation success
+semantic-validation success != runtime activation
+```
+
 An oversized input is any input for which `source_text.len() > u32::MAX`.
 The future API classifies this input-domain failure as
 `ProjectionSourceInputError::SourceTooLarge`, carrying the caller-supplied
@@ -208,10 +222,70 @@ last byte index is `u32::MAX - 1`, and the EOF byte position is `u32::MAX`.
 Therefore an EOF span is `[u32::MAX, u32::MAX)`, and a token ending at EOF may
 use `[start, u32::MAX)`.
 
+After source-size preflight succeeds, every valid parser position from zero
+through `input_byte_length` inclusive is representable as `u32`. This covers
+surface declaration starts and ends, node declaration starts and ends, token
+starts and ends, zero-width missing-token positions, duplicate-declaration
+keyword spans, offending-character and offending-token spans, the EOF
+position, and `PSP_UNEXPECTED_EOF` spans.
+
+```text
+accepted source
+    -> every parser position is in 0..=input_byte_length
+accepted source
+    -> every parser position is in 0..=u32::MAX
+accepted source
+    -> every parser-produced `SourceSpan` endpoint is representable as u32
+```
+
+Representable does not mean automatically valid, and it does not permit
+unchecked casts. Checked offset conversion and checked arithmetic remain
+required. Existing span shapes remain unchanged: surface declarations include
+their terminating semicolon, node declarations include their matching closing
+brace, token spans exclude surrounding trivia, missing-token spans may be
+zero-width, and EOF uses `[input_byte_length, input_byte_length)`.
+
 An operational host or loader may impose a smaller limit for memory, quota,
 transport or sandbox reasons. Such a host resource rejection is outside this
 grammar contract and is distinct from syntax failure, PS validation failure,
 and SourceSpan representability.
+
+### 5.1.2 Architecture portability
+
+The normative representability ceiling is `u32::MAX` bytes on every target.
+On platforms where `usize` can represent values greater than `u32::MAX`, an
+`&str` whose byte length exceeds `u32::MAX` must be rejected as
+`ProjectionSourceInputError::SourceTooLarge` before lexical processing. On platforms where `usize` cannot represent values greater than `u32::MAX`, every
+constructible `&str` is within the `SourceSpan` representability ceiling.
+The grammar limit does not change with pointer width or platform `usize` width.
+This is a representability rule; it does not claim that a 32-bit target can
+practically allocate an input of exactly `u32::MAX` bytes.
+
+```text
+normative maximum != usize::MAX
+normative maximum != platform-dependent maximum
+32-bit platform behavior != different grammar contract
+64-bit platform capability != wider SourceSpan
+```
+
+### 5.1.3 Qualification and authorization posture
+
+This documentation defines only the P1 normative source-size contract. The
+contract does not self-authorize publication. P1 requires strict review and a
+separately authorized publication task before it can be treated as landed
+evidence.
+
+```text
+P1 contract definition != P1 review completion
+P1 review completion != publication authorization
+P1 publication != P2 authorization
+P1 publication != P3 authorization
+P1 publication != parser authorization
+```
+
+WP2C-P2 is unresolved and unauthorized. WP2C-P3 is unresolved and
+unauthorized. The Projection Source parser and lexer are not implemented and unauthorized. Issue #1489 remains the coordination ledger for these decisions;
+this contract does not mark `NEXT AUTHORIZED`.
 
 ## 5.5 Source span construction
 

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -67,10 +67,37 @@ The limit is a representability ceiling, not a recommended operational file
 size. A future host or loader may impose a smaller memory, quota, transport or
 sandbox limit, but that host resource rejection remains outside Grammar v0.
 
+The normative representability ceiling is `u32::MAX` bytes on every platform.
+On platforms where `usize` can represent values greater than `u32::MAX`, an
+`&str` longer than `u32::MAX` bytes is rejected as `SourceTooLarge` before
+lexical processing. On platforms where `usize` cannot represent a value
+greater than `u32::MAX`, every constructible `&str` is within the
+representability ceiling. The grammar contract does not vary with pointer
+width; practical allocation capacity on a 32-bit platform is a separate
+matter.
+
+```text
+normative maximum != usize::MAX
+normative maximum != platform-dependent maximum
+32-bit platform behavior != different grammar contract
+64-bit platform capability != wider SourceSpan
+```
+
+After preflight succeeds, every parser position is in
+`0..=input_byte_length` and therefore in `0..=u32::MAX`. Surface and node
+declaration endpoints, token endpoints, zero-width missing-token positions,
+duplicate-declaration keyword spans, offending-character or offending-token
+spans, the EOF position and `PSP_UNEXPECTED_EOF` all use representable
+`SourceSpan` endpoints. Representability is not validity and does not permit
+unchecked conversion. Existing half-open span shapes remain unchanged.
+
 ```text
 source byte length != character count
+source-size acceptance != syntax validity
 source-size acceptance != parse success
+source-size acceptance != semantic validity
 parse success != semantic validation success
+semantic-validation success != runtime activation
 input rejection != parser diagnostic
 input rejection != runtime admission
 provenance representability != authority
@@ -80,6 +107,13 @@ Source-size policy specified != parser implementation
 source-size policy specified != parser qualification
 source-size policy specified != runtime source loading
 source-size policy specified != WP2C completion
+
+The source-size contract does not itself authorize parser implementation,
+publication, WP2C-P2, WP2C-P3, runtime loading or activation. P1 contract
+definition is not P1 review completion, review completion is not publication
+authorization, and P1 publication does not authorize P2, P3 or the parser.
+WP2C-P2 and WP2C-P3 remain unresolved and unauthorized; the Projection Source
+parser and lexer remain not implemented and unauthorized.
 
 No source-size check grants capability, performs admission, loads files,
 allocates runtime buffers, activates a ProjectionBundle, mutates shell state,

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -48,6 +48,43 @@ unknown source role != parser failure
 known role resolution != authority
 ```
 
+## Source Size and Provenance Representability
+
+Projection Source provenance uses UTF-8 byte offsets represented by the landed
+`SourceSpan` `u32` fields. The normative representability limit is
+`u32::MAX = 4_294_967_295` source bytes. This model does not widen `SourceSpan`
+to `u64`, `usize`, character offsets or line/column coordinates.
+
+For a future parser receiving `&str`, source-size preflight occurs before
+parser ownership. A source longer than `u32::MAX` bytes is classified as the
+future input-domain error `ProjectionSourceInputError::SourceTooLarge`; it
+produces no SourceSpan, PSP diagnostic, tokenization, AST or PS validation.
+The conceptual error carries the caller-supplied `SourceId`, actual UTF-8 byte
+length and maximum accepted byte length. The concrete API is not implemented
+by this model correction.
+
+The limit is a representability ceiling, not a recommended operational file
+size. A future host or loader may impose a smaller memory, quota, transport or
+sandbox limit, but that host resource rejection remains outside Grammar v0.
+
+```text
+source byte length != character count
+source-size acceptance != parse success
+parse success != semantic validation success
+input rejection != parser diagnostic
+input rejection != runtime admission
+provenance representability != authority
+```
+
+Source-size policy specified != parser implementation
+source-size policy specified != parser qualification
+source-size policy specified != runtime source loading
+source-size policy specified != WP2C completion
+
+No source-size check grants capability, performs admission, loads files,
+allocates runtime buffers, activates a ProjectionBundle, mutates shell state,
+selects a renderer, opens Gate D or claims production readiness.
+
 ## 1. Purpose
 
 The projection source model exists to prevent the bad workflow:


### PR DESCRIPTION
## Summary

Defines the normative source-size and `SourceSpan` representability policy for the future Projection Source parser.

The contract:

- keeps `SourceSpan` as half-open `u32` UTF-8 byte offsets;
- defines the maximum representable source length as `u32::MAX`, or `4_294_967_295` UTF-8 bytes;
- accepts a source of exactly `u32::MAX` bytes for lexical processing;
- rejects a source longer than `u32::MAX` before lexical scanning;
- classifies oversized input through the future conceptual `ProjectionSourceInputError::SourceTooLarge`;
- keeps oversized input outside both `PSP_*` parser diagnostics and existing `PS_*` semantic diagnostics;
- requires checked offset conversion and checked offset arithmetic;
- preserves maximum-length EOF as `[u32::MAX, u32::MAX)`;
- keeps the representability ceiling invariant across target architectures;
- separates grammar representability from host resource limits.

## Scope

Changed repository paths:

- `docs/spec/ui/projection_source_grammar_v0.md`
- `docs/spec/ui/projection_source_model.md`

No Rust source, tests, manifests, features, dependencies, workflows, roadmap files or public API surfaces are changed.

## Source-size contract

For `source_text.len() <= u32::MAX`:

- the complete source byte-position domain is representable by `SourceSpan`;
- every parser-produced span endpoint is representable;
- lexical processing may begin;
- syntax and semantic success are not implied.

For `source_text.len() > u32::MAX`:

- return conceptual `ProjectionSourceInputError::SourceTooLarge`;
- perform no lexical scan;
- produce no `SourceSpan`;
- produce no `PSP_*` diagnostic;
- produce no AST;
- perform no `PS_*` semantic validation.

For an accepted source of exactly `u32::MAX` bytes:

- the final byte index is `u32::MAX - 1`;
- the EOF position is `u32::MAX`;
- the EOF span is `[u32::MAX, u32::MAX)`.

## Preserved boundaries

- source-size acceptance is not syntax validity;
- source-size acceptance is not parse success;
- source-size acceptance is not semantic validity;
- parse success is not semantic-validation success;
- semantic-validation success is not runtime activation;
- `SourceTooLarge` is not a `PSP_*` diagnostic;
- `SourceTooLarge` is not a `PS_*` diagnostic;
- source-size preflight is not a capability check;
- source-size preflight is not runtime admission;
- provenance representability is not authority.

The normative ceiling remains `u32::MAX` on every target.

Targets with a wider `usize` reject larger inputs before lexical processing. Targets whose `usize` cannot exceed `u32::MAX` cannot construct an oversized `&str` through the future parser input contract. A wider `usize` does not widen `SourceSpan`.

## Explicit non-goals

- `ProjectionSourceInputError` implementation is not included;
- parser implementation is not included;
- lexer implementation is not included;
- `PSP_*` diagnostic implementation is not included;
- WP2C-P2 diagnostic disambiguation is not included;
- WP2C-P3 identifier disambiguation is not included;
- runtime source loading is not authorized;
- Gate D remains closed;
- production promotion is not authorized.

The P1 contract does not self-authorize publication, later prerequisites or parser implementation.

## Validation

Passed locally on the exact reviewed head:

- `scripts/harness-check.ps1`;
- `cargo test --test public_api_contracts --quiet`;
- `cargo test --test trust_boundary_guards`;
- `cargo +1.93.1 fmt --all --check`;
- `cargo test --workspace`;
- full committed-range `git diff --check`;
- documentation textual assertions;
- Markdown fence-integrity checks.

The complete two-commit candidate received:

**UI-DNA2-WP2C-P1 SOURCE SIZE POLICY REPEATED STRICT REVIEW PASS — SAFE FOR PUBLICATION PREP**

Refs #1489
