### PR TITLE
docs(ui): freeze collection-anchor declarations

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,42 +1,51 @@
 task:
-  id: SHELL-PLAYER-STAGE5-PREPARED-HANDOFF-CONTRACT
-  title: freeze stage-5 prepared handoff
+  id: COLLECTION-ANCHOR-DECLARATION-CONTRACT
+  title: freeze explicit CollectionAnchor declarations
   type: documentation
   mode: active
 
 intent:
-  summary: "docs(ui): freeze stage-5 prepared handoff"
+  summary: "docs(ui): freeze collection-anchor declarations"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
+    - docs/spec/ui/projection_source_model.md
     - docs/spec/ui/shell_player_session_state_v0.md
 
 authorization:
-  prepared_handoff_ownership_contract: true
-  manifest_capsule_concept: true
-  activation_target_evidence_concept: true
-  runtime_owned_catalog_decision: true
-  collection_anchor_source_requirement: true
-  public_bridge_stability_policy: true
-  public_api_guard_requirement: true
-  count_coherence_clarification: true
-  testability_boundary_clarification: true
+  collection_anchor_declaration_ownership: true
+  collection_anchor_identity_contract: true
+  collection_anchor_validation_contract: true
+  collection_anchor_ordering_contract: true
+  collection_anchor_diagnostic_contract: true
+  prepared_activation_collection_source_contract: true
+  shell_player_cross_reference_update: true
 
   rust_implementation: false
+  projection_source_ast_change: false
+  projection_source_parser_change: false
+  projection_source_grammar_change: false
+  static_ir_change: false
+  binding_graph_change: false
+  projection_patch_change: false
   public_api: false
   doc_hidden_pub_additions: false
   public_api_guard_changes: false
   snapshot_changes: false
-  projection_patch_visibility_changes: false
   new_crate: false
+  dependency_changes: false
   new_cargo_feature: false
-  manifest_implementation: false
-  activation_target_implementation: false
+  collection_anchor_representation: false
+  collection_anchor_lowering: false
+  collection_anchor_validation_implementation: false
+  prepared_transition_implementation: false
+  prepared_activation_implementation: false
   catalog_implementation: false
+  activated_context_expansion: false
+  stage4_integration: false
   stage5_evaluator: false
   stage6_integration: false
-  patch_traversal_implementation: false
   patch_application: false
   cursor_advancement: false
   candidate_state: false
@@ -48,30 +57,22 @@ authorization:
 
 constraints:
   docs_only: true
-  single_normative_source: true
-  no_second_stage5_document: true
-  no_rust_struct_frozen: true
-  no_serialization_frozen: true
-  no_rust_collection_type_frozen: true
-  no_hashmap_or_hashset_required: true
-  map_iteration_order_forbidden: true
-  no_diagnostic_codes_added: true
-  existing_diagnostic_classes_only: true
-  no_orchestration_authorized: true
-  stage_order_1_through_10_preserved: true
-  stage4_precedes_target_traversal: true
-  stage5_precedes_replay_compatibility: true
-  no_partial_commit: true
-  diagnostic_cap_is_output_shaping_only: true
-  manifest_and_catalog_remain_separate: true
-  prepared_transition_is_transition_scoped: true
-  prepared_activation_is_activation_scoped: true
-  catalog_is_session_scoped: true
-  collection_anchor_declaration_source_required: true
-  collection_anchor_implementation_blocked: true
-  no_reverse_dependency_authorized: true
-  no_new_shared_crate_authorized: true
-  guard_coverage_same_pr_as_bridge: true
-  no_standalone_baseline_guard_pr: true
-  no_test_fixtures_feature_authorized: true
+  single_normative_home_for_declaration_contract: true
+  no_second_specification: true
+  projection_owned_declarations: true
+  explicit_declaration_only: true
+  collection_key_is_not_anchor_identity: true
+  patch_operation_is_not_declaration: true
+  role_text_is_not_declaration: true
+  binding_domain_is_not_declaration: true
+  caller_assertion_is_not_declaration: true
+  stable_node_identity_required: true
+  deterministic_order_required: true
+  duplicate_declaration_rejected: true
+  missing_node_rejected: true
+  no_partial_declaration_set: true
+  prepared_activation_consumes_qualified_set_only: true
+  catalog_remains_runtime_owned: true
+  no_semantic_authority: true
+  gate_d: closed
   fail_closed: true

