### PR TITLE
stdlib: freeze Foundation Standard Library v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Read the authoritative documents when status precision matters:
 - [Public Maturity Snapshot](docs/roadmap/public_maturity_snapshot.md)
 - [Feature Maturity Matrix](docs/status/feature_maturity_matrix.md)
 - [Foundation Source Profile 1.0](docs/spec/foundation_source_profile_v1.md)
+- [Foundation Standard Library v0](docs/spec/foundation_stdlib_v0.md)
 
 ## How Execution Is Controlled
 

--- a/docs/examples_index.md
+++ b/docs/examples_index.md
@@ -36,7 +36,7 @@ rules.
 | [`rule_state_decision`](../examples/canonical/rule_state_decision/) | `cargo run --bin smc -- run examples/canonical/rule_state_decision/src/main.sm` |
 | [`data_audit_record_iterable`](../examples/canonical/data_audit_record_iterable/) | `cargo run --bin smc -- run examples/canonical/data_audit_record_iterable/src/main.sm` |
 | [`text_collections_toolbox`](../examples/canonical/text_collections_toolbox/) | `cargo run --bin smc -- run examples/canonical/text_collections_toolbox/src/main.sm` |
-| [`stdlib_v0_helpers`](../examples/canonical/stdlib_v0_helpers/) | `cargo run --bin smc -- check examples/canonical/stdlib_v0_helpers/src/main.sm` |
+| [`stdlib_v0_helpers`](../examples/canonical/stdlib_v0_helpers/) | `cargo run --bin smc -- run examples/canonical/stdlib_v0_helpers/src/main.sm` |
 | [`collections_core`](../examples/canonical/collections_core/) | `cargo run --bin smc -- run examples/canonical/collections_core/src/main.sm` |
 | [`text_core`](../examples/canonical/text_core/) | `cargo run --bin smc -- run examples/canonical/text_core/src/main.sm` |
 | [`match_control_flow`](../examples/canonical/match_control_flow/) | `cargo run --bin smc -- run examples/canonical/match_control_flow/src/main.sm` |

--- a/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
+++ b/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
@@ -97,16 +97,16 @@ that wording drift; it does not delete or rewrite historical evidence.
 |---|---|---|---|---|
 | Rust-like executable profile | F/I/V/R/C/D | **Qualified limited release** | Gate 1 establishes a narrow executable contour. | Primary contract in SSF-01. |
 | Logos declarative profile | F/I/C/D | **Experimental** | SSF-02 selected Model B: `semantic.logos.declarative/0.1` supports parse, semantic analysis, and non-executable `LogosIrLaw` inspection; SemCode/VM paths reject it. | Preserve the boundary through SSF-09/11/12; no automatic promotion. |
