### PR TITLE
ci: install rustfmt for Rust 1.97.1 7hell jobs

### DIFF
--- a/.github/workflows/7hell-full.yml
+++ b/.github/workflows/7hell-full.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: 7hell PCC Full Runner
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: 7hell PCC Qualification Fast Gate
         shell: powershell

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,233 +1,39 @@
 task:
-  id: MAINT-RUST-1.97.1-TOOLCHAIN-QUALIFICATION
-  title: qualify Rust 1.97.1 repository and CI baseline
+  id: MAINT-RUST-1.97.1-7HELL-RUSTFMT-COMPONENT
+  title: explicitly install rustfmt in Rust 1.97.1 7hell workflows
   type: maintenance
   mode: active
 
 intent:
-  summary: "build(ci): qualify Rust 1.97.1 toolchain baseline"
-  predecessor: "UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT-CLOSEOUT"
-
-evidence_baseline:
-  main_sha: "c71242d04c1f6962c9bc816b535b9136e9113d23"
-  predecessor_pr: "#1521"
-  predecessor_squash_sha: "c71242d04c1f6962c9bc816b535b9136e9113d23"
-  predecessor_post_merge_ci: "29640056524"
-
-layer:
-  name: repository-toolchain
-  owner: repository-maintenance
+  predecessor: MAINT-RUST-1.97.1-TOOLCHAIN-QUALIFICATION
+  summary: "ci: install rustfmt for Rust 1.97.1 7hell jobs"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - rust-toolchain.toml
     - .github/workflows/ci.yml
     - .github/workflows/7hell-full.yml