--- a/docs/spec/ui/projection_source_model.md
+++ b/docs/spec/ui/projection_source_model.md
@@ -358,3 +358,329 @@ The spec is acceptable when:
 - it treats accessibility as contract;
 - it does not implement parser grammar;
 - it does not claim production readiness.
+
+## 12. Explicit CollectionAnchor Declarations
+
+Status: normative contract freeze.
+Scope type: documentation only.
+This section amends this document. It is not a second specification.
+
+This section freezes the ownership, identity, validation, ordering,
+diagnostic, resource, integration, mutation, and authority contract for
+explicit projection-owned `CollectionAnchor` declarations. It removes the
+remaining semantic blocker recorded against future
+`PreparedActiveProjectionTargets` and `ActiveProjectionTargetCatalog`
+implementation in `docs/spec/ui/shell_player_session_state_v0.md`.
+
+This section does not implement Rust, does not modify parser grammar, does
+not add public API, and does not modify the public API guard. It does not
+authorize implementation of `PreparedActiveProjectionTargets`,
+`ActiveProjectionTargetCatalog`, or the stage-5 evaluator.
+
+### Ownership
+
+- Projection Source owns authored collection-anchor declaration intent.
+- `prom-ui` owns validation and deterministic lowering of that intent into
+  projection-owned structural declaration evidence.
+- The validated Static UI structural layer owns the stable target node
+  identities against which declarations are qualified.
+- `PreparedActiveProjectionTargets` may consume only the successfully
+  qualified collection-anchor declaration set.
+- `prom-ui-runtime` does not own source declarations, declaration
+  validation, declaration lowering, or declaration identity.
+- `ActiveProjectionTargetCatalog` remains owned by `prom-ui-runtime` only
+  after prepared activation evidence crosses the controlled handoff.
+
+Neither a composition caller nor Shell Player may become:
+
+- declaration author;
+- declaration validator;
+- declaration lowerer;
+- collection-anchor identity owner;
+- projection source owner;
+- Semantic authority;
+- action-authorization authority.
+
+No reverse dependency is authorized. No shared crate is authorized.
+
+### The `CollectionAnchorDeclaration` concept
+
+`CollectionAnchorDeclaration` is the conceptual name for one authored
+declaration. A declaration means only:
+
+```text
+the identified projection-owned static node is explicitly declared and
+qualified as an eligible collection patch target for local projection playback
+```
+
+This eligibility is projection-structural only. It is not Semantic admission,
+verifier admission, capability admission, bundle admission, patch admission,
+action admission, runtime activation, or effect authorization.
+
+A declaration does not mean:
+
+- the node currently contains collection elements;
+- a Semantic collection exists;
+- a `BindingValueDomain::Collection` binding exists;
+- the node has a collection-like role name;
+- a `CollectionKey` identifies the anchor;
+- a collection patch has already targeted it;
+- the collection is visible;
+- the collection is mutable;
+- an action is authorized;
+- a patch is valid;
+- a patch may be applied.
+
+A declaration is projection structure, not runtime state.
+
+### Source and lowered identities
+
+Two identity stages are distinguished.
+
+**Authored source target.** At the Projection Source level, an authored
+declaration targets exactly one projection source node identity. Conceptually
+this is a `ProjectionSourceNodeId`. This contract does not freeze grammar
+syntax or an AST field name. The declaration must refer to a node declared in
+the same `ProjectionSourceDocument`. A declaration must not target:
+
+- a surface ID;
+- a role name;
+- a `CollectionKey`;
+- a `BindingId`;
+- a `BindingSlot`;
+- a patch operation;
+- an arbitrary numeric ID outside the source document.
+
+**Qualified static target.** After deterministic lowering, the qualified
+anchor identity is `StaticDocumentId` + `StaticNodeId`. The declaration set is
+also bound to the corresponding `Revision` and `Epoch`.
+
+The following are frozen explicitly:
+
+- `CollectionAnchor` identity is the static target node within one exact
+  static document version.
+- `CollectionKey` is not part of `CollectionAnchor` identity.
+- `SourceSpan` is provenance, not identity.
+- Authored declaration order is not identity.
+- Storage position is not identity.
+- Map iteration position is not identity.
+
+This contract does not freeze an assumption that raw `ProjectionSourceNodeId`
+and `StaticNodeId` values must always remain numerically identical. The
+compiler owns deterministic source-node-to-static-node mapping.
+
+### The qualified declaration set
+
+`QualifiedCollectionAnchorDeclarations` is the conceptual name for the set of
+all successfully qualified collection anchors for exactly one validated
+projection-owned static document version. It is bound coherently to
+`StaticDocumentId`, `Revision`, and `Epoch`. It contains only stable
+collection target coordinates. It is:
+
+- immutable after qualification;
+- deterministically ordered;
+- local and reconstructible;
+- non-authoritative;
+- not caller-authored after qualification;
+- not the runtime catalog;
+- not prepared activation evidence by itself.
+
+It must not be mixed across documents, revisions, epochs, or projection
+activations. An empty declaration set is valid.
+
+### Validation rules
+
+Validation is fail-closed and deterministic.
+
+**Rule 1 — Source target existence.** Every authored declaration target must
+resolve to exactly one node declared in the same `ProjectionSourceDocument`.
+A missing target rejects the declaration set and emits
+`CAD_MISSING_TARGET_NODE`.
+
+**Rule 2 — Duplicate declaration.** The same qualified static node must not
+be declared more than once. A duplicate declaration rejects the declaration
+set and emits `CAD_DUPLICATE_DECLARATION`. Duplicate detection is by
+qualified collection-anchor identity, not by `SourceRef`, `CollectionKey`,
+role, authored order, or object identity.
+
+**Rule 3 — Static target existence.** After lowering, every qualified
+declaration must reference a node present in the same validated
+`StaticUiDocument`. Failure rejects the declaration set and emits
+`CAD_MISSING_STATIC_NODE`. This is a defensive compiler/adapter coherence
+diagnostic.
+
+**Rule 4 — Document-version coherence.** Declarations and the target Static
+UI document must agree on `StaticDocumentId`, `Revision`, and `Epoch`. A
+mismatch rejects the declaration set and emits
+`CAD_DOCUMENT_VERSION_MISMATCH`.
+
+**Rule 5 — No inferred declarations.** A node must not become a
+`CollectionAnchor` merely because of: `StaticNodeId` existence,
+`ProjectionSourceNode` existence, `CollectionKey` existence, role text, a
+`List`-like role, `BindingValueDomain::Collection`, `collection_key` on a
+`BindingDeclaration`, `CollectionInsert`, `CollectionUpdate`,
+`CollectionRemove`, `CollectionMove`, prior patch history, caller assertion,
+host state, backend state, map membership, or map iteration order.
+
+**Rule 6 — No extra role requirement.** A valid explicit declaration does not
+additionally require a specific role name or binding domain unless a later
+independent contract introduces such a requirement. This contract does not
+silently add a `List`-role requirement.
+
+**Rule 7 — No new reachability rule.** Collection-anchor validation must not
+invent a new surface-reachability rule. It relies on the already validated
+projection-owned structural document. This contract does not weaken existing
+Static UI IR validation.
+
+### Deterministic ordering
+
+Qualified collection anchors must be ordered solely by stable qualified
+target identity. The normative v0 order is: ascending `StaticNodeId` within
+the one bound `StaticDocumentId`/version. Because the set is bound to one
+document version, the document identity does not need to be repeated as a
+per-entry sort component.
+
+Forbidden ordering sources:
+
+- authored declaration order;
+- `Vec` insertion order;
+- `HashMap` or `HashSet` iteration;
+- source byte order as final identity order;
+- role name;
+- `CollectionKey`;
+- patch order;
+- runtime discovery order;
+- backend order;
+- host order;
+- pointer address.
+
+Qualification must produce the same ordered set for equivalent declarations
+regardless of authored declaration order. This contract does not freeze a
+Rust collection type.
+
+### Diagnostic ownership
+
+The declaration diagnostics belong to `prom-ui` projection qualification.
+They are not Shell Player `SPV0_*` diagnostics. The following stable codes
+are frozen:
+
+| Code | Class |
+| --- | --- |
+| `CAD_MISSING_TARGET_NODE` | An authored declaration target does not resolve to a node in the same `ProjectionSourceDocument`. |
+| `CAD_DUPLICATE_DECLARATION` | The same qualified static node is declared more than once. |
+| `CAD_MISSING_STATIC_NODE` | A qualified declaration references a node absent from the validated `StaticUiDocument`. |
+| `CAD_DOCUMENT_VERSION_MISMATCH` | Declarations and the target Static UI document disagree on `StaticDocumentId`, `Revision`, or `Epoch`. |
+
+Diagnostic ordering must be deterministic. Conceptual ordering is consistent
+with the existing diagnostic-coordinate posture: source provenance when
+present, then stable diagnostic code, then primary stable node identity, then
+secondary coordinate. Exact Rust diagnostic structs and field layouts remain
+unresolved.
+
+Any declaration diagnostic means: no `QualifiedCollectionAnchorDeclarations`
+value, no `PreparedActiveProjectionTargets` value from that input, and no
+runtime catalog construction from that input. No partial declaration set may
+escape.
+
+`CAD_*` diagnostics are not mapped to `SPV0_INVALID_TARGET`. `SPV0_INVALID_TARGET`
+remains a stage-5 runtime membership failure after a valid catalog already
+exists; `CAD_*` diagnostics are projection-qualification-time failures that
+occur before any catalog exists.
+
+### Resource posture
+
+The v0 declaration set is structurally bounded by the number of unique nodes
+in the validated static document. Therefore:
+
+```text
+qualified declaration count <= validated static node count
+```
+
+This contract does not introduce a separate host resource limit, an
+arbitrary declaration quota, a new `ShellLifecycleLimits` field, or a stage-4
+diagnostic. A future smaller operational limit requires a separate contract.
+Representation-size overflow and allocation strategy remain unresolved.
+
+### `PreparedActiveProjectionTargets` integration
+
+`PreparedActiveProjectionTargets` obtains `CollectionAnchor` coordinates only
+from `QualifiedCollectionAnchorDeclarations`. No other source may contribute
+`CollectionAnchor` membership. The collection-anchor coordinates retain the
+qualified deterministic order. `PreparedActiveProjectionTargets` may combine
+the qualified collection anchors with independently qualified `NodeAnchor`
+and `BindingAnchor` evidence, but it must not reinterpret or regenerate
+collection declarations.
+
+Absence rules:
+
+- no explicit declaration means no `CollectionAnchor` membership;
+- a later collection patch targeting that node means stage-5 membership
+  rejection once the runtime catalog exists;
+- a `CollectionKey` or collection patch operation never creates declaration
+  evidence.
+
+This contract does not authorize implementation of
+`PreparedActiveProjectionTargets`, `ActiveProjectionTargetCatalog`, or the
+stage-5 evaluator.
+
+### Mutation and lifetime posture
+
+Declarations belong to one projection structural version. They are not
+mutated by `ProjectionPatch`, `ShellSession`, `ActiveProjectionTargetCatalog`,
+collection inserts, collection updates, collection removals, collection
+moves, renderer activity, backend activity, focus state, or event handling.
+
+Changing declarations requires a newly qualified projection structural
+version. A patch must not add or remove `CollectionAnchor` declarations. A
+new activation may transport a new prepared declaration set only from a
+newly qualified projection version.
+
+### Authority boundaries
+
+```text
+CollectionAnchor declaration != Semantic collection truth
+CollectionAnchor declaration != collection contents
+CollectionAnchor declaration != action authorization
+CollectionAnchor declaration != patch admission
+CollectionAnchor declaration != patch application
+CollectionAnchor declaration != renderer command
+CollectionAnchor declaration != backend resource
+CollectionAnchor declaration != runtime discovery
+CollectionAnchor declaration != bundle trust
+```
+
+Declaration qualification does not load a bundle, activate a bundle, create
+a `ShellSession`, construct the runtime catalog, validate replay
+compatibility, apply a patch, advance the replay cursor, calculate candidate
+state, authorize effects, or move Gate D.
+
+### Explicitly unresolved
+
+The following remain unresolved and unauthorized by this section:
+
+- Projection Source grammar syntax;
+- parser tokens;
+- source AST field names;
+- Rust declaration type names;
+- Rust declaration-set type names;
+- module paths;
+- field layouts;
+- constructors;
+- visibility;
+- public API;
+- public re-exports;
+- serialization;
+- ABI;
+- canonical byte format;
+- source-to-static mapping representation;
+- diagnostic Rust representation;
+- storage collection;
+- allocation strategy;
+- representation-size overflow behavior;
+- prepared activation producer;
+- runtime catalog implementation;
+- `ActivatedShellSessionContext` expansion;
+- stage-5 evaluator;
+- stage-5/stage-6 orchestration.
+
+This section does not claim implementation readiness for any of the above.