-| `std.core` | F/I/V/R/D | **Roadmap** | Current helpers are builtins; no importable canonical module contract. | SSF-03. |
-| `std.quad` | F/I/V/R/D | **Roadmap** | Native quad exists, but the named module/API does not. | SSF-03. |
-| `std.math` | F/I/V/R/D | **Roadmap** | Math builtins exist; named module and compatibility contract do not. | SSF-03. |
-| `std.text` | F/I/V/R/D | **Roadmap** | Bounded text operations exist; named module/UTF-8 API is not frozen. | SSF-03/07. |
-| `std.seq` | F/I/V/R/D | **Roadmap** | Sequence helpers exist as language builtins, not a stable importable module. | SSF-03/07. |
-| `std.map` | F/I/V/R/D | **Roadmap** | Map helpers exist as language builtins, not a stable importable module. | SSF-03/07. |
-| `std.option` | F/I/V/R/D | **Roadmap** | Option is qualified; named module API is absent. | SSF-03. |
-| `std.result` | F/I/V/R/D | **Roadmap** | Result is qualified; named module API is absent. | SSF-03. |
-| `std.serde` | F/I/V/R/D | **Roadmap** | No canonical deterministic importable serialization family. | SSF-03. |
-| `std.rand` | F/I/V/R/D | **Roadmap** | Seeded PRNG builtins are qualified on main; named/versioned module is absent. | SSF-03/10. |
+| `std.core` | F/I/V/R/D | **Qualified limited release** | `semantic.foundation.std/0.1` selects language-owned `assert`; `std.*` is not an import namespace. | Preserve through SSF-12. |
+| `std.quad` | F/I/V/R/D | **Qualified limited release** | `semantic.foundation.std/0.1` selects explicit qtruth maps with N/S evidence preserved. | Preserve through SSF-12. |
+| `std.math` | F/I/V/R/D | **Roadmap** | SSF-03 selects no API; current f64 builtins remain experimental pending determinism policy. | SSF-07/10. |
+| `std.text` | F/I/V/R/D | **Qualified limited release** | Exact UTF-8 text equality/concat and bounded scalar `to_text`; no indexing/normalization. | Bound further in SSF-07. |
+| `std.seq` | F/I/V/R/D | **Qualified limited release** | Ordered persistent sequence helpers selected as language-owned equivalents. | Bound further in SSF-07. |
+| `std.map` | F/I/V/R/D | **Qualified limited release** | Persistent lookup/update helpers selected; no observable iteration/order API. | Bound further in SSF-07. |
+| `std.option` | F/I/V/R/D | **Qualified limited release** | Language-owned type/constructors/exhaustive match selected; no helper expansion. | Preserve through SSF-12. |
+| `std.result` | F/I/V/R/D | **Qualified limited release** | Language-owned type/constructors/exhaustive match selected; no helper expansion. | Preserve through SSF-12. |
+| `std.serde` | F/I/V/R/D | **Roadmap** | SSF-03 selects no API or encoding; JSON in Rust tooling is not Semantic stdlib. | Explicit future approval only. |
+| `std.rand` | F/I/V/R/D | **Qualified limited release** | Versioned xorshift64/13-7-17 seeded VM stream; no host entropy. | Compatibility window in SSF-10. |
 | `args.read` | V/R/C | **Roadmap** | No canonical admitted capability of this name. | SSF-04. |
 | `stdin.read_text` | V/R/C | **Roadmap** | No canonical admitted capability of this name. | SSF-04. |
 | `stdout.write` | V/R/C | **Roadmap** | Narrow `print(text)`/`CAP_STDOUT` exists, but the proposed structured capability does not. | SSF-04. |

--- a/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
@@ -30,10 +30,10 @@ until the preceding exit gate is accepted.
 
 | Phase | Inputs from prior phase | Owns | Exit evidence | Current state |
 |---|---|---|---|---|
-| SSF-00 / #1571 | Umbrella #1569 and live repository/release evidence | Canonical matrix, target `SSF-TARGET-0`, dependency map, status drift correction | Three accepted documents, drift guard, exact merge evidence | **Active** |
-| SSF-01 / #1572 | Accepted target and source rows | Versioned Rust-like public language contract, included/deferred source features | End-to-end positive/negative contract evidence | Blocked by SSF-00 |
-| SSF-02 / #1573 | Frozen executable contract | Rust-like/Logos Model A or B, diagnostics and package interaction | Honest profile behavior and examples | Blocked by SSF-01 |
-| SSF-03 / #1574 | Frozen language/profile contract | Minimal importable stdlib APIs and builtin boundary | Positive, negative, compatibility tests and index | Blocked by SSF-02 |
+| SSF-00 / #1571 | Umbrella #1569 and live repository/release evidence | Canonical matrix, target `SSF-TARGET-0`, dependency map, status drift correction | Three accepted documents, drift guard, exact merge evidence | Completed |
+| SSF-01 / #1572 | Accepted target and source rows | Versioned Rust-like public language contract, included/deferred source features | End-to-end positive/negative contract evidence | Completed |
+| SSF-02 / #1573 | Frozen executable contract | Rust-like/Logos Model A or B, diagnostics and package interaction | Honest profile behavior and examples | Completed: Model B |
+| SSF-03 / #1574 | Frozen language/profile contract | Versioned language-owned stdlib equivalents and builtin boundary | Positive, negative, compatibility tests and canonical index | **Active** |
 | SSF-04 / #1575 | Stable value/library carriers | Capabilities, profiles, denial/audit/replay contract | Canonical deterministic file-transform path | Blocked by SSF-03 |
 | SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | Blocked by SSF-04 |
 | SSF-06 / #1577 | Canonical project model | Local package graph, provenance/lock, capability inventory | Multi-package reproducibility and root-security evidence | Blocked by SSF-05 |

