### PR TITLE
build(ci): qualify Rust 1.97.1 toolchain baseline

### DIFF
--- a/.github/workflows/7hell-full.yml
+++ b/.github/workflows/7hell-full.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: 7hell PCC Full Runner
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.93.1
+          toolchain: 1.97.1
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: PR-ready format and clippy baseline
@@ -28,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: Root cleanliness and legacy perimeter guard
         run: cargo test --test legacy_guards --quiet
@@ -42,7 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: Public API inventory guard
         run: cargo test --test public_api_contracts --quiet
@@ -51,7 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: Runtime and SemCode release-facing validation gates
         run: |
@@ -74,7 +80,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: 7hell PCC Qualification Fast Gate
         shell: powershell
@@ -84,7 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: Test (std)
         run: cargo test --all-targets --quiet
@@ -93,7 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
       - uses: Swatinem/rust-cache@v2
       - name: Check (no default features)
         run: cargo check --no-default-features --quiet

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,12 +1,12 @@
 task:
-  id: MAINT-RUST-1.97.1-HARNESS-SCOPE-CONFLICT
-  title: resolve exact harness allow/forbidden conflict
+  id: MAINT-RUST-1.97.1-TOOLCHAIN-QUALIFICATION
+  title: qualify Rust 1.97.1 repository and CI baseline
   type: maintenance
   mode: active
 
 intent:
   summary: "build(ci): qualify Rust 1.97.1 toolchain baseline"
-  predecessor: "MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE"
+  predecessor: "UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT-CLOSEOUT"
 
 evidence_baseline:
   main_sha: "c71242d04c1f6962c9bc816b535b9136e9113d23"
@@ -69,12 +69,19 @@ actions:
     - apply_exact_workspace_clippy_compatibility_fixes
     - validate_sm_sema
     - validate_sm_ir
+    - validate_smc_cli
+    - modify_exact_test_support_compatibility
+    - validate_test_support
+    - resolve_harness_scope_conflict
 
   forbidden:
     - modify_additional_rust
-    - modify_tests
-    - modify_fixtures
-    - modify_manifests
+    - modify_test_cases
+    - modify_test_assertions
+    - modify_test_fixtures
+    - modify_additional_test_support
+    - modify_cargo_manifests
+    - modify_additional_manifests
     - modify_lockfile
     - modify_dependencies
     - change_msrv
@@ -110,11 +117,21 @@ authorization:
   workflow_toolchain_unification: true
   qualification_report: true
 
-  source_changes: false
-  test_changes: false
+  exact_source_compatibility_changes: true
+  exact_test_support_compatibility_change: true
+  workflow_changes: true
+  toolchain_manifest_change: true
+  harness_manifest_change: true
+
+  broad_source_changes: false
+  test_case_changes: false
+  test_assertion_changes: false
+  fixture_changes: false
+  cargo_manifest_changes: false
+  lockfile_changes: false
   dependency_changes: false
-  manifest_changes: false
   msrv_changes: false
+  edition_changes: false
   architecture_changes: false
   runtime_changes: false
   public_api_changes: false
@@ -143,10 +160,10 @@ source_compatibility:
   newly_authorized_diagnostic:
     - clippy::unnecessary-sort-by
   newly_authorized_correction_count: 1
-  total_clippy_correction_count: 6
+  production_clippy_correction_count: 6
   behavior_changes: false
   public_api_changes: false
-  test_changes: false
+  test_case_changes: false
   additional_source_fixes: false
 
 test_support_compatibility:
@@ -201,10 +218,14 @@ constraints:
   preserve_msrv_declarations: true
   preserve_authority_boundaries: true
   exact_new_source_fix_count: 1
-  exact_total_source_fix_count: 6
+  exact_production_source_fix_count: 6
+  exact_test_support_fix_count: 1
+  exact_total_clippy_correction_count: 7
   no_semantic_behavior_change: true
   no_public_api_change: true
-  no_test_change: true
+  no_test_case_change: true
+  no_test_assertion_change: true
+  no_fixture_change: true
   no_lint_suppression: true
   no_allow_attributes: true
   no_additional_source_cleanup: true

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,89 +1,92 @@
 task:
-  id: UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT-CLOSEOUT
-  title: close out landed Shell Player v0 boundary contract
-  type: documentation
+  id: MAINT-RUST-1.97.1-HARNESS-SCOPE-CONFLICT
+  title: resolve exact harness allow/forbidden conflict
+  type: maintenance
   mode: active
 
 intent:
-  summary: "docs(ui): close out Shell Player boundary contract"
-  issue: "#1489"
-  predecessor: "UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT"
+  summary: "build(ci): qualify Rust 1.97.1 toolchain baseline"
+  predecessor: "MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE"
 
 evidence_baseline:
-  main_sha: "b514c51455c086ba624fbfe173e510b61ebd9946"
-  predecessor_pr: "#1520"
-  predecessor_initial_head: "6cbafc3379d59cdffa1b0c5c67a41e88c2ba09e2"
-  predecessor_reviewed_head: "f3cfb9d9cd4b51af05fbf83c5f6263228dc6bb43"
-  predecessor_push_ci: "29635394874"
-  predecessor_pr_ci: "29635396064"
-  predecessor_post_merge_ci: "29636264299"
+  main_sha: "c71242d04c1f6962c9bc816b535b9136e9113d23"
+  predecessor_pr: "#1521"
+  predecessor_squash_sha: "c71242d04c1f6962c9bc816b535b9136e9113d23"
+  predecessor_post_merge_ci: "29640056524"
 
 layer:
-  name: ui-shell-runtime-contract
-  owner: prom-ui-runtime::shell_player
+  name: repository-toolchain
+  owner: repository-maintenance
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT-CLOSEOUT.md
-    - docs/roadmap/post_ui/ui_dna2_9a1_shell_player_boundary_contract_closeout.md
-    - docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
+    - rust-toolchain.toml
+    - .github/workflows/ci.yml
+    - .github/workflows/7hell-full.yml
+    - .harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
+    - crates/sm-front/src/parser.rs
+    - crates/sm-front/src/typecheck.rs
+    - crates/sm-sema/src/alloc_core.rs
+    - crates/sm-ir/src/legacy_lowering.rs
+    - crates/smc-cli/src/executable_bundle.rs
+    - tests/support/executable_bundle_support.rs
 
   forbidden_paths:
-    - crates/**
-    - experiments/**
-    - tests/**
-    - benches/**
-    - examples/**
-    - tools/**
-    - scripts/**
-    - .github/**
     - Cargo.toml
     - Cargo.lock
+    - apps/workbench/src-tauri/Cargo.toml
+    - src/**
+    - benches/**
+    - examples/**
+    - experiments/**
+    - scripts/**
+    - tools/**
+    - docs/spec/**
     - docs/dna/**
-    - docs/ERROR_CODES.md
-    - docs/spec/ui/shell_player_boundary_v0.md
-    - docs/spec/ui/projection_bundle_v0.md
-    - docs/roadmap/post_ui/shell_player_evidence_inventory.md
-    - docs/roadmap/post_ui/ui_dna2_ownership_and_compatibility_freeze.md
+    - docs/roadmap/**
+    - docs/wiki/**
+    - README.md
+    - CHANGELOG.md
+    - pr_body_action_mapping.md
+    - pr_body_intent_admission_boundary.md
 
 actions:
   allowed:
     - inspect
     - edit_harness
-    - create_closeout_report
-    - create_durable_post_ui_closeout_mirror
-    - record_project_2_ledger_evidence
-    - record_historical_pr_body_baseline
-    - rebaseline_roadmap
-    - rebaseline_issue_1489_body
+    - create_toolchain_file
+    - modify_ci_workflows
+    - create_qualification_report
     - validate
     - create_branch
     - commit
     - push
     - create_draft_pr
+    - dispatch_7hell_full_workflow
+    - apply_exact_clippy_compatibility_fixes
+    - validate_sm_front
+    - apply_exact_workspace_clippy_compatibility_fixes
+    - validate_sm_sema
+    - validate_sm_ir
 
   forbidden:
-    - modify_rust
+    - modify_additional_rust
     - modify_tests
     - modify_fixtures
-    - modify_cargo
+    - modify_manifests
     - modify_lockfile
-    - modify_workflows
+    - modify_dependencies
+    - change_msrv
     - modify_scripts
     - modify_tools
+    - modify_specs
+    - modify_dna
+    - modify_roadmap
+    - modify_issue
+    - modify_project
     - modify_public_api
     - modify_runtime
-    - apply_projection_patch
-    - implement_bundle_parser
-    - implement_bundle_validator
-    - implement_bundle_verifier
-    - implement_bundle_loader
-    - activate_bundle
-    - admit_action_intent
-    - dispatch_action_intent
-    - integrate_renderer
-    - integrate_backend
     - open_gate
     - production_promotion
     - authorize_implementation
@@ -102,54 +105,108 @@ actions:
     - modify_branch_protection
 
 authorization:
-  closeout_only: true
-  documentation_only: true
-  issue_1489_body_rebaseline: true
+  maintenance_only: true
+  toolchain_pin: true
+  workflow_toolchain_unification: true
+  qualification_report: true
 
-  implementation: false
-  public_api: false
-  runtime: false
-  patch_application: false
-  bundle_parser: false
-  bundle_validator: false
-  bundle_verifier: false
-  bundle_loader: false
-  bundle_activation: false
-  action_intent_admission: false
-  action_intent_dispatch: false
-  renderer_integration: false
-  backend_integration: false
+  source_changes: false
+  test_changes: false
+  dependency_changes: false
+  manifest_changes: false
+  msrv_changes: false
+  architecture_changes: false
+  runtime_changes: false
+  public_api_changes: false
   gate_d: closed
   production_promotion: false
   follow_on_implementation: false
 
-project_2_evidence:
-  owner: skulmakov-oss
-  number: 2
-  target_content_url: https://github.com/skulmakov-oss/Semantic/pull/1521
-  expected_item_id: PVTI_lAHOD49aK84BRzo5zgzRCvs
-  read_metadata: true
-  add_item: false
-  edit_custom_fields: false
-  delete_items: false
-  modify_other_items: false
+source_compatibility:
+  authorized: true
+  reason: rust_1_97_1_clippy_qualification
+  allowed_paths:
+    - crates/sm-front/src/parser.rs
+    - crates/sm-front/src/typecheck.rs
+    - crates/sm-sema/src/alloc_core.rs
+    - crates/sm-ir/src/legacy_lowering.rs
+    - crates/smc-cli/src/executable_bundle.rs
+  allowed_diagnostics:
+    - clippy::unnecessary-sort-by
+    - clippy::useless-conversion
+    - clippy::question-mark
+    - clippy::collapsible-match
+  initial_correction_count: 2
+  previously_authorized_correction_count: 5
+  newly_authorized_path:
+    - crates/smc-cli/src/executable_bundle.rs
+  newly_authorized_diagnostic:
+    - clippy::unnecessary-sort-by
+  newly_authorized_correction_count: 1
+  total_clippy_correction_count: 6
+  behavior_changes: false
+  public_api_changes: false
+  test_changes: false
+  additional_source_fixes: false
 
-repository_baseline:
-  tracked_pr_body_files:
-    - pr_body_action_mapping.md
-    - pr_body_intent_admission_boundary.md
-  expected_count: 2
-  cleanup_authorized: false
-  require_zero_pr_body_delta: true
+test_support_compatibility:
+  authorized: true
+  allowed_path: tests/support/executable_bundle_support.rs
+  diagnostic: clippy::unnecessary-sort-by
+  correction_count: 1
+  test_assertion_changes: false
+  test_behavior_changes: false
+  fixture_changes: false
+  production_changes: false
+
+test_scope:
+  exact_allowed_path:
+    - "tests/support/executable_bundle_support.rs"
+  broad_test_changes_authorized: false
+  test_cases_authorized: false
+  assertions_authorized: false
+  fixtures_authorized: false
+
+aggregate_compatibility:
+  total_clippy_correction_count: 7
+  production_rust_source_files_changed: 5
+  test_support_rust_files_changed: 1
+  test_case_files_changed: 0
+
+edition_compatibility:
+  authorized: true
+  path: crates/sm-ir/src/legacy_lowering.rs
+  rejected_form: rust_2024_let_chain
+  replacement_form: rust_2021_match_guard
+  formatting_only_or_structural: structural_equivalence
+  behavior_change: false
+  public_api_change: false
+  edition_change: false
+  additional_clippy_fix: false
+
+toolchain:
+  channel: "1.97.1"
+  profile: minimal
+  components:
+    - rustfmt
+    - clippy
 
 constraints:
   fail_closed: true
+  exact_base_required: true
+  deterministic_toolchain: true
+  no_floating_stable: true
+  no_source_fixes_without_separate_authorization: true
+  preserve_existing_ci_commands: true
+  preserve_msrv_declarations: true
   preserve_authority_boundaries: true
-  preserve_experimental_boundary: true
-  preserve_issue_title_state_labels_milestone_assignees_comments: true
-  no_semantic_truth_in_shell: true
-  no_admission_authority_in_shell: true
-  no_renderer_pixel_authority_in_shell: true
-  no_backend_event_loop_in_shell: true
-  ui_dna2_9_complete: false
+  exact_new_source_fix_count: 1
+  exact_total_source_fix_count: 6
+  no_semantic_behavior_change: true
+  no_public_api_change: true
+  no_test_change: true
+  no_lint_suppression: true
+  no_allow_attributes: true
+  no_additional_source_cleanup: true
+  stop_on_next_compatibility_failure: true
   next_authorized_implementation_slice: none

--- a/.harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
+++ b/.harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
@@ -182,7 +182,7 @@ out.laws.sort_by_key(|law| core::cmp::Reverse(law.priority));
 This adjustment changed formatting only. Sorting behavior, stability,
 priority ordering, parser semantics, and public API remained unchanged.
 
-## Current workspace Clippy blockers
+## Historical workspace Clippy blockers
 
 After all five targeted checks passed, the resumed workspace Clippy command
 reported three new diagnostics outside the authorized source paths:
@@ -236,7 +236,7 @@ performed.
 Rust 1.97.1 qualification required two mechanical Clippy corrections and one
 formatting-only canonicalization of the already authorized parser correction.
 The resumed workspace check exposed three additional Clippy blockers, so the
-qualification remains blocked.
+qualification remained blocked at that checkpoint.
 
 ## Second workspace compatibility correction
 
@@ -264,7 +264,7 @@ diagnostics:
 
 No additional source correction was authorized or performed.
 
-## Current targeted formatting blocker
+## Historical targeted formatting blocker
 
 The first targeted validation command failed:
 
@@ -314,7 +314,7 @@ match instr {
 The replacement preserves instruction matching, label lookup, error position,
 error text, and return behavior. No crate edition or manifest was changed.
 
-## Current workspace Clippy blocker after edition correction
+## Historical workspace Clippy blocker after edition correction
 
 After all targeted checks passed, the resumed workspace Clippy command found
 one additional diagnostic:
@@ -356,7 +356,7 @@ Rust 1.97.1 exposed one additional denied Clippy diagnostic in
 
 No adjacent bundle, token, rename, range-replacement, or output logic changed.
 
-## Current test-support Clippy blocker
+## Historical test-support Clippy blocker
 
 After all targeted checks passed, the resumed workspace Clippy command found
 one additional diagnostic:
@@ -452,9 +452,16 @@ Rust 1.97.1 qualification required seven mechanical Clippy corrections,
 one rustfmt canonicalization, one Rust-2021-compatible structural rewrite,
 and one task-manifest scope-conflict correction.
 
-No test case, assertion, fixture, dependency, manifest, lockfile, MSRV,
+No test case, assertion, fixture, dependency, Cargo manifest, lockfile, MSRV,
 edition, public API, runtime, architecture, harness script, Gate D or
 production-status change was required.
+
+The qualification intentionally added the root `rust-toolchain.toml`, updated
+the local harness task manifest, and pinned the two authorized GitHub Actions
+workflow files.
+
+- Current blocker count: `0`
+- Qualification status: `PASS`
 
 ## Governance
 

--- a/.harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
+++ b/.harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
@@ -1,0 +1,464 @@
+# Rust 1.97.1 Toolchain Baseline Qualification
+
+Status: PASS
+
+## Baseline
+
+- Main SHA: `c71242d04c1f6962c9bc816b535b9136e9113d23`
+- Branch: `maintenance/rust-1.97.1-toolchain-baseline`
+- Previous PR-ready toolchain: Rust `1.93.1`
+- Previous remaining-CI toolchain: floating `stable`
+- Previous scheduled 7hell toolchain: floating `stable`
+- Root `rust-toolchain` file previously absent: `YES`
+- Root `rust-toolchain.toml` file previously absent: `YES`
+
+## New baseline
+
+- Toolchain: Rust `1.97.1`
+- Profile: `minimal`
+- Components: `rustfmt`, `clippy`
+- Root toolchain file: `rust-toolchain.toml`
+- CI jobs pinned: `pr-ready`, `boundary-enforcement`, `public-api-guard`,
+  `runtime-release-gates`, `pcc-qualification-7hell`, `test-std`,
+  `check-no-std`
+- Scheduled workflow pinned: `7hell Full Qualification`
+
+## MSRV boundary
+
+- `Cargo.toml` modified: `NO`
+- `Cargo.lock` modified: `NO`
+- Workbench `rust-version` modified: `NO`
+- MSRV claim changed: `NO`
+- Repository development/CI baseline changed: `YES`
+
+## Validation
+
+| Command | Result |
+| --- | --- |
+| `rustup toolchain install 1.97.1 --profile minimal --component rustfmt --component clippy` | `PASS` |
+| `rustup show active-toolchain` | `PASS — 1.97.1-x86_64-pc-windows-msvc` |
+| `rustc --version --verbose` | `PASS — rustc 1.97.1 (8bab26f4f 2026-07-14)` |
+| `cargo --version --verbose` | `PASS — cargo 1.97.1 (c980f4866 2026-06-30)` |
+| `rustfmt --version` | `PASS — rustfmt 1.9.0-stable` |
+| `cargo clippy --version` | `PASS — clippy 0.1.97` |
+| `pwsh -File scripts/harness-check.ps1` | `PASS` |
+| `cargo +1.97.1 fmt --all --check` | `PASS` |
+| `cargo +1.97.1 clippy --workspace --all-targets -- -D warnings` | `BLOCKED — 2 Rust 1.97.1 Clippy errors` |
+| `cargo +1.97.1 fmt --all --check` after the two authorized corrections | `BLOCKED — rustfmt requires a one-line form in parser.rs` |
+| `cargo +1.97.1 fmt --all --check` after canonicalization | `PASS` |
+| `cargo +1.97.1 clippy -p sm-front --all-targets -- -D warnings` | `PASS` |
+| `cargo +1.97.1 test -p sm-front` | `PASS — 449 tests` |
+| `cargo +1.97.1 check -p sm-front --all-targets` | `PASS` |
+| `cargo +1.93.1 check -p sm-front --all-targets` | `PASS` |
+| resumed `pwsh -File scripts/harness-check.ps1` | `PASS` |
+| resumed `cargo +1.97.1 fmt --all --check` | `PASS` |
+| resumed `cargo +1.97.1 clippy --workspace --all-targets -- -D warnings` | `BLOCKED — 3 new Rust 1.97.1 Clippy errors outside the authorized paths` |
+| reproduced `cargo +1.97.1 clippy --workspace --all-targets --message-format=short -- -D warnings` | `BLOCKED — exact expected 3-error set reproduced` |
+| targeted `cargo +1.97.1 fmt --all --check` after the three authorized corrections | `BLOCKED — prescribed let-chain requires Rust 2024 edition` |
+| targeted `sm-sema` / `sm-ir` Clippy | `NOT RUN — fail-closed after targeted formatting blocker` |
+| targeted `sm-sema` / `sm-ir` tests | `NOT RUN — fail-closed after targeted formatting blocker` |
+| targeted `sm-sema` / `sm-ir` checks | `NOT RUN — fail-closed after targeted formatting blocker` |
+| `sm-front` regression checks | `NOT RUN — fail-closed after targeted formatting blocker` |
+| combined Rust 1.93.1 sanity check | `NOT RUN — fail-closed after targeted formatting blocker` |
+| `cargo +1.97.1 fmt --all --check` after Rust 2021 match-guard correction | `PASS` |
+| `cargo +1.97.1 clippy -p sm-ir --all-targets -- -D warnings` | `PASS` |
+| `cargo +1.97.1 test -p sm-ir` | `PASS — 99 tests` |
+| `cargo +1.97.1 check -p sm-ir --all-targets` | `PASS` |
+| modified-crate Clippy for `sm-front`, `sm-sema`, and `sm-ir` | `PASS` |
+| modified-crate tests | `PASS — sm-front 449, sm-sema 44, sm-ir 99` |
+| combined Rust 1.93.1 sanity check after match-guard correction | `PASS` |
+| resumed harness after match-guard correction | `PASS` |
+| resumed workspace formatting after match-guard correction | `PASS` |
+| resumed workspace Clippy after match-guard correction | `BLOCKED — 1 new Rust 1.97.1 Clippy error in smc-cli` |
+| reproduced workspace Clippy before the `smc-cli` correction | `BLOCKED — exact sole smc-cli diagnostic reproduced` |
+| targeted formatting after the `smc-cli` correction | `PASS` |
+| targeted `smc-cli` Clippy | `PASS` |
+| targeted `smc-cli` tests | `PASS — 78 tests` |
+| targeted `smc-cli` check | `PASS` |
+| Rust 1.93.1 `smc-cli` sanity check | `PASS` |
+| modified-crate Clippy including `smc-cli` | `PASS` |
+| modified-crate tests including `smc-cli` | `PASS — sm-front 449, sm-sema 44, sm-ir 99, smc-cli 78` |
+| resumed harness after the `smc-cli` correction | `PASS` |
+| resumed workspace formatting after the `smc-cli` correction | `PASS` |
+| resumed workspace Clippy after the `smc-cli` correction | `BLOCKED — 1 new Rust 1.97.1 Clippy error in test support` |
+| targeted `cargo +1.97.1 fmt --all --check` after the test-support correction | `PASS` |
+| targeted workspace Clippy after the test-support correction | `PASS` |
+| `cargo +1.97.1 test --test g1_frontend_trust` | `PASS — 2 tests` |
+| `cargo +1.97.1 test --test g1_execution_integrity` | `PASS — 3 tests` |
+| `cargo +1.97.1 test --test g1_benchmark_baseline` | `PASS — 1 test` |
+| `cargo +1.97.1 test --test g1_real_program_trial` | `PASS — 6 tests` |
+| `cargo +1.93.1 check --tests` | `PASS` |
+| full-qualification toolchain identity checks | `PASS — Rust 1.97.1, rustfmt 1.9.0, Clippy 0.1.97` |
+| full-qualification `pwsh -File scripts/harness-check.ps1` | `BLOCKED — authorized test-support path still matches forbidden tests/** scope` |
+| workspace all-targets/all-features check | `NOT RUN — fail-closed after resumed workspace Clippy blocker` |
+| standard tests | `NOT RUN — fail-closed after resumed workspace Clippy blocker` |
+| no-default-features gate | `NOT RUN — fail-closed after resumed workspace Clippy blocker` |
+| fast 7hell | `NOT RUN — fail-closed after resumed workspace Clippy blocker` |
+| full 7hell | `NOT RUN — fail-closed after resumed workspace Clippy blocker` |
+| restarted full-qualification toolchain identity checks | `PASS — Rust 1.97.1, rustfmt 1.9.0, Clippy 0.1.97` |
+| harness after scope-conflict correction | `PASS` |
+| restarted workspace formatting | `PASS` |
+| restarted workspace Clippy with denied warnings | `PASS` |
+| workspace all-targets/all-features check with denied warnings | `PASS` |
+| `cargo +1.97.1 test --all-targets --quiet` | `PASS` |
+| `cargo +1.97.1 check --no-default-features --quiet` | `PASS — limited gate; not a workspace-wide no_std claim` |
+| fast 7hell | `PASS` |
+| full 7hell | `PASS` |
+| ten explicit boundary and runtime gates | `PASS` |
+| final `git diff --check` | `PASS` |
+
+## Compatibility findings
+
+Rust `1.97.1` Clippy with `-D warnings` reports:
+
+```text
+error: consider using `sort_by_key`
+    --> crates\sm-front\src\parser.rs:2978:9
+     |
+2978 |         out.laws.sort_by(|a, b| b.priority.cmp(&a.priority));
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
+help: try
+     |
+2978 -         out.laws.sort_by(|a, b| b.priority.cmp(&a.priority));
+2978 +         out.laws.sort_by_key(|b| std::cmp::Reverse(b.priority));
+
+error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
+    --> crates\sm-front\src\typecheck.rs:1281:53
+     |
+1281 |             for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+     |                                                     ^^^^^^^^^^^^^^^^^^^^
+     |
+     = note: `-D clippy::useless-conversion` implied by `-D warnings`
+help: consider removing the `.into_iter()`
+     |
+1281 -             for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+1281 +             for (item, item_ty) in items.iter().zip(item_tys) {
+
+error: could not compile `sm-front` (lib) due to 2 previous errors
+```
+
+Responsible repository paths:
+
+- `crates/sm-front/src/parser.rs`
+- `crates/sm-front/src/typecheck.rs`
+
+## Authorized source compatibility corrections
+
+The two authorized mechanical corrections were applied:
+
+| Path | Diagnostic | Correction | Behavior impact |
+| --- | --- | --- | --- |
+| `crates/sm-front/src/parser.rs` | `clippy::unnecessary-sort-by` | stable `sort_by_key` with `Reverse` | none |
+| `crates/sm-front/src/typecheck.rs` | `clippy::useless-conversion` | removed redundant `.into_iter()` | none |
+
+No other source correction, lint suppression, CI-command weakening, or
+dependency change was performed.
+
+## Initial rustfmt blocker
+
+The first targeted command stopped the resumed qualification:
+
+```text
+Diff in crates/sm-front/src/parser.rs:2975:
+-        out.laws
+-            .sort_by_key(|law| core::cmp::Reverse(law.priority));
++        out.laws.sort_by_key(|law| core::cmp::Reverse(law.priority));
+```
+
+Rustfmt `1.97.1` required the authorized parser correction to use a one-line
+form.
+
+## Rustfmt canonicalization
+
+The initially authorized parser correction was written across two lines.
+Rust 1.97.1 rustfmt requires the expression in its canonical one-line form:
+
+```rust
+out.laws.sort_by_key(|law| core::cmp::Reverse(law.priority));
+```
+
+This adjustment changed formatting only. Sorting behavior, stability,
+priority ordering, parser semantics, and public API remained unchanged.
+
+## Current workspace Clippy blockers
+
+After all five targeted checks passed, the resumed workspace Clippy command
+reported three new diagnostics outside the authorized source paths:
+
+```text
+error: this block may be rewritten with the `?` operator
+   --> crates\sm-sema\src\alloc_core.rs:441:12
+    |
+441 |       } else if let Some(x) = e.strip_prefix("fx.div(") {
+    |  ____________^
+442 | |         ("div", x)
+443 | |     } else {
+444 | |         return None;
+445 | |     };
+    | |_____^
+    |
+    = note: `-D clippy::question-mark` implied by `-D warnings`
+
+error: consider using `sort_by_key`
+   --> crates\sm-ir\src\legacy_lowering.rs:572:5
+    |
+572 |     laws.sort_by(|a, b| b.priority.cmp(&a.priority));
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
+
+error: this `if` can be collapsed into the outer `match`
+    --> crates\sm-ir\src\legacy_lowering.rs:1025:17
+     |
+1025 | /                 if !labels.contains_key(label) {
+1026 | |                     return Err(FrontendError {
+1027 | |                         pos: idx,
+1028 | |                         message: format!("jump to unknown label '{}' in '{}'", label, f.name),
+1029 | |                     });
+1030 | |                 }
+     | |_________________^
+     |
+     = note: `-D clippy::collapsible-match` implied by `-D warnings`
+```
+
+Affected paths:
+
+- `crates/sm-sema/src/alloc_core.rs`
+- `crates/sm-ir/src/legacy_lowering.rs`
+
+Classification: Clippy compatibility blockers. These paths are not authorized
+for mutation. The next-failure policy therefore stopped qualification before
+the remaining full checks. No additional source fix, commit, push, or PR was
+performed.
+
+Rust 1.97.1 qualification required two mechanical Clippy corrections and one
+formatting-only canonicalization of the already authorized parser correction.
+The resumed workspace check exposed three additional Clippy blockers, so the
+qualification remains blocked.
+
+## Second workspace compatibility correction
+
+Rust 1.97.1 subsequently exposed three additional denied workspace Clippy
+diagnostics:
+
+1. `crates/sm-sema/src/alloc_core.rs`
+   - `clippy::question-mark`
+   - final `fx.div` recognition branch expressed with `?`
+
+2. `crates/sm-ir/src/legacy_lowering.rs`
+   - `clippy::unnecessary-sort-by`
+   - stable descending sort expressed with `sort_by_key` and `Reverse`
+
+3. `crates/sm-ir/src/legacy_lowering.rs`
+   - `clippy::collapsible-match`
+   - jump-validation pattern and label-existence condition collapsed without
+     changing the error path
+
+| Path | Diagnostic | Correction | Behavior impact |
+| --- | --- | --- | --- |
+| `crates/sm-sema/src/alloc_core.rs` | `clippy::question-mark` | `fx.div` fallback expressed with `?` | none |
+| `crates/sm-ir/src/legacy_lowering.rs` | `clippy::unnecessary-sort-by` | stable `sort_by_key` with `Reverse` | none |
+| `crates/sm-ir/src/legacy_lowering.rs` | `clippy::collapsible-match` | collapsed jump-validation match | none |
+
+No additional source correction was authorized or performed.
+
+## Current targeted formatting blocker
+
+The first targeted validation command failed:
+
+```text
+error: let chains are only allowed in Rust 2024 or later
+    --> crates\sm-ir\src\legacy_lowering.rs:1023:12
+     |
+1023 |         if let IrInstr::Jmp { label } | IrInstr::JmpIf { label, .. } = instr
+     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error writing files: failed to resolve mod `legacy_lowering`: cannot parse
+crates\sm-ir\src\legacy_lowering.rs
+```
+
+Command:
+
+```text
+cargo +1.97.1 fmt --all --check
+```
+
+Classification: formatting/parser compatibility blocker. The prescribed
+let-chain form requires Rust 2024 edition, while this crate uses an earlier
+edition. Replacing it with the Clippy-rendered match-guard form is outside this
+exact authorization. The remaining targeted and full checks were not run. No
+commit, push, or PR was created.
+
+## Rust 2021 edition compatibility correction
+
+The initially prescribed collapsed `if let` chain required Rust edition 2024
+and was therefore incompatible with the repository's existing Rust 2021
+edition.
+
+The jump-validation condition was expressed instead as a Rust-2021-compatible
+match guard:
+
+```rust
+match instr {
+    IrInstr::Jmp { label } | IrInstr::JmpIf { label, .. }
+        if !labels.contains_key(label) =>
+    {
+        // unchanged error path
+    }
+    _ => {}
+}
+```
+
+The replacement preserves instruction matching, label lookup, error position,
+error text, and return behavior. No crate edition or manifest was changed.
+
+## Current workspace Clippy blocker after edition correction
+
+After all targeted checks passed, the resumed workspace Clippy command found
+one additional diagnostic:
+
+```text
+error: consider using `sort_by_key`
+   --> crates\smc-cli\src\executable_bundle.rs:484:5
+    |
+484 |     replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
+help: try
+    |
+484 -     replacements.sort_by(|a, b| b.0.cmp(&a.0));
+484 +     replacements.sort_by_key(|b| std::cmp::Reverse(b.0));
+```
+
+Command:
+
+```text
+cargo +1.97.1 clippy --workspace --all-targets -- -D warnings
+```
+
+Classification: Clippy compatibility blocker. The affected
+`crates/smc-cli/src/executable_bundle.rs` path is outside this authorization.
+The remaining full qualification commands were not run. No source correction,
+commit, push, or PR was performed.
+
+## `smc-cli` compatibility correction
+
+Rust 1.97.1 exposed one additional denied Clippy diagnostic in
+`crates/smc-cli/src/executable_bundle.rs`:
+
+- diagnostic: `clippy::unnecessary-sort-by`
+- correction: stable descending `sort_by_key` with `Reverse`
+- purpose: preserve reverse-offset replacement order
+- behavior impact: none
+
+No adjacent bundle, token, rename, range-replacement, or output logic changed.
+
+## Current test-support Clippy blocker
+
+After all targeted checks passed, the resumed workspace Clippy command found
+one additional diagnostic:
+
+```text
+error: consider using `sort_by_key`
+   --> tests\support\executable_bundle_support.rs:440:5
+    |
+440 |     replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
+help: try
+    |
+440 -     replacements.sort_by(|a, b| b.0.cmp(&a.0));
+440 +     replacements.sort_by_key(|b| std::cmp::Reverse(b.0));
+```
+
+Command:
+
+```text
+cargo +1.97.1 clippy --workspace --all-targets -- -D warnings
+```
+
+Classification: Clippy compatibility blocker in test support. The affected
+`tests/support/executable_bundle_support.rs` path is outside this authorization,
+and test modification is explicitly forbidden. The remaining full
+qualification commands were not run. No test correction, commit, push, or PR
+was performed.
+
+## Test-support compatibility correction
+
+Rust 1.97.1 exposed one additional denied Clippy diagnostic in the shared
+executable-bundle test-support helper:
+
+- path: `tests/support/executable_bundle_support.rs`
+- diagnostic: `clippy::unnecessary-sort-by`
+- correction: stable descending `sort_by_key` with `Reverse`
+- behavior impact: none
+
+The helper continues to apply text replacements in descending source-offset
+order. No test case, assertion, fixture, expected result or production source
+behavior changed.
+
+## Historical harness scope blocker
+
+All seven targeted checks passed after the test-support correction. The full
+qualification then stopped at its first harness check:
+
+```text
+[harness:error] forbidden path changed: tests/support/executable_bundle_support.rs
+```
+
+Command:
+
+```text
+pwsh -File scripts/harness-check.ps1
+```
+
+The task manifest lists `tests/support/executable_bundle_support.rs` under
+`scope.allowed_paths` and separately authorizes that exact compatibility
+correction, but the same manifest still includes `tests/**` under
+`scope.forbidden_paths`. The harness applies the forbidden pattern and rejects
+the changed path. Classification: harness authorization conflict. Per the
+fail-closed and stop-on-next-failure constraints, no further qualification
+command, manifest correction, commit, push or PR was performed.
+
+## Harness scope-conflict correction
+
+The test-support file was explicitly listed in `allowed_paths`, while the
+broader `tests/**` pattern remained in `forbidden_paths`.
+
+The repository harness evaluates forbidden patterns before allowed patterns,
+so the exact authorization could not override the broad prohibition.
+
+The conflicting `tests/**` entry was removed from `forbidden_paths`.
+The exact test-support file remains the only allowed test path. All other test
+paths remain outside `allowed_paths` and therefore remain rejected.
+
+No harness script or enforcement precedence changed.
+
+## Scope
+
+- Rust source modified: `YES — exactly five authorized paths across sm-front, sm-sema, sm-ir, and smc-cli`
+- Shared test-support Rust modified: `YES — exactly one authorized helper path`
+- Test cases, assertions, fixtures or expected results modified: `NO`
+- Dependencies modified: `NO`
+- Public API modified: `NO`
+- Runtime modified: `NO`
+- Architecture modified: `NO`
+
+Rust 1.97.1 qualification required seven mechanical Clippy corrections,
+one rustfmt canonicalization, one Rust-2021-compatible structural rewrite,
+and one task-manifest scope-conflict correction.
+
+No test case, assertion, fixture, dependency, manifest, lockfile, MSRV,
+edition, public API, runtime, architecture, harness script, Gate D or
+production-status change was required.
+
+## Governance
+
+- Gate D: `CLOSED`
+- Production promotion: `NOT AUTHORIZED`
+- Follow-on implementation: `NOT AUTHORIZED`
+- NEXT AUTHORIZED IMPLEMENTATION SLICE: `NONE`

--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -2975,7 +2975,7 @@ impl<'a> Parser<'a> {
         if !errors.is_empty() {
             return Err(self.merge_logos_errors(errors));
         }
-        out.laws.sort_by(|a, b| b.priority.cmp(&a.priority));
+        out.laws.sort_by_key(|law| core::cmp::Reverse(law.priority));
         Ok(out)
     }
 

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -1278,7 +1278,7 @@ fn check_stmt(
                     ),
                 });
             }
-            for (item, item_ty) in items.iter().zip(item_tys.into_iter()) {
+            for (item, item_ty) in items.iter().zip(item_tys) {
                 let Some(name) = item else {
                     continue;
                 };

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -569,7 +569,7 @@ fn is_builtin_assert_name(
 
 pub fn lower_logos_laws_to_ir(program: &LogosProgram) -> Vec<LogosIrLaw> {
     let mut laws = program.laws.clone();
-    laws.sort_by(|a, b| b.priority.cmp(&a.priority));
+    laws.sort_by_key(|law| core::cmp::Reverse(law.priority));
     laws.into_iter()
         .map(|law| LogosIrLaw {
             name: law.name,
@@ -1021,13 +1021,13 @@ pub fn validate_ir(f: &IrFunction) -> Result<(), FrontendError> {
 
     for (idx, instr) in f.instrs.iter().enumerate() {
         match instr {
-            IrInstr::Jmp { label } | IrInstr::JmpIf { label, .. } => {
-                if !labels.contains_key(label) {
-                    return Err(FrontendError {
-                        pos: idx,
-                        message: format!("jump to unknown label '{}' in '{}'", label, f.name),
-                    });
-                }
+            IrInstr::Jmp { label } | IrInstr::JmpIf { label, .. }
+                if !labels.contains_key(label) =>
+            {
+                return Err(FrontendError {
+                    pos: idx,
+                    message: format!("jump to unknown label '{}' in '{}'", label, f.name),
+                });
             }
             _ => {}
         }

--- a/crates/sm-sema/src/alloc_core.rs
+++ b/crates/sm-sema/src/alloc_core.rs
@@ -438,10 +438,8 @@ pub fn fold_fx_const_call_core(effect: &str) -> Option<String> {
         ("sub", x)
     } else if let Some(x) = e.strip_prefix("fx.mul(") {
         ("mul", x)
-    } else if let Some(x) = e.strip_prefix("fx.div(") {
-        ("div", x)
     } else {
-        return None;
+        ("div", e.strip_prefix("fx.div(")?)
     };
     let inner = rest.strip_suffix(')')?;
     let mut parts = inner.split(',');

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -481,7 +481,7 @@ fn rewrite_selected_function_source(
         }
     }
 
-    replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    replacements.sort_by_key(|replacement| core::cmp::Reverse(replacement.0));
     let mut out = source.to_string();
     for (start, end, replacement) in replacements {
         out.replace_range(start..end, &replacement);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -437,7 +437,7 @@ fn rewrite_selected_function_source(
         }
     }
 
-    replacements.sort_by(|a, b| b.0.cmp(&a.0));
+    replacements.sort_by_key(|replacement| core::cmp::Reverse(replacement.0));
     let mut out = source.to_string();
     for (start, end, replacement) in replacements {
         out.replace_range(start..end, &replacement);


### PR DESCRIPTION
## Summary

- pins repository development and CI qualification to Rust 1.97.1;
- pins the scheduled full 7hell workflow;
- resolves seven exact Rust 1.97.1 Clippy compatibility diagnostics;
- resolves one local harness scope overlap without changing the harness script;
- changes no test cases, assertions, fixtures, dependencies, Cargo manifests or
  lockfiles, MSRV declarations, public API, runtime behavior, architecture,
  UI authority, Gate D, or production status.

The PR intentionally adds `rust-toolchain.toml`, updates the local harness task
manifest, and modifies the two authorized CI workflow files.

## Compatibility scope

- production source compatibility corrections: 6;
- shared test-support compatibility corrections: 1;
- test cases, assertions, fixtures, and expected results changed: 0;
- rustfmt canonicalizations: 1;
- Rust-2021-compatible structural rewrites: 1;
- task-manifest scope-conflict corrections: 1.

## Local qualification

- Rust 1.97.1 toolchain identity: PASS;
- harness, formatting, workspace Clippy: PASS;
- workspace all-targets/all-features check with warnings denied: PASS;
- all-targets tests and limited no-default-features gate: PASS;
- fast and full 7hell: PASS;
- ten explicit boundary/runtime gates: PASS;
- final scope and diff checks: PASS.