### PR TITLE
feat(ui): qualify explicit collection-anchor declarations

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,53 +1,67 @@
 task:
-  id: UI-DNA2-ROADMAP-SYNC-THROUGH-1536
-  title: rebaseline UI-DNA2 durable roadmap through PR #1536
-  type: documentation
+  id: COLLECTION-ANCHOR-DECLARATION-QUALIFICATION
+  title: qualify explicit CollectionAnchor declarations
+  type: implementation
   mode: active
 
 intent:
-  summary: "docs(ui): rebaseline UI-DNA2 roadmap through #1536"
+  summary: "feat(ui): qualify explicit collection-anchor declarations"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
+    - crates/prom-ui/src/contract_primitives.rs
+    - crates/prom-ui/src/projection_source.rs
+    - crates/prom-ui/src/projection_compile.rs
+    - crates/prom-ui/src/collection_anchor_declarations.rs
+    - crates/prom-ui/src/ui_dna2_collection_anchor_qualification_tests.rs
+    - crates/prom-ui/src/lib.rs
 
 authorization:
-  roadmap_evidence_baseline_update: true
-  merged_checkpoint_sync: true
-  landed_state_sync: true
-  research_matrix_sync: true
-  latest_checkpoint_sync: true
-  dependency_order_sync: true
-  acceptance_criteria_sync: true
-  unauthorized_contour_sync: true
+  rust_implementation: true
+  crate_private_only: true
+  programmatic_declaration_representation: true
+  collection_anchor_qualification: true
+  deterministic_diagnostics: true
+  qualification_tests: true
 
-  rust_implementation: false
-  normative_contract_change: false
-  ownership_change: false
-  authority_change: false
+  textual_grammar_change: false
+  parser_change: false
+  frontend_change: false
+  static_ir_artifact_change: false
+  canonical_encoding_change: false
+  prepared_transition_targets: false
+  prepared_activation_targets: false
+  runtime_catalog: false
+  activated_context_expansion: false
+  stage4_integration: false
+  stage5_evaluator: false
+  stage6_change: false
+  orchestration: false
+  patch_application: false
+  cursor_advancement: false
   public_api: false
   public_api_guard_changes: false
-  snapshot_changes: false
-  new_crate: false
   dependency_changes: false
   workflow_changes: false
+  roadmap_changes: false
   issue_1489_changes: false
   project_changes: false
-  next_slice_authorization: false
   gate_d_change: false
   production_promotion: false
 
   gate_d: closed
 
 constraints:
-  directional_roadmap_only: true
-  repository_truth_remains_external: true
-  roadmap_is_not_authority: true
-  landed_code_distinguished_from_contracts: true
-  concepts_distinguished_from_implementations: true
-  full_shell_player_not_claimed: true
-  patch_application_not_claimed: true
-  gate_d: closed
-  next_authorized_implementation_slice: none
+  no_std_alloc_compatible: true
   fail_closed: true
+  whole_set_only: true
+  no_partial_qualified_set: true
+  explicit_declarations_only: true
+  no_collection_anchor_inference: true
+  compiler_owned_source_to_static_mapping: true
+  deterministic_static_node_order: true
+  collection_key_is_not_anchor_identity: true
+  source_span_is_provenance_not_identity: true
+  no_public_surface_change: true
+  next_authorized_implementation_slice_after_this_task: none

