### PR TITLE
feat(ui): compose projection source frontend

### DIFF
--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -63,6 +63,7 @@ pub mod projection;
 pub(crate) mod projection_compile;
 pub(crate) mod projection_patch;
 pub(crate) mod projection_source;
+pub(crate) mod projection_source_frontend;
 pub(crate) mod projection_source_parser;
 pub mod raw_event;
 pub mod renderer;
@@ -81,6 +82,8 @@ pub mod validation;
 
 #[cfg(test)]
 mod ui_dna2_wp2_qualification_tests;
+#[cfg(test)]
+mod ui_dna2_wp2c_frontend_qualification_tests;
 #[cfg(test)]
 mod ui_dna2_wp2c_parser_qualification_tests;
 #[cfg(test)]

--- a/crates/prom-ui/src/projection_source_frontend.rs
+++ b/crates/prom-ui/src/projection_source_frontend.rs
@@ -1,0 +1,29 @@
+//! Crate-private in-memory Projection Source front-end composition.
+#![allow(dead_code)]
+
+use crate::contract_primitives::{SourceId, StaticDocumentId};
+use crate::projection_compile::{
+    compile_projection_source_to_static_ir, ProjectionCompileDiagnostics,
+};
+use crate::projection_source_parser::{parse_projection_source, ProjectionSourceParseError};
+use crate::role_dictionary::RoleDictionary;
+use crate::static_ir::StaticUiDocument;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProjectionSourceFrontendError {
+    Parse(ProjectionSourceParseError),
+    Compile(ProjectionCompileDiagnostics),
+}
+
+pub(crate) fn compile_projection_source_text_to_static_ir(
+    source_id: SourceId,
+    source_text: &str,
+    document_id: StaticDocumentId,
+    dictionary: RoleDictionary,
+) -> Result<StaticUiDocument, ProjectionSourceFrontendError> {
+    let source = parse_projection_source(source_id, source_text)
+        .map_err(ProjectionSourceFrontendError::Parse)?;
+
+    compile_projection_source_to_static_ir(document_id, &source, dictionary)
+        .map_err(ProjectionSourceFrontendError::Compile)
+}