--- a/docs/roadmap/stable_foundation/standard_library_v0_evidence.md
+++ b/docs/roadmap/stable_foundation/standard_library_v0_evidence.md
@@ -1,0 +1,83 @@
+# SSF-03 Standard Library v0 Evidence
+
+Status: candidate exit evidence; not Published Stable
+
+Contract: `semantic.foundation.std/0.1`
+
+Base: `0115b161f27d12aa877562b440a1cc5a84a05bcb`
+
+This map binds each selected Standard Library v0 family to existing
+implementation authority and executable evidence. SSF-03 adds no duplicate
+runtime or frontend implementation because the selected behavior is already
+owned end to end.
+
+## Family qualification map
+
+| Family | Positive evidence | Negative evidence | Compatibility baseline |
+|---|---|---|---|
+| `std.core` | `tests/pcc8_stdlib_acceptance.rs` | `tests/pcc8_stdlib_diagnostics.rs` | CTF-E1/CTF-E3 stdlib trace and trap fixtures |
+| `std.quad` | qtruth frontend/lowering/VM unit matrices in `crates/sm-front`, `crates/sm-ir`, and `crates/sm-vm` | quad type mismatch and opcode truncation/rejection unit tests | distinct QTruth opcode-byte tests and canonical `semantic-core-quad` truth maps |
+| `std.text` | `tests/pcc3_text_core_gate.rs`, `tests/pcc8_stdlib_acceptance.rs` | `tests/pcc_stdlib_negative.rs`, `tests/pcc8_stdlib_diagnostics.rs` | PCC3 lowering stability and CTF stdlib traces |
+| `std.seq` | `tests/pcc7_sequence_acceptance.rs` | `tests/pcc7_collections_diagnostics.rs` | `tests/sequence_ownership_golden.rs` plus compile/verify paths |
+| `std.map` | `tests/pcc7_map_acceptance.rs` | `tests/pcc7_collections_diagnostics.rs` | `tests/collections_map_surface_qualification.rs` plus compile/verify paths |
+| `std.option` | `tests/pcc6_option_acceptance.rs` | `tests/pcc6_option_result_diagnostics.rs` | `tests/pcc6_option_result_ownership_golden.rs` |
+| `std.result` | `tests/pcc6_result_acceptance.rs` | `tests/pcc6_option_result_diagnostics.rs` | `tests/pcc6_option_result_ownership_golden.rs` |
+| `std.rand` | seeded cases in `tests/snake_benchmark_gap_matrix.rs` | invalid-range case in `tests/snake_benchmark_gap_matrix.rs` | exact xorshift64 fixture replay and SemCode compile/verify path |
+
+`std.math` and `std.serde` are Deferred, so they have no selected API to
+qualify. Their absence is protected by the contract drift guard.
+
+## Implementation authority
+
+| Concern | Existing owner |
+|---|---|
+| builtin/type admission | `crates/sm-front` |
+| source-to-instruction lowering | `crates/sm-ir` |
+| artifact capabilities and structural admission | `crates/sm-verify` |
+| deterministic execution | `crates/sm-vm` |
+| quad truth maps | `crates/semantic-core-quad` |
+| public command path | `crates/smc-cli` |
+
+The selected surface remains verifier-first. A documentation family name does
+not authorize a helper to bypass lowering, artifact capabilities, verifier
+admission, quotas, or runtime traps.
+
+## Boundary decisions
+
+- `std.*` is a documentation identity, not an import namespace in Foundation
+  Source 1.0.
+- `print(text)` is excluded and routed into SSF-04.
+- current f64 math builtins are not promoted into `std.math`.
+- no Semantic source serialization API or encoding is claimed.
+- map iteration/order and text indexing/normalization are not claimed.
+- seeded PRNG is deterministic versioned VM state, not host entropy.
+- `N` and `S` remain evidence states; no quad-to-bool normalization exists.
+
+## Canonical example and guard
+
+`examples/canonical/stdlib_v0_helpers/src/main.sm` exercises every selected
+family in one pure, deterministic program. It is already covered by
+`tests/canonical_examples.rs` through check, run, compile, and verify.
+
+`tests/ssf_stdlib_v0_contract.rs` guards the contract ID, all ten target family
+decisions, implementation anchors, evidence files, excluded effects, exact
+PRNG algorithm, and canonical example surface.
+
+## Validation contour
+
+The phase PR must run at least:
+
+- `cargo test -q --test ssf_stdlib_v0_contract`;
+- `cargo test -q --test canonical_examples`;
+- PCC3, PCC6, PCC7, PCC8, collection, qtruth, and seeded-random focused tests;
+- the repository harness, PR-ready, boundary, public-API, release-bundle,
+  no-std, all-target, and 7hell gates.
+
+Skipped checks do not count as pass.
+
+## Exit result
+
+The selected Standard Library v0 contour is bounded by
+`semantic.foundation.std/0.1` without inventing an import system or a second
+implementation authority. SSF-04 remains blocked until the exact-head PR is
+merged and issue #1574 records the merge.

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -223,5 +223,6 @@ the contract must not be preserved by documentation alone.
 ## Explicit non-claims
 
 This contract does not claim published stable status, production readiness, a