--- a/docs/spec/ui/shell_player_session_state_v0.md
+++ b/docs/spec/ui/shell_player_session_state_v0.md
@@ -720,12 +720,14 @@ from:
 - a caller assertion;
 - map iteration order.
 
-The current Rust representation of explicit collection-anchor declarations
-does not exist and remains unresolved. Therefore, `PreparedActiveProjectionTargets`
-implementation is not authorized until an explicit collection-anchor
-declaration substrate is separately frozen and available. This does not block
-the ownership contract in 7.1.9.1; it blocks catalog implementation
-specifically.
+The normative explicit `CollectionAnchor` declaration contract is frozen in
+`docs/spec/ui/projection_source_model.md`. Its Rust representation, source
+syntax, lowering, qualification implementation, prepared-activation
+integration, and catalog integration remain unresolved and unauthorized.
+Therefore, `PreparedActiveProjectionTargets` implementation is not authorized
+until the explicit declaration representation and qualification path exist.
+This does not block the ownership contract in 7.1.9.1; it blocks catalog
+implementation specifically.
 
 ##### 7.1.9.6 Runtime-owned catalog responsibility
 
@@ -911,7 +913,9 @@ The following remain unresolved:
 - snapshot filenames;
 - prepared transition producer entry point;
 - prepared activation producer entry point;
