### PR TITLE
Remove images for the Semantic Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,6 @@ cargo run -p prom-ui-demo
 
 On 2026-07-30, Semantic completed its first visible end-to-end native application proof: a dual-mode Arithmetic and Quad Logic Calculator.
 
-<p align="center">
-  <img src="docs/images/quad-logic-calculator-arithmetic.jpg" alt="Semantic Quad Logic Calculator in arithmetic mode" width="390">
-  <img src="docs/images/quad-logic-calculator-quad-mode.jpg" alt="Semantic Quad Logic Calculator in Quad Logic mode" width="390">
-</p>
-
 The application demonstrates a complete current-main path from Semantic-owned state transitions to a visible interactive native UI:
 
 ```text


### PR DESCRIPTION
Removed images from the README for the Semantic Calculator.
<img width="408" height="556" alt="Снимок экрана 2026-07-30 073436" src="https://github.com/user-attachments/assets/6578618f-eefe-4843-95a4-05647cafd3dd" />
<img width="240" height="329" alt="Снимок экрана 2026-07-30 074453" src="https://github.com/user-attachments/assets/cd10b691-2017-4d97-b983-b10291993496" />
