### PR TITLE
feat(ui): add Shell Player lifecycle seed

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,48 +1,43 @@
 task:
-  id: UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT-CLOSEOUT
-  title: close out Shell Player session-state contract
-  type: closeout
+  id: SHELL-PLAYER-LIFECYCLE-SEED
+  title: implement crate-private Shell Player lifecycle seed
+  type: implementation
   mode: active
 
 intent:
-  summary: "docs(ui): close out Shell Player session-state contract"
-  predecessor: UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT
-  primary_pr: "#1524"
-  corrective_pr: "#1525"
+  summary: "feat(ui): add Shell Player lifecycle seed"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - .harness/reports/UI-DNA2-9B-SHELL-PLAYER-SESSION-STATE-CONTRACT-CLOSEOUT.md
-    - docs/roadmap/post_ui/ui_dna2_9b_shell_player_session_state_contract_closeout.md
-    - docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
+    - crates/prom-ui-runtime/src/lib.rs
+    - crates/prom-ui-runtime/src/shell_player.rs
 
 authorization:
-  documentation_only: true
-  evidence_closeout: true
-  roadmap_sync: true
-  project_registration: true
+  rust_implementation: true
+  crate_private_only: true
+  lifecycle_seed_only: true
 
   normative_contract_change: false
-  rust_implementation: false
-  rust_types: false
   public_api: false
   projection_patch_application: false
   projection_bundle_activation: false
+  interaction_processing: false
+  action_intent_emission: false
   action_admission: false
   renderer_integration: false
   backend_integration: false
-  runtime_integration: false
+  event_loop_integration: false
 
   gate_d: closed
   production_promotion: false
-  follow_on_implementation: false
 
 constraints:
-  preserve_9a1_ownership_boundary: true
-  preserve_9b_session_state_contract: true
-  preserve_preflight_correction: true
-  evidence_only: true
+  preserve_shell_player_ownership_boundary: true
+  preserve_semantic_non_authority: true
+  deterministic_transition: true
+  preserve_previous_state_on_rejection: true
+  no_partial_commit: true
+  no_hidden_inputs: true
   no_additional_cleanup: true
   fail_closed: true
-  next_authorized_implementation_slice: none

--- a/crates/prom-ui-runtime/src/lib.rs
+++ b/crates/prom-ui-runtime/src/lib.rs
@@ -48,6 +48,8 @@ pub mod intent_dispatch;
 pub mod interaction;
 pub mod interaction_pipeline;
 pub mod layout_primitives;
+#[allow(dead_code)] // crate-private seed not yet connected to runtime caller path
+pub(crate) mod shell_player;
 pub mod state_update;
 pub mod visual_tokens;
 