-- explicit collection-anchor declaration representation;
+- explicit `CollectionAnchor` declaration Rust representation;
+- explicit `CollectionAnchor` source/lowering implementation;
+- qualified declaration-set implementation;
 - catalog storage;
 - catalog lookup algorithm;
 - view traits;
@@ -1159,7 +1163,9 @@ The following remain unresolved:
 - `ActiveProjectionTargetCatalog` Rust storage structure and lookup algorithm;
 - `PreparedProjectionPatchTargets` Rust representation and producer entry point;
 - `PreparedActiveProjectionTargets` Rust representation and producer entry point;
-- explicit `CollectionAnchor` declaration substrate;
+- explicit `CollectionAnchor` declaration Rust representation;
+- explicit `CollectionAnchor` source/lowering implementation;
+- qualified declaration-set implementation;
 - public API guard test implementation and snapshot filenames for the future
   stage-5 bridge;
 - stage-5 stable-target evaluator implementation;
@@ -1219,6 +1225,7 @@ handoff atomicity = FROZEN
 declared/actual count coherence = FROZEN
 public API guard policy (same-PR-as-bridge) = FROZEN
 testability boundary = FROZEN
+explicit CollectionAnchor declaration contract = FROZEN
 
 replay-cursor compatibility implementation = NOT AUTHORIZED
 replay-cursor advancement = NOT AUTHORIZED
