### PR TITLE
docs(ssf): select declarative Logos profile

### DIFF
--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -257,7 +257,7 @@ fn cmd_work_seal(frame: &WorkControlFrame) -> Result<(), String> {
 fn cmd_compile(args: &[String]) -> Result<(), String> {
     if args.is_empty() {
         return Err(
-            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
+            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
                 .to_string(),
         );
     }
@@ -265,7 +265,7 @@ fn cmd_compile(args: &[String]) -> Result<(), String> {
     reject_leading_unknown_flag(input)?;
     if args.len() < 3 {
         return Err(
-            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
+            "usage: smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust] [--opt-level O0|O1] [--debug-symbols] [--metrics]"
                 .to_string(),
         );
     }
@@ -1121,7 +1121,7 @@ fn cmd_dump_ir(args: &[String]) -> Result<(), String> {
 fn cmd_dump_bytecode(args: &[String]) -> Result<(), String> {
     if args.is_empty() {
         return Err(
-            "usage: smc dump-bytecode <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]"
+            "usage: smc dump-bytecode <input.sm|project-root> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols]"
                 .to_string(),
         );
     }
@@ -1890,7 +1890,7 @@ fn cmd_hash_ir(args: &[String]) -> Result<(), String> {
 fn cmd_hash_smc(args: &[String]) -> Result<(), String> {
     if args.is_empty() {
         return Err(
-            "usage: smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--trace-cache]"
+            "usage: smc hash-smc <input.sm|project-root> [--profile auto|rust] [--opt-level O0|O1|--opt] [--trace-cache]"
                 .to_string(),
         );
     }
@@ -2643,17 +2643,17 @@ fn cmd_disasm(args: &[String]) -> Result<(), String> {
 fn usage() -> String {
     [
         "Semantic Language toolchain v0",
-        "  smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1] [--debug-symbols] [--metrics]",
+        "  smc compile <input.sm|project-root> -o <out.smc> [--profile auto|rust] [--opt-level O0|O1] [--debug-symbols] [--metrics]",
         "  smc check <input.sm|project-root> [--no-cache] [--trace-cache] [--metrics] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]",
         "  smc watch <input.sm> [--metrics] [--color auto|always|never]",
         "  smc fmt [--check] <path>",
         "  smc dump-ast <input.sm>",
         "  smc dump-ir <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
-        "  smc dump-bytecode <input.sm> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
+        "  smc dump-bytecode <input.sm> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols]",
         "  smc hash-ast <input.sm|project-root>",
         "  smc hash-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]",
-        "  smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]",
+        "  smc hash-smc <input.sm|project-root> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols]",
         "  smc snapshots [--update]",
         "  smc features",
         "  smc explain <error-code|--list>",

--- a/docs/roadmap/stable_foundation/rustlike_logos_coherence_decision.md
+++ b/docs/roadmap/stable_foundation/rustlike_logos_coherence_decision.md
@@ -1,0 +1,121 @@
+# Rust-like / Logos Coherence Decision — SSF-02
+
+Status: accepted SSF-02 decision; not a stable-release claim
+Decision: Model B — declarative Logos profile
+Evidence base: `8ce27c48ef4cb4301da99c81286b11052748e10f`
+
+## Decision
+
+Rust-like Semantic remains the only Stable Foundation executable source
+profile. Logos is a separate experimental declarative profile for describing
+systems, entities, laws, and policy-shaped `When` fragments.
+
+```text
+Rust-like source
+  -> semantic checks -> function IR -> SemCode -> verifier -> VM
+
+Logos source
+  -> Logos parser -> Logos semantic checks -> LogosIrLaw inspection projection
+```
+
+There is no arrow from `LogosIrLaw` to SemCode. Adding one would be a new
+versioned architecture decision and qualification program, not an inference
+from the current projection.
+
+## Why Model B
+
+| Criterion | Model A: executable lowering | Model B: declarative profile |
+|---|---|---|
+| Current evidence | no Logos function-IR/SemCode/verifier/VM path | parser, semantic checks, projection, fixtures, and honest rejection exist |
+| Determinism | would require defining executable meaning for text fragments | existing parse/order/projection behavior is deterministic |
+| Verifier authority | requires a new admitted artifact mapping | preserves the single existing verifier-first executable path |
+| Implementation cost | compiler, type, effect, source-map, compatibility, and runtime work | documentation, CLI honesty, and boundary qualification only |
+| Compatibility risk | high; could accidentally create a second language authority | low; freezes the actual current boundary |
+
+Model A is rejected for Stable Foundation because current `When` condition and
+effect bodies are stored as text, and `LogosIrLaw` contains only name, priority,
+and `When` count. Treating that summary as executable would invent semantics
+and bypass the frozen Rust-like contract.
+
+## Capability Inventory
+
+| Capability | Rust-like | Logos |
+|---|---|---|
+| Parse | yes | yes |
+| Semantic analysis | yes | yes, Logos-specific |
+| Inspection IR | function IR | `LogosIrLaw` summary |
+| SemCode production | yes | no; deterministic rejection |
+| Verifier admission | yes, for produced SemCode | not applicable; no artifact |
+| VM execution | yes after admission | no |
+| Canonical evidence | check/compile/verify/run examples | dump-ast/dump-ir and rejection example |
+
+## Profiles, Maturity, and Versions
+
+- Rust-like contract: `semantic.foundation.source/1.0`;
+  **Qualified limited release**, still not Published Stable.
+- Logos contract: `semantic.logos.declarative/0.1`; **Experimental**.
+- Parser admission envelope: `semantic.foundation` / `1.0`; this shared policy
+  envelope does not equalize maturity or execution authority.
+- SemCode version remains capability-derived and belongs only to the executable
+  artifact path.
+
+Changing Logos grammar, semantic meaning, or inspection projection
+incompatibly requires a new Logos contract version. It does not change the
+Rust-like source contract or SemCode version by implication.
+
+## CLI Contract
+
+| Command family | Rust-like | Logos |
+|---|---|---|
+| `dump-ast` | inspect | inspect `LogosProgram` |
+| `dump-ir`, `hash-ir` | function IR | `--profile logos` inspection projection |
+| `check` | executable-source analysis | not an admitted Logos workflow |
+| `compile`, `dump-bytecode`, `hash-smc` | SemCode-producing | rejected before artifact emission |
+| `verify`, `run`, `run-smc` | verifier-first artifact/source execution | no Logos artifact or execution path |
+
+The CLI may accept `logos` as a parser value internally so inspection commands
+can select it. Bytecode-producing usage text advertises only `auto|rust`.
+Explicit or auto-detected Logos input still reaches the canonical deterministic
+boundary rejection rather than a hidden fallback.
+
+## Files, Packages, and Source Mapping
+
+- A current source file is either Rust-like or Logos for a tool invocation.
+- Mixed Rust-like/Logos source is unsupported and rejected as one file; the CLI
+  does not split it or silently choose one authority.
+- No cross-profile imports, implicit bindings, or Logos package ecosystem are
+  admitted in Stable Foundation.
+- SSF-05/06 own Rust-like project/package completion and may consume this
+  decision but cannot invent a Logos execution route.
+- `LogosLaw` and `LogosWhen` carry frontend source marks. The current
+  `LogosIrLaw` inspection summary does not retain a general source map and is
+  not a generated executable binding artifact.
+- A future binder must be explicit, versioned, validated, provenance-bearing,
+  and subordinate to verifier admission.
+
+## Demonstrated Gaps and Bounded Resolution
+
+The compiler already rejects Logos before SemCode emission, so no compiler,
+verifier, VM, or rule-engine expansion is needed. SSF-02 resolves only:
+
+1. the missing authoritative Model A/B decision;
+2. the missing separate Logos contract/version and maturity statement;
+3. bytecode-command help that previously advertised `logos` as a successful
+   profile value;
+4. missing exact regression evidence for SemCode rejection and mixed profiles.
+
+## SSF-03 Entry Conditions
+
+SSF-03 may start only after:
+
+1. specs, CLI help, status matrix, and canonical example agree on Model B;
+2. positive Logos parse/projection and negative SemCode/mixed-profile tests pass;
+3. exact-head repository CI passes and the SSF-02 PR is merged;
+4. issue #1573 records the merge SHA and closes;
+5. a separate governance PR activates only SSF-03.
+
+## External Explanation
+
+Semantic executes Rust-like source through SemCode, the verifier, and the VM;
+Logos is currently an experimental declarative profile that can be parsed,
+checked on its own terms, and projected for inspection, but it is not executed.

--- a/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
+++ b/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
@@ -96,7 +96,7 @@ that wording drift; it does not delete or rewrite historical evidence.
 | Public feature | Owner layer | Status | Evidence and exact boundary | Foundation routing |
 |---|---|---|---|---|
 | Rust-like executable profile | F/I/V/R/C/D | **Qualified limited release** | Gate 1 establishes a narrow executable contour. | Primary contract in SSF-01. |
-| Logos declarative profile | F/I/C/D | **Experimental** | Canonical example supports `dump-ast`/Logos IR only; `check` and `run` honestly reject it. | Select Model A or B in SSF-02. |
+| Logos declarative profile | F/I/C/D | **Experimental** | SSF-02 selected Model B: `semantic.logos.declarative/0.1` supports parse, semantic analysis, and non-executable `LogosIrLaw` inspection; SemCode/VM paths reject it. | Preserve the boundary through SSF-09/11/12; no automatic promotion. |
 | `std.core` | F/I/V/R/D | **Roadmap** | Current helpers are builtins; no importable canonical module contract. | SSF-03. |
 | `std.quad` | F/I/V/R/D | **Roadmap** | Native quad exists, but the named module/API does not. | SSF-03. |
 | `std.math` | F/I/V/R/D | **Roadmap** | Math builtins exist; named module and compatibility contract do not. | SSF-03. |

--- a/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
@@ -58,10 +58,11 @@ contract but may not silently widen it.
 
 ### Profile coherence
 
-Rust-like Semantic is the executable-profile candidate. Logos remains
-experimental until SSF-02 selects and implements either executable lowering or
-an explicitly declarative profile with honest tool behavior. SSF-00 does not
-preselect that product decision.
+Rust-like Semantic is the executable-profile candidate. SSF-02 selected Model B:
+Logos is the separate experimental declarative profile
+`semantic.logos.declarative/0.1`, with parse/semantic/inspection support and no
+SemCode/verifier/VM execution path. The decision record is
+`rustlike_logos_coherence_decision.md`.
 
 ### Minimal deterministic library
 
@@ -124,7 +125,7 @@ Andromeda, and broad permanent ABI/ISA promises.
 | Decision | Owning phase | Entry assumption |
 |---|---|---|
 | Exact stable source grammar/profile and included feature subsets | SSF-01 | Start from the candidate core above; do not inherit all of current `main`. |
-| Executable versus declarative Logos | SSF-02 | Logos remains experimental. |
+| Executable versus declarative Logos | SSF-02 | Resolved as Model B; Logos remains experimental and non-executable. |
 | Builtin-to-stdlib boundary and APIs | SSF-03 | Existing builtins may be wrapped, renamed, narrowed, or deferred. |
 | Capability names, grants, denial results, audit, replay profiles | SSF-04 | Existing `print` is evidence, not the finished boundary. |
 | Canonical manifest, project layout, discovery, and command shapes | SSF-05 | Both current manifests are evidence; neither wins by implication. |

--- a/docs/roadmap/stable_foundation/stable_public_language_contract.md
+++ b/docs/roadmap/stable_foundation/stable_public_language_contract.md
@@ -42,7 +42,7 @@ is implemented by this phase.
 | `requires`/`ensures`/`invariant` | Experimental | bounded parser/typecheck/lowering evidence | no complete public full-path qualification contour |
 | Measured numeric forms | Experimental | narrow frontend/carrier evidence | measured `fx` arithmetic remains an explicit gap |
 | Broader module/package imports | Deferred | landed current-main package/module evidence | owned by SSF-05/SSF-06 |
-| Logos | Deferred | parse and Logos-IR canonical example | product/execution decision owned by SSF-02 |
+| Logos | Experimental declarative profile | parse, semantic analysis, and non-executable Logos-IR canonical example | Model B selected by SSF-02; outside this executable contract |
 
 ## Contract audit result
 
@@ -111,5 +111,6 @@ SSF-02 may start only after:
 4. issue #1572 records the exact merge commit and closes;
 5. a separate governance update activates only #1573.
 
-SSF-02 owns the Rust-like/Logos relationship and may not silently widen the
-Rust-like contract selected here.
+SSF-02 selected the declarative Model B relationship without widening the
+Rust-like contract selected here. The separate Logos contract is
+`semantic.logos.declarative/0.1`.

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -47,17 +47,17 @@ The admitted `smc` command surface is currently:
 
 Current accepted usage forms are:
 
-- `smc compile <input.sm|project-root> -o|--out <out.smc> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--metrics]`
+- `smc compile <input.sm|project-root> -o|--out <out.smc> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols] [--metrics]`
 - `smc check <input.sm|project-root> [--no-cache] [--trace-cache] [--metrics] [--deny warnings|<CODE>] [--color auto|always|never]`
 - `smc lint <input.sm> [--no-cache] [--trace-cache] [--deny warnings|<CODE>] [--color auto|always|never]`
 - `smc watch <input.sm> [--metrics] [--color auto|always|never]`
 - `smc fmt [--check] <path>`
 - `smc dump-ast <input.sm|project-root>`
 - `smc dump-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
-- `smc dump-bytecode <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols]`
+- `smc dump-bytecode <input.sm|project-root> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols]`
 - `smc hash-ast <input.sm|project-root>`
 - `smc hash-ir <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt]`
-- `smc hash-smc <input.sm|project-root> [--profile auto|rust|logos] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
+- `smc hash-smc <input.sm|project-root> [--profile auto|rust] [--opt-level O0|O1|--opt] [--debug-symbols] [--trace-cache]`
 - `smc snapshots [--update]`
 - `smc features`
 - `smc explain <error-code|--list>`
@@ -76,6 +76,26 @@ Current accepted usage forms are:
 - `smc hub audit --request <request-id>`
 
 This draft does not claim that every command is permanently frozen, but it defines the current public CLI surface that tooling may rely on.
+
+## Rust-like / Logos Profile Boundary
+
+Rust-like Semantic is the only source profile admitted to SemCode-producing and
+execution commands. Logos is the separate experimental declarative profile
+defined by `semantic.logos.declarative/0.1`.
+
+- `dump-ast` accepts either source surface for inspection.
+- `dump-ir --profile logos` and `hash-ir --profile logos` expose the
+  non-executable `LogosIrLaw` projection.
+- `compile`, `dump-bytecode`, `hash-smc`, `verify`, `run`, and `run-smc` do not
+  form a Logos execution path.
+- Explicit or auto-detected Logos input reaching a SemCode-producing path is
+  rejected before artifact emission with the existing Logos/SemCode boundary
+  diagnostic.
+- A file that mixes Rust-like items with Logos declarations is unsupported and
+  is rejected; tools do not split it into two hidden compilation units.
+
+The shared `ParserProfile::foundation_default()` admission envelope does not
+give the two source profiles equal maturity or execution authority.
 
 ## Not In The Current Surface
 

--- a/docs/spec/logos.md
+++ b/docs/spec/logos.md
@@ -1,6 +1,7 @@
 # Logos Surface Specification
 
-Status: draft v0
+Status: experimental declarative profile v0.1
+Contract identifier: `semantic.logos.declarative/0.1`
 Primary frontend owners: `sm-front`, `sm-sema`
 
 ## Purpose
@@ -9,6 +10,20 @@ This document defines the current declarative Logos-oriented source surface used
 for system, entity, and law descriptions inside Semantic.
 
 It complements the Rust-like executable surface described in `syntax.md`.
+
+## Authoritative Relationship
+
+SSF-02 selects **Model B: declarative Logos profile**.
+
+- Rust-like Semantic owns executable behavior and the SemCode/verifier/VM path.
+- Logos describes systems, entities, laws, and policy-shaped `When` fragments.
+- Logos parsing, semantic analysis, and `LogosIrLaw` projection do not imply
+  executable lowering.
+- No tool may reinterpret Logos text fragments as Rust-like expressions or
+  bypass verifier-first execution.
+
+The decision evidence and rejected Model A alternative are recorded in
+`../roadmap/stable_foundation/rustlike_logos_coherence_decision.md`.
 
 ## Current Top-Level Forms
 
@@ -94,6 +109,48 @@ Current rule:
 This behavior is part of the current public source contract and should not be
 changed silently.
 
+## Tool and Projection Contract
+
+The admitted Logos workflow is inspection-only:
+
+| Stage | Current status |
+|---|---|
+| Parse to `LogosProgram` | implemented and qualified |
+| Semantic analysis | implemented with Logos diagnostics |
+| Project laws to `LogosIrLaw` | implemented and qualified |
+| Lower to Rust-like function IR or SemCode | unsupported |
+| Verifier/VM execution | unsupported because no Logos SemCode is produced |
+
+`LogosLaw` and `LogosWhen` retain source marks in the frontend model. The
+current `LogosIrLaw` projection contains only law name, priority, and `When`
+count. It is an inspection summary, not a generated executable or a source-map
+promise for future binding.
+
+Current CLI support is `dump-ast`, `dump-ir --profile logos`, and
+`hash-ir --profile logos`. SemCode-producing and execution commands reject
+Logos input before artifact emission.
+
+## Files, Modules, and Packages
+
+- one source file belongs to one surface for the current tool invocation;
+- Rust-like items and Logos declarations may not be mixed in one admitted file;
+- Logos has no Stable Foundation package/module or cross-profile import model;
+- Rust-like package behavior remains owned by SSF-05 and SSF-06;
+- any future binding must be an explicit versioned validated artifact, not an
+  implicit import or a second execution authority.
+
+## Maturity and Version Policy
+
+`semantic.logos.declarative/0.1` is **Experimental**. The identifier versions
+the declarative grammar, semantic checks, and inspection projection described
+here; it is not a stable compatibility or execution promise. Incompatible
+changes require a new contract identifier version and updated fixtures.
+
+This status is separate from Rust-like
+`semantic.foundation.source/1.0`, which is the qualified-limited executable
+Stable Foundation candidate. The shared parser-profile version is an admission
+envelope and must not be used to collapse these maturity states.
+
 ## Policy Rule
 
 The Logos surface is policy-gated:
@@ -109,6 +166,8 @@ The current Logos contract does not yet claim stable support for:
 - rich user-defined statement semantics inside `When` beyond the current
   text-fragment contract
 - broad legacy directives as first-class long-term source features
+- executable lowering, SemCode production, verifier admission, or VM execution
+- mixed Rust-like/Logos files or implicit cross-profile imports
 
 ## Contract Rule
 

--- a/docs/spec/source_style.md
+++ b/docs/spec/source_style.md
@@ -322,7 +322,7 @@ Law "CheckSignal" [priority 10]:
   `priority`, not by source order (`logos.md`).
 - `System` parameters use `name = value` (the current parser's accepted form —
   `logos.md`'s illustrative `param: type` spelling is not what
-  `parse_logos_system` accepts; this document reflects the executable
+  `parse_logos_system` accepts; this document reflects the implemented
   parser).
 
 ## C. Permitted Alternative Author Style

--- a/docs/status/feature_maturity_matrix.md
+++ b/docs/status/feature_maturity_matrix.md
@@ -42,7 +42,8 @@ spelling.
 - The bounded Gate 1 contour remains **Qualified limited release**.
 - Current `main` contains wider qualified and unqualified implementation that
   remains unpromoted.
-- Logos remains an experimental declarative profile until SSF-02.
+- Logos is the separate experimental declarative profile selected by SSF-02;
+  it does not produce SemCode or share Rust-like execution authority.
 - Named `std.*` modules, the controlled application capability set, lock and
   provenance records, a canonical language server, and Foundation migration
   tooling remain roadmap work.

--- a/examples/canonical/quad_cycle_logos/README.md
+++ b/examples/canonical/quad_cycle_logos/README.md
@@ -4,7 +4,7 @@
   `Entity` state/prop fields, and priority-ordered `Law`/`When` rules
 - language profile: **Logos declarative surface** (`docs/spec/logos.md`) — this
   is not the Rust-like executable surface and is not combined with one in this
-  file
+  file; contract identifier: `semantic.logos.declarative/0.1`
 - supported status: **parse-qualified and IR-lowering-qualified only**. It is
   explicitly **not** `check`/`compile`/`verify`/`run`-qualified: those commands
   target the Rust-like SemCode/VM path, which does not accept Logos source.

--- a/tests/fixtures/ssf02/mixed_profiles.sm
+++ b/tests/fixtures/ssf02/mixed_profiles.sm
@@ -1,0 +1,6 @@
+fn main() -> i32 {
+    return 0;
+}
+
+Law "MixedAuthority" [priority 1]:
+    When T -> T

--- a/tests/ssf_logos_profile_boundary.rs
+++ b/tests/ssf_logos_profile_boundary.rs
@@ -1,0 +1,132 @@
+use std::path::{Path, PathBuf};
+
+const LOGOS_EXAMPLE: &str = "examples/canonical/quad_cycle_logos/src/main.sm";
+const MIXED_FIXTURE: &str = "tests/fixtures/ssf02/mixed_profiles.sm";
+const SEMCODE_BOUNDARY: &str =
+    "Logos input lowers to LogosIrLaw stream; SemCode function IR requires RustLike frontend";
+
+fn repo_path(relative: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(relative)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn run_ok(args: Vec<String>, context: &str) {
+    smc_cli::run(args).unwrap_or_else(|error| panic!("{context} failed: {error}"));
+}
+
+fn run_err(args: Vec<String>, context: &str) -> String {
+    match smc_cli::run(args) {
+        Ok(()) => panic!("{context} unexpectedly passed"),
+        Err(error) => error,
+    }
+}
+
+fn absent_artifact(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("semantic-ssf02-{}-{name}.smc", std::process::id()))
+}
+
+#[test]
+fn logos_declarative_inspection_path_remains_available() {
+    let source = repo_path(LOGOS_EXAMPLE);
+    run_ok(
+        vec!["dump-ast".to_string(), source.clone()],
+        "Logos AST inspection",
+    );
+    run_ok(
+        vec![
+            "dump-ir".to_string(),
+            source.clone(),
+            "--profile".to_string(),
+            "logos".to_string(),
+        ],
+        "Logos IR inspection",
+    );
+    run_ok(
+        vec![
+            "hash-ir".to_string(),
+            source,
+            "--profile".to_string(),
+            "logos".to_string(),
+        ],
+        "Logos IR hashing",
+    );
+}
+
+#[test]
+fn logos_cannot_emit_semcode_or_bytecode() {
+    let source = repo_path(LOGOS_EXAMPLE);
+    let artifact = absent_artifact("compile");
+    let compile_error = run_err(
+        vec![
+            "compile".to_string(),
+            source.clone(),
+            "-o".to_string(),
+            artifact.to_string_lossy().into_owned(),
+            "--profile".to_string(),
+            "logos".to_string(),
+        ],
+        "Logos SemCode compilation",
+    );
+    assert!(compile_error.contains(SEMCODE_BOUNDARY), "{compile_error}");
+    assert!(!artifact.exists(), "rejected compile emitted an artifact");
+
+    let bytecode_error = run_err(
+        vec![
+            "dump-bytecode".to_string(),
+            source,
+            "--profile".to_string(),
+            "logos".to_string(),
+        ],
+        "Logos bytecode dump",
+    );
+    assert!(
+        bytecode_error.contains(SEMCODE_BOUNDARY),
+        "{bytecode_error}"
+    );
+
+    let run_error = run_err(
+        vec!["run".to_string(), repo_path(LOGOS_EXAMPLE)],
+        "Logos source execution",
+    );
+    assert!(
+        run_error.contains("expected top-level 'Import'"),
+        "{run_error}"
+    );
+}
+
+#[test]
+fn mixed_profile_source_is_rejected_deterministically() {
+    let source = repo_path(MIXED_FIXTURE);
+    let args = vec![
+        "dump-ir".to_string(),
+        source,
+        "--profile".to_string(),
+        "logos".to_string(),
+    ];
+    let first = run_err(args.clone(), "mixed-profile Logos projection");
+    let second = run_err(args, "repeated mixed-profile Logos projection");
+    assert_eq!(first, second, "mixed-profile rejection drifted");
+    assert!(
+        first.contains("error[E0200]: expected Logos declaration"),
+        "unexpected mixed-profile diagnostic: {first}"
+    );
+}
+
+#[test]
+fn cli_and_docs_advertise_the_same_profile_boundary() {
+    let usage = run_err(Vec::new(), "empty CLI invocation");
+    assert!(usage.contains("compile <input.sm|project-root> -o <out.smc> [--profile auto|rust]"));
+    assert!(usage.contains("dump-ir <input.sm> [--profile auto|rust|logos]"));
+    assert!(usage.contains("dump-bytecode <input.sm> [--profile auto|rust]"));
+    assert!(!usage.contains("dump-bytecode <input.sm> [--profile auto|rust|logos]"));
+
+    let logos_spec = include_str!("../docs/spec/logos.md");
+    let decision =
+        include_str!("../docs/roadmap/stable_foundation/rustlike_logos_coherence_decision.md");
+    for text in [logos_spec, decision] {
+        assert!(text.contains("semantic.logos.declarative/0.1"));
+        assert!(text.contains("Model B"));
+    }
+}


### PR DESCRIPTION
Closes #1573

## SSF phase

- SSF-02 — Rust-like / Logos coherence
- base: `8ce27c48ef4cb4301da99c81286b11052748e10f`
- head: `5464beb864c2a5c5147406bcfae08ed06f6584bd`
- decision: Model B — declarative Logos profile
- Logos contract: `semantic.logos.declarative/0.1` (Experimental)

## Decision and scope

- keep Rust-like `semantic.foundation.source/1.0` as the only Stable Foundation executable source profile
- define Logos as a separate experimental declarative parser/semantic/inspection profile
- document that `LogosIrLaw` is a non-executable summary, not function IR or SemCode
- freeze no mixed-file, cross-profile import, or implicit package binding behavior
- remove `logos` from successful bytecode-producing CLI usage forms while preserving deterministic boundary rejection
- add positive inspection, SemCode/bytecode rejection, no-artifact, run rejection, mixed-profile, and CLI/docs drift evidence

## Deliberate exclusions

- no executable Logos lowering, rule engine, binder, package model, verifier path, or VM path
- no second language/runtime authority
- no Rust-like contract widening
- no stable promotion or release decision

## Validation

- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- SSF-02 boundary suite: 4/4
- golden snapshots: 9/9
- frontend parser qualification: 4/4
- sm-front Logos unit filter: 3/3
- post-commit status/CLI/canonical/public-API set: 17/17
- `scripts/harness-check.ps1`
- `git diff --check`

Windows note: `canonical_source_style` reached 16/19; the remaining three assertions are the known checkout-only CRLF mismatch on unchanged `.sm` fixtures. Git blobs are LF and this result is not counted as a pass. Exact-head Linux `test-std` CI must pass before merge.

## Promotion statement

This PR keeps Logos Experimental, keeps Rust-like below Published Stable, and makes no release decision.
