### PR TITLE
fix(ui): correct task projection bounds and identity types

### DIFF
--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -692,7 +692,7 @@ fn sort_and_dedup_diagnostics(
     diagnostics
 }
 
-fn push_value(
+pub(crate) fn push_value(
     bytes: &mut Vec<u8>,
     value: &ProjectionPatchValue,
 ) -> Result<(), ProjectionPatchEncodingError> {

--- a/crates/prom-ui/src/projection_patch.rs
+++ b/crates/prom-ui/src/projection_patch.rs
@@ -155,6 +155,7 @@ pub(crate) enum ProjectionQuadState {
 pub(crate) enum ProjectionPatchValue {
     Quad(ProjectionQuadState),
     SignedScalar(i64),
+    UnsignedScalar(u64),
     Text(String),
 }
 
@@ -707,6 +708,10 @@ fn push_value(
         ProjectionPatchValue::Text(value) => {
             push_u8(bytes, 3);
             push_string(bytes, value)?;
+        }
+        ProjectionPatchValue::UnsignedScalar(value) => {
+            push_u8(bytes, 4);
+            push_u64(bytes, *value);
         }
     }
     Ok(())

--- a/crates/prom-ui/src/task_projection.rs
+++ b/crates/prom-ui/src/task_projection.rs
@@ -338,6 +338,33 @@ fn checked_operation_add(total: usize, value: usize) -> Result<usize, TaskProjec
     })
 }
 