--- a/crates/prom-ui/src/collection_anchor_declarations.rs
+++ b/crates/prom-ui/src/collection_anchor_declarations.rs
@@ -1,0 +1,294 @@
+//! Explicit `CollectionAnchor` declaration qualification.
+//!
+//! This module implements the crate-private, pure in-memory path frozen in
+//! `docs/spec/ui/projection_source_model.md` section 12:
+//!
+//! ```text
+//! ProjectionSourceNodeId declaration
+//!     -> deterministic source-to-static lowering
+//!     -> QualifiedCollectionAnchorDeclarations
+//! ```
+//!
+//! It does not implement `PreparedActiveProjectionTargets`,
+//! `PreparedProjectionPatchTargets`, `ActiveProjectionTargetCatalog`,
+//! `ActivatedShellSessionContext` expansion, stage-4/5/6 evaluation or
+//! orchestration, `ProjectionPatch` application, replay-cursor advancement,
+//! renderer/backend integration, or any public API.
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+use crate::contract_primitives::{
+    DiagnosticCode, DiagnosticCoordinate, Epoch, Revision, SourceRef, StaticDocumentId,
+    StaticNodeId,
+};
+use crate::projection_compile::lower_projection_source_node_id;
+use crate::projection_source::ProjectionSourceDocument;
+use crate::static_ir::StaticUiDocument;
+
+/// The deterministically qualified, whole-set collection-anchor evidence for
+/// exactly one validated projection-owned static document version.
+///
+/// Same-crate private construction is allowed only through
+/// [`qualify_collection_anchor_declarations`]. It is immutable, non-runtime,
+/// non-authoritative, and it is not `PreparedActiveProjectionTargets`, the
+/// runtime catalog, or prepared activation evidence by itself.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct QualifiedCollectionAnchorDeclarations {
+    document_id: StaticDocumentId,
+    revision: Revision,
+    epoch: Epoch,
+    anchors: Vec<StaticNodeId>,
+}
+
+impl QualifiedCollectionAnchorDeclarations {
+    fn new(
+        document_id: StaticDocumentId,
+        revision: Revision,
+        epoch: Epoch,
+        anchors: Vec<StaticNodeId>,
+    ) -> Self {
+        Self {
+            document_id,
+            revision,
+            epoch,
+            anchors,
+        }
+    }
+
+    pub(crate) const fn document_id(&self) -> StaticDocumentId {
+        self.document_id
+    }
+
+    pub(crate) const fn revision(&self) -> Revision {
+        self.revision
+    }
+
+    pub(crate) const fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+
+    pub(crate) fn anchors(&self) -> &[StaticNodeId] {
+        &self.anchors
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.anchors.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.anchors.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum CollectionAnchorDeclarationDiagnosticKind {
+    MissingTargetNode,
+    DuplicateDeclaration,
+    MissingStaticNode,
+    DocumentVersionMismatch,
+}
+
+impl CollectionAnchorDeclarationDiagnosticKind {
+    const fn code(self) -> DiagnosticCode {
+        match self {
+            Self::MissingTargetNode => DiagnosticCode::new("CAD_MISSING_TARGET_NODE"),
+            Self::DuplicateDeclaration => DiagnosticCode::new("CAD_DUPLICATE_DECLARATION"),
+            Self::MissingStaticNode => DiagnosticCode::new("CAD_MISSING_STATIC_NODE"),
+            Self::DocumentVersionMismatch => DiagnosticCode::new("CAD_DOCUMENT_VERSION_MISMATCH"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct CollectionAnchorDeclarationDiagnostic {
+    coordinate: DiagnosticCoordinate,
+    kind: CollectionAnchorDeclarationDiagnosticKind,
+}
+
+impl CollectionAnchorDeclarationDiagnostic {
+    fn new(
+        source: Option<SourceRef>,
+        kind: CollectionAnchorDeclarationDiagnosticKind,
+        domain: u64,
+        secondary: u64,
+    ) -> Self {
+        Self {
+            coordinate: DiagnosticCoordinate::new(source, kind.code(), domain, secondary),
+            kind,
+        }
+    }
+
+    pub(crate) const fn kind(self) -> CollectionAnchorDeclarationDiagnosticKind {
+        self.kind
+    }
+
+    pub(crate) const fn coordinate(self) -> DiagnosticCoordinate {
+        self.coordinate
+    }
+}
+
+impl Ord for CollectionAnchorDeclarationDiagnostic {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        (self.coordinate, self.kind).cmp(&(other.coordinate, other.kind))
+    }
+}
+
+impl PartialOrd for CollectionAnchorDeclarationDiagnostic {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CollectionAnchorDeclarationDiagnostics {
+    diagnostics: Vec<CollectionAnchorDeclarationDiagnostic>,
+}
+
+impl CollectionAnchorDeclarationDiagnostics {
+    fn new(mut diagnostics: Vec<CollectionAnchorDeclarationDiagnostic>) -> Self {
+        diagnostics.sort();
+        diagnostics.dedup();
+        Self { diagnostics }
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[CollectionAnchorDeclarationDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
+/// Deterministically qualifies every authored explicit `CollectionAnchor`
+/// declaration in `source` against `static_document`.
+///
+/// Qualification is atomic: either every declaration is valid and the
+/// complete deterministically ordered `QualifiedCollectionAnchorDeclarations`
+/// is returned, or the complete deterministically ordered diagnostic
+/// sequence is returned and no qualified set escapes.
+pub(crate) fn qualify_collection_anchor_declarations(
+    expected_document_id: StaticDocumentId,
+    source: &ProjectionSourceDocument,
+    static_document: &StaticUiDocument,
+) -> Result<QualifiedCollectionAnchorDeclarations, CollectionAnchorDeclarationDiagnostics> {
+    let mut diagnostics = Vec::new();
+
+    // Pass 1: Rule 1 (source target existence) and compiler-owned lowering.
+    // Every declaration that passes contributes one (StaticNodeId, SourceRef)
+    // pair, independent of whether its lowered target later turns out to
+    // exist in `static_document` (Rule 3). Duplicate identity (Rule 2) is
+    // already fully known at this point and must not depend on Rule 3
+    // succeeding.
+    let mut lowered: Vec<(StaticNodeId, SourceRef)> = Vec::new();
+    for declaration in source.collection_anchor_declarations() {
+        let target = declaration.target();
+
+        if !source.nodes().iter().any(|node| node.id() == target) {
+            diagnostics.push(CollectionAnchorDeclarationDiagnostic::new(
+                Some(declaration.source()),
+                CollectionAnchorDeclarationDiagnosticKind::MissingTargetNode,
+                target.raw(),
+                0,
+            ));
+            continue;
+        }
+
+        // Compiler-owned deterministic lowering; the same function used by
+        // `compile_projection_source_to_static_ir`. A non-zero
+        // `ProjectionSourceNodeId` always lowers, so this branch is
+        // defensive rather than reachable in practice.
+        let Some(static_id) = lower_projection_source_node_id(target) else {
+            diagnostics.push(CollectionAnchorDeclarationDiagnostic::new(
+                Some(declaration.source()),
+                CollectionAnchorDeclarationDiagnosticKind::MissingTargetNode,
+                target.raw(),
+                0,
+            ));
+            continue;
+        };
+
+        lowered.push((static_id, declaration.source()));
+    }
+
+    // Rule 2 -- duplicate qualified declaration, computed over every
+    // successfully lowered declaration regardless of static membership.
+    // Duplicate identity is the qualified StaticNodeId; the diagnostic's
+    // provenance is the least SourceRef among the contributing declarations
+    // (`SourceRef: Ord` over `(SourceId, SourceSpan)`), which is deterministic
+    // and independent of authored declaration order or `Vec` insertion order.
+    let mut duplicated_ids: Vec<StaticNodeId> = Vec::new();
+    {
+        let mut seen: Vec<StaticNodeId> = Vec::new();
+        for (id, _) in &lowered {
+            if seen.contains(id) {
+                if !duplicated_ids.contains(id) {
+                    duplicated_ids.push(*id);
+                }
+            } else {
+                seen.push(*id);
+            }
+        }
+    }
+    for id in &duplicated_ids {
+        let provenance = lowered
+            .iter()
+            .filter(|(candidate, _)| candidate == id)
+            .map(|(_, source_ref)| *source_ref)
+            .min()
+            .expect("a duplicated id has at least two contributing declarations");
+        diagnostics.push(CollectionAnchorDeclarationDiagnostic::new(
+            Some(provenance),
+            CollectionAnchorDeclarationDiagnosticKind::DuplicateDeclaration,
+            id.raw(),
+            0,
+        ));
+    }
+
+    // Rule 3 -- static target existence, evaluated independently of Rule 2
+    // over the same lowered set.
+    let mut qualified: Vec<StaticNodeId> = Vec::new();
+    for (id, source_ref) in &lowered {
+        if !static_document.nodes().iter().any(|node| node.id() == *id) {
+            diagnostics.push(CollectionAnchorDeclarationDiagnostic::new(
+                Some(*source_ref),
+                CollectionAnchorDeclarationDiagnosticKind::MissingStaticNode,
+                id.raw(),
+                0,
+            ));
+            continue;
+        }
+        qualified.push(*id);
+    }
+
+    // Rule 4 -- document-version coherence. The expected revision and epoch
+    // are the source document's own revision and epoch.
+    if static_document.id() != expected_document_id
+        || static_document.revision() != source.revision()
+        || static_document.epoch() != source.epoch()
+    {
+        diagnostics.push(CollectionAnchorDeclarationDiagnostic::new(
+            None,
+            CollectionAnchorDeclarationDiagnosticKind::DocumentVersionMismatch,
+            expected_document_id.raw(),
+            static_document.id().raw(),
+        ));
+    }
+
+    if !diagnostics.is_empty() {
+        return Err(CollectionAnchorDeclarationDiagnostics::new(diagnostics));
+    }
+
+    // Rule 7 -- deterministic ordering by ascending StaticNodeId, independent
+    // of authored declaration order.
+    let mut anchors = qualified;
+    anchors.sort();
+
+    Ok(QualifiedCollectionAnchorDeclarations::new(
+        expected_document_id,
+        source.revision(),
+        source.epoch(),
+        anchors,
+    ))
+}

--- a/crates/prom-ui/src/lib.rs
+++ b/crates/prom-ui/src/lib.rs
@@ -39,6 +39,7 @@ pub mod admitted_action;
 pub(crate) mod binding_graph;
 pub(crate) mod binding_graph_observation;
 pub(crate) mod binding_graph_semantic_adapter;
+pub(crate) mod collection_anchor_declarations;
 pub mod commit_boundary;
 pub mod commit_boundary_result;
 pub mod committed_effect;
@@ -90,6 +91,8 @@ pub mod validation;
 mod ui_dna2_binding_observation_qualification_tests;
 #[cfg(test)]
 mod ui_dna2_binding_semantic_adapter_qualification_tests;
+#[cfg(test)]
+mod ui_dna2_collection_anchor_qualification_tests;
 #[cfg(test)]
 mod ui_dna2_denial_recovery_qualification_tests;
 #[cfg(test)]

--- a/crates/prom-ui/src/projection_compile.rs
+++ b/crates/prom-ui/src/projection_compile.rs
@@ -4,8 +4,8 @@
 use alloc::vec::Vec;
 
 use crate::contract_primitives::{
-    ChildOrder, DiagnosticCode, DiagnosticCoordinate, StaticDocumentId, StaticNodeId,
-    StaticSurfaceId,
+    ChildOrder, DiagnosticCode, DiagnosticCoordinate, ProjectionSourceNodeId, StaticDocumentId,
+    StaticNodeId, StaticSurfaceId,
 };
 use crate::projection_source::{
     ProjectionSourceDiagnosticKind, ProjectionSourceDiagnostics, ProjectionSourceDocument,
@@ -35,14 +35,14 @@ pub(crate) fn compile_projection_source_to_static_ir(
                 ))
             })?;
         let mut static_node = StaticUiNode::new(
-            static_node_id(source_node.id().raw())?,
+            static_node_id(source_node.id())?,
             role,
             source_node.key(),
             Some(source_node.source()),
         );
         for child in source_node.children() {
             static_node.push_child(StaticUiChild::new(
-                static_node_id(child.child().raw())?,
+                static_node_id(child.child())?,
                 ChildOrder::new(child.order().raw()),
             ));
         }
@@ -52,7 +52,7 @@ pub(crate) fn compile_projection_source_to_static_ir(
     for surface in normalized.surfaces() {
         document.push_surface(StaticUiSurface::new(
             static_surface_id(surface.id().raw())?,
-            static_node_id(surface.root().raw())?,
+            static_node_id(surface.root())?,
             surface.key(),
             Some(surface.source()),
         ));
@@ -63,11 +63,22 @@ pub(crate) fn compile_projection_source_to_static_ir(
         .map_err(ProjectionCompileDiagnostics::from_static_ir)
 }
 
-fn static_node_id(raw: u64) -> Result<StaticNodeId, ProjectionCompileDiagnostics> {
-    StaticNodeId::new(raw).map_err(|_| {
+/// The compiler's sole deterministic `ProjectionSourceNodeId -> StaticNodeId`
+/// lowering. This is the one mapping policy for the crate; any other
+/// crate-private consumer that needs the same lowering (for example,
+/// explicit `CollectionAnchor` declaration qualification) must call this
+/// function rather than reimplement the mapping.
+pub(crate) fn lower_projection_source_node_id(id: ProjectionSourceNodeId) -> Option<StaticNodeId> {
+    StaticNodeId::new(id.raw()).ok()
+}
+
+fn static_node_id(
+    id: ProjectionSourceNodeId,
+) -> Result<StaticNodeId, ProjectionCompileDiagnostics> {
+    lower_projection_source_node_id(id).ok_or_else(|| {
         ProjectionCompileDiagnostics::from_compile_kind(
             ProjectionCompileDiagnosticKind::InvalidLoweredIdentity,
-            raw,
+            id.raw(),
             0,
         )
     })

--- a/crates/prom-ui/src/projection_source.rs
+++ b/crates/prom-ui/src/projection_source.rs
@@ -182,6 +182,33 @@ impl ProjectionSourceNode {
     }
 }
 
+/// One authored explicit `CollectionAnchor` declaration.
+///
+/// A declaration means only that the identified projection-owned static node
+/// is explicitly declared and qualified as an eligible collection patch
+/// target. It carries no role, `CollectionKey`, binding coordinate, patch
+/// operation, runtime state, backend state, Semantic value, or authority
+/// field; see `docs/spec/ui/projection_source_model.md` section 12.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ProjectionSourceCollectionAnchorDeclaration {
+    target: ProjectionSourceNodeId,
+    source: SourceRef,
+}
+
+impl ProjectionSourceCollectionAnchorDeclaration {
+    pub(crate) const fn new(target: ProjectionSourceNodeId, source: SourceRef) -> Self {
+        Self { target, source }
+    }
+
+    pub(crate) const fn target(self) -> ProjectionSourceNodeId {
+        self.target
+    }
+
+    pub(crate) const fn source(self) -> SourceRef {
+        self.source
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ProjectionSourceDocument {
     source_id: SourceId,
@@ -189,6 +216,7 @@ pub(crate) struct ProjectionSourceDocument {
     epoch: Epoch,
     surfaces: Vec<ProjectionSourceSurface>,
     nodes: Vec<ProjectionSourceNode>,
+    collection_anchor_declarations: Vec<ProjectionSourceCollectionAnchorDeclaration>,
 }
 
 impl ProjectionSourceDocument {
@@ -199,6 +227,7 @@ impl ProjectionSourceDocument {
             epoch,
             surfaces: Vec::new(),
             nodes: Vec::new(),
+            collection_anchor_declarations: Vec::new(),
         }
     }
 
@@ -228,6 +257,19 @@ impl ProjectionSourceDocument {
 
     pub(crate) fn push_node(&mut self, node: ProjectionSourceNode) {
         self.nodes.push(node);
+    }
+
+    pub(crate) fn collection_anchor_declarations(
+        &self,
+    ) -> &[ProjectionSourceCollectionAnchorDeclaration] {
+        &self.collection_anchor_declarations
+    }
+
+    pub(crate) fn push_collection_anchor_declaration(
+        &mut self,
+        declaration: ProjectionSourceCollectionAnchorDeclaration,
+    ) {
+        self.collection_anchor_declarations.push(declaration);
     }
 
     pub(crate) fn validate(

--- a/crates/prom-ui/src/ui_dna2_collection_anchor_qualification_tests.rs
+++ b/crates/prom-ui/src/ui_dna2_collection_anchor_qualification_tests.rs
@@ -1,0 +1,589 @@
+//! UI-DNA2 explicit `CollectionAnchor` declaration qualification tests.
+//!
+//! These tests qualify the crate-private, pure in-memory
+//! `ProjectionSourceNodeId` declaration -> deterministic source-to-static
+//! lowering -> `QualifiedCollectionAnchorDeclarations` path only. They do not
+//! exercise prepared-handoff, catalog, stage-4/5/6, patch-application, or
+//! public-API surfaces, which remain separately unauthorized.
+
+use crate::collection_anchor_declarations::{
+    qualify_collection_anchor_declarations, CollectionAnchorDeclarationDiagnosticKind,
+};
+use crate::contract_primitives::{
+    ChildOrder, CollectionKey, DiagnosticCode, Epoch, ProjectionSourceNodeId,
+    ProjectionSourceSurfaceId, Revision, SourceId, SourceRef, SourceSpan, StaticDocumentId,
+    StaticNodeId, StaticSurfaceId,
+};
+use crate::projection_compile::{
+    compile_projection_source_to_static_ir, lower_projection_source_node_id,
+};
+use crate::projection_source::{
+    ProjectionSourceChild, ProjectionSourceCollectionAnchorDeclaration, ProjectionSourceDocument,
+    ProjectionSourceNode, ProjectionSourceRoleName, ProjectionSourceSurface,
+};
+use crate::role_dictionary::{RoleDictionary, RoleId};
+use crate::static_ir::{StaticUiDocument, StaticUiNode, StaticUiSurface};
+
+fn source_ref(start: u32, end: u32) -> SourceRef {
+    SourceRef::new(
+        SourceId::new(1).expect("source id"),
+        SourceSpan::new(start, end).expect("source span"),
+    )
+}
+
+fn node_id(raw: u64) -> ProjectionSourceNodeId {
+    ProjectionSourceNodeId::new(raw).expect("source node id")
+}
+
+fn static_node_id(raw: u64) -> StaticNodeId {
+    StaticNodeId::new(raw).expect("static node id")
+}
+
+fn key(raw: u64) -> CollectionKey {
+    CollectionKey::new(raw).expect("collection key")
+}
+
+fn static_doc_id(raw: u64) -> StaticDocumentId {
+    StaticDocumentId::new(raw).expect("static document id")
+}
+
+fn declaration(target: u64, span: (u32, u32)) -> ProjectionSourceCollectionAnchorDeclaration {
+    ProjectionSourceCollectionAnchorDeclaration::new(node_id(target), source_ref(span.0, span.1))
+}
+
+/// A source document with one root and `count` reachable children at raw ids
+/// `20, 21, 22, ...`.
+fn source_with_children(count: u64) -> ProjectionSourceDocument {
+    let mut source = ProjectionSourceDocument::new(
+        SourceId::new(1).expect("source id"),
+        Revision::new(1),
+        Epoch::new(1),
+    );
+    let mut root = ProjectionSourceNode::new(
+        node_id(10),
+        ProjectionSourceRoleName::new("root"),
+        key(10),
+        source_ref(0, 1),
+    );
+    for index in 0..count {
+        root.push_child(ProjectionSourceChild::new(
+            node_id(20 + index),
+            ChildOrder::new(index as u32),
+        ));
+    }
+    source.push_node(root);
+    for index in 0..count {
+        source.push_node(ProjectionSourceNode::new(
+            node_id(20 + index),
+            ProjectionSourceRoleName::new("text"),
+            key(20 + index),
+            source_ref(0, 1),
+        ));
+    }
+    source.push_surface(ProjectionSourceSurface::new(
+        ProjectionSourceSurfaceId::new(1).expect("surface id"),
+        node_id(10),
+        key(1),
+        source_ref(0, 1),
+    ));
+    source
+}
+
+fn compiled(source: &ProjectionSourceDocument) -> StaticUiDocument {
+    compile_projection_source_to_static_ir(static_doc_id(1), source, RoleDictionary::current())
+        .expect("compiled")
+}
+
+/// A static document matching `source`'s identity/version that contains only
+/// the root node (raw id 10), intentionally omitting every other node so
+/// that any declaration targeting them fails Rule 3 (static membership)
+/// while still passing Rule 1 (source membership).
+fn missing_node_static_document(source: &ProjectionSourceDocument) -> StaticUiDocument {
+    let mut static_document =
+        StaticUiDocument::new(static_doc_id(1), source.revision(), source.epoch());
+    static_document.push_node(StaticUiNode::new(
+        static_node_id(10),
+        RoleId::new("root"),
+        key(10),
+        Some(source_ref(0, 1)),
+    ));
+    static_document.push_surface(StaticUiSurface::new(
+        StaticSurfaceId::new(1).expect("surface id"),
+        static_node_id(10),
+        key(1),
+        Some(source_ref(0, 1)),
+    ));
+    static_document
+}
+
+// 1. Empty declaration set succeeds.
+#[test]
+fn collection_anchor_qualification_empty_declaration_set_succeeds() {
+    let source = source_with_children(2);
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("empty set qualifies");
+
+    assert!(qualified.is_empty());
+    assert_eq!(qualified.len(), 0);
+    assert_eq!(qualified.document_id(), static_doc_id(1));
+    assert_eq!(qualified.revision(), Revision::new(1));
+    assert_eq!(qualified.epoch(), Epoch::new(1));
+}
+
+// 2. One explicit declaration succeeds.
+#[test]
+fn collection_anchor_qualification_single_declaration_succeeds() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (2, 3)));
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("single declaration qualifies");
+
+    assert_eq!(qualified.anchors(), &[static_node_id(20)]);
+}
+
+// 3. Multiple declarations are returned in ascending StaticNodeId.
+#[test]
+fn collection_anchor_qualification_orders_ascending_static_node_id() {
+    let mut source = source_with_children(3);
+    source.push_collection_anchor_declaration(declaration(22, (0, 1)));
+    source.push_collection_anchor_declaration(declaration(20, (2, 3)));
+    source.push_collection_anchor_declaration(declaration(21, (4, 5)));
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("qualifies");
+
+    assert_eq!(
+        qualified.anchors(),
+        &[static_node_id(20), static_node_id(21), static_node_id(22)]
+    );
+}
+
+// 4. Reversed authored order produces the identical qualified result.
+#[test]
+fn collection_anchor_qualification_is_authored_order_independent() {
+    let mut forward = source_with_children(3);
+    forward.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    forward.push_collection_anchor_declaration(declaration(21, (2, 3)));
+    forward.push_collection_anchor_declaration(declaration(22, (4, 5)));
+
+    let mut reversed = source_with_children(3);
+    reversed.push_collection_anchor_declaration(declaration(22, (4, 5)));
+    reversed.push_collection_anchor_declaration(declaration(21, (2, 3)));
+    reversed.push_collection_anchor_declaration(declaration(20, (0, 1)));
+
+    let static_document = compiled(&forward);
+
+    let forward_qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &forward, &static_document)
+            .expect("forward qualifies");
+    let reversed_qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &reversed, &static_document)
+            .expect("reversed qualifies");
+
+    assert_eq!(forward_qualified, reversed_qualified);
+}
+
+// 5. Missing source target produces only CAD_MISSING_TARGET_NODE.
+#[test]
+fn collection_anchor_qualification_missing_source_target_is_isolated() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(999, (0, 1)));
+    let static_document = compiled(&source);
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("missing target");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::MissingTargetNode
+    );
+    assert_eq!(
+        diagnostics.diagnostics()[0].coordinate().code(),
+        DiagnosticCode::new("CAD_MISSING_TARGET_NODE")
+    );
+}
+
+// 6. Duplicate declaration produces CAD_DUPLICATE_DECLARATION with
+// deterministic SourceRef provenance (the least SourceRef among the
+// contributing declarations).
+#[test]
+fn collection_anchor_qualification_rejects_duplicate_declaration() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    source.push_collection_anchor_declaration(declaration(20, (2, 3)));
+    let static_document = compiled(&source);
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("duplicate declaration");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::DuplicateDeclaration
+    );
+    assert_eq!(
+        diagnostics.diagnostics()[0].coordinate().code(),
+        DiagnosticCode::new("CAD_DUPLICATE_DECLARATION")
+    );
+    assert_eq!(
+        diagnostics.diagnostics()[0].coordinate().source(),
+        Some(source_ref(0, 1))
+    );
+}
+
+// 6a. Duplicate diagnostic provenance is independent of authored order: the
+// same least SourceRef is selected regardless of which declaration was
+// pushed first.
+#[test]
+fn collection_anchor_qualification_duplicate_diagnostic_is_authored_order_independent() {
+    let mut forward = source_with_children(1);
+    forward.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    forward.push_collection_anchor_declaration(declaration(20, (2, 3)));
+
+    let mut reversed = source_with_children(1);
+    reversed.push_collection_anchor_declaration(declaration(20, (2, 3)));
+    reversed.push_collection_anchor_declaration(declaration(20, (0, 1)));
+
+    let static_document = compiled(&forward);
+
+    let forward_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &forward, &static_document)
+            .expect_err("forward duplicate");
+    let reversed_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &reversed, &static_document)
+            .expect_err("reversed duplicate");
+
+    assert_eq!(forward_diagnostics, reversed_diagnostics);
+    assert_eq!(
+        forward_diagnostics.diagnostics()[0].coordinate().source(),
+        Some(source_ref(0, 1))
+    );
+}
+
+// 6b. A duplicate declaration whose lowered target is also absent from the
+// static document must still be reported as CAD_DUPLICATE_DECLARATION;
+// duplicate detection must not depend on Rule 3 (static membership)
+// succeeding.
+#[test]
+fn collection_anchor_qualification_duplicate_with_missing_static_node() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    source.push_collection_anchor_declaration(declaration(20, (2, 3)));
+
+    // A static document that matches source identity/version but omits the
+    // lowered node entirely.
+    let static_document = missing_node_static_document(&source);
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("duplicate plus missing static node");
+
+    assert!(diagnostics.diagnostics().iter().any(|diagnostic| {
+        diagnostic.kind() == CollectionAnchorDeclarationDiagnosticKind::DuplicateDeclaration
+    }));
+    assert!(diagnostics.diagnostics().iter().any(|diagnostic| {
+        diagnostic.kind() == CollectionAnchorDeclarationDiagnosticKind::MissingStaticNode
+    }));
+}
+
+// 6c. The combined duplicate-plus-missing-static-node diagnostic set is
+// identical regardless of authored declaration order.
+#[test]
+fn collection_anchor_qualification_duplicate_with_missing_static_node_is_order_independent() {
+    let mut forward = source_with_children(1);
+    forward.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    forward.push_collection_anchor_declaration(declaration(20, (2, 3)));
+
+    let mut reversed = source_with_children(1);
+    reversed.push_collection_anchor_declaration(declaration(20, (2, 3)));
+    reversed.push_collection_anchor_declaration(declaration(20, (0, 1)));
+
+    let static_document = missing_node_static_document(&forward);
+
+    let forward_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &forward, &static_document)
+            .expect_err("forward");
+    let reversed_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &reversed, &static_document)
+            .expect_err("reversed");
+
+    assert_eq!(forward_diagnostics, reversed_diagnostics);
+}
+
+// 7. Lowered target absent from the static document produces CAD_MISSING_STATIC_NODE.
+#[test]
+fn collection_anchor_qualification_missing_static_node_is_isolated() {
+    let mut source = source_with_children(2);
+    source.push_collection_anchor_declaration(declaration(21, (0, 1)));
+
+    // A static document that matches source identity/version but omits the
+    // lowered node, isolating Rule 3 from Rule 1 and Rule 4.
+    let mut static_document =
+        StaticUiDocument::new(static_doc_id(1), source.revision(), source.epoch());
+    static_document.push_node(StaticUiNode::new(
+        static_node_id(10),
+        RoleId::new("root"),
+        key(10),
+        Some(source_ref(0, 1)),
+    ));
+    static_document.push_node(StaticUiNode::new(
+        static_node_id(20),
+        RoleId::new("text"),
+        key(20),
+        Some(source_ref(0, 1)),
+    ));
+    static_document.push_surface(StaticUiSurface::new(
+        StaticSurfaceId::new(1).expect("surface id"),
+        static_node_id(10),
+        key(1),
+        Some(source_ref(0, 1)),
+    ));
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("missing static node");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::MissingStaticNode
+    );
+    assert_eq!(
+        diagnostics.diagnostics()[0].coordinate().code(),
+        DiagnosticCode::new("CAD_MISSING_STATIC_NODE")
+    );
+}
+
+// 8. Static document ID mismatch produces CAD_DOCUMENT_VERSION_MISMATCH.
+#[test]
+fn collection_anchor_qualification_document_id_mismatch_is_isolated() {
+    let source = source_with_children(1);
+    let static_document = compile_projection_source_to_static_ir(
+        static_doc_id(2),
+        &source,
+        RoleDictionary::current(),
+    )
+    .expect("compiled");
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("document id mismatch");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::DocumentVersionMismatch
+    );
+    assert_eq!(
+        diagnostics.diagnostics()[0].coordinate().code(),
+        DiagnosticCode::new("CAD_DOCUMENT_VERSION_MISMATCH")
+    );
+}
+
+// 9. Revision mismatch produces CAD_DOCUMENT_VERSION_MISMATCH.
+#[test]
+fn collection_anchor_qualification_revision_mismatch_is_isolated() {
+    let source = source_with_children(1);
+    let compiled_document = compiled(&source);
+
+    let mut static_document =
+        StaticUiDocument::new(static_doc_id(1), Revision::new(999), source.epoch());
+    for node in compiled_document.nodes() {
+        static_document.push_node(node.clone());
+    }
+    for surface in compiled_document.surfaces() {
+        static_document.push_surface(surface.clone());
+    }
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("revision mismatch");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::DocumentVersionMismatch
+    );
+}
+
+// 10. Epoch mismatch produces CAD_DOCUMENT_VERSION_MISMATCH.
+#[test]
+fn collection_anchor_qualification_epoch_mismatch_is_isolated() {
+    let source = source_with_children(1);
+    let compiled_document = compiled(&source);
+
+    let mut static_document =
+        StaticUiDocument::new(static_doc_id(1), source.revision(), Epoch::new(999));
+    for node in compiled_document.nodes() {
+        static_document.push_node(node.clone());
+    }
+    for surface in compiled_document.surfaces() {
+        static_document.push_surface(surface.clone());
+    }
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("epoch mismatch");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::DocumentVersionMismatch
+    );
+}
+
+// 11. One valid plus one invalid declaration returns no partial set.
+#[test]
+fn collection_anchor_qualification_rejects_partial_set_on_mixed_validity() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    source.push_collection_anchor_declaration(declaration(999, (2, 3)));
+    let static_document = compiled(&source);
+
+    let diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect_err("no partial set");
+
+    assert_eq!(diagnostics.diagnostics().len(), 1);
+    assert_eq!(
+        diagnostics.diagnostics()[0].kind(),
+        CollectionAnchorDeclarationDiagnosticKind::MissingTargetNode
+    );
+}
+
+// 12. Equivalent invalid inputs with different authored order produce
+// identical ordered diagnostics.
+#[test]
+fn collection_anchor_qualification_invalid_diagnostics_are_order_independent() {
+    let mut forward = source_with_children(2);
+    forward.push_collection_anchor_declaration(declaration(998, (0, 1)));
+    forward.push_collection_anchor_declaration(declaration(999, (2, 3)));
+
+    let mut reversed = source_with_children(2);
+    reversed.push_collection_anchor_declaration(declaration(999, (2, 3)));
+    reversed.push_collection_anchor_declaration(declaration(998, (0, 1)));
+
+    let static_document = compiled(&forward);
+
+    let forward_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &forward, &static_document)
+            .expect_err("forward invalid");
+    let reversed_diagnostics =
+        qualify_collection_anchor_declarations(static_doc_id(1), &reversed, &static_document)
+            .expect_err("reversed invalid");
+
+    assert_eq!(forward_diagnostics, reversed_diagnostics);
+}
+
+// 13. Existing nodes without explicit declarations produce an empty set.
+#[test]
+fn collection_anchor_qualification_nodes_without_declarations_are_not_inferred() {
+    let source = source_with_children(3);
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("empty declarations qualify");
+
+    assert!(qualified.is_empty());
+}
+
+// 14. A valid explicit declaration does not require a list-like role.
+#[test]
+fn collection_anchor_qualification_does_not_require_list_like_role() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("qualifies despite non-list role");
+
+    assert_eq!(qualified.anchors(), &[static_node_id(20)]);
+}
+
+// 15. CollectionKey does not participate in qualified identity.
+#[test]
+fn collection_anchor_qualification_ignores_collection_key_identity() {
+    let mut source = ProjectionSourceDocument::new(
+        SourceId::new(1).expect("source id"),
+        Revision::new(1),
+        Epoch::new(1),
+    );
+    let mut root = ProjectionSourceNode::new(
+        node_id(10),
+        ProjectionSourceRoleName::new("root"),
+        key(10),
+        source_ref(0, 1),
+    );
+    root.push_child(ProjectionSourceChild::new(node_id(20), ChildOrder::new(0)));
+    source.push_node(root);
+    // CollectionKey deliberately unrelated to node identity.
+    source.push_node(ProjectionSourceNode::new(
+        node_id(20),
+        ProjectionSourceRoleName::new("text"),
+        key(555),
+        source_ref(0, 1),
+    ));
+    source.push_surface(ProjectionSourceSurface::new(
+        ProjectionSourceSurfaceId::new(1).expect("surface id"),
+        node_id(10),
+        key(1),
+        source_ref(0, 1),
+    ));
+    source.push_collection_anchor_declaration(declaration(20, (2, 3)));
+
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("qualifies regardless of CollectionKey value");
+
+    assert_eq!(qualified.anchors(), &[static_node_id(20)]);
+}
+
+// 16. Repeated qualification of identical input is exactly equal.
+#[test]
+fn collection_anchor_qualification_repeated_qualification_is_equal() {
+    let mut source = source_with_children(2);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    source.push_collection_anchor_declaration(declaration(21, (2, 3)));
+    let static_document = compiled(&source);
+
+    let first = qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+        .expect("first");
+    let second =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("second");
+
+    assert_eq!(first, second);
+}
+
+// 17. The source-to-static lowering used by qualification matches the
+// compiler's lowering path.
+#[test]
+fn collection_anchor_qualification_lowering_matches_compiler_lowering() {
+    let mut source = source_with_children(1);
+    source.push_collection_anchor_declaration(declaration(20, (0, 1)));
+    let static_document = compiled(&source);
+
+    let qualified =
+        qualify_collection_anchor_declarations(static_doc_id(1), &source, &static_document)
+            .expect("qualifies");
+
+    let expected =
+        lower_projection_source_node_id(node_id(20)).expect("compiler lowering succeeds");
+
+    assert_eq!(qualified.anchors()[0], expected);
+}