@@ -1229,7 +1236,7 @@ OrderedStableTargetManifest Rust representation = NOT AUTHORIZED
 ActiveProjectionTargetCatalog Rust representation = NOT AUTHORIZED
 PreparedProjectionPatchTargets implementation = NOT AUTHORIZED
 PreparedActiveProjectionTargets implementation = NOT AUTHORIZED
-explicit CollectionAnchor declaration substrate = NOT AUTHORIZED
+explicit CollectionAnchor declaration implementation = NOT AUTHORIZED
 any public stage-5 bridge item = NOT AUTHORIZED
 public API guard change = NOT AUTHORIZED
 cross-crate ProjectionPatch visibility change = NOT AUTHORIZED


### PR DESCRIPTION
## Result

Freezes the explicit `CollectionAnchor` declaration contract. Documentation-only normative contract slice. No Rust, no public API, no parser/grammar/AST change, no public API guard change, no implementation of `PreparedActiveProjectionTargets`, `ActiveProjectionTargetCatalog`, or the stage-5 evaluator.

## Ownership

- Projection Source owns authored collection-anchor declaration intent.
- `prom-ui` owns validation and deterministic lowering of that intent into projection-owned structural declaration evidence.
- The validated Static UI structural layer owns the stable target node identities against which declarations are qualified.
- `PreparedActiveProjectionTargets` may consume only the successfully qualified collection-anchor declaration set.
- `prom-ui-runtime` does not own source declarations, declaration validation, declaration lowering, or declaration identity.
- `ActiveProjectionTargetCatalog` remains owned by `prom-ui-runtime` only after prepared activation evidence crosses the controlled handoff.

No reverse dependency is authorized. No shared crate is authorized.

## Declaration and identity

`CollectionAnchorDeclaration` means only: the identified projection-owned static node is explicitly declared and qualified as an eligible collection patch target for local projection playback. This eligibility is projection-structural only — it is not Semantic admission, verifier admission, capability admission, bundle admission, patch admission, action admission, runtime activation, or effect authorization.