--- a/crates/prom-ui/src/ui_dna2_wp2c_frontend_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_wp2c_frontend_qualification_tests.rs
@@ -1,0 +1,207 @@
+use crate::contract_primitives::{SourceId, SourceRef, StaticDocumentId};
+use crate::projection_compile::{ProjectionCompileDiagnosticKind, ProjectionCompileStage};
+use crate::projection_source::ProjectionSourceDiagnosticKind;
+use crate::projection_source_frontend::{
+    compile_projection_source_text_to_static_ir, ProjectionSourceFrontendError,
+};
+use crate::projection_source_parser::{
+    ProjectionSourceParseError, ProjectionSourceParserDiagnosticKind,
+};
+use crate::role_dictionary::RoleDictionary;
+
+const SOURCE_RAW: u64 = 41;
+const DOCUMENT_RAW: u64 = 73;
+
+fn source_id() -> SourceId {
+    SourceId::new(SOURCE_RAW).expect("non-zero test source id")
+}
+
+fn document_id() -> StaticDocumentId {
+    StaticDocumentId::new(DOCUMENT_RAW).expect("non-zero test document id")
+}
+
+fn compile(
+    source: &str,
+) -> Result<crate::static_ir::StaticUiDocument, ProjectionSourceFrontendError> {
+    compile_projection_source_text_to_static_ir(
+        source_id(),
+        source,
+        document_id(),
+        RoleDictionary::current(),
+    )
+}
+
+fn assert_source_ref(source_ref: SourceRef, source: &str, declaration: &str) {
+    assert_eq!(source_ref.source(), source_id());
+    let start = source.find(declaration).expect("declaration start");
+    let end = start
+        .checked_add(declaration.len())
+        .expect("declaration end arithmetic");
+    assert_eq!(
+        source_ref.span().start(),
+        u32::try_from(start).expect("representable declaration start")
+    );
+    assert_eq!(
+        source_ref.span().end(),
+        u32::try_from(end).expect("representable declaration end")
+    );
+}
+
+fn valid_source() -> &'static str {
+    concat!(
+        "projection v0 {\n",
+        "revision 7; epoch 9;\n",
+        "surface 2 root 20 key 200;\n",
+        "node 20 role root key 201 { child 22 order 4; child 21 order 1; }\n",
+        "node 21 role text key 101 {}\n",
+        "node 22 role numeric_readout key 102 {}\n",
+        "}"
+    )
+}
+
+#[test]
+fn ui_dna2_wp2c_frontend_compiles_text_and_preserves_identity_and_provenance() {
+    let source = valid_source();
+    let document = compile(source).expect("valid source compiles");
+
+    assert_eq!(document.id(), document_id());
+    assert_eq!(document.revision().raw(), 7);
+    assert_eq!(document.epoch().raw(), 9);
+    assert_eq!(document.surfaces().len(), 1);
+    assert_eq!(document.nodes().len(), 3);
+
+    let surface = &document.surfaces()[0];
+    assert_eq!(surface.id().raw(), 2);
+    assert_eq!(surface.root().raw(), 20);
+    assert_eq!(surface.key().raw(), 200);
+    assert_source_ref(
+        surface.source().expect("surface source provenance"),
+        source,
+        "surface 2 root 20 key 200;",
+    );
+
+    let root = document
+        .nodes()
+        .iter()
+        .find(|node| node.id().raw() == 20)
+        .expect("root node");
+    assert_eq!(root.key().raw(), 201);
+    assert_eq!(
+        root.role(),
+        RoleDictionary::current()
+            .resolve_name("root")
+            .expect("built-in root role")
+    );
+    assert_eq!(root.children().len(), 2);
+    assert_eq!(root.children()[0].child().raw(), 21);
+    assert_eq!(root.children()[0].order().raw(), 1);
+    assert_eq!(root.children()[1].child().raw(), 22);
+    assert_eq!(root.children()[1].order().raw(), 4);
+    assert_source_ref(
+        root.source().expect("node source provenance"),
+        source,
+        "node 20 role root key 201 { child 22 order 4; child 21 order 1; }",
+    );
+
+    let text = document
+        .nodes()
+        .iter()
+        .find(|node| node.id().raw() == 21)
+        .expect("text node");
+    assert_eq!(
+        text.role(),
+        RoleDictionary::current()
+            .resolve_name("text")
+            .expect("built-in text role")
+    );
+    let numeric = document
+        .nodes()
+        .iter()
+        .find(|node| node.id().raw() == 22)
+        .expect("numeric readout node");
+    assert_eq!(
+        numeric.role(),
+        RoleDictionary::current()
+            .resolve_name("numeric_readout")
+            .expect("built-in numeric_readout role")
+    );
+}
+
+#[test]
+fn ui_dna2_wp2c_frontend_repeated_compilation_is_canonical() {
+    let first = compile(valid_source()).expect("first compilation");
+    let second = compile(valid_source()).expect("second compilation");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .canonical_bytes(RoleDictionary::current())
+            .expect("first canonical bytes"),
+        second
+            .canonical_bytes(RoleDictionary::current())
+            .expect("second canonical bytes")
+    );
+}
+
+#[test]
+fn ui_dna2_wp2c_frontend_preserves_parser_error_identity() {
+    let source = "projection v0 { revision 0; epoch 0; node 1 role Root key 1 {} }";
+
+    match compile(source).expect_err("malformed identifier must fail parsing") {
+        ProjectionSourceFrontendError::Parse(ProjectionSourceParseError::Diagnostic(
+            diagnostic,
+        )) => {
+            assert_eq!(
+                diagnostic.kind(),
+                ProjectionSourceParserDiagnosticKind::InvalidIdentifier
+            );
+            assert_eq!(diagnostic.code().as_str(), "PSP_INVALID_IDENTIFIER");
+        }
+        other => panic!("expected parser diagnostic, got {other:?}"),
+    }
+}
+
+#[test]
+fn ui_dna2_wp2c_frontend_routes_unknown_role_through_source_compile_stage() {
+    let source = concat!(
+        "projection v0 { revision 0; epoch 0; ",
+        "surface 1 root 1 key 1; node 1 role button key 2 {} }"
+    );
+
+    let ProjectionSourceFrontendError::Compile(diagnostics) =
+        compile(source).expect_err("unknown role must fail semantic compilation")
+    else {
+        panic!("semantic failure must not masquerade as parser failure");
+    };
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    let diagnostic = diagnostics.diagnostics()[0];
+    assert_eq!(
+        diagnostic.kind(),
+        ProjectionCompileDiagnosticKind::Source(ProjectionSourceDiagnosticKind::UnknownRole)
+    );
+    assert_eq!(diagnostic.stage(), ProjectionCompileStage::Source);
+    assert_eq!(diagnostic.coordinate().code().as_str(), "PS_UNKNOWN_ROLE");
+}
+
+#[test]
+fn ui_dna2_wp2c_frontend_preserves_structural_source_diagnostic() {
+    let source = concat!(
+        "projection v0 { revision 0; epoch 0; ",
+        "surface 1 root 1 key 1; ",
+        "node 1 role root key 2 { child 9 order 0; } }"
+    );
+
+    let ProjectionSourceFrontendError::Compile(diagnostics) =
+        compile(source).expect_err("missing child must fail semantic compilation")
+    else {
+        panic!("semantic failure must not masquerade as parser failure");
+    };
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    let diagnostic = diagnostics.diagnostics()[0];
+    assert_eq!(
+        diagnostic.kind(),
+        ProjectionCompileDiagnosticKind::Source(ProjectionSourceDiagnosticKind::MissingChild)
+    );
+    assert_eq!(diagnostic.stage(), ProjectionCompileStage::Source);
+    assert_eq!(diagnostic.coordinate().code().as_str(), "PS_MISSING_CHILD");
+}

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -24,7 +24,9 @@ The source model does not itself define parser grammar.
 The bounded structural grammar contract is specified separately in
 projection_source_grammar_v0.md.
 
