### PR TITLE
feat(ui): implement projection source parser core

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -63,6 +63,7 @@ pub mod projection;
 pub(crate) mod projection_compile;
 pub(crate) mod projection_patch;
 pub(crate) mod projection_source;
+pub(crate) mod projection_source_parser;
 pub mod raw_event;
 pub mod renderer;
 pub(crate) mod role_dictionary;
@@ -80,6 +81,8 @@ pub mod validation;
 
 #[cfg(test)]
 mod ui_dna2_wp2_qualification_tests;
+#[cfg(test)]
+mod ui_dna2_wp2c_parser_qualification_tests;
 #[cfg(test)]
 mod ui_dna2_wp3_qualification_tests;
 #[cfg(test)]

--- a/crates/prom-ui/src/projection_source_parser.rs
+++ b/crates/prom-ui/src/projection_source_parser.rs
@@ -110,7 +110,7 @@ pub(crate) fn preflight_source_len(
     source_id: SourceId,
     actual_len: usize,
 ) -> Result<(), ProjectionSourceInputError> {
-    if actual_len > MAX_PROJECTION_SOURCE_BYTES as usize {
+    if u32::try_from(actual_len).is_err() {
         Err(ProjectionSourceInputError::SourceTooLarge {
             source_id,
             actual_len,
@@ -181,7 +181,7 @@ impl<'a> Parser<'a> {
                 return Err(self.eof_error());
             }
             if self.peek_byte() == Some(b'}') {
-                self.pos += 1;
+                self.advance_checked(1);
                 break;
             }
 
@@ -275,7 +275,7 @@ impl<'a> Parser<'a> {
                 return Err(self.eof_error());
             }
             if self.peek_byte() == Some(b'}') {
-                self.pos += 1;
+                self.advance_checked(1);
                 break;
             }
 
@@ -304,7 +304,7 @@ impl<'a> Parser<'a> {
     fn parse_child(&mut self) -> Result<ProjectionSourceChild, ProjectionSourceParseError> {
         let child = self.parse_number(u64::MAX, true)?;
         self.expect_keyword("order")?;
-        let order = self.parse_number(u32::MAX as u64, false)?;
+        let order = self.parse_number(u64::from(u32::MAX), false)?;
         self.expect_semicolon()?;
         Ok(ProjectionSourceChild::new(
             ProjectionSourceNodeId::new(child).expect("non-zero child id"),
@@ -352,10 +352,10 @@ impl<'a> Parser<'a> {
             let sign = self.peek_byte().expect("sign was matched");
             if self
                 .bytes
-                .get(self.pos + 1)
+                .get(self.checked_position_after(self.pos, 1))
                 .is_some_and(|byte| byte.is_ascii_digit())
             {
-                self.pos += 1;
+                self.advance_checked(1);
                 self.scan_number_like();
                 return Err(self.error(
                     ProjectionSourceParserDiagnosticKind::InvalidNumber,
@@ -367,13 +367,13 @@ impl<'a> Parser<'a> {
                 self.error(
                     ProjectionSourceParserDiagnosticKind::UnexpectedToken,
                     start,
-                    start + 1,
+                    self.checked_position_after(start, 1),
                 )
             } else {
                 self.error(
                     ProjectionSourceParserDiagnosticKind::UnexpectedChar,
                     start,
-                    start + 1,
+                    self.checked_position_after(start, 1),
                 )
             });
         }
@@ -442,7 +442,7 @@ impl<'a> Parser<'a> {
             return Err(self.eof_error());
         }
         if self.peek_byte() == Some(expected) {
-            self.pos += 1;
+            self.advance_checked(1);
             Ok(self.pos)
         } else {
             Err(self.current_unexpected())
@@ -455,7 +455,7 @@ impl<'a> Parser<'a> {
             return Err(self.eof_error());
         }
         if self.peek_byte() == Some(b';') {
-            self.pos += 1;
+            self.advance_checked(1);
             Ok(self.pos)
         } else {
             Err(self.error(
@@ -469,28 +469,40 @@ impl<'a> Parser<'a> {
     fn skip_trivia(&mut self) -> Result<(), ProjectionSourceParseError> {
         loop {
             match self.peek_byte() {
-                Some(b' ' | b'\t' | b'\n') => self.pos += 1,
-                Some(b'\r') if self.bytes.get(self.pos + 1) == Some(&b'\n') => self.pos += 2,
-                Some(b'/') if self.bytes.get(self.pos + 1) == Some(&b'/') => {
-                    self.pos += 2;
+                Some(b' ' | b'\t' | b'\n') => self.advance_checked(1),
+                Some(b'\r')
+                    if self.bytes.get(self.checked_position_after(self.pos, 1)) == Some(&b'\n') =>
+                {
+                    self.advance_checked(2);
+                }
+                Some(b'/')
+                    if self.bytes.get(self.checked_position_after(self.pos, 1)) == Some(&b'/') =>
+                {
+                    self.advance_checked(2);
                     while !self.at_end() {
                         match self.peek_byte() {
                             Some(b'\n') => {
-                                self.pos += 1;
+                                self.advance_checked(1);
                                 break;
                             }
-                            Some(b'\r') if self.bytes.get(self.pos + 1) == Some(&b'\n') => {
-                                self.pos += 2;
+                            Some(b'\r')
+                                if self.bytes.get(self.checked_position_after(self.pos, 1))
+                                    == Some(&b'\n') =>
+                            {
+                                self.advance_checked(2);
                                 break;
                             }
                             Some(b'\r') => {
                                 return Err(self.error(
                                     ProjectionSourceParserDiagnosticKind::UnexpectedChar,
                                     self.pos,
-                                    self.pos + 1,
+                                    self.checked_position_after(self.pos, 1),
                                 ));
                             }
-                            Some(_) => self.pos += self.scalar_width(),
+                            Some(_) => {
+                                let width = self.scalar_width();
+                                self.advance_checked(width);
+                            }
                             None => break,
                         }
                     }
@@ -506,10 +518,10 @@ impl<'a> Parser<'a> {
             return None;
         }
         let start = self.pos;
-        self.pos += 1;
+        self.advance_checked(1);
         while let Some(byte) = self.peek_byte() {
             if byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':' | b'-') {
-                self.pos += 1;
+                self.advance_checked(1);
             } else {
                 break;
             }
@@ -524,7 +536,7 @@ impl<'a> Parser<'a> {
     fn scan_number_like(&mut self) {
         while let Some(byte) = self.peek_byte() {
             if byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':') {
-                self.pos += 1;
+                self.advance_checked(1);
             } else {
                 break;
             }
@@ -533,11 +545,11 @@ impl<'a> Parser<'a> {
 
     fn scan_quoted_role_error(&mut self) -> ProjectionSourceParseError {
         let start = self.pos;
-        self.pos += 1;
+        self.advance_checked(1);
         while !self.at_end() {
             match self.peek_byte() {
                 Some(b'"') => {
-                    self.pos += 1;
+                    self.advance_checked(1);
                     return self.error(
                         ProjectionSourceParserDiagnosticKind::InvalidIdentifier,
                         start,
@@ -551,10 +563,11 @@ impl<'a> Parser<'a> {
                         self.pos,
                     );
                 }
-                Some(byte) if byte.is_ascii() => self.pos += 1,
+                Some(byte) if byte.is_ascii() => self.advance_checked(1),
                 Some(_) => {
                     let scalar_start = self.pos;
-                    self.pos += self.scalar_width();
+                    let width = self.scalar_width();
+                    self.advance_checked(width);
                     return self.error(
                         ProjectionSourceParserDiagnosticKind::UnexpectedChar,
                         scalar_start,
@@ -597,7 +610,7 @@ impl<'a> Parser<'a> {
         }
         let byte = self.peek_byte().expect("not at EOF");
         if byte == b'+' {
-            self.pos += 1;
+            self.advance_checked(1);
             return self.error(
                 ProjectionSourceParserDiagnosticKind::UnexpectedToken,
                 start,
@@ -605,14 +618,15 @@ impl<'a> Parser<'a> {
             );
         }
         if matches!(byte, b'{' | b'}' | b';') {
-            self.pos += 1;
+            self.advance_checked(1);
             return self.error(
                 ProjectionSourceParserDiagnosticKind::UnexpectedToken,
                 start,
                 self.pos,
             );
         }
-        self.pos += self.scalar_width();
+        let width = self.scalar_width();
+        self.advance_checked(width);
         self.error(
             ProjectionSourceParserDiagnosticKind::UnexpectedChar,
             start,
@@ -674,6 +688,21 @@ impl<'a> Parser<'a> {
             .next()
             .expect("not at EOF")
             .len_utf8()
+    }
+
+    fn checked_position_after(&self, position: usize, width: usize) -> usize {
+        let next = position
+            .checked_add(width)
+            .expect("parser cursor arithmetic must not overflow");
+        assert!(
+            next <= self.bytes.len(),
+            "parser cursor must remain within accepted source"
+        );
+        next
+    }
+
+    fn advance_checked(&mut self, width: usize) {
+        self.pos = self.checked_position_after(self.pos, width);
     }
 
     fn peek_byte(&self) -> Option<u8> {

--- a/crates/prom-ui/src/projection_source_parser.rs
+++ b/crates/prom-ui/src/projection_source_parser.rs
@@ -1,0 +1,709 @@
+//! Crate-private Grammar v0 Projection Source parser.
+#![allow(dead_code)]
+
+use core::convert::TryFrom;
+
+use alloc::vec::Vec;
+
+use crate::contract_primitives::{
+    ChildOrder, CollectionKey, DiagnosticCode, DiagnosticCoordinate, Epoch, ProjectionSourceNodeId,
+    ProjectionSourceSurfaceId, Revision, SourceId, SourceRef, SourceSpan,
+};
+use crate::projection_source::{
+    ProjectionSourceChild, ProjectionSourceDocument, ProjectionSourceNode,
+    ProjectionSourceRoleName, ProjectionSourceSurface,
+};
+
+pub(crate) const MAX_PROJECTION_SOURCE_BYTES: u32 = u32::MAX;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectionSourceInputError {
+    SourceTooLarge {
+        source_id: SourceId,
+        actual_len: usize,
+        max_len: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectionSourceParseError {
+    Input(ProjectionSourceInputError),
+    Diagnostic(ProjectionSourceParserDiagnostic),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ProjectionSourceParserDiagnosticKind {
+    UnexpectedChar,
+    UnexpectedToken,
+    UnexpectedEof,
+    MissingSemicolon,
+    InvalidIdentifier,
+    InvalidNumber,
+    NumberOverflow,
+    ZeroId,
+    DuplicateRevision,
+    DuplicateEpoch,
+    UnsupportedVersion,
+    UnknownClause,
+}
+
+impl ProjectionSourceParserDiagnosticKind {
+    pub(crate) const fn code(self) -> DiagnosticCode {
+        let code = match self {
+            Self::UnexpectedChar => "PSP_UNEXPECTED_CHAR",
+            Self::UnexpectedToken => "PSP_UNEXPECTED_TOKEN",
+            Self::UnexpectedEof => "PSP_UNEXPECTED_EOF",
+            Self::MissingSemicolon => "PSP_MISSING_SEMICOLON",
+            Self::InvalidIdentifier => "PSP_INVALID_IDENTIFIER",
+            Self::InvalidNumber => "PSP_INVALID_NUMBER",
+            Self::NumberOverflow => "PSP_NUMBER_OVERFLOW",
+            Self::ZeroId => "PSP_ZERO_ID",
+            Self::DuplicateRevision => "PSP_DUP_REVISION",
+            Self::DuplicateEpoch => "PSP_DUP_EPOCH",
+            Self::UnsupportedVersion => "PSP_UNSUPPORTED_VERSION",
+            Self::UnknownClause => "PSP_UNKNOWN_CLAUSE",
+        };
+        DiagnosticCode::new(code)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceParserDiagnostic {
+    kind: ProjectionSourceParserDiagnosticKind,
+    coordinate: DiagnosticCoordinate,
+    source_id: SourceId,
+    span: SourceSpan,
+}
+
+impl ProjectionSourceParserDiagnostic {
+    pub(crate) const fn kind(self) -> ProjectionSourceParserDiagnosticKind {
+        self.kind
+    }
+
+    pub(crate) const fn code(self) -> DiagnosticCode {
+        self.kind.code()
+    }
+
+    pub(crate) const fn coordinate(self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+
+    pub(crate) const fn source_id(self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) const fn span(self) -> SourceSpan {
+        self.span
+    }
+}
+
+pub(crate) fn parse_projection_source(
+    source_id: SourceId,
+    source_text: &str,
+) -> Result<ProjectionSourceDocument, ProjectionSourceParseError> {
+    preflight_source_len(source_id, source_text.len())
+        .map_err(ProjectionSourceParseError::Input)?;
+    Parser::new(source_id, source_text).parse()
+}
+
+pub(crate) fn preflight_source_len(
+    source_id: SourceId,
+    actual_len: usize,
+) -> Result<(), ProjectionSourceInputError> {
+    if actual_len > MAX_PROJECTION_SOURCE_BYTES as usize {
+        Err(ProjectionSourceInputError::SourceTooLarge {
+            source_id,
+            actual_len,
+            max_len: MAX_PROJECTION_SOURCE_BYTES,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Candidate<'a> {
+    text: &'a str,
+    start: usize,
+    end: usize,
+}
+
+struct Parser<'a> {
+    source_id: SourceId,
+    text: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source_id: SourceId, text: &'a str) -> Self {
+        Self {
+            source_id,
+            text,
+            bytes: text.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn parse(mut self) -> Result<ProjectionSourceDocument, ProjectionSourceParseError> {
+        self.expect_keyword("projection")?;
+        self.parse_version()?;
+        self.expect_byte(b'{')?;
+
+        self.expect_keyword("revision")?;
+        let revision = self.parse_number(u64::MAX, false)?;
+        self.expect_semicolon()?;
+
+        self.skip_trivia()?;
+        if self.peek_candidate_text() == Some("revision") {
+            let token = self
+                .scan_identifier_candidate()
+                .expect("candidate was peeked");
+            return Err(self.error(
+                ProjectionSourceParserDiagnosticKind::DuplicateRevision,
+                token.start,
+                token.end,
+            ));
+        }
+        self.expect_keyword("epoch")?;
+        let epoch = self.parse_number(u64::MAX, false)?;
+        self.expect_semicolon()?;
+
+        let mut document = ProjectionSourceDocument::new(
+            self.source_id,
+            Revision::new(revision),
+            Epoch::new(epoch),
+        );
+
+        loop {
+            self.skip_trivia()?;
+            if self.at_end() {
+                return Err(self.eof_error());
+            }
+            if self.peek_byte() == Some(b'}') {
+                self.pos += 1;
+                break;
+            }
+
+            let token = match self.scan_identifier_candidate() {
+                Some(token) => token,
+                None => return Err(self.current_unexpected()),
+            };
+            match token.text {
+                "surface" => document.push_surface(self.parse_surface(token.start)?),
+                "node" => document.push_node(self.parse_node(token.start)?),
+                "revision" => {
+                    return Err(self.error(
+                        ProjectionSourceParserDiagnosticKind::DuplicateRevision,
+                        token.start,
+                        token.end,
+                    ));
+                }
+                "epoch" => {
+                    return Err(self.error(
+                        ProjectionSourceParserDiagnosticKind::DuplicateEpoch,
+                        token.start,
+                        token.end,
+                    ));
+                }
+                _ => return Err(self.clause_error(token)),
+            }
+        }
+
+        self.skip_trivia()?;
+        if self.at_end() {
+            Ok(document)
+        } else {
+            Err(self.current_unexpected())
+        }
+    }
+
+    fn parse_version(&mut self) -> Result<(), ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+        let token = match self.scan_identifier_candidate() {
+            Some(token) => token,
+            None => return Err(self.current_unexpected()),
+        };
+        if token.text == "v0" {
+            Ok(())
+        } else {
+            Err(self.error(
+                ProjectionSourceParserDiagnosticKind::UnsupportedVersion,
+                token.start,
+                token.end,
+            ))
+        }
+    }
+
+    fn parse_surface(
+        &mut self,
+        start: usize,
+    ) -> Result<ProjectionSourceSurface, ProjectionSourceParseError> {
+        let id = self.parse_number(u64::MAX, true)?;
+        self.expect_keyword("root")?;
+        let root = self.parse_number(u64::MAX, true)?;
+        self.expect_keyword("key")?;
+        let key = self.parse_number(u64::MAX, true)?;
+        let end = self.expect_semicolon()?;
+        Ok(ProjectionSourceSurface::new(
+            ProjectionSourceSurfaceId::new(id).expect("non-zero surface id"),
+            ProjectionSourceNodeId::new(root).expect("non-zero root id"),
+            CollectionKey::new(key).expect("non-zero surface key"),
+            self.source_ref(start, end),
+        ))
+    }
+
+    fn parse_node(
+        &mut self,
+        start: usize,
+    ) -> Result<ProjectionSourceNode, ProjectionSourceParseError> {
+        let id = self.parse_number(u64::MAX, true)?;
+        self.expect_keyword("role")?;
+        let role = self.parse_role_identifier()?;
+        self.expect_keyword("key")?;
+        let key = self.parse_number(u64::MAX, true)?;
+        self.expect_byte(b'{')?;
+
+        let mut children = Vec::new();
+
+        loop {
+            self.skip_trivia()?;
+            if self.at_end() {
+                return Err(self.eof_error());
+            }
+            if self.peek_byte() == Some(b'}') {
+                self.pos += 1;
+                break;
+            }
+
+            let token = match self.scan_identifier_candidate() {
+                Some(token) => token,
+                None => return Err(self.current_unexpected()),
+            };
+            if token.text != "child" {
+                return Err(self.clause_error(token));
+            }
+            children.push(self.parse_child()?);
+        }
+
+        let mut node = ProjectionSourceNode::new(
+            ProjectionSourceNodeId::new(id).expect("non-zero node id"),
+            role,
+            CollectionKey::new(key).expect("non-zero node key"),
+            self.source_ref(start, self.pos),
+        );
+        for child in children {
+            node.push_child(child);
+        }
+        Ok(node)
+    }
+
+    fn parse_child(&mut self) -> Result<ProjectionSourceChild, ProjectionSourceParseError> {
+        let child = self.parse_number(u64::MAX, true)?;
+        self.expect_keyword("order")?;
+        let order = self.parse_number(u32::MAX as u64, false)?;
+        self.expect_semicolon()?;
+        Ok(ProjectionSourceChild::new(
+            ProjectionSourceNodeId::new(child).expect("non-zero child id"),
+            ChildOrder::new(u32::try_from(order).expect("bounded child order")),
+        ))
+    }
+
+    fn parse_role_identifier(
+        &mut self,
+    ) -> Result<ProjectionSourceRoleName, ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+        if self.peek_byte() == Some(b'"') {
+            return Err(self.scan_quoted_role_error());
+        }
+        let token = match self.scan_identifier_candidate() {
+            Some(token) => token,
+            None => return Err(self.current_unexpected()),
+        };
+        if is_valid_identifier(token.text) {
+            Ok(ProjectionSourceRoleName::new(token.text))
+        } else {
+            Err(self.error(
+                ProjectionSourceParserDiagnosticKind::InvalidIdentifier,
+                token.start,
+                token.end,
+            ))
+        }
+    }
+
+    fn parse_number(
+        &mut self,
+        max: u64,
+        non_zero: bool,
+    ) -> Result<u64, ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+
+        let start = self.pos;
+        if matches!(self.peek_byte(), Some(b'+' | b'-')) {
+            let sign = self.peek_byte().expect("sign was matched");
+            if self
+                .bytes
+                .get(self.pos + 1)
+                .is_some_and(|byte| byte.is_ascii_digit())
+            {
+                self.pos += 1;
+                self.scan_number_like();
+                return Err(self.error(
+                    ProjectionSourceParserDiagnosticKind::InvalidNumber,
+                    start,
+                    self.pos,
+                ));
+            }
+            return Err(if sign == b'+' {
+                self.error(
+                    ProjectionSourceParserDiagnosticKind::UnexpectedToken,
+                    start,
+                    start + 1,
+                )
+            } else {
+                self.error(
+                    ProjectionSourceParserDiagnosticKind::UnexpectedChar,
+                    start,
+                    start + 1,
+                )
+            });
+        }
+
+        if !self.peek_byte().is_some_and(|byte| byte.is_ascii_digit()) {
+            return Err(self.current_unexpected());
+        }
+        self.scan_number_like();
+        let end = self.pos;
+        let text = &self.text[start..end];
+        if !text.bytes().all(|byte| byte.is_ascii_digit())
+            || (text.len() > 1 && text.starts_with('0'))
+        {
+            return Err(self.error(
+                ProjectionSourceParserDiagnosticKind::InvalidNumber,
+                start,
+                end,
+            ));
+        }
+        let value = text.parse::<u64>().map_err(|_| {
+            self.error(
+                ProjectionSourceParserDiagnosticKind::NumberOverflow,
+                start,
+                end,
+            )
+        })?;
+        if value > max {
+            return Err(self.error(
+                ProjectionSourceParserDiagnosticKind::NumberOverflow,
+                start,
+                end,
+            ));
+        }
+        if non_zero && value == 0 {
+            return Err(self.error(ProjectionSourceParserDiagnosticKind::ZeroId, start, end));
+        }
+        Ok(value)
+    }
+
+    fn expect_keyword(
+        &mut self,
+        expected: &str,
+    ) -> Result<Candidate<'a>, ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+        let token = match self.scan_identifier_candidate() {
+            Some(token) => token,
+            None => return Err(self.current_unexpected()),
+        };
+        if token.text == expected {
+            Ok(token)
+        } else {
+            Err(self.error(
+                ProjectionSourceParserDiagnosticKind::UnexpectedToken,
+                token.start,
+                token.end,
+            ))
+        }
+    }
+
+    fn expect_byte(&mut self, expected: u8) -> Result<usize, ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+        if self.peek_byte() == Some(expected) {
+            self.pos += 1;
+            Ok(self.pos)
+        } else {
+            Err(self.current_unexpected())
+        }
+    }
+
+    fn expect_semicolon(&mut self) -> Result<usize, ProjectionSourceParseError> {
+        self.skip_trivia()?;
+        if self.at_end() {
+            return Err(self.eof_error());
+        }
+        if self.peek_byte() == Some(b';') {
+            self.pos += 1;
+            Ok(self.pos)
+        } else {
+            Err(self.error(
+                ProjectionSourceParserDiagnosticKind::MissingSemicolon,
+                self.pos,
+                self.pos,
+            ))
+        }
+    }
+
+    fn skip_trivia(&mut self) -> Result<(), ProjectionSourceParseError> {
+        loop {
+            match self.peek_byte() {
+                Some(b' ' | b'\t' | b'\n') => self.pos += 1,
+                Some(b'\r') if self.bytes.get(self.pos + 1) == Some(&b'\n') => self.pos += 2,
+                Some(b'/') if self.bytes.get(self.pos + 1) == Some(&b'/') => {
+                    self.pos += 2;
+                    while !self.at_end() {
+                        match self.peek_byte() {
+                            Some(b'\n') => {
+                                self.pos += 1;
+                                break;
+                            }
+                            Some(b'\r') if self.bytes.get(self.pos + 1) == Some(&b'\n') => {
+                                self.pos += 2;
+                                break;
+                            }
+                            Some(b'\r') => {
+                                return Err(self.error(
+                                    ProjectionSourceParserDiagnosticKind::UnexpectedChar,
+                                    self.pos,
+                                    self.pos + 1,
+                                ));
+                            }
+                            Some(_) => self.pos += self.scalar_width(),
+                            None => break,
+                        }
+                    }
+                }
+                _ => return Ok(()),
+            }
+        }
+    }
+
+    fn scan_identifier_candidate(&mut self) -> Option<Candidate<'a>> {
+        let first = self.peek_byte()?;
+        if !(first.is_ascii_alphanumeric() || first == b'_') {
+            return None;
+        }
+        let start = self.pos;
+        self.pos += 1;
+        while let Some(byte) = self.peek_byte() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':' | b'-') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        Some(Candidate {
+            text: &self.text[start..self.pos],
+            start,
+            end: self.pos,
+        })
+    }
+
+    fn scan_number_like(&mut self) {
+        while let Some(byte) = self.peek_byte() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b':') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn scan_quoted_role_error(&mut self) -> ProjectionSourceParseError {
+        let start = self.pos;
+        self.pos += 1;
+        while !self.at_end() {
+            match self.peek_byte() {
+                Some(b'"') => {
+                    self.pos += 1;
+                    return self.error(
+                        ProjectionSourceParserDiagnosticKind::InvalidIdentifier,
+                        start,
+                        self.pos,
+                    );
+                }
+                Some(b'\n' | b'\r') => {
+                    return self.error(
+                        ProjectionSourceParserDiagnosticKind::InvalidIdentifier,
+                        start,
+                        self.pos,
+                    );
+                }
+                Some(byte) if byte.is_ascii() => self.pos += 1,
+                Some(_) => {
+                    let scalar_start = self.pos;
+                    self.pos += self.scalar_width();
+                    return self.error(
+                        ProjectionSourceParserDiagnosticKind::UnexpectedChar,
+                        scalar_start,
+                        self.pos,
+                    );
+                }
+                None => break,
+            }
+        }
+        self.error(
+            ProjectionSourceParserDiagnosticKind::InvalidIdentifier,
+            start,
+            self.pos,
+        )
+    }
+
+    fn clause_error(&self, token: Candidate<'a>) -> ProjectionSourceParseError {
+        let kind = if is_keyword(token.text) || token.text.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            ProjectionSourceParserDiagnosticKind::UnexpectedToken
+        } else if is_valid_identifier(token.text) {
+            ProjectionSourceParserDiagnosticKind::UnknownClause
+        } else {
+            ProjectionSourceParserDiagnosticKind::InvalidIdentifier
+        };
+        self.error(kind, token.start, token.end)
+    }
+
+    fn current_unexpected(&mut self) -> ProjectionSourceParseError {
+        if self.at_end() {
+            return self.eof_error();
+        }
+        let start = self.pos;
+        if let Some(token) = self.scan_identifier_candidate() {
+            return self.error(
+                ProjectionSourceParserDiagnosticKind::UnexpectedToken,
+                token.start,
+                token.end,
+            );
+        }
+        let byte = self.peek_byte().expect("not at EOF");
+        if byte == b'+' {
+            self.pos += 1;
+            return self.error(
+                ProjectionSourceParserDiagnosticKind::UnexpectedToken,
+                start,
+                self.pos,
+            );
+        }
+        if matches!(byte, b'{' | b'}' | b';') {
+            self.pos += 1;
+            return self.error(
+                ProjectionSourceParserDiagnosticKind::UnexpectedToken,
+                start,
+                self.pos,
+            );
+        }
+        self.pos += self.scalar_width();
+        self.error(
+            ProjectionSourceParserDiagnosticKind::UnexpectedChar,
+            start,
+            self.pos,
+        )
+    }
+
+    fn peek_candidate_text(&mut self) -> Option<&'a str> {
+        let saved = self.pos;
+        let candidate = self.scan_identifier_candidate().map(|token| token.text);
+        self.pos = saved;
+        candidate
+    }
+
+    fn error(
+        &self,
+        kind: ProjectionSourceParserDiagnosticKind,
+        start: usize,
+        end: usize,
+    ) -> ProjectionSourceParseError {
+        let span = self.span(start, end);
+        let source = SourceRef::new(self.source_id, span);
+        ProjectionSourceParseError::Diagnostic(ProjectionSourceParserDiagnostic {
+            kind,
+            coordinate: DiagnosticCoordinate::new(
+                Some(source),
+                kind.code(),
+                u64::from(span.start()),
+                u64::from(span.end()),
+            ),
+            source_id: self.source_id,
+            span,
+        })
+    }
+
+    fn eof_error(&self) -> ProjectionSourceParseError {
+        self.error(
+            ProjectionSourceParserDiagnosticKind::UnexpectedEof,
+            self.bytes.len(),
+            self.bytes.len(),
+        )
+    }
+
+    fn source_ref(&self, start: usize, end: usize) -> SourceRef {
+        SourceRef::new(self.source_id, self.span(start, end))
+    }
+
+    fn span(&self, start: usize, end: usize) -> SourceSpan {
+        SourceSpan::new(
+            u32::try_from(start).expect("source-size preflight bounds start"),
+            u32::try_from(end).expect("source-size preflight bounds end"),
+        )
+        .expect("parser preserves ordered spans")
+    }
+
+    fn scalar_width(&self) -> usize {
+        self.text[self.pos..]
+            .chars()
+            .next()
+            .expect("not at EOF")
+            .len_utf8()
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn at_end(&self) -> bool {
+        self.pos == self.bytes.len()
+    }
+}
+
+fn is_valid_identifier(text: &str) -> bool {
+    let mut bytes = text.bytes();
+    bytes.next().is_some_and(|byte| byte.is_ascii_lowercase())
+        && bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn is_keyword(text: &str) -> bool {
+    matches!(
+        text,
+        "projection"
+            | "v0"
+            | "revision"
+            | "epoch"
+            | "surface"
+            | "root"
+            | "key"
+            | "node"
+            | "role"
+            | "child"
+            | "order"
+    )
+}

--- a/crates/prom-ui/src/ui_dna2_wp2c_parser_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp2c_parser_qualification_tests.rs
@@ -1,0 +1,419 @@
+use crate::contract_primitives::SourceId;
+use crate::projection_source_parser::{
+    parse_projection_source, preflight_source_len, ProjectionSourceInputError,
+    ProjectionSourceParseError, ProjectionSourceParserDiagnostic,
+    ProjectionSourceParserDiagnosticKind as Kind, MAX_PROJECTION_SOURCE_BYTES,
+};
+
+const SOURCE_RAW: u64 = 41;
+
+fn source_id() -> SourceId {
+    SourceId::new(SOURCE_RAW).expect("non-zero test source id")
+}
+
+fn diagnostic(source: &str) -> ProjectionSourceParserDiagnostic {
+    match parse_projection_source(source_id(), source) {
+        Err(ProjectionSourceParseError::Diagnostic(diagnostic)) => diagnostic,
+        other => panic!("expected parser diagnostic, got {other:?}"),
+    }
+}
+
+fn assert_diagnostic(source: &str, kind: Kind, start: usize, end: usize) {
+    let diagnostic = diagnostic(source);
+    assert_eq!(diagnostic.kind(), kind);
+    assert_eq!(diagnostic.code(), kind.code());
+    assert_eq!(diagnostic.source_id(), source_id());
+    assert_eq!(diagnostic.span().start(), start as u32);
+    assert_eq!(diagnostic.span().end(), end as u32);
+    let coordinate = diagnostic.coordinate();
+    assert_eq!(coordinate.code(), kind.code());
+    assert_eq!(
+        coordinate.source().expect("source coordinate").source(),
+        source_id()
+    );
+    assert_eq!(coordinate.domain(), start as u64);
+    assert_eq!(coordinate.secondary(), end as u64);
+}
+
+fn assert_at(source: &str, kind: Kind, needle: &str) {
+    let start = source.find(needle).expect("diagnostic needle");
+    assert_diagnostic(source, kind, start, start + needle.len());
+}
+
+fn assert_zero_width_at(source: &str, needle: &str) {
+    let start = source.find(needle).expect("diagnostic needle");
+    assert_diagnostic(source, Kind::MissingSemicolon, start, start);
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_accepts_complete_grammar_and_preserves_order() {
+    let source = concat!(
+        "projection v0 {\n",
+        "revision 7; epoch 9;\n",
+        "surface 2 root 20 key 200;\n",
+        "node 20 role surface key 201 { child 22 order 4; child 21 order 1; }\n",
+        "surface 1 root 21 key 100;\n",
+        "node 21 role button key 101 {}\n",
+        "}"
+    );
+    let document = parse_projection_source(source_id(), source).expect("valid source");
+
+    assert_eq!(document.source_id(), source_id());
+    assert_eq!(document.revision().raw(), 7);
+    assert_eq!(document.epoch().raw(), 9);
+    assert_eq!(document.surfaces().len(), 2);
+    assert_eq!(document.surfaces()[0].id().raw(), 2);
+    assert_eq!(document.surfaces()[1].id().raw(), 1);
+    assert_eq!(document.nodes().len(), 2);
+    assert_eq!(document.nodes()[0].role().as_str(), "surface");
+    assert_eq!(document.nodes()[1].role().as_str(), "button");
+    assert_eq!(document.nodes()[0].children()[0].child().raw(), 22);
+    assert_eq!(document.nodes()[0].children()[0].order().raw(), 4);
+    assert_eq!(document.nodes()[0].children()[1].child().raw(), 21);
+    assert_eq!(document.nodes()[0].children()[1].order().raw(), 1);
+    assert_eq!(parse_projection_source(source_id(), source), Ok(document));
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_accepts_trivia_comments_and_unknown_roles() {
+    let cases = [
+        "projection v0 { revision 0; epoch 0; }",
+        "projection v0 { // LF comment\n revision 0; epoch 0; }",
+        "projection v0 { // CRLF comment\r\n revision 0; epoch 0; }",
+        "projection v0 { // non-ASCII: Привет 根\n revision 0; epoch 0; }",
+        "projection v0 { revision 0; epoch 0; node 1 role node key 1 {} }",
+        "projection v0 { revision 0; epoch 0; node 1 role button key 1 {} }",
+        "projection v0 { revision 0; epoch 0; node 1 role root// role comment\n key 1 {} }",
+    ];
+    for source in cases {
+        parse_projection_source(source_id(), source).expect(source);
+    }
+
+    let unknown = cases[5];
+    let document = parse_projection_source(source_id(), unknown).expect("unknown role parses");
+    assert_eq!(document.nodes()[0].role().as_str(), "button");
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_constructs_exact_declaration_spans() {
+    let source = concat!(
+        "projection v0 { revision 0; epoch 0;\n",
+        "  surface 1 root 10 key 11;\n",
+        "  node 10 role root key 12 { child 11 order 0; }\n",
+        "}"
+    );
+    let document = parse_projection_source(source_id(), source).expect("valid source");
+    let surface_text = "surface 1 root 10 key 11;";
+    let surface_start = source.find(surface_text).unwrap();
+    let surface_span = document.surfaces()[0].source().span();
+    assert_eq!(surface_span.start(), surface_start as u32);
+    assert_eq!(
+        surface_span.end(),
+        (surface_start + surface_text.len()) as u32
+    );
+
+    let node_text = "node 10 role root key 12 { child 11 order 0; }";
+    let node_start = source.find(node_text).unwrap();
+    let node_span = document.nodes()[0].source().span();
+    assert_eq!(node_span.start(), node_start as u32);
+    assert_eq!(node_span.end(), (node_start + node_text.len()) as u32);
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_covers_every_diagnostic_kind() {
+    let cases = [
+        ("\u{feff}projection v0 {}", Kind::UnexpectedChar, "\u{feff}"),
+        ("Projection v0 {}", Kind::UnexpectedToken, "Projection"),
+        (
+            "projection v0 { revision 0; epoch 0;",
+            Kind::UnexpectedEof,
+            "",
+        ),
+        (
+            "projection v0 { revision 0 epoch 0; }",
+            Kind::MissingSemicolon,
+            "epoch",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role Root key 1 {} }",
+            Kind::InvalidIdentifier,
+            "Root",
+        ),
+        (
+            "projection v0 { revision +1; epoch 0; }",
+            Kind::InvalidNumber,
+            "+1",
+        ),
+        (
+            "projection v0 { revision 18446744073709551616; epoch 0; }",
+            Kind::NumberOverflow,
+            "18446744073709551616",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; surface 0 root 1 key 1; }",
+            Kind::ZeroId,
+            "0 root",
+        ),
+        (
+            "projection v0 { revision 0; revision 1; epoch 0; }",
+            Kind::DuplicateRevision,
+            "revision 1",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; epoch 1; }",
+            Kind::DuplicateEpoch,
+            "epoch 1",
+        ),
+        (
+            "projection v1 { revision 0; epoch 0; }",
+            Kind::UnsupportedVersion,
+            "v1",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; background blue; }",
+            Kind::UnknownClause,
+            "background",
+        ),
+    ];
+
+    for (source, kind, needle) in cases {
+        if kind == Kind::UnexpectedEof {
+            assert_diagnostic(source, kind, source.len(), source.len());
+        } else if kind == Kind::MissingSemicolon {
+            assert_zero_width_at(source, needle);
+        } else if kind == Kind::ZeroId {
+            let start = source.find(needle).unwrap();
+            assert_diagnostic(source, kind, start, start + 1);
+        } else if matches!(kind, Kind::DuplicateRevision | Kind::DuplicateEpoch) {
+            let start = source.find(needle).unwrap();
+            let token_len = needle.split_once(' ').unwrap().0.len();
+            assert_diagnostic(source, kind, start, start + token_len);
+        } else {
+            assert_at(source, kind, needle);
+        }
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_enforces_character_and_identifier_boundaries() {
+    let cases = [
+        (
+            "projection v0 {\r revision 0; epoch 0; }",
+            Kind::UnexpectedChar,
+            "\r",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role røot key 1 {} }",
+            Kind::UnexpectedChar,
+            "ø",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root/name key 1 {} }",
+            Kind::UnexpectedChar,
+            "/",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root/*x*/ key 1 {} }",
+            Kind::UnexpectedChar,
+            "/",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role -root key 1 {} }",
+            Kind::UnexpectedChar,
+            "-",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role _root key 1 {} }",
+            Kind::InvalidIdentifier,
+            "_root",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role 9root key 1 {} }",
+            Kind::InvalidIdentifier,
+            "9root",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root-name key 1 {} }",
+            Kind::InvalidIdentifier,
+            "root-name",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root.name key 1 {} }",
+            Kind::InvalidIdentifier,
+            "root.name",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root::name key 1 {} }",
+            Kind::InvalidIdentifier,
+            "root::name",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role \"root\" key 1 {} }",
+            Kind::InvalidIdentifier,
+            "\"root\"",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role \"\" key 1 {} }",
+            Kind::InvalidIdentifier,
+            "\"\"",
+        ),
+    ];
+    for (source, kind, needle) in cases {
+        assert_at(source, kind, needle);
+    }
+
+    let unterminated = "projection v0 { revision 0; epoch 0; node 1 role \"root\nkey 1 {} }";
+    let start = unterminated.find('"').unwrap();
+    let end = unterminated.find('\n').unwrap();
+    assert_diagnostic(unterminated, Kind::InvalidIdentifier, start, end);
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_distinguishes_p2_clause_contexts() {
+    let cases = [
+        ("projection v0 { revision 0; epoch 0; child 2 order 0; }", Kind::UnexpectedToken, "child"),
+        ("projection v0 { revision 0; epoch 0; node 1 role root key 1 { surface 1 root 1 key 1; } }", Kind::UnexpectedToken, "surface"),
+        ("projection v0 { revision 0; epoch 0; background blue; }", Kind::UnknownClause, "background"),
+        ("projection v0 { revision 0; epoch 0; node 1 role root key 1 { width 100; } }", Kind::UnknownClause, "width"),
+        ("projection v0 { revision 0; epoch 0; Background blue; }", Kind::InvalidIdentifier, "Background"),
+        ("projection v0 { revision 0; epoch 0; background-color blue; }", Kind::InvalidIdentifier, "background-color"),
+    ];
+    for (source, kind, needle) in cases {
+        assert_at(source, kind, needle);
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_enforces_numeric_diagnostics() {
+    let cases = [
+        ("projection v0 { revision 01; epoch 0; }", Kind::InvalidNumber, "01"),
+        ("projection v0 { revision 1_000; epoch 0; }", Kind::InvalidNumber, "1_000"),
+        ("projection v0 { revision -0; epoch 0; }", Kind::InvalidNumber, "-0"),
+        ("projection v0 { revision +18446744073709551616; epoch 0; }", Kind::InvalidNumber, "+18446744073709551616"),
+        ("projection v0 { revision root; epoch 0; }", Kind::UnexpectedToken, "root"),
+        ("projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2 order 4294967296; } }", Kind::NumberOverflow, "4294967296"),
+    ];
+    for (source, kind, needle) in cases {
+        assert_at(source, kind, needle);
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_enforces_compound_sign_boundaries() {
+    let cases = [
+        ("++1", Kind::UnexpectedToken, "+"),
+        ("+-1", Kind::UnexpectedToken, "+"),
+        ("-+1", Kind::UnexpectedChar, "-"),
+        ("--1", Kind::UnexpectedChar, "-"),
+    ];
+    for (value, kind, needle) in cases {
+        let source = format!("projection v0 {{ revision {value}; epoch 0; }}");
+        assert_at(&source, kind, needle);
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_preserves_terminal_semicolon_precedence() {
+    let cases = [
+        ("projection v0 { revision 1+1; epoch 0; }", "+"),
+        ("projection v0 { revision 1-1; epoch 0; }", "-"),
+        ("projection v0 { revision 0; epoch 1+1; }", "+"),
+        ("projection v0 { revision 0; epoch 1-1; }", "-"),
+        (
+            "projection v0 { revision 0; epoch 0; surface 1 root 10 key 1+1; }",
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; surface 1 root 10 key 1-1; }",
+            "-",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2 order 1+1; } }",
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2 order 1-1; } }",
+            "-",
+        ),
+    ];
+    for (source, needle) in cases {
+        assert_zero_width_at(source, needle);
+    }
+
+    let separated = "projection v0 { revision 0; epoch 0; surface 1 root 10 key 1 1+1; }";
+    let first = separated.find("1 1+1").unwrap() + 2;
+    assert_diagnostic(separated, Kind::MissingSemicolon, first, first);
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_preserves_nonterminal_plus_minus_boundaries() {
+    let cases = [
+        (
+            "projection v0 { revision 0; epoch 0; surface 1+1 root 10 key 1; }",
+            Kind::UnexpectedToken,
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; surface 1-1 root 10 key 1; }",
+            Kind::UnexpectedChar,
+            "-",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; surface 1 root 10+1 key 1; }",
+            Kind::UnexpectedToken,
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1+1 role root key 1 {} }",
+            Kind::UnexpectedToken,
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1-1 {} }",
+            Kind::UnexpectedChar,
+            "-",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2+1 order 0; } }",
+            Kind::UnexpectedToken,
+            "+",
+        ),
+    ];
+    for (source, kind, needle) in cases {
+        assert_at(source, kind, needle);
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_handles_post_document_and_fail_fast_boundaries() {
+    let complete = "projection v0 { revision 0; epoch 0; } ";
+    for (tail, kind, width) in [
+        ("Root", Kind::UnexpectedToken, 4),
+        ("root-name", Kind::UnexpectedToken, 9),
+        ("9root", Kind::UnexpectedToken, 5),
+        ("+1", Kind::UnexpectedToken, 1),
+        ("-1", Kind::UnexpectedChar, 1),
+    ] {
+        let source = format!("{complete}{tail}");
+        assert_diagnostic(&source, kind, complete.len(), complete.len() + width);
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_preflights_source_size_without_allocating_input() {
+    assert_eq!(
+        preflight_source_len(source_id(), MAX_PROJECTION_SOURCE_BYTES as usize),
+        Ok(())
+    );
+    if usize::BITS > 32 {
+        let actual_len = MAX_PROJECTION_SOURCE_BYTES as usize + 1;
+        assert_eq!(
+            preflight_source_len(source_id(), actual_len),
+            Err(ProjectionSourceInputError::SourceTooLarge {
+                source_id: source_id(),
+                actual_len,
+                max_len: MAX_PROJECTION_SOURCE_BYTES,
+            })
+        );
+    }
+}

--- a/crates/prom-ui/src/ui_dna2_wp2c_parser_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp2c_parser_qualification_tests.rs
@@ -23,26 +23,42 @@ fn assert_diagnostic(source: &str, kind: Kind, start: usize, end: usize) {
     assert_eq!(diagnostic.kind(), kind);
     assert_eq!(diagnostic.code(), kind.code());
     assert_eq!(diagnostic.source_id(), source_id());
-    assert_eq!(diagnostic.span().start(), start as u32);
-    assert_eq!(diagnostic.span().end(), end as u32);
+    assert_eq!(
+        diagnostic.span().start(),
+        u32::try_from(start).expect("test span start is representable")
+    );
+    assert_eq!(
+        diagnostic.span().end(),
+        u32::try_from(end).expect("test span end is representable")
+    );
     let coordinate = diagnostic.coordinate();
     assert_eq!(coordinate.code(), kind.code());
     assert_eq!(
         coordinate.source().expect("source coordinate").source(),
         source_id()
     );
-    assert_eq!(coordinate.domain(), start as u64);
-    assert_eq!(coordinate.secondary(), end as u64);
+    assert_eq!(
+        coordinate.domain(),
+        u64::try_from(start).expect("test coordinate start is representable")
+    );
+    assert_eq!(
+        coordinate.secondary(),
+        u64::try_from(end).expect("test coordinate end is representable")
+    );
 }
 
 fn assert_at(source: &str, kind: Kind, needle: &str) {
     let start = source.find(needle).expect("diagnostic needle");
-    assert_diagnostic(source, kind, start, start + needle.len());
+    assert_diagnostic(source, kind, start, checked_test_add(start, needle.len()));
 }
 
 fn assert_zero_width_at(source: &str, needle: &str) {
     let start = source.find(needle).expect("diagnostic needle");
     assert_diagnostic(source, Kind::MissingSemicolon, start, start);
+}
+
+fn checked_test_add(position: usize, width: usize) -> usize {
+    position.checked_add(width).expect("test offset arithmetic")
 }
 
 #[test]
@@ -106,17 +122,32 @@ fn ui_dna2_wp2c_parser_constructs_exact_declaration_spans() {
     let surface_text = "surface 1 root 10 key 11;";
     let surface_start = source.find(surface_text).unwrap();
     let surface_span = document.surfaces()[0].source().span();
-    assert_eq!(surface_span.start(), surface_start as u32);
+    assert_eq!(
+        surface_span.start(),
+        u32::try_from(surface_start).expect("surface start is representable")
+    );
+    let surface_end = surface_start
+        .checked_add(surface_text.len())
+        .expect("surface end arithmetic");
     assert_eq!(
         surface_span.end(),
-        (surface_start + surface_text.len()) as u32
+        u32::try_from(surface_end).expect("surface end is representable")
     );
 
     let node_text = "node 10 role root key 12 { child 11 order 0; }";
     let node_start = source.find(node_text).unwrap();
     let node_span = document.nodes()[0].source().span();
-    assert_eq!(node_span.start(), node_start as u32);
-    assert_eq!(node_span.end(), (node_start + node_text.len()) as u32);
+    assert_eq!(
+        node_span.start(),
+        u32::try_from(node_start).expect("node start is representable")
+    );
+    let node_end = node_start
+        .checked_add(node_text.len())
+        .expect("node end arithmetic");
+    assert_eq!(
+        node_span.end(),
+        u32::try_from(node_end).expect("node end is representable")
+    );
 }
 
 #[test]
@@ -183,11 +214,11 @@ fn ui_dna2_wp2c_parser_covers_every_diagnostic_kind() {
             assert_zero_width_at(source, needle);
         } else if kind == Kind::ZeroId {
             let start = source.find(needle).unwrap();
-            assert_diagnostic(source, kind, start, start + 1);
+            assert_diagnostic(source, kind, start, checked_test_add(start, 1));
         } else if matches!(kind, Kind::DuplicateRevision | Kind::DuplicateEpoch) {
             let start = source.find(needle).unwrap();
             let token_len = needle.split_once(' ').unwrap().0.len();
-            assert_diagnostic(source, kind, start, start + token_len);
+            assert_diagnostic(source, kind, start, checked_test_add(start, token_len));
         } else {
             assert_at(source, kind, needle);
         }
@@ -341,7 +372,7 @@ fn ui_dna2_wp2c_parser_preserves_terminal_semicolon_precedence() {
     }
 
     let separated = "projection v0 { revision 0; epoch 0; surface 1 root 10 key 1 1+1; }";
-    let first = separated.find("1 1+1").unwrap() + 2;
+    let first = checked_test_add(separated.find("1 1+1").unwrap(), 2);
     assert_diagnostic(separated, Kind::MissingSemicolon, first, first);
 }
 
@@ -364,7 +395,22 @@ fn ui_dna2_wp2c_parser_preserves_nonterminal_plus_minus_boundaries() {
             "+",
         ),
         (
+            "projection v0 { revision 0; epoch 0; surface 1 root 10-1 key 1; }",
+            Kind::UnexpectedChar,
+            "-",
+        ),
+        (
             "projection v0 { revision 0; epoch 0; node 1+1 role root key 1 {} }",
+            Kind::UnexpectedToken,
+            "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1-1 role root key 1 {} }",
+            Kind::UnexpectedChar,
+            "-",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1+1 {} }",
             Kind::UnexpectedToken,
             "+",
         ),
@@ -377,6 +423,11 @@ fn ui_dna2_wp2c_parser_preserves_nonterminal_plus_minus_boundaries() {
             "projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2+1 order 0; } }",
             Kind::UnexpectedToken,
             "+",
+        ),
+        (
+            "projection v0 { revision 0; epoch 0; node 1 role root key 1 { child 2-1 order 0; } }",
+            Kind::UnexpectedChar,
+            "-",
         ),
     ];
     for (source, kind, needle) in cases {
@@ -395,18 +446,48 @@ fn ui_dna2_wp2c_parser_handles_post_document_and_fail_fast_boundaries() {
         ("-1", Kind::UnexpectedChar, 1),
     ] {
         let source = format!("{complete}{tail}");
-        assert_diagnostic(&source, kind, complete.len(), complete.len() + width);
+        assert_diagnostic(
+            &source,
+            kind,
+            complete.len(),
+            checked_test_add(complete.len(), width),
+        );
     }
+}
+
+#[test]
+fn ui_dna2_wp2c_parser_checks_cursor_advancement_boundaries() {
+    let ascii = "projection v0 { revision 0; epoch 0; }+";
+    assert_at(ascii, Kind::UnexpectedToken, "+");
+
+    let crlf = "projection v0 {\r\nrevision 0; epoch 0; background blue; }";
+    assert_at(crlf, Kind::UnknownClause, "background");
+
+    let multibyte_comment =
+        "projection v0 { // Привет 根\r\nrevision 0; epoch 0; background blue; }";
+    assert_at(multibyte_comment, Kind::UnknownClause, "background");
+
+    let token_at_eof = "Projection";
+    assert_diagnostic(token_at_eof, Kind::UnexpectedToken, 0, token_at_eof.len());
+
+    let eof = "projection v0 { revision 0; epoch 0;";
+    assert_diagnostic(eof, Kind::UnexpectedEof, eof.len(), eof.len());
 }
 
 #[test]
 fn ui_dna2_wp2c_parser_preflights_source_size_without_allocating_input() {
     assert_eq!(
-        preflight_source_len(source_id(), MAX_PROJECTION_SOURCE_BYTES as usize),
+        preflight_source_len(
+            source_id(),
+            usize::try_from(MAX_PROJECTION_SOURCE_BYTES).expect("u32 fits supported usize"),
+        ),
         Ok(())
     );
     if usize::BITS > 32 {
-        let actual_len = MAX_PROJECTION_SOURCE_BYTES as usize + 1;
+        let actual_len = usize::try_from(MAX_PROJECTION_SOURCE_BYTES)
+            .expect("u32 fits supported usize")
+            .checked_add(1)
+            .expect("64-bit usize represents u32 max plus one");
         assert_eq!(
             preflight_source_len(source_id(), actual_len),
             Err(ProjectionSourceInputError::SourceTooLarge {

--- a/docs/spec/ui/projection_source_grammar_v0.md
+++ b/docs/spec/ui/projection_source_grammar_v0.md
@@ -4,8 +4,8 @@ Status: PROPOSED NORMATIVE GRAMMAR CONTRACT
 Track: UI DNA v2
 Phase coverage: UI-DNA2-WP2B + WP2C-P1 + WP2C-P2 + WP2C-P3
 File posture: `.proj.sm`
-Implementation status: NOT IMPLEMENTED
-Parser authorization: NOT INCLUDED
+Implementation status: CRATE-PRIVATE PARSER IMPLEMENTATION CANDIDATE
+Parser authorization: BOUNDED WP2C-P4 IMPLEMENTATION SLICE
 Runtime activation: NOT AUTHORIZED
 
 ## 1. Ownership and Boundaries
@@ -294,8 +294,9 @@ evidence. Issue #1489 may subsequently be rebaselined to record that merged
 evidence and the current next-step authorization posture. The ledger records
 repository truth; it does not create or override repository truth.
 
-P3 diagnostic implementation is absent.
-The Projection Source parser and lexer remain unimplemented and unauthorized.
+A crate-private Grammar v0 parser/scanner implementation candidate now exists
+in `prom-ui`. It remains unpublished and does not create a public parser API,
+runtime loading, semantic admission or activation authority.
 
 Issue #1489 remains the coordination ledger for landed checkpoints and
 explicit next-step authorization. It grants no architectural authority and
@@ -784,11 +785,11 @@ this P2 choice. An oversized source returns `SourceTooLarge`, performs no
 lexical scan and produces no PSP diagnostic.
 
 P2 specification is not parser or lexer implementation, public API or parser
-authorization. The P3 identifier-tokenization contract defined below is not
-lexer, parser or diagnostic implementation. Diagnostic classification is not
-Semantic validation, capability, admission or runtime activation. The
-Projection Source parser and lexer remain unimplemented and unauthorized.
-Gate D remains closed, and production promotion remains unauthorized.
+authorization. The crate-private WP2C-P4 implementation candidate implements
+the landed P3 identifier-tokenization contract without publishing a parser or
+token API. Diagnostic classification is not Semantic validation, capability,
+admission or runtime activation. Implementation candidate does not mean
+publication, runtime loading or production promotion. Gate D remains closed.
 
 ### Diagnostic span rules
 

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -67,11 +67,18 @@ tokenization != authority
 ```
 
 The normative WP2C-P3 candidate, context, precedence and span rules remain in
-Grammar v0 and are not duplicated here. P3 specification does not implement a
-lexer, parser or diagnostic API. P3 merge does not authorize parser or lexer
-implementation and grants no runtime, capability, admission or activation
+Grammar v0 and are not duplicated here. A crate-private implementation
+candidate now exists in `prom-ui`; Grammar v0 owns its detailed tokenization
+and diagnostic selection. The implementation candidate does not publish a
+parser or token API and grants no runtime, capability, admission or activation
 authority.
-The Projection Source parser and lexer remain unimplemented and unauthorized.
+
+```text
+implementation candidate != publication
+implementation != runtime loading
+parse success != semantic validation
+parser implementation != Gate D activation
+```
 
 ## Source Size and Provenance Representability
 
@@ -85,8 +92,8 @@ parser ownership. A source longer than `u32::MAX` bytes is classified as the
 future input-domain error `ProjectionSourceInputError::SourceTooLarge`; it
 produces no SourceSpan, PSP diagnostic, tokenization, AST or PS validation.
 The conceptual error carries the caller-supplied `SourceId`, actual UTF-8 byte
-length and maximum accepted byte length. The concrete API is not implemented
-by this model correction.
+length and maximum accepted byte length. The crate-private implementation
+candidate enforces this preflight without widening the public API.
 
 The limit is a representability ceiling, not a recommended operational file
 size. A future host or loader may impose a smaller memory, quota, transport or
@@ -144,10 +151,10 @@ that evidence and the current authorization posture; it does not create or
 override repository truth. Issue state does not create Git tree state and the
 ledger grants no architectural authority.
 
-P3 specification and any future merge do not implement or authorize the
-Projection Source parser or lexer and do not authorize runtime loading or
-activation.
-The Projection Source parser and lexer remain unimplemented and unauthorized.
+P3 specification and merge did not themselves authorize implementation. The
+separately bounded WP2C-P4 task now provides a crate-private parser/scanner
+implementation candidate; publication, runtime loading and activation remain
+unauthorized.
 
 No source-size check grants capability, performs admission, loads files,
 allocates runtime buffers, activates a ProjectionBundle, mutates shell state,


### PR DESCRIPTION
## Summary

- Implements a crate-private complete Grammar v0 parser.
- Provides fail-fast deterministic `PSP_*` diagnostics.
- Uses checked UTF-8 cursor arithmetic with exact `SourceSpan` values.
- Performs a `SourceTooLarge` preflight.
- Constructs the AST without normalization or semantic validation.
- Qualifies all 12 PSP diagnostic kinds.
- Leaves the public API unchanged.
- The local `prom-ui --no-default-features` failure remains pre-existing and outside the candidate files.
- Runtime loading, Gate D, and production promotion remain unauthorized.