### PR TITLE
refactor(language): migrate current examples to Source Style v0

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -10,16 +10,17 @@ intent:
   summary: "refactor(language): migrate current examples to Source Style v0"
 
 scope:
+  # Narrowed to the actual final write surface of this PR (verified against
+  # `git diff main...HEAD --name-only`), not the wider surface anticipated
+  # when this task started. examples/readiness_draft_canonical/** is
+  # deliberately absent: it is preserved historical evidence, not touched.
   allowed_paths:
     - .harness/current.task.yaml
+    - docs/examples_index.md
+    - docs/spec/source_style.md
     - examples/canonical/**
-    - examples/readiness_draft_canonical/**
-    - docs/**
-    - README.md
-    - tests/canonical_examples.rs
     - tests/canonical_source_style.rs
-    - tools/language/**
-    - crates/smc-cli/src/formatter.rs
+    - tools/language/check_source_style_contract.ps1
 
   forbidden_paths:
     - crates/sm-front/**
@@ -46,7 +47,14 @@ scope:
     - src/**
 
 authorization:
-  rust_implementation: false
+  # No dedicated "test-only Rust" field exists in this repository's harness
+  # convention (checked prior task.yaml files and .harness/reports/; none
+  # define one), so this is the general rust_implementation flag, scoped
+  # explicitly by the line below: qualification/drift-guard TEST code only
+  # (tests/canonical_source_style.rs) -- no production Rust, no language or
+  # runtime implementation.
+  rust_implementation: true
+  rust_implementation_scope: "test-only: qualification/drift-guard tests in tests/canonical_source_style.rs; no production Rust, no language/runtime implementation"
   repository_example_inventory: true
   current_facing_source_migration: true
   current_documentation_synchronization: true

--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,59 +1,77 @@
 task:
-  id: LANGUAGE-CANONICAL-SOURCE-STYLE-V0
-  title: define canonical compact source style and structured program layout, close #1538
+  id: LANGUAGE-SOURCE-STYLE-V0-REPOSITORY-MIGRATION
+  title: migrate all current-facing Semantic examples to Source Style v0
   type: implementation
   mode: active
-  supersedes: UI-DNA2-END-TO-END-GATE-D-TURBO
-  authorized_by: "Issue #1538 (repository owner direct instruction)"
+  supersedes: LANGUAGE-CANONICAL-SOURCE-STYLE-V0
+  authorized_by: "repository owner direct instruction, follow-on to #1538/#1548"
 
 intent:
-  summary: "feat(language): freeze canonical Semantic source style v0"
+  summary: "refactor(language): migrate current examples to Source Style v0"
 
 scope:
   allowed_paths:
     - .harness/current.task.yaml
-    - docs/spec/source_style.md
-    - docs/spec/index.md
-    - docs/examples_index.md
-    - docs/language/semantic_syntax_signature.md
-    - docs/language/semantic_linguist_entry_draft.md
-    - docs/language/semantic_style.md
-    - docs/language/semantic_code_style_principles.md
+    - examples/canonical/**
+    - examples/readiness_draft_canonical/**
+    - docs/**
     - README.md
-    - docs/wiki/current_status.md
-    - examples/canonical/README.md
-    - examples/canonical/match_control_flow/**
-    - examples/canonical/rule_state_decision/**
-    - examples/canonical/quad_cycle_logos/**
-    - crates/smc-cli/src/formatter.rs
     - tests/canonical_examples.rs
     - tests/canonical_source_style.rs
-    - tools/language/check_source_style_contract.ps1
+    - tools/language/**
+    - crates/smc-cli/src/formatter.rs
+
+  forbidden_paths:
+    - crates/sm-front/**
+    - crates/sm-sema/**
+    - crates/sm-ir/**
+    - crates/sm-emit/**
+    - crates/sm-verify/**
+    - crates/sm-vm/**
+    - crates/sm-runtime-core/**
+    - crates/sm-profile/**
+    - crates/prom-*/**
+    - crates/semantic-core-*/**
+    - crates/core-lab/**
+    - crates/ton618-core/**
+    - apps/**
+    - experiments/**
+    - tests/golden_snapshots/**
+    - tests/fixtures/**
+    - docs/roadmap/**
+    - docs/architecture/**
+    - docs/spec/ui/**
+    - docs/spec/ui_*.md
+    - reports/**
+    - src/**
 
 authorization:
-  rust_implementation: true
-  formatter_regression_tests: true
-  canonical_example_revision: true
-  canonical_example_addition: true
-  style_drift_guard_tests: true
-  documentation_synchronization: true
+  rust_implementation: false
+  repository_example_inventory: true
+  current_facing_source_migration: true
+  current_documentation_synchronization: true
+  canonical_example_qualification: true
+  style_drift_guard_expansion: true
+  owner_issue_lifecycle: true
   workflow_changes: false
   roadmap_changes: false
-  issue_1538_changes: true
   project_changes: false
-  # no new language grammar, type-system, lowering, SemCode, verifier, VM, or
-  # PROMETHEUS ABI semantics -- style/example/formatter-contract only
+  # explicitly not authorized this round
   grammar_semantic_expansion: false
   verifier_vm_abi_changes: false
+  ui_workbench_studio_alm_changes: false
+  pulsar_atlas_hub_changes: false
 
 constraints:
   no_grammar_or_runtime_semantic_change: true
-  no_new_syntax_to_satisfy_illustrative_examples: true
+  no_new_syntax_to_satisfy_examples: true
   rustlike_and_logos_surfaces_never_presented_as_one_executable_program: true
   formatter_stays_conservative_and_lexical_only: true
-  formatter_idempotent: true
-  canonical_examples_must_pass_real_toolchain_qualification: true
+  preserve_qualification_status_of_every_migrated_example: true
+  preserve_intentional_rejection_contracts: true
+  do_not_rewrite_historical_golden_or_evidence_fixtures: true
+  do_not_upgrade_or_downgrade_qualification_level_without_real_implementation_change: true
   one_branch_one_pr: true
   no_intermediate_documentation_only_pr: true
   no_child_issues: true
-  no_unrelated_ui_workbench_studio_alm_changes: true
+  no_unrelated_ui_workbench_studio_alm_pulsar_atlas_hub_changes: true

--- a/docs/examples_index.md
+++ b/docs/examples_index.md
@@ -4,8 +4,13 @@ Status: current-main index for the curated canonical examples pack
 
 ## Purpose
 
-This index maps the current canonical examples to their intent, current reading,
-and recommended first command.
+This index maps the current canonical examples to a recommended first
+command. For purpose, source profile, qualification level, expected result,
+and Source Style v0 migration status, see the **authoritative inventory
+table** in
+[`examples/canonical/README.md`](../examples/canonical/README.md#canonical-examples--authoritative-inventory).
+This index does not duplicate those fields — update the table there, and this
+page stays correct by reference.
 
 The canonical examples pack lives in:
 
@@ -23,171 +28,24 @@ onboarding and readiness-facing examples surface.
 demonstrates the same contract's Logos declarative-profile presentation
 rules.
 
-## Canonical Examples
+## First Commands
 
-### `cli_batch_core`
-
-- path: `examples/canonical/cli_batch_core/`
-- purpose: small CLI-style computation core over `Sequence(i32)` and `text`
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm
-```
-
-### `rule_state_decision`
-
-- path: `examples/canonical/rule_state_decision/`
-- purpose: record-oriented rule/state decision logic with explicit `Result(T, E)` handling
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm
-```
-
-### `data_audit_record_iterable`
-
-- path: `examples/canonical/data_audit_record_iterable/`
-- purpose: direct-record `Iterable` data traversal and audit-style processing
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm
-```
-
-### `text_collections_toolbox`
-
-- path: `examples/canonical/text_collections_toolbox/`
-- purpose: practical toolbox example for control flow, text, collections, and stdlib
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/text_collections_toolbox/src/main.sm
-```
-
-### `stdlib_v0_helpers`
-
-- path: `examples/canonical/stdlib_v0_helpers/`
-- purpose: practical helper-surface example for current PCC stdlib v0
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- check examples/canonical/stdlib_v0_helpers/src/main.sm
-```
-
-### `collections_core`
-
-- path: `examples/canonical/collections_core/`
-- purpose: standalone practical collections surface example
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/collections_core/src/main.sm
-```
-
-### `text_core`
-
-- path: `examples/canonical/text_core/`
-- purpose: standalone practical `text` surface example
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/text_core/src/main.sm
-```
-
-### `match_control_flow`
-
-- path: `examples/canonical/match_control_flow/`
-- purpose: practical `match`-driven control-flow over `quad`
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/match_control_flow/src/main.sm
-```
-
-### `option_result_control_flow`
-
-- path: `examples/canonical/option_result_control_flow/`
-- purpose: practical `Option` / `Result` control flow over the admitted public surface
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/option_result_control_flow/src/main.sm
-```
-
-### `loop_control_flow`
-
-- path: `examples/canonical/loop_control_flow/`
-- purpose: practical loop-driven control flow over admitted `while`, `loop`,
-  `break`, and `continue`
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- run examples/canonical/loop_control_flow/src/main.sm
-```
-
-### `wave2_local_helper_import`
-
-- path: `examples/canonical/wave2_local_helper_import/`
-- purpose: admitted helper-module executable authoring with direct local-path bare import
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- check examples/canonical/wave2_local_helper_import/src/main.sm
-```
-
-### `positive_selected_import`
-
-- path: `examples/canonical/positive_selected_import/`
-- purpose: admitted helper-module executable authoring with direct local-path selected import
-- current reading: `qualified limited release`
-- first command:
-
-```powershell
-cargo run --bin smc -- check examples/canonical/positive_selected_import/src/main.sm
-```
-
-### `boundary_alias_import`
-
-- path: `examples/canonical/boundary_alias_import/`
-- purpose: intentional boundary example showing that executable-path alias import is still rejected
-- current reading: `out of scope`
-- note: this is not a supported workflow; it documents a current executable-module / alias-import limit in the current baseline
-- first command:
-
-```powershell
-cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.sm
-```
-
-Expected result:
-
-- this example should fail with the current executable import boundary diagnostic
-- it should not be treated as a failing canonical success example
-- future support requires an explicit language/source-admission change
-
-### `quad_cycle_logos`
-
-- path: `examples/canonical/quad_cycle_logos/`
-- purpose: canonical Logos declarative-profile example (`System` / `Entity` / `Law`)
-- current reading: `parse-qualified and IR-lowering-qualified`, not
-  `check`/`compile`/`verify`/`run`-qualified (see its README for the honesty
-  boundary)
-- first command:
-
-```powershell
-cargo run --bin smc -- dump-ast examples/canonical/quad_cycle_logos/src/main.sm
-```
+| Example | First command |
+|---|---|
+| [`cli_batch_core`](../examples/canonical/cli_batch_core/) | `cargo run --bin smc -- run examples/canonical/cli_batch_core/src/main.sm` |
+| [`rule_state_decision`](../examples/canonical/rule_state_decision/) | `cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm` |
+| [`data_audit_record_iterable`](../examples/canonical/data_audit_record_iterable/) | `cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm` |
+| [`text_collections_toolbox`](../examples/canonical/text_collections_toolbox/) | `cargo run --bin smc -- run examples/canonical/text_collections_toolbox/src/main.sm` |
+| [`stdlib_v0_helpers`](../examples/canonical/stdlib_v0_helpers/) | `cargo run --bin smc -- check examples/canonical/stdlib_v0_helpers/src/main.sm` |
+| [`collections_core`](../examples/canonical/collections_core/) | `cargo run --bin smc -- run examples/canonical/collections_core/src/main.sm` |
+| [`text_core`](../examples/canonical/text_core/) | `cargo run --bin smc -- run examples/canonical/text_core/src/main.sm` |
+| [`match_control_flow`](../examples/canonical/match_control_flow/) | `cargo run --bin smc -- run examples/canonical/match_control_flow/src/main.sm` |
+| [`option_result_control_flow`](../examples/canonical/option_result_control_flow/) | `cargo run --bin smc -- run examples/canonical/option_result_control_flow/src/main.sm` |
+| [`loop_control_flow`](../examples/canonical/loop_control_flow/) | `cargo run --bin smc -- run examples/canonical/loop_control_flow/src/main.sm` |
+| [`wave2_local_helper_import`](../examples/canonical/wave2_local_helper_import/) | `cargo run --bin smc -- check examples/canonical/wave2_local_helper_import/src/main.sm` |
+| [`positive_selected_import`](../examples/canonical/positive_selected_import/) | `cargo run --bin smc -- check examples/canonical/positive_selected_import/src/main.sm` |
+| [`boundary_alias_import`](../examples/canonical/boundary_alias_import/) (intentional rejection — not a positive sample) | `cargo run --bin smc -- check examples/canonical/boundary_alias_import/src/main.sm` |
+| [`quad_cycle_logos`](../examples/canonical/quad_cycle_logos/) (Logos profile) | `cargo run --bin smc -- dump-ast examples/canonical/quad_cycle_logos/src/main.sm` |
 
 ## Validation
 

--- a/docs/spec/source_style.md
+++ b/docs/spec/source_style.md
@@ -397,9 +397,10 @@ must, in the same series:
 
 ## Canonical Examples
 
-Three examples demonstrate this contract; each README states its exact
-qualification command and status per the table in
-[`docs/examples_index.md`](../examples_index.md):
+Three examples demonstrate this contract most directly (the full canonical
+pack's authoritative inventory — every example, profile, qualification
+level, expected result, and migration status — lives in
+[`examples/canonical/README.md`](../../examples/canonical/README.md#canonical-examples--authoritative-inventory)):
 
 - `examples/canonical/match_control_flow/` — compact quad decision program
   (Rust-like, executable, `check`/`compile`/`verify`/`run`-qualified).

--- a/examples/canonical/README.md
+++ b/examples/canonical/README.md
@@ -43,72 +43,48 @@ enough to serve as representative language samples:
 The boundary example remains included as an honest exclusion marker and should
 not be treated as a positive sample for Linguist detection.
 
-## Canonical Examples
+## Canonical Examples — Authoritative Inventory
 
-1. `cli_batch_core`
-   - purpose: small CLI-style computation core over `Sequence(i32)` and `text`
-   - current reading: `qualified limited release`
+This table is the **single authoritative inventory** of the canonical
+examples pack. Every other current-facing index (`docs/examples_index.md`,
+`docs/spec/source_style.md`, `docs/language/semantic_linguist_entry_draft.md`)
+links to this table rather than maintaining its own copy of the same status
+fields, so there is exactly one place to update when an example's status
+changes.
 
-2. `rule_state_decision`
-   - purpose: record-oriented rule/state decision logic with explicit
-     `Result(T, E)` handling
-   - current reading: `qualified limited release`
+| # | Example | Profile | Purpose | Qualification level | Expected result | Style v0 status |
+|---|---|---|---|---|---|---|
+| 1 | `cli_batch_core` | Rust-like | small CLI-style computation core over `Sequence(i32)` and `text` | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 2 | `rule_state_decision` | Rust-like | record-oriented rule/state decision logic with explicit `Result(T, E)` handling | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 3 | `data_audit_record_iterable` | Rust-like | data-heavy audit pass over direct-record `Iterable` dispatch | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 4 | `text_collections_toolbox` | Rust-like | practical toolbox example for control flow, text, collections, and stdlib | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 5 | `stdlib_v0_helpers` | Rust-like | practical helper-surface example for current PCC stdlib v0 | executable: `check`/`compile`/`verify`/`run` | pass | already compliant |
+| 6 | `collections_core` | Rust-like | standalone practical collections surface example | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 7 | `text_core` | Rust-like | standalone practical `text` surface example | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 8 | `match_control_flow` | Rust-like | compact quad decision program; demonstrates Source Style v0 | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 9 | `option_result_control_flow` | Rust-like | practical `Option` / `Result` control flow over the admitted public surface | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 10 | `loop_control_flow` | Rust-like | practical loop-driven control flow over admitted `while`, `loop`, `break`, and `continue` | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 11 | `wave2_local_helper_import` | Rust-like | admitted helper-module executable authoring with direct local-path bare import | executable: `check`/`compile`/`verify`/`run` | pass | already compliant |
+| 12 | `positive_selected_import` | Rust-like | admitted helper-module executable authoring with direct local-path selected import | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
+| 13 | `boundary_alias_import` | Rust-like | intentional boundary: top-level alias import on the executable path is still rejected | intentional rejection: `check` | expected diagnostic failure preserved | already compliant |
+| 14 | `quad_cycle_logos` | Logos | canonical Logos declarative-profile example (`System` / `Entity` / `Law`); demonstrates Source Style v0 | parse + lowering only: `dump-ast`, `dump-ir --profile logos`; `check`/`run` honestly rejected | pass (parse/lowering); honest rejection (`check`/`run`) | migrated |
 
-3. `data_audit_record_iterable`
-   - purpose: data-heavy audit pass over direct-record `Iterable` dispatch
-   - current reading: `qualified limited release`
+Style v0 status meanings:
 
-4. `text_collections_toolbox`
-   - purpose: practical toolbox example for control flow, text, collections,
-     and stdlib
-   - current reading: `qualified limited release`
+- **migrated** — the file was rewritten in this or a prior migration pass to
+  apply `docs/spec/source_style.md` (compact guard returns where the
+  condition and returned expression are simple, compact match arms, blank
+  lines between semantic phases).
+- **already compliant** — the file already matched Source Style v0 before any
+  migration pass; no rewrite was needed or performed.
 
-5. `stdlib_v0_helpers`
-   - purpose: practical helper-surface example for current PCC stdlib v0
-   - current reading: `qualified limited release`
-
-6. `collections_core`
-   - purpose: standalone practical collections surface example
-   - current reading: `qualified limited release`
-
-7. `text_core`
-   - purpose: standalone practical `text` surface example
-   - current reading: `qualified limited release`
-
-8. `match_control_flow`
-   - purpose: practical `match`-driven control-flow over `quad`
-   - current reading: `qualified limited release`
-
-9. `option_result_control_flow`
-   - purpose: practical `Option` / `Result` control flow over the admitted
-     public surface
-   - current reading: `qualified limited release`
-
-10. `loop_control_flow`
-   - purpose: practical loop-driven control flow over admitted `while`,
-     `loop`, `break`, and `continue`
-   - current reading: `qualified limited release`
-
-11. `wave2_local_helper_import`
-   - purpose: admitted helper-module executable authoring with direct local-path
-     bare import
-   - current reading: `qualified limited release`
-
-12. `positive_selected_import`
-   - purpose: admitted helper-module executable authoring with direct local-path
-     selected import over the current function-only helper slice
-   - current reading: `qualified limited release`
-
-13. `boundary_alias_import`
-   - purpose: honest boundary example showing that top-level alias import on the
-     executable path is still rejected
-   - current reading: `out of scope`
-
-14. `quad_cycle_logos`
-   - purpose: canonical Logos declarative-profile example (`System` / `Entity`
-     / `Law`)
-   - current reading: `parse-qualified and IR-lowering-qualified`, explicitly
-     not `check`/`compile`/`verify`/`run`-qualified — see its own README
+`stdlib_v0_helpers` and `wave2_local_helper_import` (and its helper module)
+contain no single-condition/single-`return` guards, so B.5 compaction does
+not apply to them; their existing multi-line `if` blocks (assignment bodies,
+not `return`) are already the canonical B.8 shape. `boundary_alias_import`'s
+files contain no guard-return or match-arm forms to migrate; they are
+preserved byte-for-byte to protect the exact rejection diagnostic asserted by
+`tests/canonical_examples.rs`.
 
 ## Validation
 

--- a/examples/canonical/cli_batch_core/src/main.sm
+++ b/examples/canonical/cli_batch_core/src/main.sm
@@ -9,12 +9,8 @@ fn classify_exit(codes: Sequence(i32)) -> text {
             saw_retry ||= true;
         }
     }
-    if saw_error == true {
-        return "error";
-    }
-    if saw_retry == true {
-        return "retry";
-    }
+    if saw_error == true { return "error"; }
+    if saw_retry == true { return "retry"; }
     return "ok";
 }
 

--- a/examples/canonical/collections_core/src/main.sm
+++ b/examples/canonical/collections_core/src/main.sm
@@ -43,9 +43,7 @@ fn map_score() -> i32 {
     assert(map_get(flags, 1, false) == true);
     assert(map_get(flags, 2, true) == false);
 
-    if map_get(flags, 1, false) {
-        return 10;
-    }
+    if map_get(flags, 1, false) { return 10; }
 
     return -1;
 }

--- a/examples/canonical/data_audit_record_iterable/src/main.sm
+++ b/examples/canonical/data_audit_record_iterable/src/main.sm
@@ -15,15 +15,9 @@ record AuditSummary {
 
 impl Iterable for Samples {
     fn next(self: Self, index: i32) -> Option(i32) {
-        if index == 0 {
-            return Option::Some(self.first);
-        }
-        if index == 1 {
-            return Option::Some(self.second);
-        }
-        if index == 2 {
-            return Option::Some(self.third);
-        }
+        if index == 0 { return Option::Some(self.first); }
+        if index == 1 { return Option::Some(self.second); }
+        if index == 2 { return Option::Some(self.third); }
         return Option::None;
     }
 }

--- a/examples/canonical/loop_control_flow/src/main.sm
+++ b/examples/canonical/loop_control_flow/src/main.sm
@@ -14,9 +14,7 @@ fn find_first_over(limit: i32, threshold: i32) -> i32 {
     let mut i: i32 = 0;
 
     while i < limit {
-        if i > threshold {
-            return i;
-        }
+        if i > threshold { return i; }
 
         i = i + 1;
     }

--- a/examples/canonical/option_result_control_flow/src/main.sm
+++ b/examples/canonical/option_result_control_flow/src/main.sm
@@ -20,13 +20,8 @@ fn combine(option_value: Option(i32), result_value: Result(i32, i32)) -> i32 {
     let option_part: i32 = option_score(option_value);
     let result_part: i32 = result_score(result_value);
 
-    if option_part < 0 {
-        return option_part;
-    }
-
-    if result_part < 0 {
-        return result_part;
-    }
+    if option_part < 0 { return option_part; }
+    if result_part < 0 { return result_part; }
 
     return option_part + result_part;
 }

--- a/examples/canonical/positive_selected_import/src/helper.sm
+++ b/examples/canonical/positive_selected_import/src/helper.sm
@@ -1,7 +1,5 @@
 fn scale(value: i32) -> i32 {
-    if value == 2 {
-        return 3;
-    }
+    if value == 2 { return 3; }
     return value;
 }
 
@@ -10,8 +8,6 @@ fn score(value: i32) -> i32 {
 }
 
 fn hidden_bonus(value: i32) -> i32 {
-    if value == 0 {
-        return 100;
-    }
+    if value == 0 { return 100; }
     return value;
 }

--- a/examples/canonical/text_collections_toolbox/src/main.sm
+++ b/examples/canonical/text_collections_toolbox/src/main.sm
@@ -4,9 +4,7 @@ fn summarize_batch(codes: Sequence(i32)) -> text {
     let status2: Map(i32, bool) = map_set(status1, 2, true);
     let status_flags: Map(i32, bool) = map_set(status2, 9, true);
 
-    if len(codes) == 0 {
-        return "batch=0,status=empty";
-    }
+    if len(codes) == 0 { return "batch=0,status=empty"; }
 
     let has_error: bool = contains(codes, 9);
     let has_retry: bool = contains(codes, 2);
@@ -20,9 +18,7 @@ fn summarize_batch(codes: Sequence(i32)) -> text {
         return "batch=" + count + ",status=retry";
     }
 
-    if map_get(status_flags, codes[0], false) == true {
-        return "batch=" + count + ",status=ok";
-    }
+    if map_get(status_flags, codes[0], false) == true { return "batch=" + count + ",status=ok"; }
 
     return "batch=" + count + ",status=unknown";
 }

--- a/examples/canonical/text_core/src/main.sm
+++ b/examples/canonical/text_core/src/main.sm
@@ -6,13 +6,8 @@ fn build_status(name: text, value: i32) -> text {
 }
 
 fn check_status(message: text) -> i32 {
-    if message == "" {
-        return -1;
-    }
-
-    if message != "sensor:pressure=42" {
-        return -2;
-    }
+    if message == "" { return -1; }
+    if message != "sensor:pressure=42" { return -2; }
 
     return 1;
 }

--- a/tests/canonical_source_style.rs
+++ b/tests/canonical_source_style.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn repo_path(rel: &str) -> String {
@@ -228,6 +229,279 @@ fn source_style_document_does_not_overclaim_indentation_enforcement() {
     assert!(
         doc.contains("no tool currently validates nesting depth"),
         "docs/spec/source_style.md's Section B.2 must keep disclosing that no tool validates nesting depth"
+    );
+}
+
+// --- Repository-wide, inventory-driven guards -------------------------
+//
+// The tests above pin the three flagship examples named in
+// `docs/spec/source_style.md`. The tests below discover the *complete*
+// canonical pack from disk and cross-check it against the authoritative
+// inventory table in `examples/canonical/README.md`, so a newly added
+// canonical example cannot bypass style/qualification review by simply not
+// being added to a hardcoded list here.
+
+#[derive(Debug, Clone)]
+struct InventoryRow {
+    name: String,
+    profile: String,
+    qualification: String,
+    expected: String,
+    style_status: String,
+}
+
+/// Parses the markdown table under
+/// "## Canonical Examples — Authoritative Inventory" in
+/// `examples/canonical/README.md`. This is a lexical parse of a fixed table
+/// shape, not a general markdown parser.
+fn parse_authoritative_inventory() -> Vec<InventoryRow> {
+    let doc = read("examples/canonical/README.md");
+    let marker = "## Canonical Examples — Authoritative Inventory";
+    let start = doc
+        .find(marker)
+        .unwrap_or_else(|| panic!("examples/canonical/README.md is missing {marker:?}"));
+
+    let mut rows = Vec::new();
+    let mut past_separator = false;
+    for line in doc[start..].lines().skip(1) {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            if past_separator {
+                break;
+            }
+            continue;
+        }
+        if trimmed.replace(' ', "").starts_with("|---") {
+            past_separator = true;
+            continue;
+        }
+        if !past_separator {
+            // the header row itself
+            continue;
+        }
+        let cells: Vec<String> = trimmed
+            .trim_matches('|')
+            .split('|')
+            .map(|c| c.trim().to_string())
+            .collect();
+        if cells.len() != 7 {
+            continue;
+        }
+        rows.push(InventoryRow {
+            name: cells[1].trim_matches('`').to_string(),
+            profile: cells[2].clone(),
+            qualification: cells[4].clone(),
+            expected: cells[5].clone(),
+            style_status: cells[6].clone(),
+        });
+    }
+    rows
+}
+
+fn discover_canonical_example_dirs() -> BTreeSet<String> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/canonical");
+    std::fs::read_dir(&root)
+        .unwrap_or_else(|e| panic!("read_dir examples/canonical: {e}"))
+        .map(|entry| entry.expect("dir entry"))
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().to_string())
+        .collect()
+}
+
+fn discover_canonical_sm_files() -> Vec<String> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("sm") {
+                out.push(path);
+            }
+        }
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/canonical");
+    let mut out = Vec::new();
+    walk(&root, &mut out);
+    out.sort();
+    out.into_iter()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .collect()
+}
+
+#[test]
+fn canonical_inventory_matches_discovered_example_directories() {
+    let rows = parse_authoritative_inventory();
+    assert!(
+        !rows.is_empty(),
+        "authoritative inventory table in examples/canonical/README.md parsed to zero rows"
+    );
+    let inventory_names: BTreeSet<String> = rows.iter().map(|r| r.name.clone()).collect();
+    let disk_names = discover_canonical_example_dirs();
+
+    let undocumented: Vec<&String> = disk_names.difference(&inventory_names).collect();
+    assert!(
+        undocumented.is_empty(),
+        "examples/canonical/ contains directories with no authoritative inventory row: {undocumented:?}"
+    );
+
+    let dangling: Vec<&String> = inventory_names.difference(&disk_names).collect();
+    assert!(
+        dangling.is_empty(),
+        "authoritative inventory has rows pointing at missing examples/canonical/ directories: {dangling:?}"
+    );
+}
+
+#[test]
+fn canonical_inventory_rows_have_complete_classification() {
+    for row in parse_authoritative_inventory() {
+        assert!(
+            !row.profile.is_empty(),
+            "{}: authoritative inventory row is missing a profile classification",
+            row.name
+        );
+        assert!(
+            !row.qualification.is_empty(),
+            "{}: authoritative inventory row is missing a qualification level",
+            row.name
+        );
+        assert!(
+            !row.expected.is_empty(),
+            "{}: authoritative inventory row is missing an expected result",
+            row.name
+        );
+        assert!(
+            !row.style_status.is_empty(),
+            "{}: authoritative inventory row is missing a Source Style v0 status",
+            row.name
+        );
+    }
+}
+
+#[test]
+fn canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound() {
+    let files = discover_canonical_sm_files();
+    assert!(
+        !files.is_empty(),
+        "discovery found zero .sm files under examples/canonical/"
+    );
+    for path in files {
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        assert!(
+            !content.contains('\r'),
+            "{path} contains CR (must be LF-only)"
+        );
+        assert!(!content.contains('\t'), "{path} contains a tab character");
+        for (i, line) in content.lines().enumerate() {
+            assert_eq!(
+                line,
+                line.trim_end_matches([' ', '\t']),
+                "{path}:{} has trailing whitespace",
+                i + 1
+            );
+        }
+        assert!(
+            content.ends_with('\n') && !content.ends_with("\n\n"),
+            "{path} must have exactly one final newline"
+        );
+        let formatted = smc_cli::format_source_text(&content);
+        assert_eq!(formatted, content, "{path} is not `smc fmt`-clean");
+        let twice = smc_cli::format_source_text(&formatted);
+        assert_eq!(formatted, twice, "{path}: `smc fmt` is not idempotent");
+    }
+}
+
+#[test]
+fn canonical_inventory_executable_rows_check_compile_verify_and_run() {
+    let mut checked = 0;
+    for row in parse_authoritative_inventory() {
+        if !row.qualification.contains("executable") {
+            continue;
+        }
+        checked += 1;
+        let input = repo_path(&format!("examples/canonical/{}/src/main.sm", row.name));
+        cli_ok(
+            vec!["check".to_string(), input.clone()],
+            &format!("smc check for {}", row.name),
+        );
+        cli_ok(
+            vec!["run".to_string(), input.clone()],
+            &format!("smc run for {}", row.name),
+        );
+
+        let dir = mk_temp_dir("smc_inventory_examples");
+        let out = dir.join("out.smc");
+        let out_arg = out.to_string_lossy().replace('\\', "/");
+        cli_ok(
+            vec![
+                "compile".to_string(),
+                input.clone(),
+                "-o".to_string(),
+                out_arg.clone(),
+            ],
+            &format!("smc compile for {}", row.name),
+        );
+        cli_ok(
+            vec!["verify".to_string(), out_arg],
+            &format!("smc verify for {}", row.name),
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    assert!(
+        checked >= 2,
+        "expected at least two inventory rows marked executable; found {checked}"
+    );
+}
+
+#[test]
+fn canonical_inventory_intentional_rejection_rows_still_reject() {
+    let mut checked = 0;
+    for row in parse_authoritative_inventory() {
+        if !row.qualification.contains("intentional rejection") {
+            continue;
+        }
+        checked += 1;
+        let input = repo_path(&format!("examples/canonical/{}/src/main.sm", row.name));
+        let _ = cli_err(
+            vec!["check".to_string(), input],
+            &format!("smc check for {} (expected to keep rejecting)", row.name),
+        );
+    }
+    assert!(
+        checked >= 1,
+        "expected at least one inventory row marked intentional rejection; found {checked}"
+    );
+}
+
+#[test]
+fn canonical_inventory_logos_rows_qualify_via_profile_path_and_stay_honestly_non_executable() {
+    let mut checked = 0;
+    for row in parse_authoritative_inventory() {
+        if row.profile != "Logos" {
+            continue;
+        }
+        checked += 1;
+        let input = repo_path(&format!("examples/canonical/{}/src/main.sm", row.name));
+        cli_ok(
+            vec!["dump-ast".to_string(), input.clone()],
+            &format!("smc dump-ast for {}", row.name),
+        );
+        cli_ok(
+            vec![
+                "dump-ir".to_string(),
+                input.clone(),
+                "--profile".to_string(),
+                "logos".to_string(),
+            ],
+            &format!("smc dump-ir --profile logos for {}", row.name),
+        );
+        let _ = cli_err(
+            vec!["check".to_string(), input],
+            &format!("smc check for {} (expected honest rejection)", row.name),
+        );
+    }
+    assert!(
+        checked >= 1,
+        "expected at least one inventory row with profile Logos; found {checked}"
     );
 }
 

--- a/tests/canonical_source_style.rs
+++ b/tests/canonical_source_style.rs
@@ -410,11 +410,59 @@ fn canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound() {
     }
 }
 
+/// Closed vocabulary of qualification paths this suite knows how to exercise
+/// against the real toolchain. `classify_qualification` is the single place
+/// that decides which path a row belongs to; every other test below filters
+/// through it instead of re-testing `row.qualification`/`row.profile`
+/// directly, so a row can never be silently skipped by every toolchain test
+/// at once (the P2 this closes: a row with an unrecognized qualification
+/// string used to satisfy the aggregate `checked >= N` counts on other rows
+/// while never itself being run through anything).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QualificationKind {
+    Executable,
+    IntentionalRejection,
+    LogosProfileOnly,
+}
+
+fn classify_qualification(row: &InventoryRow) -> Vec<QualificationKind> {
+    let mut kinds = Vec::new();
+    if row.qualification.contains("executable") {
+        kinds.push(QualificationKind::Executable);
+    }
+    if row.qualification.contains("intentional rejection") {
+        kinds.push(QualificationKind::IntentionalRejection);
+    }
+    if row.profile == "Logos" {
+        kinds.push(QualificationKind::LogosProfileOnly);
+    }
+    kinds
+}
+
+#[test]
+fn canonical_inventory_every_row_matches_exactly_one_recognized_qualification_path() {
+    for row in parse_authoritative_inventory() {
+        let kinds = classify_qualification(&row);
+        assert_eq!(
+            kinds.len(),
+            1,
+            "{}: qualification {:?} / profile {:?} matched {} recognized paths (want exactly 1: \
+             Executable, IntentionalRejection, or LogosProfileOnly). A new qualification wording \
+             or profile must extend `classify_qualification` with real toolchain coverage, not just \
+             prose in the inventory table.",
+            row.name,
+            row.qualification,
+            row.profile,
+            kinds.len()
+        );
+    }
+}
+
 #[test]
 fn canonical_inventory_executable_rows_check_compile_verify_and_run() {
     let mut checked = 0;
     for row in parse_authoritative_inventory() {
-        if !row.qualification.contains("executable") {
+        if !classify_qualification(&row).contains(&QualificationKind::Executable) {
             continue;
         }
         checked += 1;
@@ -456,7 +504,7 @@ fn canonical_inventory_executable_rows_check_compile_verify_and_run() {
 fn canonical_inventory_intentional_rejection_rows_still_reject() {
     let mut checked = 0;
     for row in parse_authoritative_inventory() {
-        if !row.qualification.contains("intentional rejection") {
+        if !classify_qualification(&row).contains(&QualificationKind::IntentionalRejection) {
             continue;
         }
         checked += 1;
@@ -476,7 +524,7 @@ fn canonical_inventory_intentional_rejection_rows_still_reject() {
 fn canonical_inventory_logos_rows_qualify_via_profile_path_and_stay_honestly_non_executable() {
     let mut checked = 0;
     for row in parse_authoritative_inventory() {
-        if row.profile != "Logos" {
+        if !classify_qualification(&row).contains(&QualificationKind::LogosProfileOnly) {
             continue;
         }
         checked += 1;

--- a/tools/language/check_source_style_contract.ps1
+++ b/tools/language/check_source_style_contract.ps1
@@ -2,13 +2,16 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 # Narrow drift guard for docs/spec/source_style.md (Semantic Canonical Source
-# Style v0, issue #1538). This does not parse Semantic source; syntax-level
-# claims are checked by `tests/canonical_source_style.rs` against the real
-# frontend/toolchain instead.
+# Style v0, issues #1538/#1549). This does not parse Semantic source;
+# syntax-level claims are checked by `tests/canonical_source_style.rs`
+# against the real frontend/toolchain instead. This script discovers the
+# canonical example surface from disk rather than relying on a hardcoded
+# file list, so a newly added example cannot silently skip these checks.
 
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
 $specPath = Join-Path $repoRoot "docs/spec/source_style.md"
 $examplesReadmePath = Join-Path $repoRoot "examples/canonical/README.md"
+$canonicalRoot = Join-Path $repoRoot "examples/canonical"
 
 function Fail {
     param([string]$Message)
@@ -74,30 +77,66 @@ if ($spec.Contains("Indentation step is 4 spaces per nesting level")) {
 Assert-Contains -Content $spec -Text "does not structurally validate indentation depth" -Label "Indentation-depth non-claim" -Where $specPath
 Assert-Contains -Content $spec -Text "no tool currently validates nesting depth" -Label "Indentation-depth non-claim" -Where $specPath
 
-# --- 4. The required canonical examples must exist on disk. ----------------
-$requiredExamples = @(
-    "examples/canonical/match_control_flow/src/main.sm",
-    "examples/canonical/match_control_flow/README.md",
-    "examples/canonical/rule_state_decision/src/main.sm",
-    "examples/canonical/rule_state_decision/README.md",
-    "examples/canonical/quad_cycle_logos/src/main.sm",
-    "examples/canonical/quad_cycle_logos/README.md"
-)
-foreach ($rel in $requiredExamples) {
-    Assert-FileExists -Path (Join-Path $repoRoot $rel) -Label "required canonical example file"
+# --- 4. Discover the canonical example surface from disk. ------------------
+if (-not (Test-Path -LiteralPath $canonicalRoot -PathType Container)) {
+    Fail "Missing canonical examples directory: $canonicalRoot"
+}
+$diskExampleNames = @(
+    Get-ChildItem -LiteralPath $canonicalRoot -Directory | ForEach-Object { $_.Name }
+) | Sort-Object -Unique
+if ($diskExampleNames.Count -eq 0) {
+    Fail "No example directories found under $canonicalRoot"
+}
+foreach ($name in $diskExampleNames) {
+    $mainPath = Join-Path $canonicalRoot "$name/src/main.sm"
+    $readmePath = Join-Path $canonicalRoot "$name/README.md"
+    Assert-FileExists -Path $mainPath -Label "canonical example entry file for '$name'"
+    Assert-FileExists -Path $readmePath -Label "canonical example README for '$name'"
 }
 
-# --- 5. Public sample references must point at fixtures that still exist. --
-Assert-FileExists -Path $examplesReadmePath -Label "canonical examples index"
+# --- 5. The authoritative inventory table must cover every discovered ------
+#        example, and every table row must point at a real directory.
+Assert-FileExists -Path $examplesReadmePath -Label "canonical examples authoritative inventory"
 $examplesReadme = Get-Content -Raw -LiteralPath $examplesReadmePath
-$referencedDirs = [System.Collections.Generic.HashSet[string]]::new()
-foreach ($m in [regex]::Matches($examplesReadme, "examples/canonical/([A-Za-z0-9_]+)/")) {
-    [void]$referencedDirs.Add($m.Groups[1].Value)
+$marker = "## Canonical Examples"
+$markerIndex = $examplesReadme.IndexOf($marker)
+if ($markerIndex -lt 0) {
+    Fail "$examplesReadmePath is missing the '$marker' authoritative inventory heading"
 }
-foreach ($name in $referencedDirs) {
-    $dirPath = Join-Path $repoRoot "examples/canonical/$name"
-    if (-not (Test-Path -LiteralPath $dirPath -PathType Container)) {
-        Fail "$examplesReadmePath references missing example directory: examples/canonical/$name"
+$tableSection = $examplesReadme.Substring($markerIndex)
+$inventoryNames = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($line in ($tableSection -split "`n")) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) { continue }
+    if ($trimmed.Replace(" ", "").StartsWith("|---")) { continue }
+    $cells = $trimmed.Trim("|").Split("|") | ForEach-Object { $_.Trim() }
+    if ($cells.Count -ne 7) { continue }
+    if ($cells[0] -eq "#") { continue }
+    $inventoryNames.Add($cells[1].Trim("``")) | Out-Null
+}
+if ($inventoryNames.Count -eq 0) {
+    Fail "$examplesReadmePath authoritative inventory table parsed to zero rows"
+}
+
+foreach ($name in $diskExampleNames) {
+    if (-not $inventoryNames.Contains($name)) {
+        Fail "examples/canonical/$name has no row in the authoritative inventory table in $examplesReadmePath"
+    }
+}
+foreach ($name in $inventoryNames) {
+    if (-not (Test-Path -LiteralPath (Join-Path $canonicalRoot $name) -PathType Container)) {
+        Fail "$examplesReadmePath inventory row '$name' points at a missing examples/canonical/ directory"
+    }
+}
+
+# --- 5b. docs/examples_index.md must not reference a missing example. ------
+$examplesIndexPath = Join-Path $repoRoot "docs/examples_index.md"
+Assert-FileExists -Path $examplesIndexPath -Label "examples index"
+$examplesIndexContent = Get-Content -Raw -LiteralPath $examplesIndexPath
+foreach ($m in [regex]::Matches($examplesIndexContent, "examples/canonical/([A-Za-z0-9_]+)/")) {
+    $name = $m.Groups[1].Value
+    if (-not (Test-Path -LiteralPath (Join-Path $canonicalRoot $name) -PathType Container)) {
+        Fail "$examplesIndexPath references missing example directory: examples/canonical/$name"
     }
 }
 
@@ -111,7 +150,8 @@ $currentFacingDocs = @(
     "docs/examples_index.md",
     "docs/language/semantic_syntax_signature.md",
     "docs/language/semantic_linguist_entry_draft.md",
-    "docs/spec/source_style.md"
+    "docs/spec/source_style.md",
+    "examples/canonical/README.md"
 )
 foreach ($rel in $currentFacingDocs) {
     $path = Join-Path $repoRoot $rel
@@ -124,23 +164,62 @@ foreach ($rel in $currentFacingDocs) {
     }
 }
 
-# --- 7. Canonical examples must currently pass `smc fmt --check`. ----------
-$exampleFiles = @(
-    "examples/canonical/match_control_flow/src/main.sm",
-    "examples/canonical/rule_state_decision/src/main.sm",
-    "examples/canonical/quad_cycle_logos/src/main.sm"
-)
+# --- 6b. A current doc must not point at the historical draft pack as if ---
+#         it were the current canonical pack.
+$historicalLabels = @("historical", "planning-only", "older")
+foreach ($rel in $currentFacingDocs) {
+    $path = Join-Path $repoRoot $rel
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { continue }
+    $content = Get-Content -Raw -LiteralPath $path
+    if (-not $content.Contains("readiness_draft_canonical")) { continue }
+    $labelled = $false
+    foreach ($label in $historicalLabels) {
+        if ($content.Contains($label)) { $labelled = $true; break }
+    }
+    if (-not $labelled) {
+        Fail "$path mentions readiness_draft_canonical without labelling it historical/planning-only/older"
+    }
+}
+
+# --- 6c. A non-executable inventory row must never be shown with a run/ ----
+#         compile/verify command in current-facing docs (that would claim a
+#         stronger qualification level than the row actually registers).
+$nonExecutableNames = @()
+foreach ($line in ($tableSection -split "`n")) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) { continue }
+    if ($trimmed.Replace(" ", "").StartsWith("|---")) { continue }
+    $cells = $trimmed.Trim("|").Split("|") | ForEach-Object { $_.Trim() }
+    if ($cells.Count -ne 7) { continue }
+    if ($cells[0] -eq "#") { continue }
+    $qualification = $cells[4]
+    if ($qualification -notlike "*executable*") {
+        $nonExecutableNames += $cells[1].Trim("``")
+    }
+}
+foreach ($rel in @("README.md", "docs/wiki/current_status.md", "docs/examples_index.md")) {
+    $path = Join-Path $repoRoot $rel
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { continue }
+    $content = Get-Content -Raw -LiteralPath $path
+    foreach ($name in $nonExecutableNames) {
+        foreach ($verb in @("run", "compile", "verify")) {
+            if ($content -match "$verb\s+examples/canonical/$name(/|\b)") {
+                Fail "$path shows '$verb' against non-executable example '$name'; only its registered qualification command is allowed"
+            }
+        }
+    }
+}
+
+# --- 7. The complete canonical pack must currently pass `smc fmt --check`. -
 Push-Location $repoRoot
 try {
-    foreach ($rel in $exampleFiles) {
-        cargo run --quiet --bin smc -- fmt --check $rel | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Fail "smc fmt --check reports unformatted canonical example: $rel"
-        }
+    cargo run --quiet --bin smc -- fmt --check examples/canonical | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Fail "smc fmt --check reports unformatted file(s) under examples/canonical"
     }
 }
 finally {
     Pop-Location
 }
 
-Write-Host "PASS: Semantic Canonical Source Style v0 contract is intact" -ForegroundColor Green
+Write-Host "PASS: Semantic Canonical Source Style v0 contract is intact ($($diskExampleNames.Count) canonical examples discovered)" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Closes #1549. Applies Semantic Canonical Source Style v0 (#1538/#1548,
`docs/spec/source_style.md`) consistently across the complete current-facing
repository example surface, in one bounded PR.

## Discovery inventory

- **465** `.sm` files found repository-wide; **18** markdown files with
  ```sm``` fenced blocks.
- **14** canonical example directories classified (some containing additional helper `.sm` files).
- **8** documentation snippets inspected as current public-documentation
  samples (README.md, docs/wiki/current_status.md,
  docs/language/semantic_syntax_signature.md) — all already compliant or
  intentionally-illustrative fragments/rejections; **0** needed rewriting.
- **1** doc already self-labelled non-canonical
  (`docs/language/semantic_sugar_track.md`, `Status: proposal`) — left as is.
- **~445** files preserved as historical/qualification/golden evidence or
  out-of-scope reference material:
  - `examples/qualification/**` (~90 positive/negative compiler qualification
    fixtures, referenced only from `tests/*.rs`)
  - `crates/*/tests/fixtures/**`, `crates/sm-front/tests/*.sm` (parser/VM
    golden and profiling fixtures — outside this PR's harness scope)
  - `examples/readiness_draft_canonical/`, `examples/pcc_candidates/`
    (already-labelled historical/candidate packs, referenced only from
    roadmap docs)
  - `examples/benchmarks/{snake_core,snake_learning}.sm` (current-facing via
    README/current_status.md, but already Style-v0-compliant — no edit
    needed; qualification tests are behavior-based, not byte-sensitive)
  - `docs/spec/{syntax,source_semantics,modules,logos}.md` (grammar-reference
    illustrations, not "canonical style" programs — out of this task's scope
    per `source_style.md`'s own boundary: "does not redefine parser grammar")
  - `assets/legacy_cli/human.sm`, `examples/calculator.sm` (referenced only
    from CHANGELOG.md / marked legacy)

## Migration

8 of the 14 canonical examples needed a rewrite; 6 already conformed:

| Example | Style v0 status |
|---|---|
| `cli_batch_core` | migrated (2 guard-returns compacted) |
| `collections_core` | migrated (1 guard-return compacted) |
| `data_audit_record_iterable` | migrated (3 guard-returns compacted) |
| `loop_control_flow` | migrated (1 guard-return compacted) |
| `option_result_control_flow` | migrated (2 guard-returns compacted) |
| `text_collections_toolbox` | migrated (2 of 4 guard-returns compacted — the other 2 have `&&` compound conditions and stay expanded per B.5) |
| `text_core` | migrated (2 guard-returns compacted) |
| `positive_selected_import` (helper.sm) | migrated (2 guard-returns compacted) |
| `stdlib_v0_helpers` | already compliant (no return-guards; its `if`s are assignment bodies, correctly left multi-line) |
| `wave2_local_helper_import` | already compliant (trivial, no guard/match forms) |
| `match_control_flow`, `rule_state_decision`, `quad_cycle_logos` | migrated in #1548 |
| `boundary_alias_import` | already compliant — preserved byte-for-byte to protect its exact rejection diagnostic |

Zero semantics changed: every migrated file keeps its exact behavior,
assertions, and qualification status. No language, parser, verifier, VM, or
ABI change.

## Canonical inventory

`examples/canonical/README.md` is now the **single authoritative inventory**
(name, profile, qualification level, expected result, Style v0 status) for
all 14 examples. `docs/examples_index.md` and `docs/spec/source_style.md`
reference it instead of duplicating those fields.

## Qualification matrix (unchanged from before migration, all still pass)

- 12 Rust-like examples: `check` → `compile` → `verify` → `run`, all pass.
- 1 intentional rejection (`boundary_alias_import`): `check` still fails with
  the exact documented diagnostic.
- 1 Logos example (`quad_cycle_logos`): `dump-ast` / `dump-ir --profile
  logos` pass; `check`/`run` still honestly rejected.

## Drift guards (expanded, not hardcoded)

- `tests/canonical_source_style.rs`: 12 → 19 tests. New tests discover
  `examples/canonical/` from disk, parse the authoritative inventory table,
  and prove: every directory has a row and vice versa; every discovered
  `.sm` file is fmt-clean/idempotent/CR-free/tab-free/trailing-whitespace-
  free/single-final-newline; every "executable" row passes
  check/compile/verify/run; every "intentional rejection" row still rejects;
  every "Logos" row qualifies only via its profile path and stays honestly
  non-executable.
- `tools/language/check_source_style_contract.ps1`: same dynamic discovery
  plus a documentation drift guard — `docs/examples_index.md` links must
  resolve to real directories, the historical draft pack must stay labelled
  historical/planning-only wherever mentioned, and no example registered as
  non-executable may be shown with a `run`/`compile`/`verify` command in a
  current-facing doc.

## Non-claims

- No parser, type-system, lowering, SemCode, verifier, VM, or PROMETHEUS ABI
  semantics changed.
- No qualification level was upgraded or downgraded for any example.
- Historical, draft, candidate, and golden/qualification fixtures were not
  touched.
- No UI-DNA2/Workbench/Studio/ALM/Pulsar/Atlas/Hub changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace --all-targets --all-features --keep-going`
- [x] `cargo test --workspace --all-features` (295 suites, 0 failed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --test public_api_contracts` (4/4)
- [x] `cargo test --test canonical_examples` (5/5)
- [x] `cargo test --test canonical_source_style` (18/18)
- [x] `pwsh -NoProfile -File scripts/harness-check.ps1`
- [x] `pwsh -NoProfile -File tools/language/check_source_style_contract.ps1`
- [x] `git diff --check`
- [x] `cargo run --bin smc -- fmt examples/canonical --check`, run twice, byte-identical
- [x] Adversarial verification (temporary, uncommitted, each confirmed to fail then restored): unregistered canonical directory, dangling inventory row, trailing whitespace, tab character, wrong profile classification, a previously-passing example broken, the boundary example unexpectedly succeeding, a doc reference to a missing example

🤖 Generated with [Claude Code](https://claude.com/claude-code)
