### PR TITLE
feat(language): freeze canonical Semantic source style v0

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,134 +1,59 @@
 task:
-  id: UI-DNA2-END-TO-END-GATE-D-TURBO
-  title: complete UI-DNA2 end-to-end, activate Gate D for one bounded reference contour, close #1489
+  id: LANGUAGE-CANONICAL-SOURCE-STYLE-V0
+  title: define canonical compact source style and structured program layout, close #1538
   type: implementation
   mode: active
-  supersedes: SHELL-PLAYER-END-TO-END-TURBO
-  authorized_by: "Issue #1543 (repository owner direct instruction), umbrella Issue #1489"
+  supersedes: UI-DNA2-END-TO-END-GATE-D-TURBO
+  authorized_by: "Issue #1538 (repository owner direct instruction)"
 
 intent:
-  summary: "feat(ui): complete UI-DNA2 end-to-end reference application, activate Gate D with limits"
+  summary: "feat(language): freeze canonical Semantic source style v0"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - Cargo.toml
-    - Cargo.lock
-    - crates/prom-ui/Cargo.toml
-    - crates/prom-ui/src/**
-    - crates/prom-ui/tests/**
-    - crates/prom-ui-runtime/Cargo.toml
-    - crates/prom-ui-runtime/src/**
-    - crates/prom-ui-runtime/tests/**
-    - crates/prom-ui-backend-native/Cargo.toml
-    - crates/prom-ui-backend-native/src/**
-    - crates/prom-ui-backend-native/tests/**
-    - crates/prom-ui-demo/Cargo.toml
-    - crates/prom-ui-demo/src/**
-    - tests/public_api_contracts.rs
-    - tests/golden_snapshots/public_api/**
-    - docs/roadmap/post_ui/ui_dna2_implementation_roadmap.md
-    - docs/spec/ui/projection_source_grammar_v0.md
-    - docs/spec/ui/projection_source_model.md
-    - docs/spec/ui/projection_bundle_v0.md
-    - docs/spec/ui/shell_player_session_state_v0.md
-    - docs/spec/ui/gate_d_activation_policy_v0.md
+    - docs/spec/source_style.md
+    - docs/spec/index.md
+    - docs/examples_index.md
+    - docs/language/semantic_syntax_signature.md
+    - docs/language/semantic_linguist_entry_draft.md
+    - docs/language/semantic_style.md
+    - docs/language/semantic_code_style_principles.md
+    - README.md
+    - docs/wiki/current_status.md
+    - examples/canonical/README.md
+    - examples/canonical/match_control_flow/**
+    - examples/canonical/rule_state_decision/**
+    - examples/canonical/quad_cycle_logos/**
+    - crates/smc-cli/src/formatter.rs
+    - tests/canonical_examples.rs
+    - tests/canonical_source_style.rs
+    - tools/language/check_source_style_contract.ps1
 
 authorization:
   rust_implementation: true
-  # -- textual CollectionAnchor grammar amendment (Grammar v0 explicit extension) --
-  grammar_v0_extension_collection_anchor: true
-  parser_frontend_collection_anchor_wiring: true
-  # -- ProjectionBundle codec (resolves the "unresolved" concrete representation
-  #    decisions left open by the UI-DNA2-8A documentation-only freeze, exactly as
-  #    prior UI-DNA2 implementation PRs (#1507/#1508/#1511/#1541) have always
-  #    resolved analogous "Rust representation unresolved" spec language) --
-  projection_bundle_codec: true
-  projection_bundle_structural_validation: true
-  projection_bundle_cross_artifact_validation: true
-  projection_bundle_compatibility_validation: true
-  projection_bundle_trust_stage: true          # deterministic self-consistency verification only;
-                                                 # NOT cryptographic digest/signature trust -- no crypto
-                                                 # algorithm has been selected by any owner decision, and
-                                                 # none is added by this task. This stage rejects placeholder/
-                                                 # malformed trust material and proves canonical self-
-                                                 # consistency (mirrors the existing Static UI IR Artifact V1
-                                                 # precedent's own explicit disclaimer). Real cryptographic
-                                                 # trust remains a distinct, separately-ownable future decision.
-  projection_bundle_inert_loader: true
-  # -- Gate D: this task IS the owner authorization that opens it, for the bounded
-  #    reference contour only. Prior CLOSED state described the repository before
-  #    this authorization and does not override it. --
-  gate_d_change: true
-  gate_d_activation_policy: true
-  bundle_activation: true
-  # -- Action IR -> existing admission boundary wiring --
-  action_intent_admission_wiring: true
-  # -- renderer / input / accessibility --
-  renderer_integration: true
-  backend_integration: true
-  native_text_rendering: true
-  hit_test_wiring: true
-  focus_and_pointer_capture: true
-  accessibility_integration: true
-  demo_integration: true
-  reference_application: true
-  # -- shared bridge/runtime plumbing already authorized by the closed Shell Player task,
-  #    preserved here since the reference app builds on it --
-  crate_private_and_public_bridge: true
-  public_api: true
-  public_api_guard_changes: true
-  dependency_changes: true   # new: glyphon 0.7 (text rendering; paired with a wgpu
-                               # 0.20 -> 23 bump, the nearest glyphon-compatible version).
-                               # Accessibility ships as deterministic evidence
-                               # (BridgeAccessibilityEntry) only, not full accesskit/OS
-                               # accessibility-tree integration -- see
-                               # gate_d_activation_policy_v0.md section 9. Deliberately
-                               # NOT adding any crypto/hash/signature crate -- see
-                               # projection_bundle_trust_stage above.
+  formatter_regression_tests: true
+  canonical_example_revision: true
+  canonical_example_addition: true
+  style_drift_guard_tests: true
+  documentation_synchronization: true
   workflow_changes: false
-  roadmap_changes: true
-  issue_1489_changes: true
-  issue_1543_changes: true
+  roadmap_changes: false
+  issue_1538_changes: true
   project_changes: false
-  production_promotion: false   # UI-DNA2-11 decision is PROMOTE WITH LIMITS at most, recorded
-                                  # in the roadmap; this is not unrestricted production promotion.
-
-  gate_d: open_with_limits   # bounded non-critical reference contour only; see
-                              # docs/spec/ui/gate_d_activation_policy_v0.md for the exact
-                              # machine-checkable limits and exclusions once landed.
+  # no new language grammar, type-system, lowering, SemCode, verifier, VM, or
+  # PROMETHEUS ABI semantics -- style/example/formatter-contract only
+  grammar_semantic_expansion: false
+  verifier_vm_abi_changes: false
 
 constraints:
-  no_std_alloc_compatible_in_prom_ui_and_runtime: true
-  fail_closed: true
-  deterministic_output: true
-  deterministic_operation_ordering: true
-  deterministic_diagnostic_ordering: true
-  no_partial_target_acceptance: true
-  no_partial_patch_application: true
-  no_partial_state_commit: true
-  no_cursor_advancement_on_rejection: true
-  no_state_mutation_on_rejection: true
-  atomic_commit_semantics: true
-  explicit_collection_anchor_declarations_are_sole_source: true
-  runtime_catalog_not_constructed_from_patch_operations: true
-  runtime_catalog_not_constructed_from_raw_caller_ids: true
-  stage6_does_not_repeat_stage5: true
-  shell_player_not_owner_of_semantic_truth: true
-  shell_player_no_action_or_effect_authorization: true
-  renderer_gains_no_semantic_authority: true
-  no_fabrication_via_public_fields_default_raw_vec_from_into_deserialization: true
-  new_public_bridge_receives_guard_coverage_same_change: true
-  no_unrelated_compiler_verifier_vm_capability_effect_boundary_widening: true
-  no_unrelated_workbench_studio_or_ui_shell_kit_changes: true
-  projection_bundle_stage_separation: "parser != validator != verifier != loader != activation != production promotion"
-  projection_bundle_trust_stage_is_self_consistency_not_cryptographic_trust: true
-  gate_d_fail_closed_before_shell_session_construction: true
-  gate_d_bounded_to_reference_contour_only: true
-  hit_test_result_not_action_authorization: true
-  action_intent_candidate_not_admitted_action: true
-  ui_owns_interaction_candidates_only_not_authority_decisions: true
+  no_grammar_or_runtime_semantic_change: true
+  no_new_syntax_to_satisfy_illustrative_examples: true
+  rustlike_and_logos_surfaces_never_presented_as_one_executable_program: true
+  formatter_stays_conservative_and_lexical_only: true
+  formatter_idempotent: true
+  canonical_examples_must_pass_real_toolchain_qualification: true
   one_branch_one_pr: true
   no_intermediate_documentation_only_pr: true
-  roadmap_and_issues_updated_once_at_end: true
-  next_authorized_implementation_slice_after_this_task: none
+  no_child_issues: true
+  no_unrelated_ui_workbench_studio_alm_changes: true

--- a/README.md
+++ b/README.md
@@ -122,18 +122,9 @@ Save this as `decision.sm`:
 
 ```sm
 fn decide(sensor: quad, ready: bool) -> quad {
-    if sensor == N {
-        return N;
-    }
-
-    if sensor == S {
-        return S;
-    }
-
-    if ready == true {
-        return T;
-    }
-
+    if sensor == N { return N; }
+    if sensor == S { return S; }
+    if ready == true { return T; }
     return F;
 }
 
@@ -142,6 +133,9 @@ fn main() {
     assert(verdict == T);
 }
 ```
+
+This follows the canonical compact guard-return style frozen in
+[`docs/spec/source_style.md`](docs/spec/source_style.md).
 
 Check and run it:
 
@@ -412,6 +406,7 @@ Choose the path that matches what you need:
 | Browse working programs | [Examples Index](docs/examples_index.md) |
 | Learn the language philosophy | [Semantic Language Principles](docs/language/semantic_language_principles.md) |
 | Learn quad syntax | [Semantic Quad Surface](docs/language/semantic_quad_surface.md) |
+| Write canonical-style source | [Canonical Source Style v0](docs/spec/source_style.md) |
 | Read the public contract | [Specification Index](docs/spec/index.md) |
 | Understand the architecture | [ARCHITECTURE.md](ARCHITECTURE.md) |
 | Check feature maturity | [Feature Maturity Matrix](docs/status/feature_maturity_matrix.md) |

--- a/crates/smc-cli/src/formatter.rs
+++ b/crates/smc-cli/src/formatter.rs
@@ -159,6 +159,79 @@ mod tests {
     }
 
     #[test]
+    fn format_source_text_is_idempotent() {
+        let input = "fn main() {  \r\n    return;\t\r\n}\r\n\r\n";
+        let once = format_source_text(input);
+        let twice = format_source_text(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn format_source_text_preserves_string_and_comment_contents() {
+        let input = "fn main() {\n    // keep this comment intact\n    let s: text = \"  spaced text  \";\n    return;\n}\n";
+        assert_eq!(format_source_text(input), input);
+    }
+
+    #[test]
+    fn format_source_text_preserves_compact_guard_returns() {
+        let input = "fn f(x: i32) -> i32 {\n    if x == 0 { return 1; }\n    return 0;\n}\n";
+        assert_eq!(format_source_text(input), input);
+    }
+
+    #[test]
+    fn format_source_text_does_not_collapse_multiline_control_flow() {
+        let input =
+            "fn f(x: i32) -> i32 {\n    if x == 0 {\n        return 1;\n    }\n    return 0;\n}\n";
+        assert_eq!(format_source_text(input), input);
+    }
+
+    #[test]
+    fn format_source_text_preserves_logos_significant_indentation() {
+        let input = "Entity Sensor:\n    state val: quad\n    prop active: bool\n";
+        assert_eq!(format_source_text(input), input);
+    }
+
+    #[test]
+    fn format_path_write_is_idempotent_on_disk() {
+        let dir = mk_temp_dir("smc_fmt_idempotent");
+        let file = dir.join("main.sm");
+        fs::write(&file, "fn main() {  \r\n    return;\n}\n\n").expect("write");
+
+        format_path(&file, FormatterMode::Write).expect("first write");
+        let after_first = fs::read_to_string(&file).expect("read after first");
+
+        let summary = format_path(&file, FormatterMode::Write).expect("second write");
+        let after_second = fs::read_to_string(&file).expect("read after second");
+
+        assert_eq!(after_first, after_second);
+        assert_eq!(
+            summary.files_changed, 0,
+            "second write pass should change nothing"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn collect_semantic_files_walks_in_deterministic_sorted_order() {
+        let dir = mk_temp_dir("smc_fmt_dir_order");
+        fs::write(dir.join("zeta.sm"), "fn main() { return; }\n").expect("write zeta");
+        fs::write(dir.join("alpha.sm"), "fn main() { return; }\n").expect("write alpha");
+        fs::write(dir.join("mid.sm"), "fn main() { return; }\n").expect("write mid");
+
+        let mut files = Vec::new();
+        collect_semantic_files(&dir, &mut files).expect("collect");
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["alpha.sm", "mid.sm", "zeta.sm"]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn format_path_write_updates_recursive_tree() {
         let dir = mk_temp_dir("smc_fmt_write");
         let nested = dir.join("nested");

--- a/docs/examples_index.md
+++ b/docs/examples_index.md
@@ -18,6 +18,11 @@ The older planning-only pack remains in:
 The draft pack is historical context. The canonical pack is the current
 onboarding and readiness-facing examples surface.
 
+`match_control_flow` and `rule_state_decision` demonstrate the frozen
+[Canonical Source Style v0](spec/source_style.md); `quad_cycle_logos`
+demonstrates the same contract's Logos declarative-profile presentation
+rules.
+
 ## Canonical Examples
 
 ### `cli_batch_core`
@@ -171,10 +176,24 @@ Expected result:
 - it should not be treated as a failing canonical success example
 - future support requires an explicit language/source-admission change
 
+### `quad_cycle_logos`
+
+- path: `examples/canonical/quad_cycle_logos/`
+- purpose: canonical Logos declarative-profile example (`System` / `Entity` / `Law`)
+- current reading: `parse-qualified and IR-lowering-qualified`, not
+  `check`/`compile`/`verify`/`run`-qualified (see its README for the honesty
+  boundary)
+- first command:
+
+```powershell
+cargo run --bin smc -- dump-ast examples/canonical/quad_cycle_logos/src/main.sm
+```
+
 ## Validation
 
 The canonical examples pack is covered by:
 
 ```powershell
 cargo test -q --test canonical_examples
+cargo test -q --test canonical_source_style
 ```

--- a/docs/language/semantic_code_style_principles.md
+++ b/docs/language/semantic_code_style_principles.md
@@ -24,6 +24,8 @@ This document complements:
 
 - [`docs/language/semantic_style.md`](semantic_style.md)
 - [`docs/language/semantic_language_principles.md`](semantic_language_principles.md)
+- [`docs/spec/source_style.md`](../spec/source_style.md) — the frozen
+  canonical presentation contract for currently executable Semantic source
 
 It does not replace them.
 

--- a/docs/language/semantic_linguist_entry_draft.md
+++ b/docs/language/semantic_linguist_entry_draft.md
@@ -52,7 +52,10 @@ Recommended plan:
 - `samples/Semantic/positive_selected_import.sm`
 
 These should mirror the existing canonical examples pack rather than invent new
-syntax or new behavior.
+syntax or new behavior. The plan intentionally draws only from the Rust-like
+executable surface; `examples/canonical/quad_cycle_logos/` (Logos profile) is
+a separate, parse/lowering-only qualified example and is not part of this
+`.sm` Linguist sample set (see `docs/spec/source_style.md`).
 
 ## Extension Review
 

--- a/docs/language/semantic_style.md
+++ b/docs/language/semantic_style.md
@@ -5,6 +5,11 @@ Status: first-pass compact quad-style density doctrine
 See also:
 
 - [`semantic_command_lexicon.md`](semantic_command_lexicon.md)
+- [`docs/spec/source_style.md`](../spec/source_style.md) — the frozen
+  canonical style contract for the *current* executable and Logos surfaces.
+  This document remains a future-vocabulary density sketch (`entry` /
+  `require` / `observe` / `complete` is not accepted syntax); it does not
+  describe present-day source.
 
 ## 1. Purpose
 

--- a/docs/language/semantic_syntax_signature.md
+++ b/docs/language/semantic_syntax_signature.md
@@ -110,9 +110,17 @@ Do not treat these as evidence for Linguist classification:
 - benchmark-only samples
 - private qualification scaffolding
 
+## Canonical Presentation
+
+The preferred layout and density of these markers — top-level ordering,
+indentation, line width, compact guard/match forms — is frozen separately in
+`docs/spec/source_style.md` (Semantic Canonical Source Style v0). This note
+covers identity markers; that document covers presentation.
+
 ## Related Documents
 
 - `docs/LANGUAGE.md`
 - `docs/NAMING.md`
 - `docs/spec/syntax.md`
+- `docs/spec/source_style.md`
 - `examples/canonical/README.md`

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -13,6 +13,8 @@ Current documents in this PR:
 - `diagnostics.md` - source-facing parse, policy, type, and module diagnostics
 - `modules.md` - module, import, and re-export contract
 - `logos.md` - declarative Logos source-surface contract
+- `source_style.md` - Semantic Canonical Source Style v0: presentation, layout,
+  and formatter contract for both source surfaces
 - `semcode.md` - SemCode binary contract and compatibility rules
 - `profile.md` - `ParserProfile` policy contract
 - `verifier.md` - SemCode admission verification contract

--- a/docs/spec/source_style.md
+++ b/docs/spec/source_style.md
@@ -102,18 +102,23 @@ and `tests/canonical_source_style.rs`.
 1. Source is UTF-8.
 2. Line endings are LF (`\n`) only; no CR.
 3. No trailing spaces or tabs at the end of any line.
-4. Indentation uses spaces only — no tab characters, no mixed indentation on
-   one line.
-5. Indentation step is 4 spaces per nesting level (Rust-like surface).
-6. Exactly one trailing newline; no trailing blank lines.
-7. No formatting-dependent semantic claim: layout never changes what a program
+4. No tab characters anywhere in a canonical file.
+5. Exactly one trailing newline; no trailing blank lines.
+6. No formatting-dependent semantic claim: layout never changes what a program
    means. (`quad` control flow, in particular, is governed entirely by
    `source_semantics.md`, never by indentation or spacing.)
 
-Rules 1–4 and 6 are already what `smc fmt` enforces today (see
-[Section D](#d-formatter-contract)). Rule 5 and the "one final newline" part
-of rule 6 are checked against canonical examples by
-`tests/canonical_source_style.rs` rather than rewritten automatically.
+Rules 1–3 and 5 are already what `smc fmt` enforces today: CRLF/CR
+normalization, trailing-whitespace trimming, and final-newline normalization
+(see [Section D](#d-formatter-contract)). Rule 4 (no tabs) and the "exactly
+one final newline" part of rule 5 are also asserted directly against
+canonical examples by `tests/canonical_source_style.rs`.
+
+**Current tooling does not structurally validate indentation depth or
+nesting.** The absence of tabs (rule 4) means a canonical file cannot mix tabs
+and spaces, but it does not by itself prove any particular indentation width
+is followed — that is a Section B canonical presentation rule (B.2), checked
+only by code review today, not by `smc fmt` or by an automated depth check.
 
 ## B. Canonical Presentation Rules
 
@@ -136,7 +141,11 @@ dependency-resolution rule enforced by the compiler.
 
 ### B.2 Indentation
 
-- 4 spaces per level, no tabs (also a Section A invariant).
+- 4 spaces per nesting level. This is the frozen canonical presentation,
+  enforced by code review — **no tool currently validates nesting depth**.
+  The Section A tab prohibition is a separate, machine-checked invariant; it
+  rules out mixed tab/space indentation but does not by itself prove 4-space
+  depth is followed.
 - Continuation lines (wrapped call arguments, wrapped parameter lists) add one
   further 4-space level relative to the line being continued.
 - Braces open on the same line as the construct they belong to (`fn f() {`,
@@ -329,8 +338,10 @@ should not appear in canonical examples:
 - Block-bodied functions for logic that could be expressed with the B.7
   expression-bodied sugar.
 - Wrapping a signature that would still fit on one line under the B.3 target.
-- A different (but still consistent, tab-free, 4-space) indentation width
-  chosen by an author for a non-canonical, non-repository-owned program.
+- A different, but still internally consistent and tab-free, indentation
+  width chosen by an author for a non-canonical, non-repository-owned
+  program. Canonical, repository-owned examples still follow the 4-space
+  presentation rule in B.2, but nothing currently checks that automatically.
 
 ## D. Formatter Contract
 

--- a/docs/spec/source_style.md
+++ b/docs/spec/source_style.md
@@ -1,0 +1,407 @@
+# Semantic Canonical Source Style v0
+
+Status: frozen v0
+Primary owners: `smc-cli` (formatter), `docs/spec` (contract)
+Tracking issue: #1538
+
+## Purpose
+
+This document freezes the canonical presentation style for Semantic `.sm`
+source: how a supported program should look, not what it is allowed to mean.
+
+It is a style and layout contract. It does not redefine:
+
+- parser grammar (`syntax.md`)
+- source-level execution semantics (`source_semantics.md`)
+- the type contract (`types.md`)
+- the Logos declarative surface grammar (`logos.md`)
+- SemCode, verifier, VM, or PROMETHEUS ABI behavior
+
+Every rule below classifies into exactly one of four categories, and no rule
+implies a stronger guarantee than its category allows:
+
+| Category | Meaning | Enforced by |
+|---|---|---|
+| **A. Required lexical/file invariant** | Machine-checked baseline; a canonical example that violates it is malformed | `smc fmt --check`, `tests/canonical_source_style.rs` |
+| **B. Canonical presentation rule** | The preferred public shape; canonical examples and current-facing docs follow it | code review + `tests/canonical_source_style.rs` shape checks |
+| **C. Permitted alternative author style** | Still accepted by the language and not rejected by any tool; simply not the preferred public presentation | none (author discretion) |
+| **D. Future formatter behavior** | Documented intent; **not** currently applied automatically by `smc fmt` | none yet — see [Section D](#d-formatter-contract) |
+
+A recommended layout is never a parser or verifier rule unless `syntax.md` or
+`source_semantics.md` already says so independently.
+
+## Compactness Is Not Minification
+
+The target shape is:
+
+```text
+compact local logic
++ visible architectural structure
++ native Semantic vocabulary
++ low syntactic ceremony
++ deterministic reviewability
+!=
+minification
+```
+
+Horizontal space is spent on one coherent, complete causal action. Vertical
+space is spent on boundaries between architectural phases (data/contracts,
+domain types, domain transformations, validation, orchestration), not on every
+brace or trivial statement. A line that mixes unrelated responsibilities is
+never canonical, no matter how short it is.
+
+## Mandatory Honesty Boundary: Two Source Surfaces
+
+Semantic currently exposes two distinct, non-interchangeable source surfaces.
+This document presents canonical style **separately for each** and never
+implies they combine into one executable program today.
+
+### Rust-like executable surface
+
+Parsed by `sm-front`'s rustlike parser, type-checked by `sm-sema`, lowered by
+`sm-ir`, emitted by `sm-emit`, admitted by `sm-verify`, executed by `sm-vm`.
+Qualified end-to-end through `smc check`, `smc compile`, `smc verify`, and
+`smc run` (see `tests/canonical_examples.rs`).
+
+Currently includes (per `syntax.md` / `source_semantics.md`): `record`;
+compile-time-only `schema` (including `config schema` / `api schema` /
+`wire schema` and `version(N)`); `fn` (block- and expression-bodied);
+`requires` / `ensures` / `invariant`; `let` / `const` / destructuring /
+`let-else`; `quad` and its literals `N`, `F`, `T`, `S`; `if` / `else if` /
+`else` (condition must be `bool` — `quad` is never an implicit condition);
+`match` (over `quad`, nominal enums, `Option`, `Result`); `for` / `while` /
+`loop` / `guard`; `assert`; `Result` / `Option`; `Sequence(T)`; imports;
+`fn main()`.
+
+### Logos declarative surface
+
+Parsed by `sm-front`'s Logos parser (`parse_logos_program_with_profile`).
+`System` / `Entity` / `Law` / `When` describe systems, entities, and priority
+laws. **This surface does not compile, verify, or run through the Rust-like
+SemCode/VM path.** Its current qualification path is parse-level
+(`smc dump-ast`) and IR-lowering-level for laws only
+(`smc dump-ir --profile logos`, which lowers `Law`/`When` bodies to
+`LogosIrLaw` — condition/effect text fragments, not executable SemCode).
+`smc check` / `compile` / `verify` / `run` do not accept Logos source; passing
+Logos source to them produces a Rust-like parser diagnostic, not a Logos
+result. **A program is never presented as one canonical example unless the
+exact commands used to qualify it are the ones documented here for its
+surface.**
+
+These two surfaces are never merged into a single "canonical executable
+program" claim. A document or example that shows both `schema`/`fn main()`
+Rust-like forms and `System`/`Entity`/`Law` Logos forms together must label
+the Logos portion as its own separately-qualified profile example, not as
+part of the same executable program.
+
+## A. Required Lexical/File Invariants
+
+These apply to every canonical `.sm` file and are enforced by `smc fmt --check`
+and `tests/canonical_source_style.rs`.
+
+1. Source is UTF-8.
+2. Line endings are LF (`\n`) only; no CR.
+3. No trailing spaces or tabs at the end of any line.
+4. Indentation uses spaces only — no tab characters, no mixed indentation on
+   one line.
+5. Indentation step is 4 spaces per nesting level (Rust-like surface).
+6. Exactly one trailing newline; no trailing blank lines.
+7. No formatting-dependent semantic claim: layout never changes what a program
+   means. (`quad` control flow, in particular, is governed entirely by
+   `source_semantics.md`, never by indentation or spacing.)
+
+Rules 1–4 and 6 are already what `smc fmt` enforces today (see
+[Section D](#d-formatter-contract)). Rule 5 and the "one final newline" part
+of rule 6 are checked against canonical examples by
+`tests/canonical_source_style.rs` rather than rewritten automatically.
+
+## B. Canonical Presentation Rules
+
+### B.1 Top-level order (Rust-like surface)
+
+Recommended, not a parser restriction:
+
+1. imports
+2. `schema` / compile-time contract declarations
+3. `record` / domain type declarations
+4. module-level `const` where supported
+5. pure domain transformation functions
+6. stateful or aggregation functions
+7. validation functions
+8. `fn main()`
+
+`main` is always last. Declarations that later functions depend on come
+before their use where practical; this list is a default reading order, not a
+dependency-resolution rule enforced by the compiler.
+
+### B.2 Indentation
+
+- 4 spaces per level, no tabs (also a Section A invariant).
+- Continuation lines (wrapped call arguments, wrapped parameter lists) add one
+  further 4-space level relative to the line being continued.
+- Braces open on the same line as the construct they belong to (`fn f() {`,
+  `if cond {`, `match x {`) and close aligned with that construct's starting
+  column.
+
+### B.3 Line width
+
+- **100 columns** is the canonical target (matches the workspace's default
+  `rustfmt` width; no `rustfmt.toml` overrides it at the repository root).
+- **120 columns** is the review ceiling — a canonical example must not exceed
+  it.
+- Narrow exceptions are permitted for long string literals, diagnostic error
+  codes/identifiers, generated values, and URLs that cannot be wrapped without
+  changing their meaning.
+- `smc fmt` does not perform destructive automatic line-wrapping to satisfy
+  this target (see [Section D](#d-formatter-contract)); authors wrap manually.
+
+### B.4 Blank lines
+
+- One blank line between top-level declarations.
+- One blank line between distinct semantic phases inside a function (for
+  example: between guard checks and the main computation, or between
+  computation and the final `return`).
+- No blank line between tightly coupled guard clauses that check related
+  preconditions in sequence.
+- No decorative or repeated blank lines (never more than one consecutive blank
+  line).
+
+### B.5 Compact guard returns
+
+Canonical for one simple condition and one immediate `return`:
+
+```sm
+if slot == 0 { return N; }
+if slot == 1 { return F; }
+```
+
+Expand vertically once the condition or the returned expression stops being
+simple:
+
+```sm
+if ctx.override_state == T && ctx.ready {
+    return Result::Ok(T);
+}
+```
+
+An unrelated second effect never shares the line with a compact guard:
+
+```sm
+// not canonical: two responsibilities on one line
+if slot == 0 { n_count += 1; audit(slot); }
+```
+
+### B.6 Match arms
+
+```sm
+match state {
+    N => { 0 }
+    F => { 1 }
+    T => { 2 }
+    S => { 3 }
+}
+```
+
+- A single-expression or single-statement arm stays on one line as
+  `Pattern => { expr }`.
+- An arm with more than one statement, or with nested control flow, expands
+  vertically:
+
+```sm
+match state {
+    T => {
+        let boosted: i32 = priority * 2;
+        boosted
+    }
+    _ => { 0 }
+}
+```
+
+- Guarded arms (`Pattern if cond => { ... }`) follow the same one-line/expand
+  rule based on the arm body, not the guard.
+- `quad` matches always keep the required `_` default arm (`source_semantics.md`);
+  it is formatted like any other arm.
+
+### B.7 Expression-bodied functions
+
+```sm
+fn dispatch_code(state: quad) -> i32 = match state {
+    N => { 0 }
+    F => { 1 }
+    T => { 2 }
+    _ => { 3 }
+};
+```
+
+Canonical for small, pure, single-expression transformations. Block-bodied
+functions are not mechanically converted to expression-bodied form — the
+choice is the author's, based on whether the whole function is genuinely one
+expression.
+
+### B.8 Multiple statements on one physical line
+
+- One ordinary statement per line.
+- The one documented exception is the compact guard-return form in B.5.
+- Multiple unrelated declarations packed onto one line are not canonical, even
+  though the parser accepts semicolon-separated statements.
+- Multiple `assert(...)` calls on one line are syntactically permitted but not
+  canonical — see [Section C](#c-permitted-alternative-author-style).
+
+### B.9 Function parameters
+
+- Keep the full signature (name, parameters, return type, contract clauses) on
+  one line while it fits the B.3 line-width target.
+- When it does not fit, wrap one parameter per continuation line, each at one
+  additional indent level, with the closing `)` and return type on their own
+  line:
+
+```sm
+fn validate_distribution(
+    n_count: i32,
+    f_count: i32,
+    t_count: i32,
+    s_count: i32,
+    code_sum: i32,
+) -> bool {
+    ...
+}
+```
+
+- `requires(...)`, `ensures(...)`, and `invariant(...)` clauses each take
+  their own line, after the parameter list and before the opening `{`, in the
+  order the language accepts them (`requires`, then `ensures`, then
+  `invariant`).
+
+### B.10 `main` orchestration
+
+`main` constructs or selects inputs, calls domain functions, coordinates the
+computation, invokes final validation, and returns. A domain decision that
+needs a named condition or a multi-step transformation belongs in a named
+function, not inlined into `main`.
+
+### B.11 Comments
+
+- A comment explains a boundary, an invariant, a rationale, or a non-obvious
+  domain meaning — never syntax that names and structure already communicate.
+- No decorative banner comments (`// ============`) inside canonical examples.
+- Canonical examples stay self-documenting primarily through naming and
+  structure; comments are the exception, not the default.
+
+### B.12 Logos declarative surface presentation
+
+Logos indentation is significant and is not reformatted using Rust-like
+brace/indent assumptions:
+
+```sm
+System QuadCycle(sample_count = 48, state_period = 4):
+
+Entity Sensor:
+    state val: quad
+    prop threshold: f64
+
+Law "CheckSignal" [priority 10]:
+    When Sensor.val == T -> Log.emit("Signal OK")
+    When Sensor.val == S -> System.recovery()
+```
+
+- One blank line between `System`, each `Entity`, and each `Law` block.
+- `Entity` and `Law` bodies indent their fields/`When` clauses by 4 spaces,
+  matching the Rust-like indentation step even though indentation is
+  semantically significant here (unlike the Rust-like surface).
+- Multiple `When` clauses inside one `Law` are one per line, ordered as
+  authored; the compiler orders `Law` declarations themselves by descending
+  `priority`, not by source order (`logos.md`).
+- `System` parameters use `name = value` (the current parser's accepted form —
+  `logos.md`'s illustrative `param: type` spelling is not what
+  `parse_logos_system` accepts; this document reflects the executable
+  parser).
+
+## C. Permitted Alternative Author Style
+
+These remain valid, accepted source; they are not rejected by the parser or
+by `smc fmt --check`, but they are not the preferred public presentation and
+should not appear in canonical examples:
+
+- Expanding a simple guard (B.5) into a vertical `if { ... }` block even when
+  the compact one-line form would fit.
+- Multiple `assert(...)` statements chained on one physical line.
+- Fully vertical `match` arms even when every arm is a single expression.
+- Block-bodied functions for logic that could be expressed with the B.7
+  expression-bodied sugar.
+- Wrapping a signature that would still fit on one line under the B.3 target.
+- A different (but still consistent, tab-free, 4-space) indentation width
+  chosen by an author for a non-canonical, non-repository-owned program.
+
+## D. Formatter Contract
+
+### What `smc fmt` currently enforces
+
+`smc fmt` (`crates/smc-cli/src/formatter.rs`) is intentionally conservative.
+Given any `.sm` file under the target path, it currently and only:
+
+1. normalizes `\r\n` and `\r` to `\n`;
+2. trims trailing spaces/tabs from every line;
+3. removes trailing blank lines and writes exactly one final `\n`
+   (or an empty file for empty input);
+4. walks directories in sorted order, skipping `.git`, `target`,
+   `node_modules`, `dist`, and `.semantic-cache`.
+
+`smc fmt --check` reports files that would change without writing them;
+`smc fmt <path>` writes the normalized bytes. Both modes are deterministic and
+idempotent: running either twice in a row produces no further changes on the
+second run.
+
+`smc fmt` does **not** currently:
+
+- re-indent code;
+- wrap or unwrap lines to a width target;
+- rewrite `if { return ...; }` in either direction;
+- expand or collapse `match` arms;
+- convert between block-bodied and expression-bodied functions;
+- combine or split statements;
+- reorder declarations;
+- touch string or comment contents beyond trailing-whitespace trimming at
+  end-of-line;
+- distinguish Rust-like from Logos indentation — it never rewrites indentation
+  at all, so Logos's significant indentation is preserved by construction.
+
+Every Section B rule beyond the four points above is documentation guidance,
+enforced by code review and by the shape assertions in
+`tests/canonical_source_style.rs`, not by automatic rewriting.
+
+### Future formatter behavior
+
+If a future change teaches `smc fmt` to enforce a Section B rule
+automatically (for example, canonical match-arm collapsing), that change
+must, in the same series:
+
+- move the rule's row in the category table from **B** to a formatter-owned
+  behavior documented in this section;
+- add positive tests (the rule is applied), negative preservation tests (the
+  rule does not fire when it should not), idempotence tests, profile-specific
+  tests (Logos indentation is still untouched unless explicitly in scope), and
+  comment/string preservation tests;
+- keep the change narrowly scoped — this document does not authorize a full
+  AST-based formatter as an incidental side effect of any single rule.
+
+## Canonical Examples
+
+Three examples demonstrate this contract; each README states its exact
+qualification command and status per the table in
+[`docs/examples_index.md`](../examples_index.md):
+
+- `examples/canonical/match_control_flow/` — compact quad decision program
+  (Rust-like, executable, `check`/`compile`/`verify`/`run`-qualified).
+- `examples/canonical/rule_state_decision/` — structured practical program
+  with `record`, domain transformations, validation, and orchestration
+  (Rust-like, executable, `check`/`compile`/`verify`/`run`-qualified).
+- `examples/canonical/quad_cycle_logos/` — Logos profile example
+  (`System`/`Entity`/`Law`), parse- and lowering-qualified only via
+  `dump-ast` / `dump-ir --profile logos`, explicitly not executable through
+  `check`/`compile`/`verify`/`run`.
+
+## Contract Rule
+
+Any change that widens what `smc fmt` rewrites automatically, or that changes
+which category (A/B/C/D) a rule belongs to, must update this document in the
+same change series.

--- a/docs/wiki/current_status.md
+++ b/docs/wiki/current_status.md
@@ -150,18 +150,9 @@ source check
 
 ```sm
 fn decide(sensor: quad, ready: bool) -> quad {
-    if sensor == N {
-        return N;
-    }
-
-    if sensor == S {
-        return S;
-    }
-
-    if ready == true {
-        return T;
-    }
-
+    if sensor == N { return N; }
+    if sensor == S { return S; }
+    if ready == true { return T; }
     return F;
 }
 
@@ -170,6 +161,9 @@ fn main() {
     assert(verdict == T);
 }
 ```
+
+This follows the canonical compact guard-return style frozen in
+[`docs/spec/source_style.md`](../spec/source_style.md).
 
 Save it as `decision.sm`, then run:
 
@@ -564,6 +558,7 @@ and controlled expansion
 | Browse working programs | [Examples Index](../examples_index.md) |
 | Understand the language | [Language Overview](../LANGUAGE.md) |
 | Learn quad syntax | [Semantic Quad Surface](../language/semantic_quad_surface.md) |
+| Write canonical-style source | [Canonical Source Style v0](../spec/source_style.md) |
 | Read the public contract | [Specification Index](../spec/index.md) |
 | Understand architecture | [ARCHITECTURE.md](../../ARCHITECTURE.md) |
 | Check feature maturity | [Feature Maturity Matrix](../status/feature_maturity_matrix.md) |

--- a/examples/canonical/README.md
+++ b/examples/canonical/README.md
@@ -15,6 +15,13 @@ This pack is intentionally split into:
 
 - twelve positive examples inside the current `qualified limited release` contour
 - one boundary example that shows a still-real limit honestly
+- one Logos declarative-profile example, qualified through its own
+  parse/lowering path rather than `check`/`compile`/`verify`/`run`
+
+`match_control_flow` and `rule_state_decision` also serve as the canonical
+demonstrations of `docs/spec/source_style.md` (Semantic Canonical Source Style
+v0): compact guard returns, compact `match` arms, and a data/domain/validation/
+orchestration top-level order.
 
 This pack is also the canonical `.sm` sample surface intended for future GitHub
 Linguist review. The twelve positive examples are small, readable, and stable
@@ -97,12 +104,19 @@ not be treated as a positive sample for Linguist detection.
      executable path is still rejected
    - current reading: `out of scope`
 
+14. `quad_cycle_logos`
+   - purpose: canonical Logos declarative-profile example (`System` / `Entity`
+     / `Law`)
+   - current reading: `parse-qualified and IR-lowering-qualified`, explicitly
+     not `check`/`compile`/`verify`/`run`-qualified — see its own README
+
 ## Validation
 
 Canonical examples are validated by:
 
 ```text
 cargo test -q --test canonical_examples
+cargo test -q --test canonical_source_style
 ```
 
 Positive examples are checked, compiled, verified, and run through the public
@@ -110,3 +124,9 @@ Positive examples are checked, compiled, verified, and run through the public
 
 The boundary example is checked to ensure the current diagnostic remains
 explicit and deterministic.
+
+The Logos example is validated through `smc dump-ast` and
+`smc dump-ir --profile logos`, and is checked to confirm that `smc check`
+still fails on it with a Rust-like frontend diagnostic (the documented
+honesty boundary between the two source surfaces — see
+`docs/spec/source_style.md`).

--- a/examples/canonical/match_control_flow/README.md
+++ b/examples/canonical/match_control_flow/README.md
@@ -1,26 +1,28 @@
 # match_control_flow
 
-- benchmark-class application anchor: practical `match`-driven control-flow
-  over `quad`
-- purpose: show explicit quad-state branching without implicit truthiness
-- demonstrates:
-  - `match` over `quad`
-  - explicit `T / F / N / S` handling
-  - deterministic branch selection
-  - terminal return paths through ordinary control flow
-  - ordinary `if` inside a `match` branch
+- purpose: compact quad decision program showing `record`-carried configuration,
+  `quad` domain values with the same syntactic dignity as `bool`/`i32`, compact
+  guard returns, and a `match`-driven dispatch/aggregation pass
+- language profile: Rust-like executable surface
+- supported status: `qualified limited release` (parses, type-checks, compiles,
+  verifies, and runs on current `main`)
+- demonstrates (`docs/spec/source_style.md`):
+  - B.1 top-level order: data (`CycleConfig`) -> domain transformations
+    (`state_from_index`, `dispatch_code`) -> validation
+    (`validate_distribution`) -> orchestration (`main`)
+  - B.5 compact guard returns (`if slot == 0 { return N; }`)
+  - B.6 compact `match` arms with the required `_` default arm
+  - B.10 `main` limited to construction, orchestration, and final validation
 - commands:
   - `cargo run --bin smc -- check examples/canonical/match_control_flow/src/main.sm`
   - `cargo run --bin smc -- run examples/canonical/match_control_flow/src/main.sm`
   - `cargo run --bin smc -- compile examples/canonical/match_control_flow/src/main.sm -o out.smc`
   - `cargo run --bin smc -- verify out.smc`
-- expected output:
-  - `check` succeeds
-  - `run` exits successfully
-  - `verify` accepts the compiled `.smc`
-- non-goals:
-  - no Option / Result surface
-  - no pattern guards
-  - no fallthrough semantics
-- no implicit quad truthiness
-- self-check via assertions rather than return code
+- expected result:
+  - `check` passes with 0 warnings
+  - `run` exits 0 (all `assert`s hold)
+  - `compile` + `verify` accept the emitted `.smc`
+- non-claims:
+  - does not demonstrate `Option` / `Result`, pattern guards, or Logos syntax
+  - `CycleConfig` is an ordinary executable `record`, not a `System` block —
+    `System` is Logos-only and does not appear in this file

--- a/examples/canonical/match_control_flow/src/main.sm
+++ b/examples/canonical/match_control_flow/src/main.sm
@@ -1,53 +1,56 @@
-fn classify_signal(state: quad) -> i32 {
-    let result: i32 = match state {
-        T => { 10 }
-        F => { 0 }
-        N => { 1 }
-        S => { -10 }
-        _ => { 0 }
-    };
-    return result;
+record CycleConfig {
+    sample_count: i32,
+    state_period: i32,
 }
 
-fn route_signal(state: quad, priority: i32) -> i32 {
-    let result: i32 = match state {
-        S => { -100 }
+fn state_from_index(index: i32, config: CycleConfig) -> quad {
+    let slot: i32 = index % config.state_period;
+
+    if slot == 0 { return N; }
+    if slot == 1 { return F; }
+    if slot == 2 { return T; }
+    return S;
+}
+
+fn dispatch_code(state: quad) -> i32 {
+    return match state {
         N => { 0 }
-        F => { -1 }
-        T => {
-            if priority > 5 {
-                20
-            } else {
-                10
-            }
-        }
-        _ => { 0 }
+        F => { 1 }
+        T => { 2 }
+        _ => { 3 }
     };
-    return result;
 }
 
-fn alarm_level(state: quad, priority: i32) -> i32 {
-    let class: i32 = classify_signal(state);
-    let route: i32 = route_signal(state, priority);
-
-    if class < 0 {
-        return class;
-    }
-
-    if route < 0 {
-        return route;
-    }
-
-    return class + route;
+fn validate_distribution(n_count: i32, f_count: i32, t_count: i32, s_count: i32, code_sum: i32) {
+    assert(n_count > 0);
+    assert(f_count > 0);
+    assert(t_count > 0);
+    assert(s_count > 0);
+    assert(code_sum > 0);
+    return;
 }
 
 fn main() {
-    let stable: i32 = alarm_level(T, 7);
-    let unknown: i32 = alarm_level(N, 3);
-    let conflict: i32 = alarm_level(S, 9);
+    let config: CycleConfig = CycleConfig { sample_count: 48, state_period: 4 };
 
-    assert(stable == 30);
-    assert(unknown == 1);
-    assert(conflict == -10);
+    let mut n_count: i32 = 0;
+    let mut f_count: i32 = 0;
+    let mut t_count: i32 = 0;
+    let mut s_count: i32 = 0;
+    let mut code_sum: i32 = 0;
+
+    for index in 0..config.sample_count {
+        let state: quad = state_from_index(index, config);
+        code_sum += dispatch_code(state);
+
+        match state {
+            N => { n_count += 1; }
+            F => { f_count += 1; }
+            T => { t_count += 1; }
+            _ => { s_count += 1; }
+        }
+    }
+
+    validate_distribution(n_count, f_count, t_count, s_count, code_sum);
     return;
 }

--- a/examples/canonical/quad_cycle_logos/README.md
+++ b/examples/canonical/quad_cycle_logos/README.md
@@ -1,0 +1,36 @@
+# quad_cycle_logos
+
+- purpose: canonical Logos declarative profile example — `System` context,
+  `Entity` state/prop fields, and priority-ordered `Law`/`When` rules
+- language profile: **Logos declarative surface** (`docs/spec/logos.md`) — this
+  is not the Rust-like executable surface and is not combined with one in this
+  file
+- supported status: **parse-qualified and IR-lowering-qualified only**. It is
+  explicitly **not** `check`/`compile`/`verify`/`run`-qualified: those commands
+  target the Rust-like SemCode/VM path, which does not accept Logos source.
+  Feeding this file to `smc check` produces a Rust-like parser/type diagnostic,
+  not a Logos result — that is expected and is exercised by
+  `tests/canonical_source_style.rs` as an honesty-boundary check.
+- demonstrates (`docs/spec/source_style.md` section B.12):
+  - one blank line between `System`, `Entity`, and `Law` blocks
+  - 4-space indentation for `Entity` fields and `Law`/`When` clauses even
+    though Logos indentation is semantically significant
+  - `System` parameters using the parser's actual accepted `name = value` form
+  - `Law` declarations are reordered by descending `priority` by the parser,
+    independent of source order
+- commands:
+  - `cargo run --bin smc -- dump-ast examples/canonical/quad_cycle_logos/src/main.sm`
+  - `cargo run --bin smc -- dump-ir examples/canonical/quad_cycle_logos/src/main.sm --profile logos`
+- expected result:
+  - `dump-ast` prints a `LogosProgram` with one `System`, one `Entity`, and one
+    `Law` carrying two ordered `When` clauses
+  - `dump-ir --profile logos` prints one `LogosIrLaw` for `"CheckSignal"` with
+    `when_count: 2`
+  - `smc check` / `smc run` on this file fail with a Rust-like frontend
+    diagnostic — this is the expected, documented boundary, not a bug
+- non-claims:
+  - does not execute through SemCode, the verifier, or the VM
+  - `When` condition/effect bodies are structured text fragments at this
+    stage, not type-checked Rust-like expressions
+  - not a claim that `System`/`Entity`/`Law` can appear inside a Rust-like
+    `fn main()` program

--- a/examples/canonical/quad_cycle_logos/src/main.sm
+++ b/examples/canonical/quad_cycle_logos/src/main.sm
@@ -1,0 +1,9 @@
+System QuadCycle(sample_count = 48, state_period = 4):
+
+Entity Sensor:
+    state val: quad
+    prop threshold: f64
+
+Law "CheckSignal" [priority 10]:
+    When Sensor.val == T -> Log.emit("Signal OK")
+    When Sensor.val == S -> System.recovery()

--- a/examples/canonical/rule_state_decision/README.md
+++ b/examples/canonical/rule_state_decision/README.md
@@ -1,25 +1,28 @@
 # rule_state_decision
 
-- benchmark-class application anchor: deterministic policy/admission decision
-  logic on the admitted surface
-- purpose: record-oriented rule/state decision logic with explicit
-  `Result(T, E)` handling
-- demonstrates:
-  - nominal records
-  - `quad`
-  - contextual `Result::Ok` / `Result::Err`
-  - explicit `match` settlement
-  - deterministic decision path with `assert(verdict == T)`
+- purpose: structured practical program — record-oriented rule/state decision
+  logic with explicit `Result(T, E)` handling, a separate validation phase, and
+  compact orchestration
+- language profile: Rust-like executable surface
+- supported status: `qualified limited release` (parses, type-checks, compiles,
+  verifies, and runs on current `main`); also the first application-completeness
+  anchor covered by `tests/canonical_examples.rs`
+- demonstrates (`docs/spec/source_style.md`):
+  - B.1 top-level order: data (`DecisionContext`) -> domain transformation
+    (`decide`) -> validation (`validate_verdict`) -> orchestration (`main`)
+  - B.5 compact guard returns in `decide`
+  - contextual `Result::Ok` / `Result::Err` and explicit `match` settlement
+  - B.4 blank lines separating construction, decision, and validation phases
+    inside `main`
 - commands:
   - `cargo run --bin smc -- check examples/canonical/rule_state_decision/src/main.sm`
   - `cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm`
   - `cargo run --bin smc -- compile examples/canonical/rule_state_decision/src/main.sm -o out.smc`
   - `cargo run --bin smc -- verify out.smc`
-- expected output:
-  - `check` succeeds
-  - `run` exits successfully
-  - `verify` accepts the compiled `.smc`
-- non-goals:
-  - no host effects
-  - no UI
-  - no package or release packaging work
+- expected result:
+  - `check` passes with 0 warnings
+  - `run` exits 0 (all `assert`s hold)
+  - `compile` + `verify` accept the emitted `.smc`
+- non-claims:
+  - no host effects, UI, or package/release packaging work
+  - no Logos syntax

--- a/examples/canonical/rule_state_decision/src/main.sm
+++ b/examples/canonical/rule_state_decision/src/main.sm
@@ -5,19 +5,16 @@ record DecisionContext {
 }
 
 fn decide(ctx: DecisionContext) -> Result(quad, quad) {
-    if ctx.override_state == T {
-        return Result::Ok(T);
-    }
-    if ctx.override_state == F {
-        return Result::Ok(F);
-    }
-    if ctx.camera == N {
-        return Result::Err(N);
-    }
-    if ctx.ready == true {
-        return Result::Ok(T);
-    }
+    if ctx.override_state == T { return Result::Ok(T); }
+    if ctx.override_state == F { return Result::Ok(F); }
+    if ctx.camera == N { return Result::Err(N); }
+    if ctx.ready == true { return Result::Ok(T); }
     return Result::Err(S);
+}
+
+fn validate_verdict(verdict: quad) {
+    assert(verdict == T || verdict == F || verdict == N || verdict == S);
+    return;
 }
 
 fn main() {
@@ -26,10 +23,13 @@ fn main() {
         override_state: S,
         ready: true,
     };
+
     let verdict: quad = match decide(ctx) {
         Result::Ok(value) => { value }
         Result::Err(code) => { code }
     };
+
+    validate_verdict(verdict);
     assert(verdict == T);
     return;
 }

--- a/tests/canonical_source_style.rs
+++ b/tests/canonical_source_style.rs
@@ -98,7 +98,9 @@ fn style_contract_examples_have_no_tab_indentation() {
         let content = read(rel);
         assert!(
             !content.contains('\t'),
-            "{rel} contains a tab character; Section A requires 4-space indentation"
+            "{rel} contains a tab character; Section A requires no tab characters. \
+             (This does not by itself prove 4-space nesting depth, which is a Section B \
+             canonical presentation rule, not machine-checked.)"
         );
     }
 }
@@ -205,6 +207,27 @@ fn style_contract_examples_do_not_regress_to_verbose_pre_contract_shape() {
     assert!(
         quad_cycle_logos.contains("):\n\nEntity") && quad_cycle_logos.contains("\n\nLaw"),
         "quad_cycle_logos/src/main.sm lost the required blank line between System/Entity/Law blocks"
+    );
+}
+
+#[test]
+fn source_style_document_does_not_overclaim_indentation_enforcement() {
+    // Regression guard for a reviewed P2: 4-space nesting depth is a Section B
+    // canonical presentation rule, not a Section A machine-checked invariant.
+    // Neither `smc fmt` nor this test suite validates nesting depth -- only
+    // the absence of tab characters is machine-checked.
+    let doc = read("docs/spec/source_style.md");
+    assert!(
+        !doc.contains("Indentation step is 4 spaces per nesting level"),
+        "docs/spec/source_style.md must not list 4-space nesting as a Section A required invariant"
+    );
+    assert!(
+        doc.contains("does not structurally validate indentation depth"),
+        "docs/spec/source_style.md must keep disclosing that no tool validates nesting depth"
+    );
+    assert!(
+        doc.contains("no tool currently validates nesting depth"),
+        "docs/spec/source_style.md's Section B.2 must keep disclosing that no tool validates nesting depth"
     );
 }
 

--- a/tests/canonical_source_style.rs
+++ b/tests/canonical_source_style.rs
@@ -1,0 +1,232 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_path(rel: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(rel)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn read(rel: &str) -> String {
+    std::fs::read_to_string(repo_path(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+fn cli_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|err| panic!("{context} failed: {err}"));
+}
+
+fn cli_err(args: Vec<String>, context: &str) -> String {
+    smc_cli::run(args).expect_err(&format!("{context} unexpectedly passed"))
+}
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn mk_temp_dir(prefix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos(),
+        DIR_COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    dir
+}
+
+/// The three examples `docs/spec/source_style.md` names as its canonical
+/// demonstrations: two Rust-like executable programs and one Logos profile
+/// program.
+const STYLE_CONTRACT_EXAMPLES: [&str; 3] = [
+    "examples/canonical/match_control_flow/src/main.sm",
+    "examples/canonical/rule_state_decision/src/main.sm",
+    "examples/canonical/quad_cycle_logos/src/main.sm",
+];
+
+const RUSTLIKE_STYLE_CONTRACT_EXAMPLES: [&str; 2] = [
+    "examples/canonical/match_control_flow/src/main.sm",
+    "examples/canonical/rule_state_decision/src/main.sm",
+];
+
+const LOGOS_STYLE_CONTRACT_EXAMPLE: &str = "examples/canonical/quad_cycle_logos/src/main.sm";
+
+#[test]
+fn style_contract_examples_pass_fmt_check() {
+    for rel in STYLE_CONTRACT_EXAMPLES {
+        let original = read(rel);
+        let formatted = smc_cli::format_source_text(&original);
+        assert_eq!(
+            formatted, original,
+            "{rel} is not already `smc fmt`-clean (Section A invariants)"
+        );
+    }
+}
+
+#[test]
+fn style_contract_examples_are_fmt_idempotent() {
+    for rel in STYLE_CONTRACT_EXAMPLES {
+        let original = read(rel);
+        let once = smc_cli::format_source_text(&original);
+        let twice = smc_cli::format_source_text(&once);
+        assert_eq!(once, twice, "{rel}: formatting is not idempotent");
+    }
+}
+
+#[test]
+fn style_contract_examples_have_no_trailing_whitespace() {
+    for rel in STYLE_CONTRACT_EXAMPLES {
+        let content = read(rel);
+        for (i, line) in content.lines().enumerate() {
+            assert_eq!(
+                line,
+                line.trim_end_matches([' ', '\t']),
+                "{rel}:{} has trailing whitespace",
+                i + 1
+            );
+        }
+    }
+}
+
+#[test]
+fn style_contract_examples_have_no_tab_indentation() {
+    for rel in STYLE_CONTRACT_EXAMPLES {
+        let content = read(rel);
+        assert!(
+            !content.contains('\t'),
+            "{rel} contains a tab character; Section A requires 4-space indentation"
+        );
+    }
+}
+
+#[test]
+fn style_contract_examples_have_exactly_one_final_newline() {
+    for rel in STYLE_CONTRACT_EXAMPLES {
+        let content = read(rel);
+        assert!(content.ends_with('\n'), "{rel} is missing a final newline");
+        assert!(
+            !content.ends_with("\n\n"),
+            "{rel} has trailing blank line(s)"
+        );
+    }
+}
+
+#[test]
+fn style_contract_rustlike_examples_check_compile_verify_and_run() {
+    for rel in RUSTLIKE_STYLE_CONTRACT_EXAMPLES {
+        let input = repo_path(rel);
+        cli_ok(
+            vec!["check".to_string(), input.clone()],
+            &format!("smc check for {input}"),
+        );
+        cli_ok(
+            vec!["run".to_string(), input.clone()],
+            &format!("smc run for {input}"),
+        );
+
+        let dir = mk_temp_dir("smc_style_contract_examples");
+        let out = dir.join("out.smc");
+        let out_arg = out.to_string_lossy().replace('\\', "/");
+        cli_ok(
+            vec![
+                "compile".to_string(),
+                input.clone(),
+                "-o".to_string(),
+                out_arg.clone(),
+            ],
+            &format!("smc compile for {input}"),
+        );
+        cli_ok(
+            vec!["verify".to_string(), out_arg],
+            &format!("smc verify for {input}"),
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[test]
+fn style_contract_logos_example_qualifies_via_dump_ast_and_dump_ir() {
+    let input = repo_path(LOGOS_STYLE_CONTRACT_EXAMPLE);
+    cli_ok(
+        vec!["dump-ast".to_string(), input.clone()],
+        &format!("smc dump-ast for {input}"),
+    );
+    cli_ok(
+        vec![
+            "dump-ir".to_string(),
+            input,
+            "--profile".to_string(),
+            "logos".to_string(),
+        ],
+        "smc dump-ir --profile logos",
+    );
+}
+
+#[test]
+fn style_contract_logos_example_is_honestly_rejected_by_rustlike_check() {
+    let input = repo_path(LOGOS_STYLE_CONTRACT_EXAMPLE);
+    // The Logos profile does not compile/verify/run through the Rust-like
+    // SemCode/VM path. `smc check` must keep failing on it; a pass here would
+    // mean unsupported/proposed syntax silently became executable.
+    let _ = cli_err(
+        vec!["check".to_string(), input.clone()],
+        &format!("smc check for {input}"),
+    );
+}
+
+#[test]
+fn style_contract_logos_readme_declares_its_non_executable_status() {
+    let readme = read("examples/canonical/quad_cycle_logos/README.md");
+    assert!(
+        readme.contains("not** `check`/`compile`/`verify`/`run`-qualified"),
+        "quad_cycle_logos/README.md must explicitly disclaim check/compile/verify/run qualification"
+    );
+}
+
+#[test]
+fn style_contract_examples_do_not_regress_to_verbose_pre_contract_shape() {
+    let match_control_flow = read("examples/canonical/match_control_flow/src/main.sm");
+    assert!(
+        match_control_flow.contains("if slot == 0 { return N; }"),
+        "match_control_flow/src/main.sm drifted away from the compact guard-return contract"
+    );
+
+    let rule_state_decision = read("examples/canonical/rule_state_decision/src/main.sm");
+    assert!(
+        rule_state_decision.contains("if ctx.override_state == T { return Result::Ok(T); }"),
+        "rule_state_decision/src/main.sm drifted away from the compact guard-return contract"
+    );
+
+    let quad_cycle_logos = read("examples/canonical/quad_cycle_logos/src/main.sm");
+    assert!(
+        quad_cycle_logos.contains("):\n\nEntity") && quad_cycle_logos.contains("\n\nLaw"),
+        "quad_cycle_logos/src/main.sm lost the required blank line between System/Entity/Law blocks"
+    );
+}
+
+#[test]
+fn source_style_document_has_required_classification_sections() {
+    let doc = read("docs/spec/source_style.md");
+    for required in [
+        "Semantic Canonical Source Style v0",
+        "Required lexical/file invariant",
+        "Canonical presentation rule",
+        "Permitted alternative author style",
+        "Future formatter behavior",
+        "Rust-like executable surface",
+        "Logos declarative surface",
+        "## A. Required Lexical/File Invariants",
+        "## B. Canonical Presentation Rules",
+        "## C. Permitted Alternative Author Style",
+        "## D. Formatter Contract",
+    ] {
+        assert!(
+            doc.contains(required),
+            "docs/spec/source_style.md is missing required section/text: {required:?}"
+        );
+    }
+}

--- a/tools/language/check_source_style_contract.ps1
+++ b/tools/language/check_source_style_contract.ps1
@@ -1,0 +1,137 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Narrow drift guard for docs/spec/source_style.md (Semantic Canonical Source
+# Style v0, issue #1538). This does not parse Semantic source; syntax-level
+# claims are checked by `tests/canonical_source_style.rs` against the real
+# frontend/toolchain instead.
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$specPath = Join-Path $repoRoot "docs/spec/source_style.md"
+$examplesReadmePath = Join-Path $repoRoot "examples/canonical/README.md"
+
+function Fail {
+    param([string]$Message)
+    Write-Host "FAIL: $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Assert-FileExists {
+    param([string]$Path, [string]$Label)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "Missing $($Label): $Path"
+    }
+}
+
+function Assert-Contains {
+    param([string]$Content, [string]$Text, [string]$Label, [string]$Where)
+    if (-not $Content.Contains($Text)) {
+        Fail "$Label missing from $($Where): '$Text'"
+    }
+}
+
+# --- 1. The contract document itself must exist. ---------------------------
+Assert-FileExists -Path $specPath -Label "source style contract"
+$spec = Get-Content -Raw -LiteralPath $specPath
+
+# --- 2. Required classification vocabulary/sections must be present. -------
+$requiredSections = @(
+    "Semantic Canonical Source Style v0",
+    "Required lexical/file invariant",
+    "Canonical presentation rule",
+    "Permitted alternative author style",
+    "Future formatter behavior",
+    "Rust-like executable surface",
+    "Logos declarative surface",
+    "## A. Required Lexical/File Invariants",
+    "## B. Canonical Presentation Rules",
+    "## C. Permitted Alternative Author Style",
+    "## D. Formatter Contract"
+)
+foreach ($section in $requiredSections) {
+    Assert-Contains -Content $spec -Text $section -Label "Required section" -Where $specPath
+}
+
+# --- 3. The formatter contract must not overclaim automatic rewriting. -----
+# `smc fmt` is lexical-only today; the contract must keep saying so.
+$formatterDisclaimers = @(
+    "does **not** currently:",
+    "re-indent code;",
+    "wrap or unwrap lines to a width target;",
+    "convert between block-bodied and expression-bodied functions;",
+    "distinguish Rust-like from Logos indentation"
+)
+foreach ($text in $formatterDisclaimers) {
+    Assert-Contains -Content $spec -Text $text -Label "Formatter non-claim" -Where $specPath
+}
+
+# --- 4. The required canonical examples must exist on disk. ----------------
+$requiredExamples = @(
+    "examples/canonical/match_control_flow/src/main.sm",
+    "examples/canonical/match_control_flow/README.md",
+    "examples/canonical/rule_state_decision/src/main.sm",
+    "examples/canonical/rule_state_decision/README.md",
+    "examples/canonical/quad_cycle_logos/src/main.sm",
+    "examples/canonical/quad_cycle_logos/README.md"
+)
+foreach ($rel in $requiredExamples) {
+    Assert-FileExists -Path (Join-Path $repoRoot $rel) -Label "required canonical example file"
+}
+
+# --- 5. Public sample references must point at fixtures that still exist. --
+Assert-FileExists -Path $examplesReadmePath -Label "canonical examples index"
+$examplesReadme = Get-Content -Raw -LiteralPath $examplesReadmePath
+$referencedDirs = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($m in [regex]::Matches($examplesReadme, "examples/canonical/([A-Za-z0-9_]+)/")) {
+    [void]$referencedDirs.Add($m.Groups[1].Value)
+}
+foreach ($name in $referencedDirs) {
+    $dirPath = Join-Path $repoRoot "examples/canonical/$name"
+    if (-not (Test-Path -LiteralPath $dirPath -PathType Container)) {
+        Fail "$examplesReadmePath references missing example directory: examples/canonical/$name"
+    }
+}
+
+# --- 6. Current-facing docs must never show the two surfaces merged. -------
+# The one forbidden illustrative shape is #1538's own non-executable sketch:
+# a `System` block feeding straight into a Rust-like `fn main()`.
+$forbiddenCombination = "System QuadCycle {"
+$currentFacingDocs = @(
+    "README.md",
+    "docs/wiki/current_status.md",
+    "docs/examples_index.md",
+    "docs/language/semantic_syntax_signature.md",
+    "docs/language/semantic_linguist_entry_draft.md",
+    "docs/spec/source_style.md"
+)
+foreach ($rel in $currentFacingDocs) {
+    $path = Join-Path $repoRoot $rel
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        continue
+    }
+    $content = Get-Content -Raw -LiteralPath $path
+    if ($content.Contains($forbiddenCombination)) {
+        Fail "$path presents the unsupported merged Rust-like+Logos combination '$forbiddenCombination' as current"
+    }
+}
+
+# --- 7. Canonical examples must currently pass `smc fmt --check`. ----------
+$exampleFiles = @(
+    "examples/canonical/match_control_flow/src/main.sm",
+    "examples/canonical/rule_state_decision/src/main.sm",
+    "examples/canonical/quad_cycle_logos/src/main.sm"
+)
+Push-Location $repoRoot
+try {
+    foreach ($rel in $exampleFiles) {
+        cargo run --quiet --bin smc -- fmt --check $rel | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Fail "smc fmt --check reports unformatted canonical example: $rel"
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "PASS: Semantic Canonical Source Style v0 contract is intact" -ForegroundColor Green

--- a/tools/language/check_source_style_contract.ps1
+++ b/tools/language/check_source_style_contract.ps1
@@ -65,6 +65,15 @@ foreach ($text in $formatterDisclaimers) {
     Assert-Contains -Content $spec -Text $text -Label "Formatter non-claim" -Where $specPath
 }
 
+# --- 3b. Indentation depth must stay a Section B claim, not Section A. -----
+# Regression guard for a reviewed P2: no tool validates nesting depth today;
+# only the absence of tab characters is machine-checked (Section A).
+if ($spec.Contains("Indentation step is 4 spaces per nesting level")) {
+    Fail "$specPath lists 4-space nesting as a Section A required invariant; it must live in Section B (no tool validates nesting depth)"
+}
+Assert-Contains -Content $spec -Text "does not structurally validate indentation depth" -Label "Indentation-depth non-claim" -Where $specPath
+Assert-Contains -Content $spec -Text "no tool currently validates nesting depth" -Label "Indentation-depth non-claim" -Where $specPath
+
 # --- 4. The required canonical examples must exist on disk. ----------------
 $requiredExamples = @(
     "examples/canonical/match_control_flow/src/main.sm",


### PR DESCRIPTION
## Summary

Closes #1538. Defines, implements, and validates **Semantic Canonical Source
Style v0** in one bounded PR: contract + executable examples + formatter
contract + automated drift guards + synchronized public samples.

- `docs/spec/source_style.md` freezes every open decision from #1538 (top-level
  order, indentation, line width, blank lines, guard returns, match arms,
  expression-bodied functions, one-statement-per-line, parameters, `main`
  orchestration, comments) under a machine-checkable classification:
  **A** required lexical invariant, **B** canonical presentation, **C**
  permitted alternative author style, **D** future formatter behavior.
- Keeps the Rust-like executable surface and the Logos declarative surface
  honestly separate — they are never presented as one combined executable
  program, matching what the current frontend/toolchain actually accepts.
- Three real, qualified canonical examples demonstrate the contract:
  - `examples/canonical/match_control_flow/` (revised) — compact quad decision
    program, `check`/`compile`/`verify`/`run`-qualified.
  - `examples/canonical/rule_state_decision/` (revised) — structured practical
    program with a validation phase, `check`/`compile`/`verify`/`run`-qualified.
  - `examples/canonical/quad_cycle_logos/` (new) — Logos profile example,
    honestly labelled parse/lowering-qualified only (`dump-ast` /
    `dump-ir --profile logos`), explicitly **not** claimed as
    check/compile/verify/run-executable.
- `crates/smc-cli/src/formatter.rs` gains regression tests proving `smc fmt`
  stays lexical-only (no re-indent, no line-wrap, no control-flow rewriting)
  and is idempotent — no formatter behavior changed, only proven.
- `tests/canonical_source_style.rs` is a new automated guard suite (12 tests):
  fmt-check/idempotence/no-trailing-whitespace/no-tabs/final-newline on the
  three examples, real check/compile/verify/run qualification, the Logos
  honesty boundary (parses via `dump-ast`/`dump-ir`, still correctly rejected
  by `smc check`), a drift guard against regressing to the old verbose shape,
  and required-section presence in the contract doc.
- `tools/language/check_source_style_contract.ps1` is a narrow PowerShell
  drift checker (contract exists, required sections present, formatter
  non-claims intact, required examples exist, public sample references
  resolve, no forbidden merged-profile example, `smc fmt --check` on the
  three examples).
- README/wiki/examples-index/syntax-signature snippets are synchronized to the
  frozen style (compact guard returns in the "first program" walkthrough,
  cross-links to the new contract). Historical/archived docs are untouched.

## Non-claims

- No parser, type-system, lowering, SemCode, verifier, VM, or PROMETHEUS ABI
  semantics changed.
- No new syntax was added to make any illustrative sample compile — the
  Logos `System` parameter form in the example uses the parser's actual
  accepted `name = value` spelling, not the (stale) `name: type` spelling
  shown in `docs/spec/logos.md`'s own illustrative snippet.
- `smc fmt` behavior is unchanged; only its existing (lexical-only, CRLF→LF +
  trailing-whitespace + final-newline) behavior is now regression-tested and
  documented exactly.
- No child issues, no Workbench/Studio/ALM/UI changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace --all-targets --all-features --keep-going`
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --test public_api_contracts`
- [x] `cargo test --test canonical_examples`
- [x] `cargo test --test canonical_source_style`
- [x] `pwsh -NoProfile -File scripts/harness-check.ps1`
- [x] `pwsh -NoProfile -File tools/language/check_source_style_contract.ps1`
- [x] `git diff --check`
- [x] `cargo run --bin smc -- fmt examples/canonical/{match_control_flow,rule_state_decision,quad_cycle_logos} --check`, formatter run twice confirmed byte-identical
- [x] Adversarial verification (temporary, uncommitted mutations, each confirmed to fail, then restored): trailing whitespace, tab indentation, removed required contract section, unsupported mixed Rust-like+Logos syntax swapped into a Rust-like example

🤖 Generated with [Claude Code](https://claude.com/claude-code)
