### PR TITLE
SSF-05: complete Project Model v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ The VM does not receive unrestricted authority over the host. Effects cross the 
 | `smc check <file.sm|project-root>` | Parse and semantically check source. |
 | `smc run <file.sm|project-root>` | Compile and execute from source through the standard route. |
 | `smc compile <input> -o app.smc` | Produce a SemCode artifact. |
-| `smc verify app.smc` | Admit or reject the artifact without running it. |
+| `smc verify <app.smc|project-root>` | Admit source-derived or persisted SemCode without running it. |
+| `smc test <project-root>` | Run discovered project tests in deterministic path order. |
 | `smc run-smc app.smc` | Execute a persisted artifact through the verified route. |
 | `smc disasm app.smc` | Inspect SemCode instructions. |
 | `smc dump-ast <input>` | Inspect the parsed source model. |
@@ -297,9 +298,13 @@ From a supported project root:
 smc check .
 smc run .
 smc compile . -o app.smc
+smc verify .
+smc test .
 ```
 
 This is not yet a complete package ecosystem. It does not claim a public registry, dependency solver, multi-package workspace manager, or `smc new` scaffolding.
+The canonical layout, deterministic discovery rules, and identity boundary are
+defined in [Project Model v0](docs/spec/project_model_v0.md).
 
 When running from this repository without installing the binaries, prefix commands with:
 

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -108,6 +108,7 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
         "explain" => cmd_explain(&args[1..]),
         "repl" => cmd_repl(&args[1..]),
         "verify" => cmd_verify(&args[1..]),
+        "test" => cmd_test(&args[1..]),
         "run" => cmd_run(&args[1..]),
         "run-smc" => cmd_run_smc(&args[1..]),
         "disasm" => cmd_disasm(&args[1..]),
@@ -2720,11 +2721,18 @@ fn application_run_usage() -> String {
 
 fn cmd_verify(args: &[String]) -> Result<(), String> {
     if args.len() != 1 {
-        return Err("usage: smc verify <input.smc>".to_string());
+        return Err("usage: smc verify <input.smc|project-root>".to_string());
     }
     let input = args[0].as_str();
     reject_leading_unknown_flag(input)?;
-    let bytes = std::fs::read(input).map_err(|e| format!("failed to read '{}': {}", input, e))?;
+    let input_path = Path::new(input);
+    let bytes = if input_path.is_dir() {
+        let entry = resolve_project_root_check_entry(input_path)?;
+        let source = read_source_with_package_admission(&entry)?;
+        compile_program_to_semcode(&source).map_err(|error| error.to_string())?
+    } else {
+        std::fs::read(input).map_err(|e| format!("failed to read '{}': {}", input, e))?
+    };
     let verified = verify_semcode(&bytes).map_err(|report| report.to_string())?;
     println!(
         "verified '{}' ({} function(s), header={}, epoch={}.{})",
@@ -2735,6 +2743,142 @@ fn cmd_verify(args: &[String]) -> Result<(), String> {
         verified.header.rev
     );
     Ok(())
+}
+
+fn cmd_test(args: &[String]) -> Result<(), String> {
+    if args.len() != 1 {
+        return Err("usage: smc test <project-root>".to_string());
+    }
+    let input = args[0].as_str();
+    reject_leading_unknown_flag(input)?;
+    let project_root = Path::new(input);
+    if !project_root.is_dir() {
+        return Err("smc test requires a project root directory".to_string());
+    }
+
+    resolve_project_root_check_entry(project_root)?;
+    let project_root = project_root
+        .canonicalize()
+        .map_err(|error| format!("failed to resolve project root '{}': {error}", input))?;
+    let tests = discover_project_test_sources(&project_root)?;
+    if tests.is_empty() {
+        return Err(format!(
+            "project '{}' contains no tests/*.sm programs",
+            project_root.display()
+        ));
+    }
+
+    for test in &tests {
+        let source = std::fs::read_to_string(test)
+            .map_err(|error| format!("failed to read test '{}': {error}", test.display()))?;
+        let bytes = compile_program_to_semcode(&source)
+            .map_err(|error| format!("test '{}' failed to compile: {error}", test.display()))?;
+        let token = verify_semcode_token(&bytes)
+            .map_err(|error| format!("test '{}' failed verification: {error}", test.display()))?;
+        let entry = token
+            .require_entry("main")
+            .map_err(|error| format!("test '{}' has no main entry: {error}", test.display()))?;
+        let mut host = CliApplicationHost::new(&project_root, Vec::new(), None)?;
+        run_verified_entry_semcode_with_application_host_and_capabilities_and_config(
+            &entry,
+            &mut host,
+            &CapabilityManifest::for_application_profile(ApplicationCapabilityProfile::Pure),
+            ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+        )
+        .map_err(|error| format!("test '{}' failed: {error}", test.display()))?;
+        let relative = test
+            .strip_prefix(&project_root)
+            .expect("discovered test remains inside project root")
+            .to_string_lossy()
+            .replace('\\', "/");
+        println!("ok {relative}");
+    }
+    println!("test result: ok. {} passed", tests.len());
+    Ok(())
+}
+
+fn discover_project_test_sources(project_root: &Path) -> Result<Vec<PathBuf>, String> {
+    fn is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+        if metadata.file_type().is_symlink() {
+            return true;
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+            metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+        }
+        #[cfg(not(windows))]
+        false
+    }
+
+    fn visit(root: &Path, directory: &Path, tests: &mut Vec<PathBuf>) -> Result<(), String> {
+        let entries = std::fs::read_dir(directory).map_err(|error| {
+            format!(
+                "failed to read test directory '{}': {error}",
+                directory.display()
+            )
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!(
+                    "failed to inspect test directory '{}': {error}",
+                    directory.display()
+                )
+            })?;
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path).map_err(|error| {
+                format!("failed to inspect test path '{}': {error}", path.display())
+            })?;
+            if is_link_or_reparse(&metadata) {
+                return Err(format!(
+                    "test discovery rejects symbolic link or reparse path '{}'",
+                    path.display()
+                ));
+            }
+            if metadata.is_dir() {
+                visit(root, &path, tests)?;
+            } else if metadata.is_file() && path.extension().is_some_and(|ext| ext == "sm") {
+                let canonical = path.canonicalize().map_err(|error| {
+                    format!(
+                        "failed to resolve test source '{}': {error}",
+                        path.display()
+                    )
+                })?;
+                canonical.strip_prefix(root).map_err(|_| {
+                    format!("test source '{}' escapes the project root", path.display())
+                })?;
+                tests.push(canonical);
+            }
+        }
+        Ok(())
+    }
+
+    let test_root = project_root.join("tests");
+    if !test_root.exists() {
+        return Ok(Vec::new());
+    }
+    let metadata = std::fs::symlink_metadata(&test_root).map_err(|error| {
+        format!(
+            "failed to inspect test directory '{}': {error}",
+            test_root.display()
+        )
+    })?;
+    if is_link_or_reparse(&metadata) || !metadata.is_dir() {
+        return Err(format!(
+            "project test root '{}' must be a real directory",
+            test_root.display()
+        ));
+    }
+    let mut tests = Vec::new();
+    visit(project_root, &test_root, &mut tests)?;
+    tests.sort_by_key(|path| {
+        path.strip_prefix(project_root)
+            .expect("discovered test remains inside project root")
+            .to_string_lossy()
+            .replace('\\', "/")
+    });
+    Ok(tests)
 }
 
 fn cmd_run_smc(args: &[String]) -> Result<(), String> {
@@ -2781,7 +2925,8 @@ fn usage() -> String {
         "  smc explain <error-code|--list>",
         "  smc repl",
         "  smc work <subject> <intent> [to <target>] [with <profile>]",
-        "  smc verify <input.smc>",
+        "  smc verify <input.smc|project-root>",
+        "  smc test <project-root>",
         "  smc run <input.sm|project-root>",
         "  smc run <input.sm|project-root> --profile <pure|cli-read-only|cli-file-transform> --root <directory> [--duration-ms <u32>] [-- <application-args...>]",
         "  smc run-smc <input.smc>",

--- a/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
+++ b/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
@@ -122,19 +122,20 @@ that wording drift; it does not delete or rewrite historical evidence.
 
 | Public feature | Owner layer | Status | Evidence and exact boundary | Foundation routing |
 |---|---|---|---|---|
-| Single-file fallback | C/F | **Qualified limited release** | Gate 1 explicitly admits single-file programs. | SSF-05. |
-| `semantic.toml` project root and entrypoint | C/F | **Landed and qualified on `main`** | PCC9 positive/negative/root-preference and command-route tests. | Canonical manifest decision in SSF-05. |
-| `Semantic.package` baseline | C/F | **Landed and qualified on `main`** | PCC9/project-manifest and local import evidence. | Relationship to `semantic.toml` in SSF-05/06. |
-| Source/module root resolution | C/F | **Landed and qualified on `main`** | PCC9 and import qualification include deterministic root behavior. | Freeze in SSF-05. |
-| Test/example discovery | C | **Roadmap** | Repository tests exist; no canonical project discovery contract or `smc test`. | SSF-05. |
-| Deterministic path normalization/root-escape rejection | C/F | **Landed and qualified on `main`** | Project/import negative fixtures cover escapes and missing paths. | Requalify contract in SSF-05/06. |
-| Project identity/content hashing boundary | C/D | **Landed but unqualified** | Hash routes exist, but the stable identity/provenance contract is not frozen. | SSF-05/10. |
+| Single-file fallback | C/F | **Landed and qualified on `main`** | Project Model v0 preserves direct `.sm` inputs; PCC9 exercises the full single-file CLI path. | Preserve through SSF-12. |
+| `semantic.toml` project root and entrypoint | C/F | **Landed and qualified on `main`** | `semantic.foundation.project/0.1`; PCC9 positive/negative/root-preference and command-route tests. | Preserve through SSF-12. |
+| `Semantic.package` baseline | C/F | **Landed and qualified on `main`** | Explicit compatibility/package input; `semantic.toml` wins when both exist. | SSF-06 owns its local-package contract. |
+| Source/module root resolution | C/F | **Landed and qualified on `main`** | Project Model v0 plus PCC9 import/root qualification. | Preserve through SSF-12. |
+| Test/example discovery | C | **Landed and qualified on `main`** | Sorted `tests/**/*.sm` execution and explicit `examples/**/*.sm` contract; SSF05 focused tests. | Preserve through SSF-12. |
+| Deterministic path normalization/root-escape rejection | C/F | **Landed and qualified on `main`** | Project/import escape fixtures plus link/reparse rejection in test discovery. | Requalify local dependencies in SSF-06. |
+| Project identity/content hashing boundary | C/D | **Landed and qualified on `main`** | Project Model v0 freezes descriptive name versus `hash-smc` content and SemCode epoch/revision boundaries; cryptographic provenance remains SSF-10. | Preserve boundary; SSF-10 owns trust policy. |
 | `smc check <project-root>` | C/F | **Landed and qualified on `main`** | PCC9 full project-root check path. | SSF-05. |
 | `smc compile <project-root>` | C/I | **Landed and qualified on `main`** | PCC9 compile and artifact command tests. | SSF-05. |
 | `smc verify <artifact>` | C/V | **Qualified limited release** | Core Gate 1 verified path and artifact diagnostics. | Preserve in SSF-05/10. |
+| `smc verify <project-root>` | C/F/V | **Landed and qualified on `main`** | Resolves the canonical entry, compiles in memory, and verifies without execution or artifact persistence. | Preserve through SSF-12. |
 | `smc run <project-root>` | C/V/R | **Landed and qualified on `main`** | PCC9 run path. | SSF-05. |
-| `smc test <project-root>` | C | **Roadmap** | Command is not part of the current canonical CLI. | SSF-05. |
-| `smc new` | C | **Roadmap** | Explicitly absent/non-required unless narrowly approved. | Optional SSF-05 decision. |
+| `smc test <project-root>` | C/F/V/R | **Landed and qualified on `main`** | Root-contained sorted discovery; every test compiles, verifies, and runs under the pure profile. | Preserve through SSF-12. |
+| `smc new` | C | **Out of scope** | Project Model v0 is manually creatable; scaffolding is not required. | Excluded from Stable Foundation. |
 | Package identity | C/F/D | **Landed but unqualified** | Package names/manifests exist; long-term identity contract is not frozen. | SSF-06. |
 | Local path dependencies | C/F | **Landed and qualified on `main`** | Deterministic local dependency loading and tests exist. | Requalify Foundation scope in SSF-06. |
 | Deterministic package graph and cycle diagnostics | C/F | **Landed and qualified on `main`** | Import/package cycle positives and negatives. | SSF-06. |

--- a/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
@@ -34,8 +34,8 @@ until the preceding exit gate is accepted.
 | SSF-01 / #1572 | Accepted target and source rows | Versioned Rust-like public language contract, included/deferred source features | End-to-end positive/negative contract evidence | Completed |
 | SSF-02 / #1573 | Frozen executable contract | Rust-like/Logos Model A or B, diagnostics and package interaction | Honest profile behavior and examples | Completed: Model B |
 | SSF-03 / #1574 | Frozen language/profile contract | Versioned language-owned stdlib equivalents and builtin boundary | Positive, negative, compatibility tests and canonical index | Completed |
-| SSF-04 / #1575 | Stable value/library carriers | Capabilities, profiles, denial/audit/replay contract | Canonical deterministic file-transform path | **Active: candidate exit** |
-| SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | Blocked by SSF-04 |
+| SSF-04 / #1575 | Stable value/library carriers | Capabilities, profiles, denial/audit/replay contract | Canonical deterministic file-transform path | Completed |
+| SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | **Active: candidate exit** |
 | SSF-06 / #1577 | Canonical project model | Local package graph, provenance/lock, capability inventory | Multi-package reproducibility and root-security evidence | Blocked by SSF-05 |
 | SSF-07 / #1578 | Stable project/package usage needs | Numeric/text/collections/closures/generics/traits/pattern bounds | Ordinary programs without undocumented workarounds | Blocked by SSF-06 |
 | SSF-08 / #1579 | Selected abstraction surface | Ownership Position A/B, value paths, frames, host ownership, quotas | Positive/negative ownership and deterministic failure suite | Blocked by SSF-07 |

--- a/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
@@ -128,7 +128,7 @@ Andromeda, and broad permanent ABI/ISA promises.
 | Executable versus declarative Logos | SSF-02 | Resolved as Model B; Logos remains experimental and non-executable. |
 | Builtin-to-stdlib boundary and APIs | SSF-03 | Existing builtins may be wrapped, renamed, narrowed, or deferred. |
 | Capability names, grants, denial results, audit, replay profiles | SSF-04 | Existing `print` is evidence, not the finished boundary. |
-| Canonical manifest, project layout, discovery, and command shapes | SSF-05 | Both current manifests are evidence; neither wins by implication. |
+| Canonical manifest, project layout, discovery, and command shapes | SSF-05 | Resolved by `semantic.foundation.project/0.1`: `semantic.toml` is canonical; `Semantic.package` is an explicit compatibility/package input. |
 | Package identity, provenance, and lock record | SSF-06 | Local dependencies remain unpromoted. |
 | Numeric, text, collection, closure, generic, trait, and pattern limits | SSF-07 | Prefer the smallest ordinary-program contour. |
 | Ownership Position A or B | SSF-08 | Position A is the conservative candidate, not a pre-decided result. |

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -34,6 +34,7 @@ The admitted `smc` command surface is currently:
 - `explain`
 - `repl`
 - `verify`
+- `test`
 - `run`
 - `run-smc`
 - `disasm`
@@ -62,7 +63,8 @@ Current accepted usage forms are:
 - `smc features`
 - `smc explain <error-code|--list>`
 - `smc repl`
-- `smc verify <input.smc>`
+- `smc verify <input.smc|project-root>`
+- `smc test <project-root>`
 - `smc run <input.sm|project-root>`
 - `smc run-smc <input.smc>`
 - `smc disasm <input.smc>`
@@ -115,6 +117,7 @@ The following commands expose persisted artifact, admission, or build-surface be
 
 - `smc compile`
 - `smc verify`
+- `smc test`
 - `smc run-smc`
 - `smc features`
 - `smc hub invoke`
@@ -275,7 +278,8 @@ Current output rules:
 Current execution-facing commands follow this split:
 
 - `smc run <input.sm|project-root>` resolves source input, then compiles and executes the produced in-memory SemCode path
-- `smc verify <input.smc>` performs verifier admission without execution
+- `smc verify <input.smc|project-root>` performs verifier admission without execution; project roots compile the canonical entry in memory first
+- `smc test <project-root>` discovers and executes `tests/**/*.sm` in normalized relative-path order under the pure application profile
 - `smc run-smc <input.smc>` executes compiled SemCode through the verified artifact path
 
 Public rule:

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -18,6 +18,8 @@ Current documents in this PR:
   source contract candidate and explicit experimental/deferred boundary
 - `foundation_stdlib_v0.md` - versioned language-owned Standard Library v0
   family index, deterministic semantics, and deferred APIs
+- `project_model_v0.md` - canonical manifest/layout, discovery, project command,
+  path-containment, and identity boundary
 - `syntax.md` - canonical Rust-like source syntax contract
 - `types.md` - source-level type contract and current type-family limits
 - `source_semantics.md` - source-level execution and binding semantics

--- a/docs/spec/project_model_v0.md
+++ b/docs/spec/project_model_v0.md
@@ -1,0 +1,110 @@
+# Semantic Project Model v0
+
+Status: SSF-05 candidate contract; not a Stable release claim
+Contract: `semantic.foundation.project/0.1`
+
+## Canonical layout
+
+```text
+project-root/
+  semantic.toml
+  src/
+    main.sm
+    lib.sm        # optional module source; not a second entrypoint
+  examples/       # explicit runnable programs
+  tests/          # standalone test programs
+```
+
+`semantic.toml` is the only canonical Project Model v0 manifest. The older
+`Semantic.package` form remains a compatibility input and the SSF-06 local
+package baseline; when both files exist, `semantic.toml` wins.
+
+The minimal manifest is:
+
+```toml
+[package]
+name = "hello"
+
+[project]
+entry = "src/main.sm"
+```
+
+`[project].entry` defaults to `src/main.sm`. It must be a relative path inside
+the project root. Absolute paths, `..`, missing entries, unknown sections, and
+unknown fields are rejected deterministically. `[package].version` is accepted
+as descriptive compatibility metadata and does not grant capabilities or
+change verifier admission.
+
+## Source and discovery rules
+
+- The manifest directory is the project root.
+- The entry's parent directory is its module root. `src/lib.sm`, when present,
+  is an importable module source; it is not discovered as another executable.
+- `examples/**/*.sm` are explicit programs and run only when named by path.
+- `smc test <project-root>` discovers regular `tests/**/*.sm` files,
+  recursively, in normalized relative-path order. Each file is a standalone
+  program with `fn main()`, compiled, verified, and executed under the `pure`
+  application profile. Empty test sets fail explicitly.
+- Symbolic-link/reparse discovery paths and paths resolving outside the project
+  root are rejected. Filesystem enumeration order is never observable.
+- A direct `.sm` input remains the single-file form and needs no manifest.
+
+## Command agreement
+
+```text
+smc check <file.sm|project-root>
+smc compile <file.sm|project-root> -o <artifact.smc>
+smc verify <artifact.smc|project-root>
+smc run <file.sm|project-root>
+smc test <project-root>
+```
+
+Project-root `check`, `compile`, `verify`, and `run` resolve the same canonical
+entry and executable module bundle. Project-root `verify` compiles the resolved
+source in memory and performs verifier admission without persisting or running
+the artifact. `test` uses the separate bounded discovery rule above.
+
+## Identity boundary
+
+`[package].name` is a descriptive project identifier, not trust. The existing
+`smc hash-smc <project-root>` output is the reproducible content identity of the
+resolved source/module graph and selected compiler options. `smc verify`
+records the SemCode header epoch/revision, which is the currently admitted
+artifact-format/toolchain compatibility identity. Manifest spelling, package
+names, and hashes do not grant capabilities and cannot override verification.
+
+Project Model v0 makes no signing, cryptographic provenance, registry identity,
+or source-compatibility promise. SSF-10 owns those contracts.
+
+## Manual cold-start flow
+
+Create the three required files shown above, put this in `src/main.sm`:
+
+```semantic
+fn main() {
+    assert(true);
+    return;
+}
+```
+
+Then run:
+
+```text
+smc check .
+smc compile . -o app.smc
+smc verify .
+smc verify app.smc
+smc run .
+smc test .
+```
+
+For the last command, add `tests/smoke.sm` containing the same program. From a
+repository checkout, use `cargo run --bin smc --` before each argument list.
+
+## SSF-06 entry boundary
+
+SSF-06 may add only reproducible local path dependencies, deterministic graph
+ordering/cycle rejection, package hashes, capability-request inventory, and a
+minimal provenance/lock record if evidence requires it. Registry access,
+remote solving, build/install hooks, implicit capability propagation, and a
+broad workspace model remain excluded.

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -328,6 +328,17 @@ fn assert_artifact_only_command_rejects_project_root_input(
     }
 }
 
+fn assert_verify_accepts_project_root_input(dir: &std::path::Path, context: &str) {
+    let absolute = cli_command_project_root_output("verify", dir, context);
+    let dot = cli_command_project_root_output_dot("verify", dir, context);
+    assert!(
+        absolute.contains("header=SEMCODE0"),
+        "{context}: {absolute}"
+    );
+    assert!(dot.contains("header=SEMCODE0"), "{context}: {dot}");
+    assert_no_semcode_artifacts(dir, context);
+}
+
 fn cli_compile_project_root_err_no_overwrite(
     dir: &std::path::Path,
     out_name: &str,
@@ -679,16 +690,12 @@ fn pcc9_artifact_only_disasm_rejects_project_root_inputs_without_fallback() {
 }
 
 #[test]
-fn pcc9_artifact_only_verify_rejects_project_root_inputs_without_fallback() {
+fn pcc9_verify_accepts_project_root_inputs_without_persisting_artifacts() {
     let dir = mk_temp_dir("pcc9_artifact_only_verify_project_root");
     write_semantic_toml(&dir, Some("src/main.sm"));
     write_source(&dir.join("src").join("main.sm"));
 
-    assert_artifact_only_command_rejects_project_root_input(
-        "verify",
-        &dir,
-        "smc verify must reject project-root inputs",
-    );
+    assert_verify_accepts_project_root_input(&dir, "smc verify project-root input");
 
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -2898,18 +2905,14 @@ fn pcc9_project_root_smoke_fixture_remains_source_only_after_compile() {
 }
 
 #[test]
-fn pcc9_project_root_smoke_fixture_rejects_artifact_only_commands_on_project_root() {
+fn pcc9_project_root_smoke_fixture_preserves_artifact_command_boundaries() {
     let root = canonical_project_root_fixture();
     assert_artifact_only_command_rejects_project_root_input(
         "disasm",
         &root,
         "smc disasm must reject canonical project-root fixture input",
     );
-    assert_artifact_only_command_rejects_project_root_input(
-        "verify",
-        &root,
-        "smc verify must reject canonical project-root fixture input",
-    );
+    assert_verify_accepts_project_root_input(&root, "smc verify canonical project-root fixture");
     assert_artifact_only_command_rejects_project_root_input(
         "run-smc",
         &root,
@@ -3028,17 +3031,16 @@ fn pcc9_project_root_package_baseline_fixture_accepts_admitted_surface() {
 }
 
 #[test]
-fn pcc9_project_root_package_baseline_fixture_rejects_artifact_only_commands_on_project_root() {
+fn pcc9_project_root_package_baseline_fixture_preserves_artifact_command_boundaries() {
     let root = package_baseline_project_root_fixture();
     assert_artifact_only_command_rejects_project_root_input(
         "disasm",
         &root,
         "smc disasm must reject package baseline project-root fixture input",
     );
-    assert_artifact_only_command_rejects_project_root_input(
-        "verify",
+    assert_verify_accepts_project_root_input(
         &root,
-        "smc verify must reject package baseline project-root fixture input",
+        "smc verify package baseline project-root fixture",
     );
     assert_artifact_only_command_rejects_project_root_input(
         "run-smc",
@@ -3074,8 +3076,9 @@ fn pcc9_project_root_surface_inventory_guard() {
         "hash-ast",
         "hash-ir",
         "hash-smc",
+        "verify",
     ];
-    let artifact_only_commands = ["disasm", "verify", "run-smc"];
+    let artifact_only_commands = ["disasm", "run-smc"];
 
     assert_eq!(
         admitted_project_root_commands,
@@ -3089,12 +3092,13 @@ fn pcc9_project_root_surface_inventory_guard() {
             "hash-ast",
             "hash-ir",
             "hash-smc",
+            "verify",
         ],
         "admitted project-root command surface changed unexpectedly",
     );
     assert_eq!(
         artifact_only_commands,
-        ["disasm", "verify", "run-smc"],
+        ["disasm", "run-smc"],
         "artifact-only command boundary changed unexpectedly",
     );
 

--- a/tests/ssf05_project_model.rs
+++ b/tests/ssf05_project_model.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn project() -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "semantic_ssf05_project_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(root.join("src")).expect("create src");
+    std::fs::create_dir_all(root.join("tests/nested")).expect("create tests");
+    std::fs::write(
+        root.join("semantic.toml"),
+        "[package]\nname = \"ssf05\"\n\n[project]\nentry = \"src/main.sm\"\n",
+    )
+    .expect("write manifest");
+    std::fs::write(
+        root.join("src/main.sm"),
+        "fn main() { assert(true); return; }\n",
+    )
+    .expect("write main");
+    std::fs::write(
+        root.join("tests/zeta.sm"),
+        "fn main() { assert(true); return; }\n",
+    )
+    .expect("write zeta test");
+    std::fs::write(
+        root.join("tests/nested/alpha.sm"),
+        "fn main() { assert(true); return; }\n",
+    )
+    .expect("write alpha test");
+    root
+}
+
+fn smc(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_smc"))
+        .args(args)
+        .output()
+        .expect("run smc")
+}
+
+#[test]
+fn project_verify_and_tests_use_the_canonical_root() {
+    let root = project();
+    let root_arg = root.to_string_lossy().replace('\\', "/");
+
+    let verify = smc(&["verify", &root_arg]);
+    assert!(
+        verify.status.success(),
+        "verify failed: {}",
+        String::from_utf8_lossy(&verify.stderr)
+    );
+    assert!(String::from_utf8_lossy(&verify.stdout).contains("header=SEMCODE0"));
+
+    let first = smc(&["test", &root_arg]);
+    let second = smc(&["test", &root_arg]);
+    assert!(
+        first.status.success(),
+        "test failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(first.stdout, second.stdout);
+    assert_eq!(
+        String::from_utf8_lossy(&first.stdout),
+        "ok tests/nested/alpha.sm\nok tests/zeta.sm\ntest result: ok. 2 passed\n"
+    );
+
+    std::fs::remove_dir_all(root).expect("remove project");
+}
+
+#[test]
+fn project_test_fails_explicitly_when_no_tests_exist() {
+    let root = project();
+    std::fs::remove_dir_all(root.join("tests")).expect("remove tests");
+    let root_arg = root.to_string_lossy().replace('\\', "/");
+
+    let output = smc(&["test", &root_arg]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("contains no tests/*.sm programs"));
+
+    std::fs::remove_dir_all(root).expect("remove project");
+}
+
+#[test]
+fn project_test_propagates_a_deterministic_runtime_failure() {
+    let root = project();
+    std::fs::write(
+        root.join("tests/nested/alpha.sm"),
+        "fn main() { assert(false); return; }\n",
+    )
+    .expect("write failing test");
+    let root_arg = root.to_string_lossy().replace('\\', "/");
+
+    let first = smc(&["test", &root_arg]);
+    let second = smc(&["test", &root_arg]);
+    assert!(!first.status.success());
+    assert_eq!(first.stderr, second.stderr);
+    assert!(String::from_utf8_lossy(&first.stderr).contains("alpha.sm"));
+
+    std::fs::remove_dir_all(root).expect("remove project");
+}
+
+#[test]
+fn project_test_rejects_a_non_directory_test_root() {
+    let root = project();
+    std::fs::remove_dir_all(root.join("tests")).expect("remove tests");
+    std::fs::write(root.join("tests"), "not a directory\n").expect("write test-root file");
+    let root_arg = root.to_string_lossy().replace('\\', "/");
+
+    let output = smc(&["test", &root_arg]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must be a real directory"));
+
+    std::fs::remove_dir_all(root).expect("remove project");
+}


### PR DESCRIPTION
## SSF phase

SSF-05 — Project Model v0 completion (#1576), under umbrella #1569.

## Problem / demonstrated gap

Current `main` already had deterministic `semantic.toml` entry resolution, single-file compatibility, project-root `check`/`compile`/`run`, and PCC9 path diagnostics. It did not yet have a canonical Project Model v0 contract, project-root `verify`, or deterministic project test discovery/execution.

## Target contract

- `semantic.foundation.project/0.1`
- `semantic.toml` is canonical; `Semantic.package` remains an explicit compatibility/package input
- direct `.sm` remains the single-file form
- project metadata is descriptive and never capability/verifier/runtime authority
- tests are root-contained `tests/**/*.sm` standalone programs, sorted by normalized relative path and run under the pure profile

## Implementation slice

- admit `smc verify <project-root>` via the existing entry/bundle compiler and verifier path, without persistence or execution
- add `smc test <project-root>` with deterministic recursive discovery, link/reparse rejection, verifier-first execution, and explicit empty/failure behavior
- publish the canonical layout, discovery, command agreement, identity boundary, manual cold-start flow, and SSF-06 entry boundary
- update current-facing CLI/README/matrix evidence and PCC9 artifact-boundary tests

## Tests / qualification

- `cargo fmt --all -- --check`
- `cargo test -p smc-cli --lib` — 132 passed
- `cargo test --test ssf05_project_model` — 4 passed
- `cargo test --test project_manifest_surface_qualification` — 3 passed
- `cargo test --test pcc9_project_model_diagnostics` — 9 passed
- `cargo test --test pcc9_project_model_acceptance` — 119 passed
- `cargo test --test ssf_status_drift`
- `cargo test --test ssf_language_contract_drift`
- `cargo test --test vm_token_first_policy_guard`
- `cargo test --test public_api_contracts`
- `cargo test --test dependency_boundaries`
- `cargo test --test trust_boundary_guards`
- `cargo clippy -p smc-cli --all-targets --all-features -- -D warnings`
- `cargo check -p smc-cli --no-default-features --lib`
- `git diff --cached --check`

A local full-workspace run exceeded the command wrapper limit while still compiling heavyweight UI/graphics dependencies; it produced no test failure. Exact-head CI is the authoritative clean-machine regression gate.

## Non-goals

No registry, remote solver, build/install hooks, broad workspace model, package expansion, dependency change, workflow change, UI product work, signing/provenance claim, or Stable promotion.