### PR DESCRIPTION
## Result

Implements the crate-private, pure in-memory qualification path for explicit
`CollectionAnchor` declarations in `prom-ui`.

The implementation provides:

- an authored `ProjectionSourceCollectionAnchorDeclaration`;
- declaration storage in `ProjectionSourceDocument`;
- immutable `QualifiedCollectionAnchorDeclarations`;
- deterministic source-to-static qualification;
- whole-set fail-closed behavior;
- stable `CAD_*` diagnostics;
- ascending-`StaticNodeId` qualified ordering;
- 20 focused qualification tests.

## Contract implemented

The implemented path is:

```text
explicit ProjectionSourceNodeId declaration
    -> compiler-owned source-to-static lowering
    -> source/static/version qualification
    -> QualifiedCollectionAnchorDeclarations
```

The qualified result is bound coherently to:

* `StaticDocumentId`;
* `Revision`;
* `Epoch`.

An empty explicit declaration set is valid.
No implicit collection-anchor inference is performed.

## Validation rules

The implementation enforces the frozen declaration rules:

1. authored source target existence;
2. duplicate declaration rejection by qualified static identity;
3. static target existence;
4. document, revision and epoch coherence;
5. no inferred declarations;
6. no role-name requirement;
7. deterministic ascending-`StaticNodeId` output.

