### PR TITLE
chore(harness): activate SSF-05 Project Model v0

### DIFF
--- a/.harness/current.task.yaml
+++ b/.harness/current.task.yaml
@@ -1,22 +1,22 @@
 task:
-  id: SEMANTIC-STABLE-FOUNDATION-SSF-04
-  title: "runtime: freeze Controlled Application Boundary v0"
-  type: contract_qualification_and_bounded_implementation
+  id: SEMANTIC-STABLE-FOUNDATION-SSF-05
+  title: "tooling: complete Semantic Project Model v0"
+  type: project_model_contract_qualification_and_bounded_implementation
   mode: active
-  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-03
+  supersedes: SEMANTIC-STABLE-FOUNDATION-SSF-04
   authorized_by: >-
     Repository owner direct instruction (chat, 2026-08-08) to execute GitHub
     umbrella #1569 continuously in strict SSF-00 through SSF-12 dependency
-    order. SSF-03 closed through PR #1591 at main commit
-    8ae1e2ae5b7496764d82029197ba079c0e066fd9; only SSF-04 is now active.
+    order. SSF-04 closed through PR #1593 at main commit
+    3e71356fbad7720ec150fa895b940b55a0b7b5ac; only SSF-05 is now active.
 
 intent:
   summary: >-
-    Inventory existing capability, ABI, verifier, runtime, audit, and CLI
-    authority; define one deny-by-default Controlled Application Boundary v0;
-    select only effects required by the Stable Foundation application contour;
-    freeze structured denial, path containment, audit, and replay semantics;
-    and prove one bounded CLI file-transform flow without capability bypasses.
+    Inventory existing manifest, project-root, module, entrypoint, CLI, and
+    identity behavior; select one canonical Semantic Project Model v0; freeze
+    deterministic root-contained path and unsupported-field rules; preserve
+    single-file compatibility; and prove a manually creatable project through
+    the admitted check, compile, verify, run, and test command contour.
 
 scope:
   allowed_paths:
@@ -35,9 +35,6 @@ scope:
     - examples/canonical/**
     - examples/qualification/**
     - tests/**
-    - crates/prom-abi/**
-    - crates/prom-audit/**
-    - crates/prom-cap/**
     - crates/sm-format/**
     - crates/sm-front/**
     - crates/sm-sema/**
@@ -45,7 +42,6 @@ scope:
     - crates/sm-emit/**
     - crates/sm-verify/**
     - crates/sm-vm/**
-    - crates/sm-runtime-core/**
     - crates/smc-cli/**
 
   forbidden_paths:
@@ -71,25 +67,26 @@ authorization:
 
 constraints:
   one_active_ssf_phase: true
-  active_phase: SSF-04
-  issue: 1575
+  active_phase: SSF-05
+  issue: 1576
   umbrella_issue: 1569
   base_branch: main
   one_logical_change_per_pr: true
   evidence_before_claims: true
   current_main_is_not_stable: true
-  capability_abi_verifier_runtime_audit_inventory_first: true
-  capability_ids_and_profiles_before_effect_implementation: true
-  request_or_manifest_metadata_is_never_a_grant: true
-  verifier_and_runtime_remain_effect_authority: true
-  deny_by_default_with_structured_results: true
-  path_root_containment_before_file_access: true
-  replay_safe_host_observation_contract: true
-  audit_without_unnecessary_payload_leakage: true
-  observation_before_write_effects: true
-  no_network_process_or_ambient_environment_access: true
-  no_hidden_stdlib_or_ui_host_effects: true
-  project_and_package_expansion_deferred_to_ssf_05_and_ssf_06: true
+  manifest_project_module_entrypoint_cli_identity_inventory_first: true
+  one_canonical_semantic_toml_manifest: true
+  single_file_fallback_remains_explicit_and_compatible: true
+  deterministic_project_root_and_entrypoint_resolution: true
+  source_module_test_and_example_discovery_is_versioned: true
+  path_normalization_and_root_containment_before_widening: true
+  unknown_or_unsupported_manifest_fields_fail_deterministically: true
+  manifest_metadata_is_not_capability_or_runtime_authority: true
+  project_identity_and_toolchain_metadata_are_reproducible: true
+  check_compile_verify_run_and_test_agree_on_project_model: true
+  no_registry_remote_solver_build_scripts_or_install_hooks: true
+  no_broad_workspace_model: true
+  package_model_expansion_deferred_to_ssf_06: true
   no_ui_product_expansion: true
   no_stable_release_claim: true
   no_historical_document_rewrite: true


### PR DESCRIPTION
Parent: #1569
Prepares: #1576

Governance-only activation of SSF-05 after SSF-04 closed through PR #1593 at main commit `3e71356fbad7720ec150fa895b940b55a0b7b5ac`.

This update authorizes only the bounded Semantic Project Model v0 contour: inventory current manifest/project/module/CLI behavior, select canonical `semantic.toml`, freeze deterministic root-contained paths and unsupported-field handling, preserve single-file compatibility, record reproducible project identity, and prove the documented project command path.

Hard boundaries remain: project metadata is not capability/runtime authority; no registry, remote solver, build scripts, install hooks, broad workspace model, SSF-06 package expansion, workflow changes, UI/product work, or Stable promotion.

Only `.harness/current.task.yaml` changes.