-Parser implementation remains a separate, unauthorized slice.
+The WP2C-P4 Grammar v0 parser/scanner is landed and remains crate-private.
+WP2C-P5 adds only a crate-private, pure in-memory composition from source text
+through that parser and the existing semantic compiler to Static UI IR.
 
 ## Source Role Representation Boundary
 
@@ -67,17 +69,20 @@ tokenization != authority
 ```
 
 The normative WP2C-P3 candidate, context, precedence and span rules remain in
-Grammar v0 and are not duplicated here. A crate-private implementation
-candidate now exists in `prom-ui`; Grammar v0 owns its detailed tokenization
-and diagnostic selection. The implementation candidate does not publish a
-parser or token API and grants no runtime, capability, admission or activation
-authority.
+Grammar v0 and are not duplicated here. The landed crate-private P4
+parser/scanner owns its detailed tokenization and diagnostic selection. P5
+composes that parser with the existing crate-private compiler without
+publishing a parser or token API. Parse success remains distinct from semantic
+validity.
 
 ```text
-implementation candidate != publication
-implementation != runtime loading
+parser/scanner landed != public parser or token API
+composition != file loading
+composition != runtime loading
 parse success != semantic validation
-parser implementation != Gate D activation
+composition != activation or admission
+composition != capability authority or shell mutation
+composition != Gate D activation or production promotion
 ```
 
 ## Source Size and Provenance Representability
@@ -87,13 +92,13 @@ Projection Source provenance uses UTF-8 byte offsets represented by the landed
 `u32::MAX = 4_294_967_295` source bytes. This model does not widen `SourceSpan`
 to `u64`, `usize`, character offsets or line/column coordinates.
 
-For a future parser receiving `&str`, source-size preflight occurs before
-parser ownership. A source longer than `u32::MAX` bytes is classified as the
-future input-domain error `ProjectionSourceInputError::SourceTooLarge`; it
+For the crate-private parser receiving `&str`, source-size preflight occurs
+before parser ownership. A source longer than `u32::MAX` bytes is classified as
+the input-domain error `ProjectionSourceInputError::SourceTooLarge`; it
 produces no SourceSpan, PSP diagnostic, tokenization, AST or PS validation.
 The conceptual error carries the caller-supplied `SourceId`, actual UTF-8 byte
-length and maximum accepted byte length. The crate-private implementation
-candidate enforces this preflight without widening the public API.
+length and maximum accepted byte length. The landed crate-private
+implementation enforces this preflight without widening the public API.
 
 The limit is a representability ceiling, not a recommended operational file
 size. A future host or loader may impose a smaller memory, quota, transport or
@@ -140,21 +145,11 @@ source-size policy specified != parser qualification
 source-size policy specified != runtime source loading
 source-size policy specified != WP2C completion
 
-The P1 source-size contract and P2 clause-context diagnostic contract are
-landed. Grammar v0 separately defines the normative WP2C-P3 identifier
-candidate and malformed-identifier diagnostic contract. Definition of that
-contract is separate from review, publication, merge and implementation.
-
-A future merge of P3 into `main` establishes repository landed evidence through
-the merge commit and resulting Git tree. A later issue #1489 rebaseline records
-that evidence and the current authorization posture; it does not create or
-override repository truth. Issue state does not create Git tree state and the
-ledger grants no architectural authority.
-
-P3 specification and merge did not themselves authorize implementation. The
-separately bounded WP2C-P4 task now provides a crate-private parser/scanner
-implementation candidate; publication, runtime loading and activation remain
-unauthorized.
+The P1 source-size, P2 clause-context and P3 identifier-candidate diagnostic
+contracts are landed and unchanged. The P4 parser/scanner implementation is
+also landed and crate-private. P5 supplies only the pure in-memory composition
+to the existing Static UI IR compiler. Repository state and ledger state grant
+no runtime, activation, admission, capability or production authority.
 
 No source-size check grants capability, performs admission, loads files,
 allocates runtime buffers, activates a ProjectionBundle, mutates shell state,


### PR DESCRIPTION
## Summary

Adds the crate-private WP2C-P5 Projection Source front-end composition seam:

`UTF-8 text → Grammar v0 parser → ProjectionSourceDocument → existing semantic validation/normalization → StaticUiDocument`

## Contract

- pure in-memory composition;
- existing parser reused unchanged;
- existing semantic validation and normalization reused unchanged;
- existing Static UI IR lowering and canonicalization reused unchanged;
- parser and compiler error identities remain distinct;
- public parser/token API remains absent;
- public API remains unchanged.

## Error preservation

- `SourceTooLarge` → front-end `Parse(Input(...))`;
- `PSP_*` → front-end `Parse(Diagnostic(...))`;
- `PS_*` → `Compile(...)` at `ProjectionCompileStage::Source`;
- existing Lowering and StaticIr stages remain unchanged;
- no diagnostic flattening, recovery, fallback or partial IR.

## Qualification

- front-end qualification: 5/5 passed;
- parser qualification: 13/13 passed;
- full `prom-ui` suite passed;
- public API contracts passed;
- trust-boundary guards passed;
- workspace suite passed.

`prom-ui --no-default-features` retains the established pre-existing failure baseline. Neither candidate file nor changed `lib.rs` is implicated.

## Boundaries

This PR does not authorize or implement:

- filesystem or Projection Source loading;
- ProjectionBundle loading or activation;
- runtime integration;
- admission or capability authority;
- shell or renderer integration;
- Gate D activation;
- production promotion.