-stable ABI/ISA, a completed stdlib, a package ecosystem, broad host effects,
-Rust-equivalent ownership, executable Logos, or editor/tooling completion.
+stable ABI/ISA, a broad or comprehensive stdlib, a package ecosystem, broad
+host effects, Rust-equivalent ownership, executable Logos, or editor/tooling
+completion.

--- a/docs/spec/foundation_stdlib_v0.md
+++ b/docs/spec/foundation_stdlib_v0.md
@@ -1,0 +1,181 @@
+# Semantic Foundation Standard Library v0
+
+Status: SSF-03 candidate contract; not published stable
+
+Contract ID: `semantic.foundation.std/0.1`
+
+Base source contract: `semantic.foundation.source/1.0`
+
+This document is the canonical Standard Library v0 index for the Stable
+Foundation contour. It freezes the smallest already-implemented library
+surface needed by ordinary Foundation programs. It does not promote the
+repository, language, or library to Published Stable.
+
+## Binding model
+
+Foundation Source 1.0 does not admit namespace-qualified `std.*` imports.
+Consequently the names below are public documentation family identities, not
+import paths. Their callable surface is the listed canonical language-owned
+equivalent: a builtin, operator, type, constructor, or match form already
+owned by the frontend, lowering, verifier, and VM.
+
+`std.*` source spellings remain reserved and deterministically rejected. A
+future importable module facade belongs to SSF-05/SSF-06 and must delegate to
+this authority rather than copy it.
+
+| Family identity | State in `semantic.foundation.std/0.1` | Canonical language-owned surface |
+|---|---|---|
+| `std.core` | Selected | statement-only `assert(bool)` |
+| `std.quad` | Selected | `qtruth_and`, `qtruth_or`, `qtruth_not`, `qtruth_impl` |
+| `std.math` | Deferred | no selected API; arithmetic stays language-operator owned |
+| `std.text` | Selected | `text + text`, text equality, `to_text(text|bool|i32|u32|quad)` |
+| `std.seq` | Selected | `len`, `is_empty`, `contains`, `push`, `prepend`, `pop` over `Sequence(T)` |
+| `std.map` | Selected | `map_empty`, `map_contains`, `map_get`, `map_set` over `Map(K, V)` |
+| `std.option` | Selected | `Option(T)`, `Option::Some`, `Option::None`, exhaustive match |
+| `std.result` | Selected | `Result(T, E)`, `Result::Ok`, `Result::Err`, exhaustive match |
+| `std.serde` | Deferred | no selected API or encoding |
+| `std.rand` | Selected | `random_seed`, `random_next_i32` |
+
+Only Selected rows are compatibility candidates. Deferred rows are named so
+that absence cannot be mistaken for an undocumented promise.
+
+## Selected API semantics
+
+### `std.core`
+
+`assert(condition)` accepts exactly one positional `bool` and is
+statement-only. `true` continues execution. `false` produces the canonical
+deterministic assertion runtime trap. It performs no host effect.
+
+### `std.quad`
+
+The four `qtruth_*` functions operate on the two independent truth and falsity
+evidence planes through the canonical quad truth-map instructions. `N`, `F`,
+`T`, and `S` remain distinct. In particular, neither `N` nor `S` is normalized
+to `bool`, and no hidden lattice/truth-map substitution is permitted.
+
+For operands `a = (a.t, a.f)` and `b = (b.t, b.f)`, the exact maps are:
+
+- `qtruth_and(a, b) = (a.t & b.t, a.f | b.f)`;
+- `qtruth_or(a, b) = (a.t | b.t, a.f & b.f)`;
+- `qtruth_not(a) = (a.f, a.t)`;
+- `qtruth_impl(a, b) = qtruth_not(a) lattice_join b`, where lattice join is
+  plane-wise OR. This frozen compatibility rule means `qtruth_impl(T, T) = S`.
+
+The legacy quad operators and their lattice semantics are separate language
+operations. They are not aliases for this family.
+
+### `std.text`
+
+`text` carries valid UTF-8. Concatenation preserves the left then right byte
+sequence; equality is exact and performs no locale folding or Unicode
+normalization. This version exposes no indexing, slicing, ordering, or length
+API, so no code-point-versus-byte indexing promise is implied.
+
+`to_text` is defined only for `text`, `bool`, `i32`, `u32`, and `quad`:
+
+- `text` is returned unchanged;
+- booleans are `true` or `false`;
+- integers use canonical base-10 text;
+- quad values are exactly `N`, `F`, `T`, or `S`.
+
+Records and collections are rejected. `print` is deliberately excluded: its
+controlled observation/capability boundary is an SSF-04 input, not a pure text
+helper.
+
+### `std.seq`
+
+Sequences have observable left-to-right index and iteration order.
+`push` appends, `prepend` inserts at index zero, and `pop` returns a new
+sequence without the final element. These operations are persistent: the
+input value is not modified. `pop` on an empty sequence traps
+deterministically.
+
+`len` returns `i32`; `is_empty` tests zero length. `contains` uses exact value
+equality and is selected only for `i32`, `u32`, `bool`, `text`, and `quad`
+elements. Capacity and quota failures remain VM/runtime policy, not hidden
+fallback behavior.
+
+### `std.map`
+
+Maps are persistent values. `map_empty()` requires a contextual `Map(K, V)`
+type. `map_set` returns a new map, `map_contains` reports key presence, and
+`map_get` returns the stored value or its explicit default.
+
+Selected key families are `i32`, `u32`, `bool`, `text`, and `quad`, using exact
+same-family equality. This version exposes no iteration or ordering API and
+makes no observable map-order promise. It also selects no removal, mutation,
+or serialization API.
+
+### `std.option` and `std.result`
+
+These are language-owned standard forms, not user-defined library ADTs.
+`Option::Some` carries one value and `Option::None` carries none.
+`Result::Ok` and `Result::Err` each carry one contextually typed value. Match
+uses the frozen Foundation exhaustiveness and type-compatibility rules. No
+unwrap, conversion, ordering, or formatting helpers are selected.
+
+### `std.rand`
+
+This family is deterministic VM state, never host entropy and never
+cryptographic randomness.
+
+- `random_seed(seed: i32) -> ()` uses the Rust widening cast `seed as u64`
+  (negative values sign-extend modulo 2^64); zero becomes one.
+- `random_next_i32(lo: i32, hi: i32) -> i32` requires `lo < hi` and returns a
+  value in `[lo, hi)`.
+- The algorithm is `xorshift64/13-7-17`: `x ^= x << 13`, `x ^= x >> 7`, then
+  `x ^= x << 17`, with wrapping `u64` operations.
+- Range selection is `lo + (next_u64 % (hi - lo))`, with the span evaluated in
+  `i64`.
+- An unseeded VM stream behaves as if seeded with one.
+
+The algorithm and range mapping are part of contract `0.1`; changing either
+requires a new contract version and migration decision in SSF-10.
+
+## Deferred families
+
+`std.math` selects no API. Current `sin`, `cos`, `tan`, `sqrt`, `abs`, and
+`pow` builtins remain current-main/experimental because their exact
+cross-platform determinism and compatibility policy is not qualified.
+Foundation numeric operators remain governed by the source contract and
+SSF-07.
+
+`std.serde` selects no API and therefore no wire encoding. JSON use inside the
+Rust implementation, CLI, Hub, or test infrastructure is not a Semantic source
+library. A future serialization family must first freeze one deterministic
+encoding, UTF-8 rules, map ordering, duplicate-key behavior, and rejection
+semantics.
+
+## Errors, effects, and compatibility
+
+Type/arity/context errors reject during frontend analysis or lowering.
+Malformed or capability-inconsistent artifacts reject before VM execution.
+Only failures of already-admitted operations, such as `assert(false)`, empty
+`pop`, or an invalid random range, are runtime traps/errors.
+
+No selected API reads time, environment variables, arguments, stdin, files,
+network, processes, or host entropy. No selected API writes host output.
+
+Contract `0.1` is the first compatibility baseline. SSF-10 owns its retention
+window; until then, compatibility means that the names and semantics above
+cannot change silently on the Stable Foundation branch. Additive or breaking
+changes require an explicit contract revision and renewed evidence.
+
+## Evidence and runnable example
+
+The per-family positive, negative, and compatibility anchors are recorded in
+`docs/roadmap/stable_foundation/standard_library_v0_evidence.md`.
+
+The canonical executable example is
+`examples/canonical/stdlib_v0_helpers/src/main.sm`. It uses the public
+language-owned names because `std.*` imports are intentionally outside
+Foundation Source 1.0.
+
+## SSF-04 entry conditions
+
+SSF-04 may start only after this contract and its evidence map are reviewed,
+green on the exact PR head, merged, and recorded on issue #1574. SSF-04 must
+then define capability names, grants, denial, audit, and replay behavior. It
+may use `print(text)` as existing evidence, but must not reinterpret this pure
+stdlib contract as host authority.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -7,6 +7,8 @@ execution contract.
 
 The versioned Stable Foundation source-language candidate is the narrower
 [`foundation_source_profile_v1.md`](foundation_source_profile_v1.md) overlay.