Any diagnostic rejects the complete declaration set. No partial qualified set
escapes.

## Diagnostics

The implementation preserves the dedicated projection-qualification diagnostic
namespace:

* `CAD_MISSING_TARGET_NODE`;
* `CAD_DUPLICATE_DECLARATION`;
* `CAD_MISSING_STATIC_NODE`;
* `CAD_DOCUMENT_VERSION_MISMATCH`.

Diagnostics are deterministically ordered and deduplicated.

Duplicate declaration diagnostics preserve deterministic source provenance by
selecting the least contributing `SourceRef`, independently of authored
insertion order.

Duplicate detection and static-membership validation are independent. A
duplicate declaration whose lowered target is absent from the static document
reports both applicable diagnostic classes.

`CAD_*` diagnostics are not translated into Shell Player `SPV0_*` diagnostics.

## Source-to-static ownership

`projection_compile` remains the sole owner of deterministic
`ProjectionSourceNodeId -> StaticNodeId` lowering.

The existing lowering helper was narrowed into one shared crate-private
function used by both:

* Projection Source compilation;
* CollectionAnchor declaration qualification.

No second mapping policy or public lowering API was introduced.

## Qualification

Focused tests cover:

* empty and single declaration sets;
* deterministic ascending qualified order;
* authored-order independence;
* missing source targets;
* duplicate declarations;
* deterministic duplicate provenance;
* missing static targets;
* combined duplicate and missing-static diagnostics;
* combined-diagnostic order independence;
* document ID, revision and epoch mismatches;
* atomic no-partial-result behavior;
* absence of inference;
* absence of role requirements;
* `CollectionKey` exclusion from identity;
* repeatability;
* compiler-lowering coherence.

