### PR TITLE
docs(ui): preflight Shell Player input limits

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,56 +1,31 @@
 task:
-  id: UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT
-  title: freeze Shell Player session and local-state contract v0
-  type: architecture
+  id: UI-DNA2-9B-P2-INPUT-RESOURCE-PREFLIGHT-CORRECTION
+  title: correct Shell Player input resource preflight ordering
+  type: corrective-qualification
   mode: active
 
 intent:
-  summary: "docs(ui): freeze Shell Player session-state contract"
-  predecessor: UI-DNA2-9A1-SHELL-PLAYER-BOUNDARY-CONTRACT
-
-evidence_baseline:
-  main_sha: "3e229a821cebc013acd5f294c4872efaa6fd37a1"
-  predecessor_pr: "#1520"
-  predecessor_closeout_pr: "#1521"
+  summary: "docs(ui): preflight Shell Player input limits"
+  predecessor: UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT
+  origin_pr: "#1524"
+  origin_thread: PRRT_kwDOROOm386SAqRT
+  origin_comment: "3608926265"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT.md
+    - .harness/reports/UI-DNA2-9B-P2-INPUT-RESOURCE-PREFLIGHT-CORRECTION.md
     - docs/spec/ui/shell_player_session_state_v0.md
-    - docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
-
-  forbidden_paths:
-    - Cargo.toml
-    - Cargo.lock
-    - rust-toolchain.toml
-    - crates/**
-    - src/**
-    - tests/**
-    - tools/**
-    - scripts/**
-    - apps/**
-    - examples/**
-    - benches/**
-    - experiments/**
-    - docs/dna/**
-    - docs/spec/ui/shell_player_boundary_v0.md
-    - docs/spec/ui/projection_bundle_v0.md
 
 authorization:
   documentation_only: true
-  normative_contract: true
-  roadmap_sync: true
+  normative_correction: true
 
   rust_implementation: false
   rust_types: false
   public_api: false
   projection_patch_application: false
-  projection_bundle_parser: false
-  projection_bundle_validator: false
-  projection_bundle_verifier: false
-  projection_bundle_loader: false
-  projection_bundle_activation: false
+  bundle_activation: false
   action_admission: false
   renderer_integration: false
   backend_integration: false
@@ -58,21 +33,15 @@ authorization:
 
   gate_d: closed
   production_promotion: false
+  closeout: false
   follow_on_implementation: false
 
 constraints:
   preserve_9a1_ownership_boundary: true
-  semantic_truth_remains_external: true
-  caller_supplied_inputs_only: true
-  deterministic_transition_model: true
+  preserve_9b_session_state_contract: true
+  input_limits_before_collection_traversal: true
+  bounded_outer_preflight_only: true
   no_partial_state_commit: true
-  no_host_clock: true
-  no_randomness: true
-  no_filesystem_access: true
-  no_network_access: true
-  no_backend_polling: true
-  no_live_semantic_reads: true
-  no_ambient_global_state: true
   no_additional_cleanup: true
   fail_closed: true
   next_authorized_implementation_slice: none

--- a/.harness/reports/UI-DNA2-9B-P2-INPUT-RESOURCE-PREFLIGHT-CORRECTION.md
+++ b/.harness/reports/UI-DNA2-9B-P2-INPUT-RESOURCE-PREFLIGHT-CORRECTION.md
@@ -1,0 +1,59 @@
+# UI-DNA2-9B P2 Input Resource Preflight Correction
+
+Status: PASS
+
+## Baseline
+
+- Main SHA: `0eede9391f6f5d1aaf446e94326b74797f1973d7`
+- Branch: `ui-dna2/shell-player-input-preflight-correction`
+- Origin PR: `#1524`
+- Origin thread: `PRRT_kwDOROOm386SAqRT`
+- Origin comment: `3608926265`
+- Post-merge finding severity: P2
+- Finding appeared after merge: YES
+- Technical validity: ACCEPTED
+
+## Finding
+
+The merged order performed stable-target identity and replay-cursor checks
+before validating input-side resource bounds. An oversized transition could
+therefore cause per-target or replay traversal before deterministic rejection.
+
+## Corrected order
+
+1. bounded session check;
+2. bounded lifecycle check;
+3. bounded outer-envelope and stimulus-class check;
+4. input-side resource preflight;
+5. stable-target validation;
+6. replay-cursor validation;
+7. candidate calculation without commit;
+8. candidate-state/output validation;
+9. complete state commit or previous-state preservation;
+10. bounded output publication and diagnostic emission cap.
+
+## Oversized-input behavior
+
+- disposition: `Rejected`;
+- per-target traversal: NONE;
+- replay traversal: NONE;
+- previous `ShellLocalState`: PRESERVED;
+- diagnostics: subject to the immutable stage-10 emission cap.
+
+## Preserved boundaries
+
+- Shell Player implementation: NOT AUTHORIZED
+- `ProjectionPatch` application: NOT AUTHORIZED
+- Gate D: CLOSED
+- production promotion: NOT AUTHORIZED
+- closeout: NOT COMPLETE
+- next authorized implementation slice: NONE
+
+## Validation
+
+- harness: PASS
+- claim-boundary guard: PASS
+- POST-UI fixture guard: PASS
+- fast 7hell: PASS
+- Rust 1.97.1 formatting: PASS
+- diff check: PASS

--- a/docs/spec/ui/shell_player_session_state_v0.md
+++ b/docs/spec/ui/shell_player_session_state_v0.md
@@ -179,12 +179,12 @@ Every transition is evaluated in this deterministic order:
 
 1. validate session identity;
 2. validate lifecycle eligibility;
-3. validate stimulus shape;
-4. validate stable target identities;
-5. validate replay-cursor compatibility where applicable;
-6. validate input-side resource bounds;
+3. validate the outer transition envelope and primary stimulus class;
+4. validate input-side resource bounds;
+5. validate stable target identities;
+6. validate replay-cursor compatibility where applicable;
 7. calculate the candidate next state and candidate outputs without committing;
-8. validate candidate invariants and all candidate-state/output resource bounds;
+8. validate candidate invariants and candidate-state/output resource bounds;
 9. commit the complete candidate state or preserve the previous state;
 10. publish the disposition and already validated bounded outputs, then apply
     the immutable diagnostic emission cap to the stable logical diagnostic
@@ -192,10 +192,26 @@ Every transition is evaluated in this deterministic order:
 
 No partial local-state commit is permitted.
 
-Stage 6 validates limits measurable directly from the supplied stimulus:
+Stages 1 and 2 perform only bounded session and lifecycle checks.
+
+Stage 3 validates only the fixed outer envelope and primary stimulus
+discriminant required to identify the stimulus class. It does not traverse
+patch operations, target collections, route collections, or other
+variable-length semantic contents.
+
+Stage 4 validates every resource bound that can reject the supplied input
+before per-element processing begins:
 
 - maximum patches per transition;
 - maximum transition stimulus bytes.
+
+Patch count and transition stimulus byte length must be available through
+bounded structural metadata or another representation-independent bounded
+preflight mechanism. This contract does not select a Rust representation,
+serialized format, or counting algorithm.
+
+Stable-target validation and replay-cursor compatibility traversal do not begin
+until stage 4 succeeds.
 
 Stage 8 validates limits that depend on the calculated candidate state or
 candidate outputs:
@@ -211,9 +227,14 @@ candidate outputs:
 - maximum invalidation entries;
 - maximum damage regions.
 
-No candidate state is committed until stage 8 succeeds. Failure at either
-resource-validation stage produces `Rejected` and preserves the complete
-previous state.
+No candidate state is committed until stage 8 succeeds. Failure at stage 4 or
+stage 8 produces `Rejected` and preserves the complete previous
+`ShellLocalState`.
+
+After stage-4 rejection, no target, replay, candidate-state, draw,
+accessibility, hit-test, focus, or `ActionIntent` processing occurs. Any
+diagnostic produced by stage-4 rejection remains subject to the immutable
+stage-10 diagnostic emission cap.
 
 Before stage 10 emission, the transition has determined its disposition and
 complete logical diagnostic sequence in stable diagnostic order. Stage 10


### PR DESCRIPTION
## Summary

- moves input-side resource preflight ahead of target and replay traversal;
- bounds the outer transition-envelope check;
- ensures oversized patch inputs are rejected before per-element processing;
- preserves the previous Shell Player state on preflight rejection;
- preserves the stage-10 diagnostic emission cap.

## Origin

Post-merge P2 follow-up to PR #1524.

## Explicit non-goals

- no Rust implementation;
- no ProjectionPatch application;
- no bundle activation;
- no renderer or backend integration;
- no Gate D movement;
- no production promotion.