+Its bounded Standard Library v0 companion is
+[`foundation_stdlib_v0.md`](foundation_stdlib_v0.md).
 Component specs below describe current implementation and draft contracts; they
 do not widen that selected public contour by implication.
 
@@ -14,6 +16,8 @@ Current documents in this PR:
 
 - `foundation_source_profile_v1.md` - versioned Stable Foundation Rust-like
   source contract candidate and explicit experimental/deferred boundary
+- `foundation_stdlib_v0.md` - versioned language-owned Standard Library v0
+  family index, deterministic semantics, and deferred APIs
 - `syntax.md` - canonical Rust-like source syntax contract
 - `types.md` - source-level type contract and current type-family limits
 - `source_semantics.md` - source-level execution and binding semantics
@@ -80,9 +84,10 @@ versioning, and release-facing validation specifications.
 
 Contract precedence:
 
-1. `foundation_source_profile_v1.md` selects the versioned public
-   stable-candidate source contour; the remaining `docs/spec/*` files define
-   its referenced component behavior and current implementation contracts.
+1. `foundation_source_profile_v1.md` and `foundation_stdlib_v0.md` select the
+   versioned public stable-candidate source and library contours; the remaining
+   `docs/spec/*` files define their referenced component behavior and current
+   implementation contracts.
 2. Code must implement that contract.
 3. Architecture and roadmap documents constrain ownership and sequencing around
    that contract.