--- a/crates/prom-ui-runtime/src/shell_player.rs
+++ b/crates/prom-ui-runtime/src/shell_player.rs
@@ -1,0 +1,534 @@
+//! This is a lifecycle-only Shell Player seed.
+//! It is not the complete Shell Player implementation.
+//! It owns no Semantic truth or authority.
+
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellSessionId(pub(crate) u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShellLifecycle {
+    Created,
+    Active,
+    Suspended,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShellLifecycleCommand {
+    Activate,
+    Suspend,
+    Resume,
+    Close,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShellLifecycleStimulus {
+    Command(ShellLifecycleCommand),
+    ExplicitNoOp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellLifecycleLimits {
+    pub(crate) max_transition_stimulus_bytes: usize,
+    pub(crate) max_diagnostics_per_transition: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ActivatedShellSessionContext {
+    pub(crate) session_id: ShellSessionId,
+    pub(crate) limits: ShellLifecycleLimits,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellLocalState {
+    pub(crate) session_id: ShellSessionId,
+    pub(crate) lifecycle: ShellLifecycle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellTransitionInput {
+    pub(crate) stimulus: ShellLifecycleStimulus,
+    pub(crate) stimulus_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShellTransitionDisposition {
+    Applied,
+    NoChange,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellDiagnostic {
+    pub(crate) stable_code: &'static str,
+    pub(crate) evaluation_stage: usize,
+}
+
+pub(crate) const SPV0_SESSION_MISMATCH: &str = "SPV0_SESSION_MISMATCH";
+pub(crate) const SPV0_INVALID_LIFECYCLE: &str = "SPV0_INVALID_LIFECYCLE";
+pub(crate) const SPV0_SESSION_CLOSED: &str = "SPV0_SESSION_CLOSED";
+pub(crate) const SPV0_RESOURCE_LIMIT_EXCEEDED: &str = "SPV0_RESOURCE_LIMIT_EXCEEDED";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellTransitionResult {
+    pub(crate) disposition: ShellTransitionDisposition,
+    pub(crate) state: ShellLocalState,
+    pub(crate) diagnostics: Vec<ShellDiagnostic>,
+    pub(crate) stimulus_bytes: usize,
+    pub(crate) logical_diagnostic_count: usize,
+    pub(crate) emitted_diagnostic_count: usize,
+}
+
+fn apply_diagnostic_cap(
+    cap: usize,
+    mut logical_diagnostics: Vec<ShellDiagnostic>,
+) -> (Vec<ShellDiagnostic>, usize, usize) {
+    let logical_count = logical_diagnostics.len();
+    if cap == 0 {
+        return (Vec::new(), logical_count, 0);
+    }
+    if logical_count > cap {
+        logical_diagnostics.truncate(cap);
+    }
+    let emitted_count = logical_diagnostics.len();
+    (logical_diagnostics, logical_count, emitted_count)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValidatedLifecycleAction {
+    ExplicitNoOp,
+    Activate,
+    Suspend,
+    Resume,
+    Close,
+}
+
+fn validate_lifecycle_action(
+    lifecycle: ShellLifecycle,
+    stimulus: ShellLifecycleStimulus,
+) -> Result<ValidatedLifecycleAction, ShellDiagnostic> {
+    match stimulus {
+        ShellLifecycleStimulus::ExplicitNoOp => Ok(ValidatedLifecycleAction::ExplicitNoOp),
+        ShellLifecycleStimulus::Command(cmd) => match (lifecycle, cmd) {
+            (ShellLifecycle::Created, ShellLifecycleCommand::Activate) => {
+                Ok(ValidatedLifecycleAction::Activate)
+            }
+            (ShellLifecycle::Created, ShellLifecycleCommand::Close) => {
+                Ok(ValidatedLifecycleAction::Close)
+            }
+            (ShellLifecycle::Active, ShellLifecycleCommand::Suspend) => {
+                Ok(ValidatedLifecycleAction::Suspend)
+            }
+            (ShellLifecycle::Active, ShellLifecycleCommand::Close) => {
+                Ok(ValidatedLifecycleAction::Close)
+            }
+            (ShellLifecycle::Suspended, ShellLifecycleCommand::Resume) => {
+                Ok(ValidatedLifecycleAction::Resume)
+            }
+            (ShellLifecycle::Suspended, ShellLifecycleCommand::Close) => {
+                Ok(ValidatedLifecycleAction::Close)
+            }
+            _ => Err(ShellDiagnostic {
+                stable_code: SPV0_INVALID_LIFECYCLE,
+                evaluation_stage: 2, // LifecycleEligibility
+            }),
+        },
+    }
+}
+
+fn calculate_candidate_lifecycle(
+    previous: ShellLifecycle,
+    action: ValidatedLifecycleAction,
+) -> ShellLifecycle {
+    match action {
+        ValidatedLifecycleAction::ExplicitNoOp => previous,
+        ValidatedLifecycleAction::Activate => ShellLifecycle::Active,
+        ValidatedLifecycleAction::Suspend => ShellLifecycle::Suspended,
+        ValidatedLifecycleAction::Resume => ShellLifecycle::Active,
+        ValidatedLifecycleAction::Close => ShellLifecycle::Closed,
+    }
+}
+
+pub(crate) fn evaluate_lifecycle_transition(
+    context: &ActivatedShellSessionContext,
+    previous: &ShellLocalState,
+    input: ShellTransitionInput,
+) -> ShellTransitionResult {
+    // 1. validate session identity
+    if context.session_id != previous.session_id {
+        let (diagnostics, logical_count, emitted_count) = apply_diagnostic_cap(
+            context.limits.max_diagnostics_per_transition,
+            alloc::vec![ShellDiagnostic {
+                stable_code: SPV0_SESSION_MISMATCH,
+                evaluation_stage: 1, // SessionIdentity
+            }],
+        );
+        return ShellTransitionResult {
+            disposition: ShellTransitionDisposition::Rejected,
+            state: *previous,
+            diagnostics,
+            stimulus_bytes: input.stimulus_bytes,
+            logical_diagnostic_count: logical_count,
+            emitted_diagnostic_count: emitted_count,
+        };
+    }
+
+    // 2. validate lifecycle eligibility
+    if previous.lifecycle == ShellLifecycle::Closed {
+        let (diagnostics, logical_count, emitted_count) = apply_diagnostic_cap(
+            context.limits.max_diagnostics_per_transition,
+            alloc::vec![ShellDiagnostic {
+                stable_code: SPV0_SESSION_CLOSED,
+                evaluation_stage: 2, // LifecycleEligibility
+            }],
+        );
+        return ShellTransitionResult {
+            disposition: ShellTransitionDisposition::Rejected,
+            state: *previous,
+            diagnostics,
+            stimulus_bytes: input.stimulus_bytes,
+            logical_diagnostic_count: logical_count,
+            emitted_diagnostic_count: emitted_count,
+        };
+    }
+
+    // 2. validate lifecycle eligibility (command combination)
+    let action = match validate_lifecycle_action(previous.lifecycle, input.stimulus) {
+        Ok(a) => a,
+        Err(diag) => {
+            let (diagnostics, logical_count, emitted_count) = apply_diagnostic_cap(
+                context.limits.max_diagnostics_per_transition,
+                alloc::vec![diag],
+            );
+            return ShellTransitionResult {
+                disposition: ShellTransitionDisposition::Rejected,
+                state: *previous,
+                diagnostics,
+                stimulus_bytes: input.stimulus_bytes,
+                logical_diagnostic_count: logical_count,
+                emitted_diagnostic_count: emitted_count,
+            };
+        }
+    };
+
+    // 3. typed lifecycle envelope is structurally valid
+    // This is implicitly guaranteed by Rust's enum representation of input.stimulus and the parsed action.
+
+    // 4. validate max_transition_stimulus_bytes
+    if input.stimulus_bytes > context.limits.max_transition_stimulus_bytes {
+        let (diagnostics, logical_count, emitted_count) = apply_diagnostic_cap(
+            context.limits.max_diagnostics_per_transition,
+            alloc::vec![ShellDiagnostic {
+                stable_code: SPV0_RESOURCE_LIMIT_EXCEEDED,
+                evaluation_stage: 4, // InputResourcePreflight
+            }],
+        );
+        return ShellTransitionResult {
+            disposition: ShellTransitionDisposition::Rejected,
+            state: *previous,
+            diagnostics,
+            stimulus_bytes: input.stimulus_bytes,
+            logical_diagnostic_count: logical_count,
+            emitted_diagnostic_count: emitted_count,
+        };
+    }
+
+    // Stages 5, 6, and 8 have no work in this lifecycle-only seed.
+
+    // 7. calculate candidate lifecycle state without commit
+    let candidate_lifecycle = calculate_candidate_lifecycle(previous.lifecycle, action);
+
+    // 9. return complete candidate state or complete previous state
+    let state = ShellLocalState {
+        session_id: previous.session_id,
+        lifecycle: candidate_lifecycle,
+    };
+
+    let disposition = if action == ValidatedLifecycleAction::ExplicitNoOp {
+        ShellTransitionDisposition::NoChange
+    } else {
+        ShellTransitionDisposition::Applied
+    };
+
+    // 10. apply diagnostic emission cap
+    let (diagnostics, logical_count, emitted_count) =
+        apply_diagnostic_cap(context.limits.max_diagnostics_per_transition, Vec::new());
+
+    ShellTransitionResult {
+        disposition,
+        state,
+        diagnostics,
+        stimulus_bytes: input.stimulus_bytes,
+        logical_diagnostic_count: logical_count,
+        emitted_diagnostic_count: emitted_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ctx(cap: usize, max_bytes: usize) -> ActivatedShellSessionContext {
+        ActivatedShellSessionContext {
+            session_id: ShellSessionId(1),
+            limits: ShellLifecycleLimits {
+                max_transition_stimulus_bytes: max_bytes,
+                max_diagnostics_per_transition: cap,
+            },
+        }
+    }
+
+    fn make_state(lifecycle: ShellLifecycle) -> ShellLocalState {
+        ShellLocalState {
+            session_id: ShellSessionId(1),
+            lifecycle,
+        }
+    }
+
+    fn cmd(c: ShellLifecycleCommand, bytes: usize) -> ShellTransitionInput {
+        ShellTransitionInput {
+            stimulus: ShellLifecycleStimulus::Command(c),
+            stimulus_bytes: bytes,
+        }
+    }
+
+    #[test]
+    fn test_valid_transitions() {
+        let ctx = make_ctx(10, 100);
+
+        let valid_cases = alloc::vec![
+            (
+                ShellLifecycle::Created,
+                ShellLifecycleCommand::Activate,
+                ShellLifecycle::Active
+            ),
+            (
+                ShellLifecycle::Created,
+                ShellLifecycleCommand::Close,
+                ShellLifecycle::Closed
+            ),
+            (
+                ShellLifecycle::Active,
+                ShellLifecycleCommand::Suspend,
+                ShellLifecycle::Suspended
+            ),
+            (
+                ShellLifecycle::Active,
+                ShellLifecycleCommand::Close,
+                ShellLifecycle::Closed
+            ),
+            (
+                ShellLifecycle::Suspended,
+                ShellLifecycleCommand::Resume,
+                ShellLifecycle::Active
+            ),
+            (
+                ShellLifecycle::Suspended,
+                ShellLifecycleCommand::Close,
+                ShellLifecycle::Closed
+            ),
+        ];
+
+        for (start, command, expected) in valid_cases {
+            let state = make_state(start);
+            let input = cmd(command, 10);
+            let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+            assert_eq!(res.disposition, ShellTransitionDisposition::Applied);
+            assert_eq!(res.state.lifecycle, expected);
+            assert_eq!(res.diagnostics.len(), 0);
+            assert_eq!(res.state.session_id, state.session_id);
+        }
+    }
+
+    #[test]
+    fn test_invalid_lifecycle_command() {
+        let ctx = make_ctx(10, 100);
+
+        let invalid_cases = alloc::vec![
+            (ShellLifecycle::Created, ShellLifecycleCommand::Suspend),
+            (ShellLifecycle::Created, ShellLifecycleCommand::Resume),
+            (ShellLifecycle::Active, ShellLifecycleCommand::Activate),
+            (ShellLifecycle::Active, ShellLifecycleCommand::Resume),
+            (ShellLifecycle::Suspended, ShellLifecycleCommand::Activate),
+            (ShellLifecycle::Suspended, ShellLifecycleCommand::Suspend),
+        ];
+
+        for (start, command) in invalid_cases {
+            let state = make_state(start);
+            let input = cmd(command, 10);
+            let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+            assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+            assert_eq!(res.state, state);
+            assert_eq!(res.logical_diagnostic_count, 1);
+            assert_eq!(res.diagnostics[0].stable_code, SPV0_INVALID_LIFECYCLE);
+            assert_eq!(res.diagnostics[0].evaluation_stage, 2);
+        }
+    }
+
+    #[test]
+    fn test_closed_state_rejection() {
+        let ctx = make_ctx(10, 100);
+        let state = make_state(ShellLifecycle::Closed);
+
+        let commands = alloc::vec![
+            ShellLifecycleStimulus::ExplicitNoOp,
+            ShellLifecycleStimulus::Command(ShellLifecycleCommand::Activate),
+            ShellLifecycleStimulus::Command(ShellLifecycleCommand::Suspend),
+            ShellLifecycleStimulus::Command(ShellLifecycleCommand::Resume),
+            ShellLifecycleStimulus::Command(ShellLifecycleCommand::Close),
+        ];
+
+        for stimulus in commands {
+            let input = ShellTransitionInput {
+                stimulus,
+                stimulus_bytes: 10,
+            };
+            let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+            assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+            assert_eq!(res.state, state);
+            assert_eq!(res.logical_diagnostic_count, 1);
+            assert_eq!(res.diagnostics[0].stable_code, SPV0_SESSION_CLOSED);
+        }
+    }
+
+    #[test]
+    fn test_explicit_noop() {
+        let ctx = make_ctx(10, 100);
+        let states = alloc::vec![
+            ShellLifecycle::Created,
+            ShellLifecycle::Active,
+            ShellLifecycle::Suspended,
+        ];
+
+        for lifecycle in states {
+            let state = make_state(lifecycle);
+            let input = ShellTransitionInput {
+                stimulus: ShellLifecycleStimulus::ExplicitNoOp,
+                stimulus_bytes: 10,
+            };
+            let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+            assert_eq!(res.disposition, ShellTransitionDisposition::NoChange);
+            assert_eq!(res.state, state);
+            assert_eq!(res.logical_diagnostic_count, 0);
+        }
+    }
+
+    #[test]
+    fn test_session_mismatch() {
+        let ctx = make_ctx(10, 100);
+        let mut state = make_state(ShellLifecycle::Created);
+        state.session_id = ShellSessionId(999);
+
+        let input = cmd(ShellLifecycleCommand::Activate, 10);
+        let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+        assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+        assert_eq!(res.state, state);
+        assert_eq!(res.logical_diagnostic_count, 1);
+        assert_eq!(res.diagnostics[0].stable_code, SPV0_SESSION_MISMATCH);
+        assert_eq!(res.diagnostics[0].evaluation_stage, 1);
+    }
+
+    #[test]
+    fn test_oversized_stimulus() {
+        let ctx = make_ctx(10, 100);
+        let state = make_state(ShellLifecycle::Created);
+
+        let input = cmd(ShellLifecycleCommand::Activate, 101);
+        let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+        assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+        assert_eq!(res.state, state);
+        assert_eq!(res.logical_diagnostic_count, 1);
+        assert_eq!(res.diagnostics[0].stable_code, SPV0_RESOURCE_LIMIT_EXCEEDED);
+        assert_eq!(res.diagnostics[0].evaluation_stage, 4);
+    }
+
+    #[test]
+    fn test_oversized_stimulus_precedence_over_candidate_calculation() {
+        let ctx = make_ctx(10, 100);
+        let state = make_state(ShellLifecycle::Created);
+
+        // Valid command, but oversized stimulus
+        let input = cmd(ShellLifecycleCommand::Activate, 101);
+        let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+        // Should be rejected due to limits (Stage 4), NOT invalid lifecycle (Stage 2)
+        // And the candidate calculation (Stage 7) should not have been applied
+        assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+        assert_eq!(res.state, state); // previous state preserved
+        assert_eq!(res.logical_diagnostic_count, 1);
+        assert_eq!(res.diagnostics[0].stable_code, SPV0_RESOURCE_LIMIT_EXCEEDED);
+        assert_eq!(res.diagnostics[0].evaluation_stage, 4);
+    }
+
+    #[test]
+    fn test_diagnostic_cap_zero() {
+        let ctx = make_ctx(0, 100);
+        let state = make_state(ShellLifecycle::Closed);
+
+        let input = cmd(ShellLifecycleCommand::Activate, 10);
+        let res = evaluate_lifecycle_transition(&ctx, &state, input);
+
+        assert_eq!(res.disposition, ShellTransitionDisposition::Rejected);
+        assert_eq!(res.state, state);
+        assert_eq!(res.logical_diagnostic_count, 1);
+        assert_eq!(res.emitted_diagnostic_count, 0);
+        assert_eq!(res.diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_diagnostic_prefix() {
+        let diags = alloc::vec![
+            ShellDiagnostic {
+                stable_code: "A",
+                evaluation_stage: 1
+            },
+            ShellDiagnostic {
+                stable_code: "B",
+                evaluation_stage: 2
+            },
+            ShellDiagnostic {
+                stable_code: "C",
+                evaluation_stage: 3
+            },
+        ];
+
+        let (res_diags, logical, emitted) = apply_diagnostic_cap(2, diags.clone());
+        assert_eq!(logical, 3);
+        assert_eq!(emitted, 2);
+        assert_eq!(res_diags.len(), 2);
+        assert_eq!(res_diags[0].stable_code, "A");
+        assert_eq!(res_diags[1].stable_code, "B");
+    }
+
+    #[test]
+    fn test_identical_input_produces_identical_results() {
+        let ctx = make_ctx(10, 100);
+        let state = make_state(ShellLifecycle::Created);
+        let input = cmd(ShellLifecycleCommand::Activate, 10);
+
+        let res1 = evaluate_lifecycle_transition(&ctx, &state, input);
+        let res2 = evaluate_lifecycle_transition(&ctx, &state, input);
+
+        assert_eq!(res1, res2);
+    }
+
+    #[test]
+    fn test_valid_transition_does_not_mutate_previous_state() {
+        let ctx = make_ctx(10, 100);
+        let previous = make_state(ShellLifecycle::Created);
+        let input = cmd(ShellLifecycleCommand::Activate, 10);
+
+        let res = evaluate_lifecycle_transition(&ctx, &previous, input);
+
+        assert_eq!(previous.lifecycle, ShellLifecycle::Created);
+        assert_eq!(res.state.lifecycle, ShellLifecycle::Active);
+    }
+}


### PR DESCRIPTION
## Result

- adds a crate-private lifecycle-only Shell Player seed;
- implements deterministic Created / Active / Suspended / Closed transitions;
- preserves previous local state on rejected transitions;
- applies input resource preflight before candidate-state calculation;
- keeps ProjectionPatch, interaction, renderer and backend work out of scope.

## Validation

- focused Shell Player tests pass;
- prom-ui-runtime library tests pass;
- formatting and Clippy pass;
- the no-default-features failure is unchanged from the parent baseline and introduces no Shell Player errors.

## Non-goals

- no ProjectionPatch application;
- no bundle activation;
- no public API;
- no renderer or backend integration;
- no Gate D movement;
- no production promotion.