+const fn u64_text_len(mut val: u64) -> usize {
+    if val == 0 {
+        return 1;
+    }
+    let mut len = 0;
+    while val > 0 {
+        len += 1;
+        val /= 10;
+    }
+    len
+}
+
+fn control_value_len(control: &TaskControlOffer) -> usize {
+    let mut len = control.kind.token().len() + 1 + u64_text_len(control.action.raw());
+    if let Some(token) = &control.resume_token {
+        len += 1
+            + u64_text_len(token.issuer())
+            + 1
+            + u64_text_len(token.namespace() as u64)
+            + 1
+            + u64_text_len(token.generation() as u64)
+            + 1
+            + u64_text_len(token.value());
+    }
+    len
+}
+
 fn control_value(control: &TaskControlOffer) -> String {
     match control.resume_token {
         Some(token) => alloc::format!(
@@ -371,6 +398,16 @@ pub(crate) fn project_task_state(
     }
 
     let mut total_text_bytes = 0usize;
+    total_text_bytes = checked_text_add(total_text_bytes, evidence.state.token().len())?;
+    total_text_bytes = checked_text_add(total_text_bytes, evidence.freshness.token().len())?;
+    let progress_len = match evidence.current_progress {
+        TaskProgress::Indeterminate => 13,
+        TaskProgress::Determinate { completed, total } => {
+            u64_text_len(completed) + 1 + u64_text_len(total)
+        }
+    };
+    total_text_bytes = checked_text_add(total_text_bytes, progress_len)?;
+
     for phase in &evidence.phases {
         if phase.label.len() > limits.phase_label_bytes {
             return Err(task_error(
@@ -378,7 +415,12 @@ pub(crate) fn project_task_state(
                 TaskProjectionDiagnosticKind::ResourceLimitExceeded,
             ));
         }
-        total_text_bytes = checked_text_add(total_text_bytes, phase.label.len())?;
+        let phase_len =
+            u64_text_len(phase.id) + 1 + phase.status.token().len() + 1 + phase.label.len();
+        total_text_bytes = checked_text_add(total_text_bytes, phase_len)?;
+    }
+    for control in &evidence.controls {
+        total_text_bytes = checked_text_add(total_text_bytes, control_value_len(control))?;
     }
     if let Some(awaiting_input) = &evidence.awaiting_input {
         if awaiting_input.len() > limits.awaiting_input_bytes {
@@ -396,7 +438,16 @@ pub(crate) fn project_task_state(
                 TaskProjectionDiagnosticKind::ResourceLimitExceeded,
             ));
         }
-        total_text_bytes = checked_text_add(total_text_bytes, lock.explanation.len())?;
+        let lock_len = u64_text_len(lock.reference.issuer())
+            + 1
+            + u64_text_len(lock.reference.namespace() as u64)
+            + 1
+            + u64_text_len(lock.reference.generation() as u64)
+            + 1
+            + u64_text_len(lock.reference.value())
+            + 1
+            + lock.explanation.len();
+        total_text_bytes = checked_text_add(total_text_bytes, lock_len)?;
     }
     if total_text_bytes > limits.total_projected_text_bytes {
         return Err(task_error(
@@ -704,7 +755,7 @@ pub(crate) fn project_task_state(
     let mut operations = Vec::with_capacity(operation_count);
     operations.push(ProjectionPatchOperation::SetBindingValue {
         target: routes.identity_route,
-        value: ProjectionPatchValue::SignedScalar(canonical.task_ref.raw() as i64),
+        value: ProjectionPatchValue::UnsignedScalar(canonical.task_ref.raw()),
     });
     operations.push(ProjectionPatchOperation::SetBindingValue {
         target: routes.state_route,

--- a/crates/prom-ui/src/ui_dna2_task_projection_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_task_projection_qualification_tests.rs
@@ -809,10 +809,10 @@ fn projected_text_bytes_resource_limits_are_exact() {
     evidence.previous_progress = None;
     evidence.state = TaskProjectionState::Pending; // "pending" = 7
     evidence.freshness = FreshnessState::Fresh; // "fresh" = 5
-    // exact text bytes = "started".len() + "indeterminate".len() + "fresh".len() = 7 + 13 + 5 = 25.
-    
+                                                // exact text bytes = "pending".len() + "indeterminate".len() + "fresh".len() = 7 + 13 + 5 = 25.
+
     let exact_total = 25;
-    
+
     let mut failing_limits = limits();
     failing_limits.total_projected_text_bytes = exact_total - 1;
     assert_task_error(
@@ -820,7 +820,7 @@ fn projected_text_bytes_resource_limits_are_exact() {
         ValidationStage::ResourcePreflight,
         TaskProjectionDiagnosticKind::ResourceLimitExceeded,
     );
-    
+
     let mut passing_limits = limits();
     passing_limits.total_projected_text_bytes = exact_total;
     assert!(project_task_state(envelope(), evidence, routes(), passing_limits).is_ok());
@@ -831,10 +831,10 @@ fn unsigned_scalar_canonical_bytes_are_deterministic() {
     let val = ProjectionPatchValue::UnsignedScalar(42);
     let mut bytes = alloc::vec::Vec::new();
     crate::projection_patch::push_value(&mut bytes, &val).unwrap();
-    
+
     let mut expected = alloc::vec::Vec::new();
     expected.push(4); // Tag for UnsignedScalar
     expected.extend_from_slice(&42u64.to_le_bytes());
-    
+
     assert_eq!(bytes, expected);
 }

--- a/crates/prom-ui/src/ui_dna2_task_projection_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_task_projection_qualification_tests.rs
@@ -784,3 +784,57 @@ fn awaiting_input_projection_sets_value_and_availability() {
         } if *target_node == node(4)
     )));
 }
+
+#[test]
+fn task_record_ref_uses_unsigned_scalar() {
+    let mut evidence = running_evidence();
+    evidence.task_ref = TaskRecordRef::new(u64::MAX);
+    let artifact = project_task_state(envelope(), evidence, routes(), limits()).unwrap();
+    assert!(artifact.patch.operations().iter().any(|operation| matches!(
+        operation,
+        ProjectionPatchOperation::SetBindingValue {
+            target: _,
+            value: ProjectionPatchValue::UnsignedScalar(u64::MAX),
+        }
+    )));
+}
+
+#[test]
+fn projected_text_bytes_resource_limits_are_exact() {
+    let mut evidence = running_evidence();
+    evidence.phases.clear();
+    evidence.controls.clear();
+    evidence.locks.clear();
+    evidence.current_progress = TaskProgress::Indeterminate;
+    evidence.previous_progress = None;
+    evidence.state = TaskProjectionState::Pending; // "pending" = 7
+    evidence.freshness = FreshnessState::Fresh; // "fresh" = 5
+    // exact text bytes = "started".len() + "indeterminate".len() + "fresh".len() = 7 + 13 + 5 = 25.
+    
+    let exact_total = 25;
+    
+    let mut failing_limits = limits();
+    failing_limits.total_projected_text_bytes = exact_total - 1;
+    assert_task_error(
+        project_task_state(envelope(), evidence.clone(), routes(), failing_limits),
+        ValidationStage::ResourcePreflight,
+        TaskProjectionDiagnosticKind::ResourceLimitExceeded,
+    );
+    
+    let mut passing_limits = limits();
+    passing_limits.total_projected_text_bytes = exact_total;
+    assert!(project_task_state(envelope(), evidence, routes(), passing_limits).is_ok());
+}
+
+#[test]
+fn unsigned_scalar_canonical_bytes_are_deterministic() {
+    let val = ProjectionPatchValue::UnsignedScalar(42);
+    let mut bytes = alloc::vec::Vec::new();
+    crate::projection_patch::push_value(&mut bytes, &val).unwrap();
+    
+    let mut expected = alloc::vec::Vec::new();
+    expected.push(4); // Tag for UnsignedScalar
+    expected.extend_from_slice(&42u64.to_le_bytes());
+    
+    assert_eq!(bytes, expected);
+}


### PR DESCRIPTION
Addresses P2 defects from #1517. Corrects total_projected_text_bytes logic to count all projection strings. Upgrades TaskRecordRef format to UnsignedScalar to avoid i64 overflow.