--- a/examples/canonical/README.md
+++ b/examples/canonical/README.md
@@ -58,7 +58,7 @@ changes.
 | 2 | `rule_state_decision` | Rust-like | record-oriented rule/state decision logic with explicit `Result(T, E)` handling | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
 | 3 | `data_audit_record_iterable` | Rust-like | data-heavy audit pass over direct-record `Iterable` dispatch | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
 | 4 | `text_collections_toolbox` | Rust-like | practical toolbox example for control flow, text, collections, and stdlib | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
-| 5 | `stdlib_v0_helpers` | Rust-like | practical helper-surface example for current PCC stdlib v0 | executable: `check`/`compile`/`verify`/`run` | pass | already compliant |
+| 5 | `stdlib_v0_helpers` | Rust-like | pure deterministic example for `semantic.foundation.std/0.1` language-owned equivalents | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
 | 6 | `collections_core` | Rust-like | standalone practical collections surface example | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
 | 7 | `text_core` | Rust-like | standalone practical `text` surface example | executable: `check`/`compile`/`verify`/`run` | pass | migrated |
 | 8 | `match_control_flow` | Rust-like | compact quad decision program; demonstrates Source Style v0 | executable: `check`/`compile`/`verify`/`run` | pass | migrated |

--- a/examples/canonical/stdlib_v0_helpers/README.md
+++ b/examples/canonical/stdlib_v0_helpers/README.md
@@ -1,20 +1,22 @@
 # Canonical example: stdlib_v0_helpers
 
-This canonical example demonstrates the current Practical Core helper surface
-for Stdlib v0.
+This canonical example demonstrates `semantic.foundation.std/0.1`, the bounded
+Stable Foundation Standard Library v0 candidate.
 
 ## Purpose
 
 The example shows currently admitted helper functions used together in a small
 practical program.
 
-It does not define the final standard library architecture.
+The `std.*` family names are documentation identities. Foundation Source 1.0
+uses canonical language-owned builtins and standard forms rather than
+namespace-qualified imports.
 
 ## What this example covers
 
 - `assert`;
+- `qtruth_and`, `qtruth_or`, `qtruth_not`, `qtruth_impl`;
 - `to_text(...)`;
-- `print(text)`;
 - `Sequence(i32)` helpers:
   - `len`;
   - `is_empty`;
@@ -27,12 +29,16 @@ It does not define the final standard library architecture.
   - `map_set`;
   - `map_get`;
   - `map_contains`.
+- `Option::Some` / `Option::None` and match;
+- `Result::Ok` / `Result::Err` and match;
+- deterministic `random_seed` / `random_next_i32` replay.
 
 ## What this example does not cover
 