Two identity stages are distinguished:
- **Authored source target** — a `ProjectionSourceNodeId` within the same `ProjectionSourceDocument`.
- **Qualified static target** — `StaticDocumentId` + `StaticNodeId`, bound to `Revision` and `Epoch` after deterministic lowering.

`CollectionKey` is explicitly not part of `CollectionAnchor` identity. `SourceSpan`, authored order, storage position, and map iteration position are explicitly not identity.

## Structural eligibility / Validation

Fail-closed, deterministic validation with 7 rules, including:
- Rule 1 — source target existence (`CAD_MISSING_TARGET_NODE`)
- Rule 2 — duplicate declaration rejection by qualified identity (`CAD_DUPLICATE_DECLARATION`)
- Rule 3 — static target existence (`CAD_MISSING_STATIC_NODE`)
- Rule 4 — document-version coherence (`CAD_DOCUMENT_VERSION_MISMATCH`)
- Rule 5 — no inferred declarations (explicitly rejects `CollectionKey` existence, role text, `BindingValueDomain::Collection`, patch history, caller/host/backend state, and map order as inference sources)
- Rule 6 — no extra role requirement
- Rule 7 — no new reachability rule

Any declaration diagnostic means no qualified set, no `PreparedActiveProjectionTargets` value, and no runtime catalog construction from that input. No partial declaration set may escape. `CAD_*` diagnostics are a distinct namespace from Shell Player `SPV0_*` diagnostics and are not mapped to `SPV0_INVALID_TARGET`.

## Ordering and lifetime

Deterministic ordering: ascending `StaticNodeId` within the one bound `StaticDocumentId`/version. Authored order, `Vec` insertion order, hash-collection iteration, role name, `CollectionKey`, patch order, and runtime/backend/host/pointer order are all explicitly forbidden as ordering sources.

Declarations are immutable after qualification, bound to one projection structural version, and are not mutated by `ProjectionPatch`, `ShellSession`, catalog activity, or collection operations. Changing declarations requires a newly qualified projection structural version.

## CollectionAnchor source rule

`PreparedActiveProjectionTargets` obtains `CollectionAnchor` coordinates only from `QualifiedCollectionAnchorDeclarations` — no other source may contribute membership. Absence of an explicit declaration means no `CollectionAnchor` membership; a later collection patch targeting an undeclared node means stage-5 membership rejection once the runtime catalog exists.

## Boundary

```
CollectionAnchor declaration != Semantic collection truth
CollectionAnchor declaration != collection contents
CollectionAnchor declaration != action authorization
CollectionAnchor declaration != patch admission
CollectionAnchor declaration != patch application
CollectionAnchor declaration != renderer command
CollectionAnchor declaration != backend resource
CollectionAnchor declaration != runtime discovery
CollectionAnchor declaration != bundle trust
```

Declaration qualification does not load or activate a bundle, create a `ShellSession`, construct the runtime catalog, validate replay compatibility, apply a patch, advance the replay cursor, calculate candidate state, authorize effects, or move Gate D.

## Validation (scope)

Normative home is `docs/spec/ui/projection_source_model.md` §12 (new section, single specification, no duplication). `docs/spec/ui/shell_player_session_state_v0.md` receives only minimal cross-reference and status updates: the prior "does not exist and remains unresolved" `CollectionAnchor`-provenance paragraph in §7.1.9.5 now cross-references §12 instead of restating it; the unresolved lists in §7.1.9.14 and §13 are narrowed from one broad bullet to three specific implementation-only bullets; §15 final status gains `explicit CollectionAnchor declaration contract = FROZEN` and renames the implementation-status entry to `explicit CollectionAnchor declaration implementation = NOT AUTHORIZED`.

`.harness/current.task.yaml` authorizes only the seven documentation-contract concepts for this task (declaration ownership, identity, validation, ordering, diagnostic, prepared-activation-collection-source, and shell-player cross-reference-update contracts). All Rust/implementation/public-API/guard/catalog/evaluator/orchestration flags remain `false`. `gate_d: closed`.

Changed files (exactly 3):
- `.harness/current.task.yaml`
- `docs/spec/ui/projection_source_model.md`
- `docs/spec/ui/shell_player_session_state_v0.md`

No Rust files, no `Cargo.toml`/`Cargo.lock`, no workflow files, no snapshot files.

---

Draft PR. Not authorized to mark Ready or merge. No implementation, public API, catalog, evaluator, or orchestration work is authorized by this change.