-    - .harness/reports/MAINT-RUST-1.97.1-TOOLCHAIN-BASELINE.md
-    - crates/sm-front/src/parser.rs
-    - crates/sm-front/src/typecheck.rs
-    - crates/sm-sema/src/alloc_core.rs
-    - crates/sm-ir/src/legacy_lowering.rs
-    - crates/smc-cli/src/executable_bundle.rs
-    - tests/support/executable_bundle_support.rs
-
-  forbidden_paths:
-    - Cargo.toml
-    - Cargo.lock
-    - apps/workbench/src-tauri/Cargo.toml
-    - src/**
-    - benches/**
-    - examples/**
-    - experiments/**
-    - scripts/**
-    - tools/**
-    - docs/spec/**
-    - docs/dna/**
-    - docs/roadmap/**
-    - docs/wiki/**
-    - README.md
-    - CHANGELOG.md
-    - pr_body_action_mapping.md
-    - pr_body_intent_admission_boundary.md
-
-actions:
-  allowed:
-    - inspect
-    - edit_harness
-    - create_toolchain_file
-    - modify_ci_workflows
-    - create_qualification_report
-    - validate
-    - create_branch
-    - commit
-    - push
-    - create_draft_pr
-    - dispatch_7hell_full_workflow
-    - apply_exact_clippy_compatibility_fixes
-    - validate_sm_front
-    - apply_exact_workspace_clippy_compatibility_fixes
-    - validate_sm_sema
-    - validate_sm_ir
-    - validate_smc_cli
-    - modify_exact_test_support_compatibility
-    - validate_test_support
-    - resolve_harness_scope_conflict
-
-  forbidden:
-    - modify_additional_rust
-    - modify_test_cases
-    - modify_test_assertions
-    - modify_test_fixtures
-    - modify_additional_test_support
-    - modify_cargo_manifests
-    - modify_additional_manifests
-    - modify_lockfile
-    - modify_dependencies
-    - change_msrv
-    - modify_scripts
-    - modify_tools
-    - modify_specs
-    - modify_dna
-    - modify_roadmap
-    - modify_issue
-    - modify_project
-    - modify_public_api
-    - modify_runtime
-    - open_gate
-    - production_promotion
-    - authorize_implementation
-    - authorize_follow_on
-    - mark_ready
-    - submit_review
-    - merge
-    - amend
-    - rebase
-    - force_push
-    - enable_auto_merge
-    - admin_bypass
-    - delete_branch
-    - modify_repository_settings
-    - modify_rulesets
-    - modify_branch_protection
+    - .harness/reports/MAINT-RUST-1.97.1-7HELL-RUSTFMT.md
 
 authorization:
-  maintenance_only: true
-  toolchain_pin: true
-  workflow_toolchain_unification: true
-  qualification_report: true
-
-  exact_source_compatibility_changes: true
-  exact_test_support_compatibility_change: true
   workflow_changes: true
-  toolchain_manifest_change: true
-  harness_manifest_change: true
-
-  broad_source_changes: false
-  test_case_changes: false
-  test_assertion_changes: false
-  fixture_changes: false
-  cargo_manifest_changes: false
-  lockfile_changes: false
+  qualification_report: true
+  source_changes: false
+  test_changes: false
+  script_changes: false
   dependency_changes: false
-  msrv_changes: false
-  edition_changes: false
-  architecture_changes: false
+  toolchain_version_changes: false
   runtime_changes: false
   public_api_changes: false
   gate_d: closed
   production_promotion: false
-  follow_on_implementation: false
-
-source_compatibility:
-  authorized: true
-  reason: rust_1_97_1_clippy_qualification
-  allowed_paths:
-    - crates/sm-front/src/parser.rs
-    - crates/sm-front/src/typecheck.rs
-    - crates/sm-sema/src/alloc_core.rs
-    - crates/sm-ir/src/legacy_lowering.rs
-    - crates/smc-cli/src/executable_bundle.rs
-  allowed_diagnostics:
-    - clippy::unnecessary-sort-by
-    - clippy::useless-conversion
-    - clippy::question-mark
-    - clippy::collapsible-match
-  initial_correction_count: 2
-  previously_authorized_correction_count: 5
-  newly_authorized_path:
-    - crates/smc-cli/src/executable_bundle.rs
-  newly_authorized_diagnostic:
-    - clippy::unnecessary-sort-by
-  newly_authorized_correction_count: 1
-  production_clippy_correction_count: 6
-  behavior_changes: false
-  public_api_changes: false
-  test_case_changes: false
-  additional_source_fixes: false
-
-test_support_compatibility:
-  authorized: true
-  allowed_path: tests/support/executable_bundle_support.rs
-  diagnostic: clippy::unnecessary-sort-by
-  correction_count: 1
-  test_assertion_changes: false
-  test_behavior_changes: false
-  fixture_changes: false
-  production_changes: false
-
-test_scope:
-  exact_allowed_path:
-    - "tests/support/executable_bundle_support.rs"
-  broad_test_changes_authorized: false
-  test_cases_authorized: false
-  assertions_authorized: false
-  fixtures_authorized: false
-
-aggregate_compatibility:
-  total_clippy_correction_count: 7
-  production_rust_source_files_changed: 5
-  test_support_rust_files_changed: 1
-  test_case_files_changed: 0
-
-edition_compatibility:
-  authorized: true
-  path: crates/sm-ir/src/legacy_lowering.rs
-  rejected_form: rust_2024_let_chain
-  replacement_form: rust_2021_match_guard
-  formatting_only_or_structural: structural_equivalence
-  behavior_change: false
-  public_api_change: false
-  edition_change: false
-  additional_clippy_fix: false
-
-toolchain:
-  channel: "1.97.1"
-  profile: minimal
-  components:
-    - rustfmt
-    - clippy
 
 constraints:
+  exact_workflow_change_count: 2
+  exact_component_addition: rustfmt
+  preserve_rust_version: "1.97.1"
+  preserve_workflow_commands: true
+  preserve_workflow_triggers: true
+  preserve_permissions: true
+  no_additional_cleanup: true
   fail_closed: true
-  exact_base_required: true
-  deterministic_toolchain: true
-  no_floating_stable: true
-  no_source_fixes_without_separate_authorization: true
-  preserve_existing_ci_commands: true
-  preserve_msrv_declarations: true
-  preserve_authority_boundaries: true
-  exact_new_source_fix_count: 1
-  exact_production_source_fix_count: 6
-  exact_test_support_fix_count: 1
-  exact_total_clippy_correction_count: 7
-  no_semantic_behavior_change: true
-  no_public_api_change: true
-  no_test_case_change: true
-  no_test_assertion_change: true
-  no_fixture_change: true
-  no_lint_suppression: true
-  no_allow_attributes: true
-  no_additional_source_cleanup: true
-  stop_on_next_compatibility_failure: true
-  next_authorized_implementation_slice: none

--- a/.harness/reports/MAINT-RUST-1.97.1-7HELL-RUSTFMT.md
+++ b/.harness/reports/MAINT-RUST-1.97.1-7HELL-RUSTFMT.md
@@ -1,0 +1,49 @@
+# Rust 1.97.1 7hell Rustfmt Component Qualification
+
+Status: PASS
+
+## Baseline
+
+- Main SHA: `6219e67e6f5f233797cfe8047cc54e0148a5a223`
+- Origin: post-merge P2 on PR `#1522`
+- Predecessor PR: `#1522`
+- Review thread: `PRRT_kwDOROOm386R_6YL`
+- Rust toolchain: `1.97.1`
+- Affected workflows: `2`
+- Explicit component: `rustfmt`
+
+## Finding
+
+The 7hell workflows installed Rust 1.97.1 through
+`dtolnay/rust-toolchain@master` without explicitly requesting `rustfmt`.
+
+The action installs the minimal profile unless extra components are supplied.
+The minimal profile does not include rustfmt.
+
+## Correction
+
+- `.github/workflows/ci.yml`
+  - `pcc-qualification-7hell`
+  - added `components: rustfmt`
+
+- `.github/workflows/7hell-full.yml`
+  - `full-qualification`
+  - added `components: rustfmt`
+
+## Non-changes
+
+- Rust source changes: `0`;
+- test changes: `0`;
+- script changes: `0`;
+- dependency changes: `0`;
+- toolchain-version changes: `0`;
+- no runtime or API change;
+- no Gate D or production-status change.
+
+## Validation
+
+- harness: PASS
+- formatting: PASS
+- fast 7hell: PASS
+- full 7hell: PASS
+- diff check: PASS


### PR DESCRIPTION
## Summary

- explicitly installs `rustfmt` in the Rust 1.97.1 fast 7hell CI job;
- explicitly installs `rustfmt` in the scheduled/manual full 7hell workflow;
- removes reliance on runner state or implicit component installation;
- changes no Rust source, tests, scripts, dependencies, runtime behavior,
  public API, Gate D, or production status.

## Origin

Follow-up to the post-merge P2 review comment on PR #1522.