## Validation

Passed on exact head:
`327c52bb05191a5e6a01f93d7a32874f119540c3`

* `pwsh -NoProfile -File scripts/harness-check.ps1`;
* `cargo fmt --check`;
* `cargo check -p prom-ui --all-targets --all-features`;
* `cargo test -p prom-ui --all-features`;
* `cargo clippy -p prom-ui --all-targets --all-features -- -D warnings`;
* `cargo test --test public_api_contracts`;
* `cargo check --workspace --all-targets --all-features --keep-going`;
* committed-range `git diff --check`.

The package-level:

```text
cargo check -p prom-ui --no-default-features
```

retains the independently compared parent-baseline failure set in untouched
legacy modules. The exact compiler error locations are unchanged between parent
`70fbc36a0533698ec17434bcd34f6f50844682e1` and this candidate. No
CollectionAnchor candidate file is implicated.

## Scope

Changed files:

* `.harness/current.task.yaml`;
* `crates/prom-ui/src/collection_anchor_declarations.rs`;
* `crates/prom-ui/src/lib.rs`;
* `crates/prom-ui/src/projection_compile.rs`;
* `crates/prom-ui/src/projection_source.rs`;
* `crates/prom-ui/src/ui_dna2_collection_anchor_qualification_tests.rs`.

No Cargo manifest, lockfile, workflow, normative specification, roadmap,
runtime, renderer or backend file is changed.

## Boundary

This PR does not implement or authorize:

* textual Projection Source declaration syntax;
* parser or frontend changes;
* `PreparedProjectionPatchTargets`;
* `PreparedActiveProjectionTargets`;
* `ActiveProjectionTargetCatalog`;
* `ActivatedShellSessionContext` expansion;
* stage-4 prepared-evidence integration;
* stage-5 stable-target evaluation;
* stage-5/stage-6 orchestration;
* ProjectionPatch application;
* replay-cursor advancement;
* candidate-state calculation or commit;
* renderer/backend integration;
* public stage-5 bridge;
* Gate D activation;
* production promotion.

```text
explicit declaration != Semantic collection truth
qualification != prepared activation evidence
qualification != runtime catalog construction
qualification != stage-5 acceptance
qualification != patch application
implementation != public API
Gate D = CLOSED
production promotion = NOT AUTHORIZED
```

Draft PR.
Not authorized to mark Ready or merge.

Refs #1489