-- stdlib module layout;
-- `core.*`, `text.*`, `seq.*`, `map.*` namespacing;
-- import policy;
+- importable `std.*` namespace facades;
+- `std.math` APIs;
+- `std.serde` APIs or encodings;
+- `print(text)` or any other host effect;
 - formatting API;
 - debug/logging framework;
 - host ABI widening;
@@ -55,12 +61,13 @@ sum_values(build_values()) == 10
 pop_score() == 3
 score_flags(build_flags()) == 10
 build_report(10, 10) == "stdlib-v0:10:10"
+seeded random values replay exactly after reseeding
 ```
 
 ## Validation
 
 ```bash
-cargo run --bin smc -- check examples/canonical/stdlib_v0_helpers/src/main.sm
+cargo run --bin smc -- run examples/canonical/stdlib_v0_helpers/src/main.sm
 ```
 
 This example should also be included in:

--- a/examples/canonical/stdlib_v0_helpers/src/main.sm
+++ b/examples/canonical/stdlib_v0_helpers/src/main.sm
@@ -67,6 +67,43 @@ fn build_report(total: i32, score: i32) -> text {
     return prefix + to_text(total) + separator + to_text(score);
 }
 
+fn option_score(value: Option(i32)) -> i32 {
+    let score: i32 = match value {
+        Option::Some(item) => { item }
+        Option::None => { 0 }
+        _ => { -100 }
+    };
+    return score;
+}
+
+fn result_score(value: Result(i32, i32)) -> i32 {
+    let score: i32 = match value {
+        Result::Ok(item) => { item }
+        Result::Err(code) => { 0 - code }
+        _ => { -100 }
+    };
+    return score;
+}
+
+fn assert_quad_truth_maps() {
+    assert(qtruth_and(T, T) == T);
+    assert(qtruth_or(F, F) == F);
+    assert(qtruth_not(S) == S);
+    assert(qtruth_impl(T, T) == S);
+    return;
+}
+
+fn assert_seeded_random_replay() {
+    random_seed(7);
+    let first: i32 = random_next_i32(-100, 100);
+    let second: i32 = random_next_i32(-100, 100);
+
+    random_seed(7);
+    assert(random_next_i32(-100, 100) == first);
+    assert(random_next_i32(-100, 100) == second);
+    return;
+}
+
 fn main() {
     let values: Sequence(i32) = build_values();
     let flags: Map(i32, bool) = build_flags();
@@ -83,6 +120,11 @@ fn main() {
 
     assert(report == "stdlib-v0:10:10");
     assert(report != "");
-
-    print(report);
+    assert(option_score(Option::Some(5)) == 5);
+    assert(option_score(Option::None) == 0);
+    assert(result_score(Result::Ok(8)) == 8);
+    assert(result_score(Result::Err(3)) == -3);
+    assert_quad_truth_maps();
+    assert_seeded_random_replay();
+    return;
 }

--- a/tests/ssf_stdlib_v0_contract.rs
+++ b/tests/ssf_stdlib_v0_contract.rs
@@ -1,0 +1,151 @@
+use std::{fs, path::Path};
+
+fn read(root: &Path, relative: &str) -> String {
+    fs::read_to_string(root.join(relative))
+        .unwrap_or_else(|error| panic!("failed to read {relative}: {error}"))
+}
+
+#[test]
+fn ssf_03_contract_freezes_selected_and_deferred_families() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let contract = read(root, "docs/spec/foundation_stdlib_v0.md");
+    let evidence = read(
+        root,
+        "docs/roadmap/stable_foundation/standard_library_v0_evidence.md",
+    );
+
+    for required in [
+        "semantic.foundation.std/0.1",
+        "not published stable",
+        "canonical language-owned",
+        "`std.core`",
+        "`std.quad`",
+        "`std.math`",
+        "`std.text`",
+        "`std.seq`",
+        "`std.map`",
+        "`std.option`",
+        "`std.result`",
+        "`std.serde`",
+        "`std.rand`",
+        "`std.*` source spellings remain reserved",
+        "`std.math` selects no API",
+        "`std.serde` selects no API",
+        "`print` is deliberately excluded",
+        "xorshift64/13-7-17",
+        "no observable map-order promise",
+        "neither `N` nor `S` is normalized",
+        "qtruth_impl(T, T) = S",
+        "sign-extend modulo 2^64",
+        "SSF-04 entry conditions",
+    ] {
+        assert!(
+            contract.contains(required),
+            "contract is missing {required}"
+        );
+    }
+
+    for required in [
+        "Positive evidence",
+        "Negative evidence",
+        "Compatibility baseline",
+        "crates/sm-front",
+        "crates/sm-ir",
+        "crates/sm-verify",
+        "crates/sm-vm",
+        "crates/semantic-core-quad",
+        "0115b161f27d12aa877562b440a1cc5a84a05bcb",
+    ] {
+        assert!(
+            evidence.contains(required),
+            "evidence is missing {required}"
+        );
+    }
+}
+
+#[test]
+fn ssf_03_contract_points_at_real_implementation_and_test_authority() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let front = read(root, "crates/sm-front/src/typecheck.rs");
+    for builtin in [
+        "len",
+        "is_empty",
+        "contains",
+        "push",
+        "prepend",
+        "pop",
+        "map_empty",
+        "map_contains",
+        "map_get",
+        "map_set",
+        "to_text",
+        "random_seed",
+        "random_next_i32",
+    ] {
+        assert!(
+            front.contains(&format!("\"{builtin}\"")),
+            "frontend is missing selected builtin {builtin}"
+        );
+    }
+
+    let builtin_sigs = read(root, "crates/sm-front/src/lib.rs");
+    for builtin in ["qtruth_and", "qtruth_or", "qtruth_not", "qtruth_impl"] {
+        assert!(
+            builtin_sigs.contains(&format!("\"{builtin}\"")),
+            "frontend is missing selected quad builtin {builtin}"
+        );
+    }
+
+    let vm = read(root, "crates/sm-vm/src/semcode_vm.rs");
+    for step in ["x ^= x << 13", "x ^= x >> 7", "x ^= x << 17"] {
+        assert!(
+            vm.contains(step),
+            "VM PRNG algorithm drifted: missing {step}"
+        );
+    }
+
+    for relative in [
+        "tests/pcc3_text_core_gate.rs",
+        "tests/pcc6_option_acceptance.rs",
+        "tests/pcc6_result_acceptance.rs",
+        "tests/pcc6_option_result_diagnostics.rs",
+        "tests/pcc7_sequence_acceptance.rs",
+        "tests/pcc7_map_acceptance.rs",
+        "tests/pcc7_collections_diagnostics.rs",
+        "tests/pcc8_stdlib_acceptance.rs",
+        "tests/pcc8_stdlib_diagnostics.rs",
+        "tests/snake_benchmark_gap_matrix.rs",
+        "tests/canonical_examples.rs",
+    ] {
+        assert!(root.join(relative).is_file(), "missing evidence {relative}");
+    }
+}
+
+#[test]
+fn canonical_example_uses_every_selected_language_owned_family() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let example = read(root, "examples/canonical/stdlib_v0_helpers/src/main.sm");
+
+    for required in [
+        "assert(",
+        "qtruth_and(",
+        "qtruth_or(",
+        "qtruth_not(",
+        "qtruth_impl(",
+        "to_text(",
+        "len(",
+        "map_empty(",
+        "Option::Some(",
+        "Result::Ok(",
+        "random_seed(",
+        "random_next_i32(",
+    ] {
+        assert!(example.contains(required), "example is missing {required}");
+    }
+
+    assert!(
+        !example.contains("print("),
+        "SSF-03 canonical example must remain host-effect free"
+    );
+}


### PR DESCRIPTION
Parent: #1569
Closes: #1574

## Outcome
- freeze candidate contract `semantic.foundation.std/0.1`
- select existing language-owned equivalents for core, quad, text, seq, map, option, result, and deterministic rand
- defer `std.math` and `std.serde` without inventing APIs
- keep `std.*` namespace imports outside Foundation Source 1.0 and route host effects such as `print` to SSF-04
- preserve N/S evidence and freeze xorshift64/13-7-17 replay semantics

## Scope
Documentation, one contract drift guard, and the existing canonical stdlib example only. No production Rust API, runtime, verifier, dependency, workflow, UI, or release-promotion change.

## Local evidence
- harness: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: pass
- SSF-03 contract/evidence tests: pass
- focused PCC3/PCC6/PCC7/PCC8, collection, Option/Result, seeded-random, CTF, and canonical-example suites: pass
- qtruth lowering/VM/core truth-map unit matrices: pass
- changed canonical example: LF-only and `smc fmt --check` pass

The full Windows canonical-source-style target still reports the three pre-existing CRLF-only fixture failures on unchanged files; exact-head Linux CI is the closing authority for that checkout-specific uncertainty.

## Boundaries
- not Published Stable
- no import-system or package expansion
- no hidden host effects
- no duplicate language authority
- no UI/product expansion

SSF-04 remains blocked until this PR is reviewed, green on its exact head, and merged.