### PR TITLE
SSF-06: close local package baseline v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ The complete current command contract is in [docs/spec/cli.md](docs/spec/cli.md)
 
 Current `main` supports a bounded project-root baseline using the existing `semantic.toml` or `Semantic.package` layouts represented by repository fixtures and tests.
 
+For the local-only package baseline, `smc package inspect <project-root>` emits
+a deterministic provenance record containing the declared dependency graph,
+manifest/content fingerprints, and capability-request inventory. It performs no
+remote fetch and grants no capability; see
+[`docs/spec/package_baseline_v0.md`](docs/spec/package_baseline_v0.md).
+
 From a supported project root:
 
 ```bash

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -34,16 +34,12 @@ fn iterable_for_impl_out_of_scope_message() -> &'static str {
 }
 
 fn executable_import_wave2_out_of_scope_message() -> &'static str {
-    "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope"
+    "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports; alias, wildcard, and re-export forms remain out of scope"
 }
 
 fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
     for import in &program.imports {
-        if import.reexport
-            || import.wildcard
-            || import.alias.is_some()
-            || import.spec.contains("::")
-        {
+        if import.reexport || import.wildcard || import.alias.is_some() {
             return Err(FrontendError {
                 pos: 0,
                 message: executable_import_wave2_out_of_scope_message().to_string(),
@@ -3333,7 +3329,7 @@ mod tests {
     }
 
     #[test]
-    fn executable_package_qualified_import_rejects_as_wave2_out_of_scope() {
+    fn executable_package_qualified_import_typechecks_in_package_baseline() {
         let src = r#"
             Import "math::core.sm"
 
@@ -3342,11 +3338,7 @@ mod tests {
             }
         "#;
 
-        let err = typecheck_source(src)
-            .expect_err("package-qualified executable import must stay out of scope in wave2");
-        assert!(err
-            .message
-            .contains(executable_import_wave2_out_of_scope_message()));
+        typecheck_source(src).expect("package-qualified executable import should typecheck");
     }
 
     #[test]

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -39,7 +39,11 @@ fn executable_import_wave2_out_of_scope_message() -> &'static str {
 
 fn validate_executable_imports(program: &Program) -> Result<(), FrontendError> {
     for import in &program.imports {
-        if import.reexport || import.wildcard || import.alias.is_some() {
+        if import.reexport
+            || import.wildcard
+            || import.alias.is_some()
+            || (import.spec.contains("::") && !import.select_items.is_empty())
+        {
             return Err(FrontendError {
                 pos: 0,
                 message: executable_import_wave2_out_of_scope_message().to_string(),
@@ -3339,6 +3343,23 @@ mod tests {
         "#;
 
         typecheck_source(src).expect("package-qualified executable import should typecheck");
+    }
+
+    #[test]
+    fn executable_package_qualified_selected_import_stays_out_of_scope() {
+        let src = r#"
+            Import "math::core.sm" { helper }
+
+            fn main() {
+                return;
+            }
+        "#;
+
+        let err = typecheck_source(src)
+            .expect_err("package-qualified selected import must stay out of scope");
+        assert!(err
+            .message
+            .contains(executable_import_wave2_out_of_scope_message()));
     }
 
     #[test]

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -681,18 +681,21 @@ fn cmd_watch(args: &[String]) -> Result<(), String> {
     let mut last_fp: Option<u64> = None;
     let mut last_snapshot: Option<String> = None;
     loop {
+        // Reset unconditionally, every iteration, BEFORE computing the fingerprint below --
+        // not only when a change is detected. module_graph_fingerprint tracks source Import
+        // edges only (see collect_module_graph in incremental.rs), so a change to a
+        // declared-but-unimported dependency (exactly what DL-021's admission-side
+        // validation exists to catch) never changes `fp` and would never reach a
+        // conditional reset gated on `last_fp != Some(fp)`. Resetting here is cheap (an
+        // empty-cache clear costs nothing on ticks where nothing changed) and guarantees
+        // admission never depends on a prior tick's cached answer (DL-022).
+        reset_pinned_dependency_fingerprint_cache();
+        reset_declared_dependency_graph_cache();
         match module_graph_fingerprint(&root, CACHE_SCHEMA_VERSION) {
             Ok(fp) => {
                 if last_fp != Some(fp) {
                     let t0 = Instant::now();
                     last_fp = Some(fp);
-                    // smc watch is a long-lived process, so any pinned-dependency
-                    // content-fingerprint cache must be reset before each rebuild pass or
-                    // a dependency change made between passes could go undetected
-                    // (DL-020). Same reasoning applies to the declared-dependency-graph
-                    // validation cache (DL-021).
-                    reset_pinned_dependency_fingerprint_cache();
-                    reset_declared_dependency_graph_cache();
                     let src = match read_source_with_package_admission(&root) {
                         Ok(s) => s,
                         Err(e) => {

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -5,7 +5,8 @@ use crate::incremental::{
     update_cache_index, CacheEvent, CacheReason, ModuleGraphSnapshot,
 };
 use crate::package_manifest::{
-    admit_package_entry_module, resolve_package_import_path, resolve_project_root_check_entry,
+    admit_package_entry_module, inspect_local_package_graph, resolve_package_import_path,
+    resolve_project_root_check_entry,
 };
 use crate::{format_path, FormatterMode};
 use prom_audit::hello_observation_audit::{
@@ -109,6 +110,7 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
         "repl" => cmd_repl(&args[1..]),
         "verify" => cmd_verify(&args[1..]),
         "test" => cmd_test(&args[1..]),
+        "package" => cmd_package(&args[1..]),
         "run" => cmd_run(&args[1..]),
         "run-smc" => cmd_run_smc(&args[1..]),
         "disasm" => cmd_disasm(&args[1..]),
@@ -121,6 +123,22 @@ pub fn run(args: Vec<String>) -> Result<(), String> {
         }
         other => Err(format!("unknown command '{}'\n\n{}", other, usage())),
     }
+}
+
+fn cmd_package(args: &[String]) -> Result<(), String> {
+    if args.len() != 2 || args[0] != "inspect" {
+        return Err("usage: smc package inspect <project-root>".to_string());
+    }
+    reject_leading_unknown_flag(&args[1])?;
+    let root = Path::new(&args[1]);
+    if !root.is_dir() {
+        return Err(format!(
+            "package inspect project root '{}' is not a directory",
+            root.display()
+        ));
+    }
+    println!("{}", inspect_local_package_graph(root)?);
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -2934,6 +2952,7 @@ fn usage() -> String {
         "  smc work <subject> <intent> [to <target>] [with <profile>]",
         "  smc verify <input.smc|project-root>",
         "  smc test <project-root>",
+        "  smc package inspect <project-root>",
         "  smc run <input.sm|project-root>",
         "  smc run <input.sm|project-root> --profile <pure|cli-read-only|cli-file-transform> --root <directory> [--duration-ms <u32>] [-- <application-args...>]",
         "  smc run-smc <input.smc>",

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -681,20 +681,20 @@ fn cmd_watch(args: &[String]) -> Result<(), String> {
     let mut last_fp: Option<u64> = None;
     let mut last_snapshot: Option<String> = None;
     loop {
-        // Reset unconditionally, every iteration, BEFORE computing the fingerprint below --
-        // not only when a change is detected. module_graph_fingerprint tracks source Import
-        // edges only (see collect_module_graph in incremental.rs), so a change to a
-        // declared-but-unimported dependency (exactly what DL-021's admission-side
-        // validation exists to catch) never changes `fp` and would never reach a
-        // conditional reset gated on `last_fp != Some(fp)`. Resetting here is cheap (an
-        // empty-cache clear costs nothing on ticks where nothing changed) and guarantees
-        // admission never depends on a prior tick's cached answer (DL-022).
-        reset_pinned_dependency_fingerprint_cache();
-        reset_declared_dependency_graph_cache();
         match module_graph_fingerprint(&root, CACHE_SCHEMA_VERSION) {
             Ok(fp) => {
                 if last_fp != Some(fp) {
                     let t0 = Instant::now();
+                    // Reset only when the fingerprint actually changed, not on every idle
+                    // tick: `module_graph_fingerprint` now folds each module's governing
+                    // manifest content into its hash (see collect_module_graph in
+                    // incremental.rs), so a change to a declared dependency in that
+                    // manifest already changes `fp` and reaches this branch -- the
+                    // unconditional-every-tick reset DL-022 introduced was itself a real
+                    // regression (rehashing every declared package's full content on every
+                    // idle tick, not just real rebuilds). See DL-023.
+                    reset_pinned_dependency_fingerprint_cache();
+                    reset_declared_dependency_graph_cache();
                     last_fp = Some(fp);
                     let src = match read_source_with_package_admission(&root) {
                         Ok(s) => s,

--- a/crates/smc-cli/src/app.rs
+++ b/crates/smc-cli/src/app.rs
@@ -5,7 +5,8 @@ use crate::incremental::{
     update_cache_index, CacheEvent, CacheReason, ModuleGraphSnapshot,
 };
 use crate::package_manifest::{
-    admit_package_entry_module, inspect_local_package_graph, resolve_package_import_path,
+    admit_package_entry_module, inspect_local_package_graph, reset_declared_dependency_graph_cache,
+    reset_pinned_dependency_fingerprint_cache, resolve_package_import_path,
     resolve_project_root_check_entry,
 };
 use crate::{format_path, FormatterMode};
@@ -55,7 +56,18 @@ impl ModuleProvider for CliFsModuleProvider {
 
     fn resolve_import(&self, importer_module_id: &str, spec: &str) -> Result<String, String> {
         resolve_package_import_path(Path::new(importer_module_id), spec)
-            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .map(|path| {
+                let text = path.to_string_lossy();
+                // Only fold '\' into '/' on Windows -- on Unix it is an ordinary filename
+                // character, and resolve_package_import_path already preserves it, so
+                // folding it here would make this module_id identify a different file
+                // than the one that was actually resolved (same class as DL-012/DL-016).
+                if cfg!(windows) {
+                    text.replace('\\', "/")
+                } else {
+                    text.into_owned()
+                }
+            })
             .map_err(|e| e.to_string())
     }
 }
@@ -674,6 +686,13 @@ fn cmd_watch(args: &[String]) -> Result<(), String> {
                 if last_fp != Some(fp) {
                     let t0 = Instant::now();
                     last_fp = Some(fp);
+                    // smc watch is a long-lived process, so any pinned-dependency
+                    // content-fingerprint cache must be reset before each rebuild pass or
+                    // a dependency change made between passes could go undetected
+                    // (DL-020). Same reasoning applies to the declared-dependency-graph
+                    // validation cache (DL-021).
+                    reset_pinned_dependency_fingerprint_cache();
+                    reset_declared_dependency_graph_cache();
                     let src = match read_source_with_package_admission(&root) {
                         Ok(s) => s,
                         Err(e) => {
@@ -2033,6 +2052,32 @@ Import "c.sm" as Core
 "#;
         let specs = parse_import_specs(src);
         assert_eq!(specs, vec!["a.sm", "b.sm", "c.sm"]);
+    }
+
+    // CliFsModuleProvider::resolve_import folded '\' into '/' unconditionally, even though
+    // resolve_package_import_path (which it wraps) already preserves a literal backslash
+    // on Unix. On Unix a resolved import whose path contains a literal '\' must come back
+    // unchanged from this provider method too, or check/compile/run would try to read a
+    // different or nonexistent module than the one actually resolved (DL-018).
+    #[cfg(unix)]
+    #[test]
+    fn cli_fs_module_provider_resolve_import_preserves_literal_backslash_on_unix() {
+        let dir = mk_temp_dir("cli_fs_module_provider_backslash_import");
+        let importer = dir.join("main.sm");
+        std::fs::write(&importer, "fn main() { return; }\n").expect("write importer");
+        std::fs::write(dir.join("dep\\lib.sm"), "fn dep() { return; }\n")
+            .expect("write literal-backslash dependency");
+
+        let provider = CliFsModuleProvider;
+        let resolved = provider
+            .resolve_import(importer.to_str().expect("importer utf8"), "dep\\lib.sm")
+            .expect("resolve");
+        assert!(
+            resolved.ends_with("dep\\lib.sm"),
+            "resolved module_id must preserve the literal backslash, got: {resolved}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 pub(crate) fn executable_import_wave2_out_of_scope_message() -> &'static str {
-    "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope"
+    "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports; alias, wildcard, and re-export forms remain out of scope"
 }
 
 pub(crate) fn read_source_with_package_admission(path: &Path) -> Result<String, String> {
@@ -210,7 +210,7 @@ fn validate_executable_bundle_import(
     importer: &Path,
     import: &ExecutableImport,
 ) -> Result<(), String> {
-    if import.reexport || import.wildcard || import.alias.is_some() || import.spec.contains("::") {
+    if import.reexport || import.wildcard || import.alias.is_some() {
         return Err(format!(
             "{} in '{}'",
             executable_import_wave2_out_of_scope_message(),

--- a/crates/smc-cli/src/executable_bundle.rs
+++ b/crates/smc-cli/src/executable_bundle.rs
@@ -1,4 +1,6 @@
-use crate::package_manifest::{admit_package_entry_module, resolve_package_import_path};
+use crate::package_manifest::{
+    admit_package_entry_module, resolve_package_import_path, PACKAGE_IMPORT_SEPARATOR,
+};
 use sm_front::types::{
     AstArena, ExecutableImport, Expr, ExprId, Function, Stmt, StmtId, SymbolId, TokenKind, Type,
 };
@@ -210,7 +212,11 @@ fn validate_executable_bundle_import(
     importer: &Path,
     import: &ExecutableImport,
 ) -> Result<(), String> {
-    if import.reexport || import.wildcard || import.alias.is_some() {
+    if import.reexport
+        || import.wildcard
+        || import.alias.is_some()
+        || (import.spec.contains(PACKAGE_IMPORT_SEPARATOR) && !import.select_items.is_empty())
+    {
         return Err(format!(
             "{} in '{}'",
             executable_import_wave2_out_of_scope_message(),

--- a/crates/smc-cli/src/incremental.rs
+++ b/crates/smc-cli/src/incremental.rs
@@ -1,4 +1,6 @@
-use crate::package_manifest::{admit_package_entry_module, resolve_package_import_path};
+use crate::package_manifest::{
+    admit_package_entry_module, find_nearest_manifest, resolve_package_import_path,
+};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -279,7 +281,24 @@ fn collect_module_graph(
     }
     let source = std::fs::read_to_string(&canonical)
         .map_err(|e| format!("read '{}': {}", canonical.display(), e))?;
-    let source_hash = fnv1a64(source.as_bytes());
+    let mut source_hash = fnv1a64(source.as_bytes());
+    // Fold the governing manifest's own (small, single-file) content into the module's
+    // change fingerprint. Without this, module_graph_fingerprint -- the cheap signal
+    // `smc watch` polls every ~600ms to decide whether to rebuild -- has no way to see a
+    // change to a declared-but-unimported dependency (added/removed/re-pinned), so admission's
+    // full declared-dependency-graph validation (see admit_package_entry_module) would need
+    // to run on every idle tick just to catch that case, not only on real rebuilds. Reading
+    // one small manifest file is cheap enough to do unconditionally every tick; the full
+    // graph walk stays gated on an actual fingerprint change (DL-023).
+    if let Some(manifest_path) = find_nearest_manifest(&canonical) {
+        if let Ok(manifest_source) = std::fs::read_to_string(&manifest_path) {
+            let manifest_hash = fnv1a64(manifest_source.as_bytes());
+            let mut combined = Vec::with_capacity(16);
+            combined.extend_from_slice(&source_hash.to_le_bytes());
+            combined.extend_from_slice(&manifest_hash.to_le_bytes());
+            source_hash = fnv1a64(&combined);
+        }
+    }
     let mut deps = Vec::new();
     for spec in parse_import_specs(&source) {
         let child = resolve_package_import_path(&canonical, &spec).map_err(|e| e.to_string())?;
@@ -423,6 +442,61 @@ Law "Core2" [priority 2]:
         .expect("rewrite child");
         let fp2 = module_graph_fingerprint(&root, 2).expect("fp2");
         assert_ne!(fp1, fp2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // `smc watch` polls module_graph_fingerprint every ~600ms to decide whether to
+    // rebuild, and only resets admission's declared-dependency-graph cache when the
+    // fingerprint actually changes (see cmd_watch in app.rs). Before this fix, the
+    // fingerprint tracked source Import edges only, so adding/removing a declared-but-
+    // unimported dependency in the entry's own manifest left `fp` unchanged -- meaning
+    // `smc watch` would never notice or re-validate that change. collect_module_graph now
+    // folds the governing manifest's own content into each module's hash, so this must
+    // change `fp` even though `root.sm` never imports the added dependency (DL-023).
+    #[test]
+    fn module_graph_fingerprint_changes_on_unused_declared_dependency_edit() {
+        let dir = mk_temp_dir("smc_module_graph_fp_unused_dep");
+        let app_src = dir.join("app").join("src");
+        std::fs::create_dir_all(&app_src).expect("mkdir app src");
+        std::fs::write(
+            dir.join("app").join("Semantic.package"),
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write app manifest without a dependency");
+        let root = app_src.join("main.sm");
+        std::fs::write(
+            &root,
+            r#"
+Law "Root" [priority 1]:
+    When true -> System.recovery()
+"#,
+        )
+        .expect("write root");
+        let fp1 = module_graph_fingerprint(&root, 2).expect("fp1");
+
+        // Declare an unused dependency -- root.sm still imports nothing. The dependency
+        // must actually exist (DL-021 rejects a missing declared dependency outright,
+        // regardless of usage, and module_graph_fingerprint now admits the entry as part
+        // of computing the fingerprint).
+        let math_src = dir.join("math").join("src");
+        std::fs::create_dir_all(&math_src).expect("mkdir math src");
+        std::fs::write(
+            dir.join("math").join("Semantic.package"),
+            "format 1\npackage math\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write math manifest");
+        std::fs::write(math_src.join("core.sm"), "fn core() { return; }\n")
+            .expect("write math source");
+        std::fs::write(
+            dir.join("app").join("Semantic.package"),
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep math math ../math\n",
+        )
+        .expect("rewrite app manifest with an unused dependency");
+        let fp2 = module_graph_fingerprint(&root, 2).expect("fp2");
+        assert_ne!(
+            fp1, fp2,
+            "adding a declared-but-unimported dependency must change the watch fingerprint"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -111,7 +111,18 @@ impl ModuleProvider for CliFsProvider {
 
     fn resolve_import(&self, importer_module_id: &str, spec: &str) -> Result<String, String> {
         package_manifest::resolve_package_import_path(Path::new(importer_module_id), spec)
-            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .map(|path| {
+                let text = path.to_string_lossy();
+                // Only fold '\' into '/' on Windows -- on Unix it is an ordinary filename
+                // character, and resolve_package_import_path already preserves it, so
+                // folding it here would make this module_id identify a different file
+                // than the one that was actually resolved (same class as DL-012/DL-016).
+                if cfg!(windows) {
+                    text.replace('\\', "/")
+                } else {
+                    text.into_owned()
+                }
+            })
             .map_err(|e| e.to_string())
     }
 }
@@ -235,6 +246,35 @@ Law "L" [priority 1]:
 
         let report = CliPipeline::semantic_check_file(&entry).expect("check");
         assert_eq!(report.scheduled_laws.len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // CliFsProvider::resolve_import folded '\' into '/' unconditionally, even though
+    // resolve_package_import_path (which it wraps) already preserves a literal backslash
+    // on Unix (that fix landed earlier in this same repair chain -- see
+    // docs/spec/project_model_v0.md-adjacent DL entries in issue #1598). On Unix a
+    // resolved import whose path contains a literal '\' must come back unchanged from
+    // this provider method too, or CliPipeline::semantic_check_file (and compile/run)
+    // would try to read a different or nonexistent module than the one actually
+    // resolved (DL-018).
+    #[cfg(unix)]
+    #[test]
+    fn cli_fs_provider_resolve_import_preserves_literal_backslash_on_unix() {
+        let dir = mk_temp_dir("cli_fs_provider_backslash_import");
+        let importer = dir.join("main.sm");
+        std::fs::write(&importer, "fn main() { return; }\n").expect("write importer");
+        std::fs::write(dir.join("dep\\lib.sm"), "fn dep() { return; }\n")
+            .expect("write literal-backslash dependency");
+
+        let provider = CliFsProvider;
+        let resolved = provider
+            .resolve_import(importer.to_str().expect("importer utf8"), "dep\\lib.sm")
+            .expect("resolve");
+        assert!(
+            resolved.ends_with("dep\\lib.sm"),
+            "resolved module_id must preserve the literal backslash, got: {resolved}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/smc-cli/src/lib.rs
+++ b/crates/smc-cli/src/lib.rs
@@ -71,13 +71,14 @@ pub use config::{
 pub use formatter::{format_path, format_source_text, FormatterMode, FormatterSummary};
 #[cfg(feature = "std")]
 pub use package_manifest::{
-    admit_package_entry_module, parse_package_manifest_baseline, resolve_package_import_path,
-    validate_package_manifest_baseline, PackageDependency, PackageDependencySource,
-    PackageIdentity, PackageImportResolutionCode, PackageImportResolutionError, PackageManifest,
-    PackageManifestParseCode, PackageManifestParseError, PackageManifestValidationCode,
-    PackageManifestValidationError, PackageModuleAdmission, PackageModuleAdmissionCode,
-    PackageModuleAdmissionError, PackageRoot, PACKAGE_IMPORT_SEPARATOR,
-    PACKAGE_MANIFEST_BASELINE_VERSION, PACKAGE_MANIFEST_FILE_NAME,
+    admit_package_entry_module, parse_package_manifest_baseline,
+    reset_declared_dependency_graph_cache, reset_pinned_dependency_fingerprint_cache,
+    resolve_package_import_path, validate_package_manifest_baseline, PackageDependency,
+    PackageDependencySource, PackageIdentity, PackageImportResolutionCode,
+    PackageImportResolutionError, PackageManifest, PackageManifestParseCode,
+    PackageManifestParseError, PackageManifestValidationCode, PackageManifestValidationError,
+    PackageModuleAdmission, PackageModuleAdmissionCode, PackageModuleAdmissionError, PackageRoot,
+    PACKAGE_IMPORT_SEPARATOR, PACKAGE_MANIFEST_BASELINE_VERSION, PACKAGE_MANIFEST_FILE_NAME,
 };
 #[cfg(feature = "std")]
 pub use schema_versioning::{

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -63,6 +63,7 @@ pub struct PackageManifest {
     pub format_version: u32,
     pub package: PackageIdentity,
     pub dependencies: Vec<PackageDependency>,
+    pub capability_requests: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -107,6 +108,8 @@ pub enum PackageManifestValidationCode {
     EmptyLocalDependencyPath,
     LocalDependencyPathMustBeRelative,
     InvalidDependencyFingerprint,
+    EmptyCapabilityRequest,
+    DuplicateCapabilityRequest,
     PackageRootMustBeRelative,
     PackageRootMustNotEscapeManifest,
     ModuleRootMustBeRelative,
@@ -133,6 +136,7 @@ impl PackageManifest {
             format_version: PACKAGE_MANIFEST_BASELINE_VERSION,
             package,
             dependencies,
+            capability_requests: Vec::new(),
         }
     }
 }
@@ -152,6 +156,7 @@ pub enum PackageModuleAdmissionCode {
     ManifestValidationFailed,
     PackageRootResolutionFailed,
     ModuleRootResolutionFailed,
+    NestedManifestInsideModuleRoot,
     EntryOutsideModuleRoot,
 }
 
@@ -372,6 +377,7 @@ pub fn parse_package_manifest_baseline(
             },
         },
         dependencies,
+        capability_requests: capability_requests.into_iter().collect(),
     })
 }
 
@@ -481,6 +487,22 @@ pub fn validate_package_manifest_baseline(
         }
     }
 
+    let mut seen_capabilities = std::collections::BTreeSet::new();
+    for capability in &manifest.capability_requests {
+        if capability.trim().is_empty() {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::EmptyCapabilityRequest,
+                message: "package capability request must not be empty".to_string(),
+            });
+        }
+        if !seen_capabilities.insert(capability.as_str()) {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::DuplicateCapabilityRequest,
+                message: format!("duplicate package capability request '{}'", capability),
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -543,6 +565,7 @@ pub fn admit_package_entry_module(
         Some(path) => path,
         None => return Ok(None),
     };
+    reject_nested_manifest_authority(&manifest_path)?;
     let manifest = load_and_validate_manifest(&manifest_path)?;
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
     let package_root = manifest_dir.join(&manifest.package.root.manifest_dir);
@@ -856,6 +879,61 @@ fn find_nearest_manifest(entry_canonical: &Path) -> Option<PathBuf> {
     None
 }
 
+fn reject_nested_manifest_authority(
+    manifest_path: &Path,
+) -> Result<(), PackageModuleAdmissionError> {
+    let manifest_canonical =
+        manifest_path
+            .canonicalize()
+            .map_err(|error| PackageModuleAdmissionError {
+                code: PackageModuleAdmissionCode::ManifestReadFailed,
+                message: format!(
+                    "failed to resolve package manifest '{}': {error}",
+                    manifest_path.display()
+                ),
+            })?;
+    let mut current = manifest_canonical
+        .parent()
+        .and_then(|directory| directory.parent());
+    while let Some(directory) = current {
+        let semantic_toml = directory.join(SEMANTIC_TOML_FILE_NAME);
+        let package_manifest = directory.join(PACKAGE_MANIFEST_FILE_NAME);
+        let outer_manifest = if semantic_toml.is_file() {
+            Some(semantic_toml)
+        } else if package_manifest.is_file() {
+            Some(package_manifest)
+        } else {
+            None
+        };
+        if let Some(outer_manifest) = outer_manifest {
+            let outer = resolve_manifest_context(
+                &outer_manifest,
+                PackageImportResolutionCode::ImporterManifestReadFailed,
+                PackageImportResolutionCode::ImporterManifestParseFailed,
+                PackageImportResolutionCode::ImporterManifestValidationFailed,
+                PackageImportResolutionCode::ImporterPackageRootResolutionFailed,
+                PackageImportResolutionCode::ImporterModuleRootResolutionFailed,
+            )
+            .map_err(|error| PackageModuleAdmissionError {
+                code: PackageModuleAdmissionCode::ManifestValidationFailed,
+                message: error.to_string(),
+            })?;
+            if manifest_canonical.strip_prefix(&outer.module_root).is_ok() {
+                return Err(PackageModuleAdmissionError {
+                    code: PackageModuleAdmissionCode::NestedManifestInsideModuleRoot,
+                    message: format!(
+                        "nested package manifest '{}' is inside outer package module_root '{}'",
+                        manifest_canonical.display(),
+                        outer.module_root.display()
+                    ),
+                });
+            }
+        }
+        current = directory.parent();
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 struct ResolvedPackageContext {
     manifest: PackageManifest,
@@ -1003,12 +1081,11 @@ fn resolve_dependency_import(
     }
     if let Some(expected) = expected_content {
         let actual =
-            package_content_fingerprint(&dependency_ctx.module_root).map_err(|message| {
-                PackageImportResolutionError {
+            package_content_fingerprint(&dependency_ctx.module_root, &dependency_manifest_path)
+                .map_err(|message| PackageImportResolutionError {
                     code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
                     message,
-                }
-            })?;
+                })?;
         if actual != expected {
             return Err(PackageImportResolutionError {
                 code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
@@ -1633,11 +1710,11 @@ impl PackageGraphBuilder {
         }
         let _ = self.visiting.pop();
 
-        let capability_requests = package_capability_requests(&source)?;
+        let capability_requests = manifest.capability_requests.clone();
         let node = PackageGraphNode {
             name: package_name.clone(),
             manifest_fingerprint: fingerprint(normalize_line_endings(&source).as_bytes()),
-            content_fingerprint: package_content_fingerprint(&module_root)?,
+            content_fingerprint: package_content_fingerprint(&module_root, &manifest_path)?,
             capability_requests,
             dependencies,
         };
@@ -1652,21 +1729,18 @@ fn manifest_fingerprint(path: &Path) -> Result<String, String> {
     Ok(fingerprint(normalize_line_endings(&source).as_bytes()))
 }
 
-fn package_capability_requests(source: &str) -> Result<Vec<String>, String> {
-    let mut capabilities = Vec::new();
-    for (index, line) in source.lines().enumerate() {
-        let tokens = split_manifest_tokens(line, index + 1).map_err(|error| error.to_string())?;
-        if tokens.first().is_some_and(|token| token == "capability") {
-            capabilities.push(tokens[1].clone());
-        }
-    }
-    capabilities.sort();
-    Ok(capabilities)
-}
-
-fn package_content_fingerprint(module_root: &Path) -> Result<String, String> {
+fn package_content_fingerprint(
+    module_root: &Path,
+    authority_manifest: &Path,
+) -> Result<String, String> {
     let mut files = Vec::<(String, Vec<u8>)>::new();
-    collect_package_files(module_root, module_root, &mut files)?;
+    let authority_manifest = authority_manifest.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve '{}': {error}",
+            authority_manifest.display()
+        )
+    })?;
+    collect_package_files(module_root, module_root, &authority_manifest, &mut files)?;
     files.sort_by(|left, right| left.0.cmp(&right.0));
     let mut material = Vec::new();
     for (path, bytes) in files {
@@ -1681,6 +1755,7 @@ fn package_content_fingerprint(module_root: &Path) -> Result<String, String> {
 fn collect_package_files(
     module_root: &Path,
     directory: &Path,
+    authority_manifest: &Path,
     files: &mut Vec<(String, Vec<u8>)>,
 ) -> Result<(), String> {
     let mut entries = fs::read_dir(directory)
@@ -1710,7 +1785,21 @@ fn collect_package_files(
             .file_type()
             .map_err(|error| format!("failed to inspect '{}': {error}", path.display()))?;
         if file_type.is_dir() {
-            collect_package_files(module_root, &path, files)?;
+            collect_package_files(module_root, &path, authority_manifest, files)?;
+        } else if file_type.is_file()
+            && path != authority_manifest
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    name == PACKAGE_MANIFEST_FILE_NAME || name == SEMANTIC_TOML_FILE_NAME
+                })
+        {
+            return Err(format!(
+                "nested package manifest '{}' is inside package module_root '{}'",
+                path.display(),
+                module_root.display()
+            ));
         } else if file_type.is_file()
             && path
                 .extension()
@@ -1914,11 +2003,22 @@ manifest_dir "."
 module_root "src"
 dep math math "../math"
 dep ui ui "../ui"
+capability fs.read
+capability stdout.write
 "#,
         )
         .expect("parse");
         assert_eq!(manifest.package.name, "app");
         assert_eq!(manifest.dependencies.len(), 2);
+        assert_eq!(
+            manifest.capability_requests,
+            vec!["fs.read".to_string(), "stdout.write".to_string()]
+        );
+        let without_capabilities = parse_package_manifest_baseline(
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep math math ../math\ndep ui ui ../ui\n",
+        )
+        .expect("parse without capabilities");
+        assert_ne!(manifest, without_capabilities);
         validate_package_manifest_baseline(&manifest).expect("validate");
     }
 

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1502,7 +1502,15 @@ fn normalize_relative_path(path: &Path) -> Result<String, String> {
     let text = path
         .to_str()
         .ok_or_else(|| format!("package path '{}' is not valid UTF-8", path.display()))?;
-    let normalized = text.replace('\\', "/");
+    // `\` is only a path separator on Windows -- on Unix it is an ordinary filename
+    // character, so folding it into `/` unconditionally would collapse a real
+    // subdirectory path (`dir/helper.sm`) and a file literally named `dir\helper.sm`
+    // onto the same normalized string.
+    let normalized = if cfg!(windows) {
+        text.replace('\\', "/")
+    } else {
+        text.to_string()
+    };
     let normalized = normalized.strip_prefix("//?/").unwrap_or(&normalized);
     Ok(if normalized.is_empty() {
         ".".to_string()
@@ -2718,5 +2726,55 @@ module_root src
         assert!(err.contains("not valid UTF-8"), "unexpected error: {err}");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // On Unix, `\` is an ordinary filename character, not a separator. Blindly replacing
+    // `\` with `/` when normalizing a relative path therefore collapses a real subdirectory
+    // path (`dir/helper.sm`) and a single file literally named `dir\helper.sm` onto the same
+    // fingerprint key, so renaming between those two forms while keeping the bytes unchanged
+    // would leave `content_fingerprint` unchanged too. Only fold `\` into `/` on Windows,
+    // where it is the actual path separator.
+    #[cfg(unix)]
+    #[test]
+    fn package_content_fingerprint_does_not_collapse_literal_backslash_with_separator() {
+        let content = "fn main() { return; }\n";
+
+        let real_dir = mk_temp_dir("package_content_fingerprint_backslash_real");
+        let real_module_root = real_dir.join("src");
+        std::fs::create_dir_all(real_module_root.join("dir")).expect("mkdir src/dir");
+        let real_manifest = real_dir.join(PACKAGE_MANIFEST_FILE_NAME);
+        std::fs::write(
+            &real_manifest,
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write manifest");
+        std::fs::write(real_module_root.join("dir").join("helper.sm"), content)
+            .expect("write dir/helper.sm");
+        let real_fingerprint = package_content_fingerprint(&real_module_root, &real_manifest)
+            .expect("real subdirectory path must fingerprint");
+
+        let literal_dir = mk_temp_dir("package_content_fingerprint_backslash_literal");
+        let literal_module_root = literal_dir.join("src");
+        std::fs::create_dir_all(&literal_module_root).expect("mkdir src");
+        let literal_manifest = literal_dir.join(PACKAGE_MANIFEST_FILE_NAME);
+        std::fs::write(
+            &literal_manifest,
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write manifest");
+        std::fs::write(literal_module_root.join("dir\\helper.sm"), content)
+            .expect("write literal dir\\helper.sm");
+        let literal_fingerprint =
+            package_content_fingerprint(&literal_module_root, &literal_manifest)
+                .expect("literal backslash filename must fingerprint");
+
+        assert_ne!(
+            real_fingerprint, literal_fingerprint,
+            "a real dir/helper.sm subdirectory path and a file literally named \
+             dir\\helper.sm must not collapse onto the same content fingerprint"
+        );
+
+        let _ = std::fs::remove_dir_all(&real_dir);
+        let _ = std::fs::remove_dir_all(&literal_dir);
     }
 }

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -639,6 +639,7 @@ enum ProjectRootResolutionCode {
     SemanticTomlReadFailed,
     SemanticTomlManifest(SemanticTomlManifestErrorCode),
     SemanticTomlEntryMissing,
+    EntrySymlinkOrReparse,
     MissingProjectManifest,
 }
 
@@ -683,6 +684,9 @@ fn resolve_project_root_check_entry_structured(
                 )
             })?;
         let entry_path = root.join(&project_manifest.entry);
+        reject_reparse_path(&entry_path).map_err(|message| {
+            project_root_resolution_error(ProjectRootResolutionCode::EntrySymlinkOrReparse, message)
+        })?;
         if !entry_path.is_file() {
             return Err(project_root_resolution_error(
                 ProjectRootResolutionCode::SemanticTomlEntryMissing,
@@ -699,7 +703,11 @@ fn resolve_project_root_check_entry_structured(
 
     let package_manifest = root.join(PACKAGE_MANIFEST_FILE_NAME);
     if package_manifest.is_file() {
-        return Ok(root.join("src/main.sm"));
+        let entry_path = root.join("src/main.sm");
+        reject_reparse_path(&entry_path).map_err(|message| {
+            project_root_resolution_error(ProjectRootResolutionCode::EntrySymlinkOrReparse, message)
+        })?;
+        return Ok(entry_path);
     }
 
     Err(project_root_resolution_error(

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -524,6 +524,10 @@ fn is_valid_package_fingerprint(value: &str) -> bool {
 pub fn admit_package_entry_module(
     entry: &Path,
 ) -> Result<Option<PackageModuleAdmission>, PackageModuleAdmissionError> {
+    reject_reparse_path(entry).map_err(|message| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::EntryResolutionFailed,
+        message,
+    })?;
     let entry_canonical = entry
         .canonicalize()
         .map_err(|e| PackageModuleAdmissionError {
@@ -538,10 +542,6 @@ pub fn admit_package_entry_module(
         Some(path) => path,
         None => return Ok(None),
     };
-    reject_reparse_path(entry).map_err(|message| PackageModuleAdmissionError {
-        code: PackageModuleAdmissionCode::EntryResolutionFailed,
-        message,
-    })?;
     let manifest = load_and_validate_manifest(&manifest_path)?;
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
     let package_root = manifest_dir.join(&manifest.package.root.manifest_dir);

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -189,6 +189,7 @@ pub enum PackageImportResolutionCode {
     DependencyPackageNameMismatch,
     DependencyManifestFingerprintMismatch,
     DependencyContentFingerprintMismatch,
+    RelativeImportOutsideModuleRoot,
     DependencyImportOutsideModuleRoot,
 }
 
@@ -745,7 +746,28 @@ pub fn resolve_package_import_path(
     let base = importer_canonical
         .parent()
         .unwrap_or_else(|| Path::new("."));
-    Ok(resolve_relative_import_path(base, spec))
+    let resolved = resolve_relative_import_path(base, spec);
+    if let Some(manifest_path) = find_nearest_manifest(&importer_canonical) {
+        let importer_ctx = resolve_manifest_context(
+            &manifest_path,
+            PackageImportResolutionCode::ImporterManifestReadFailed,
+            PackageImportResolutionCode::ImporterManifestParseFailed,
+            PackageImportResolutionCode::ImporterManifestValidationFailed,
+            PackageImportResolutionCode::ImporterPackageRootResolutionFailed,
+            PackageImportResolutionCode::ImporterModuleRootResolutionFailed,
+        )?;
+        if resolved.strip_prefix(&importer_ctx.module_root).is_err() {
+            return Err(PackageImportResolutionError {
+                code: PackageImportResolutionCode::RelativeImportOutsideModuleRoot,
+                message: format!(
+                    "relative package import '{}' escapes package module_root '{}'",
+                    spec,
+                    importer_ctx.module_root.display()
+                ),
+            });
+        }
+    }
+    Ok(resolved)
 }
 
 fn parse_error(
@@ -1033,11 +1055,23 @@ fn resolve_manifest_context(
             code: read_code,
             message: format!("failed to read '{}': {}", manifest_path.display(), e),
         })?;
-    let manifest =
+    let manifest = if manifest_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == SEMANTIC_TOML_FILE_NAME)
+    {
+        parse_semantic_toml_manifest(manifest_path, &source)
+            .map(|project_manifest| project_manifest.manifest)
+            .map_err(|e| PackageImportResolutionError {
+                code: parse_code,
+                message: format!("failed to parse '{}': {}", manifest_path.display(), e),
+            })?
+    } else {
         parse_package_manifest_baseline(&source).map_err(|e| PackageImportResolutionError {
             code: parse_code,
             message: format!("failed to parse '{}': {}", manifest_path.display(), e),
-        })?;
+        })?
+    };
     validate_package_manifest_baseline(&manifest).map_err(|e| PackageImportResolutionError {
         code: validate_code,
         message: format!("failed to validate '{}': {}", manifest_path.display(), e),

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -194,6 +194,7 @@ pub enum PackageImportResolutionCode {
     DependencyPackageNameMismatch,
     DependencyManifestFingerprintMismatch,
     DependencyContentFingerprintMismatch,
+    UnsupportedModuleExtension,
     RelativeImportOutsideModuleRoot,
     DependencyImportOutsideModuleRoot,
 }
@@ -565,6 +566,10 @@ pub fn admit_package_entry_module(
         Some(path) => path,
         None => return Ok(None),
     };
+    reject_reparse_path(&manifest_path).map_err(|message| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::ManifestReadFailed,
+        message,
+    })?;
     reject_nested_manifest_authority(&manifest_path)?;
     let manifest = load_and_validate_manifest(&manifest_path)?;
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
@@ -763,6 +768,7 @@ pub fn resolve_package_import_path(
                 ),
             })?;
     if let Some((alias, module_spec)) = spec.split_once(PACKAGE_IMPORT_SEPARATOR) {
+        validate_package_import_extension(module_spec, spec)?;
         return resolve_dependency_import(&importer_canonical, alias, module_spec, spec);
     }
 
@@ -779,6 +785,7 @@ pub fn resolve_package_import_path(
             PackageImportResolutionCode::ImporterPackageRootResolutionFailed,
             PackageImportResolutionCode::ImporterModuleRootResolutionFailed,
         )?;
+        validate_package_import_extension(spec, spec)?;
         if resolved.strip_prefix(&importer_ctx.module_root).is_err() {
             return Err(PackageImportResolutionError {
                 code: PackageImportResolutionCode::RelativeImportOutsideModuleRoot,
@@ -791,6 +798,25 @@ pub fn resolve_package_import_path(
         }
     }
     Ok(resolved)
+}
+
+fn validate_package_import_extension(
+    module_spec: &str,
+    original_spec: &str,
+) -> Result<(), PackageImportResolutionError> {
+    match Path::new(module_spec)
+        .extension()
+        .and_then(|value| value.to_str())
+    {
+        None | Some("sm" | "exo") => Ok(()),
+        Some(_) => Err(PackageImportResolutionError {
+            code: PackageImportResolutionCode::UnsupportedModuleExtension,
+            message: format!(
+                "package import '{}' must use a .sm or .exo module extension",
+                original_spec
+            ),
+        }),
+    }
 }
 
 fn parse_error(

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -994,7 +994,9 @@ fn select_manifest_in_directory(dir: &Path) -> Option<PathBuf> {
     None
 }
 
-fn find_nearest_manifest(entry_canonical: &Path) -> Option<PathBuf> {
+/// Crate-visible so `incremental.rs`'s `collect_module_graph` can fold the governing
+/// manifest's own content into its cheap watch-mode change fingerprint (see DL-023).
+pub(crate) fn find_nearest_manifest(entry_canonical: &Path) -> Option<PathBuf> {
     let mut current = entry_canonical.parent();
     while let Some(dir) = current {
         if let Some(manifest) = select_manifest_in_directory(dir) {

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1005,7 +1005,10 @@ fn resolve_dependency_import(
     module_spec: &str,
     original_spec: &str,
 ) -> Result<PathBuf, PackageImportResolutionError> {
-    if alias.trim().is_empty() || module_spec.trim().is_empty() {
+    if alias.trim().is_empty()
+        || module_spec.trim().is_empty()
+        || module_spec.contains(PACKAGE_IMPORT_SEPARATOR)
+    {
         return Err(PackageImportResolutionError {
             code: PackageImportResolutionCode::InvalidQualifiedImportSpec,
             message: format!(

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -459,9 +459,12 @@ pub fn validate_package_manifest_baseline(
             });
         }
         if Path::new(path).is_absolute()
-            || Path::new(path)
-                .components()
-                .any(|component| matches!(component, std::path::Component::Prefix(_)))
+            || Path::new(path).components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::Prefix(_) | std::path::Component::RootDir
+                )
+            })
         {
             return Err(PackageManifestValidationError {
                 code: PackageManifestValidationCode::LocalDependencyPathMustBeRelative,
@@ -515,9 +518,12 @@ fn validate_contained_relative_path(
 ) -> Result<(), PackageManifestValidationError> {
     let path = Path::new(value);
     if path.is_absolute()
-        || path
-            .components()
-            .any(|component| matches!(component, std::path::Component::Prefix(_)))
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::Prefix(_) | std::path::Component::RootDir
+            )
+        })
     {
         return Err(PackageManifestValidationError {
             code: absolute_code,
@@ -1277,7 +1283,14 @@ fn parse_semantic_toml_manifest(
 
     fn normalize_project_entry(entry: &str) -> Result<String, SemanticTomlManifestError> {
         let path = Path::new(entry);
-        if path.is_absolute() {
+        if path.is_absolute()
+            || path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::Prefix(_) | std::path::Component::RootDir
+                )
+            })
+        {
             return Err(semantic_toml_error(
                 SemanticTomlManifestErrorCode::ProjectEntryMustBeRelative,
                 format!("project entry '{}' must be relative", entry),
@@ -2318,6 +2331,46 @@ name "app"
                 err.message
             );
         }
+    }
+
+    // A Windows root-relative path such as `\rooted\main.sm` has a `RootDir` component
+    // but no `Prefix`, so `Path::is_absolute()` reports it as NOT absolute. Joining it to
+    // a canonical base resets to the current drive's root, escaping containment. This
+    // must be rejected the same as a fully absolute (drive-prefixed) path.
+    #[cfg(windows)]
+    #[test]
+    fn parse_semantic_toml_manifest_rejects_rooted_project_entry_without_drive_prefix() {
+        let source = r#"
+[package]
+name = "app"
+
+[project]
+entry = "\rooted\main.sm"
+"#;
+        let err = parse_semantic_toml_manifest(Path::new("semantic.toml"), source)
+            .expect_err("rooted entry without a drive prefix must reject");
+        assert_eq!(
+            err.code,
+            SemanticTomlManifestErrorCode::ProjectEntryMustBeRelative
+        );
+        assert!(err.message.contains("must be relative"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_contained_relative_path_rejects_rooted_path_without_drive_prefix() {
+        let err = validate_contained_relative_path(
+            r"\rooted\dep",
+            PackageManifestValidationCode::PackageRootMustBeRelative,
+            PackageManifestValidationCode::PackageRootMustNotEscapeManifest,
+            "package root",
+        )
+        .expect_err("rooted path without a drive prefix must reject");
+        assert_eq!(
+            err.code,
+            PackageManifestValidationCode::PackageRootMustBeRelative
+        );
+        assert!(err.message.contains("must be relative"));
     }
 
     #[test]

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1322,7 +1322,17 @@ fn parse_semantic_toml_manifest(
                 format!("project entry '{}' must not escape the project root", entry),
             ));
         }
-        Ok(path.to_string_lossy().replace('\\', "/"))
+        // `entry` is already a valid-UTF-8 `&str` (parsed from semantic.toml text), so
+        // `to_string_lossy` never loses information here; only fold '\' into '/' on
+        // Windows, where it is the actual separator -- on Unix it is an ordinary filename
+        // character and folding it unconditionally would change which file this entry
+        // names (same defect class as DL-012/DL-014).
+        let text = path.to_string_lossy();
+        Ok(if cfg!(windows) {
+            text.replace('\\', "/")
+        } else {
+            text.into_owned()
+        })
     }
 
     let mut parsed = ParsedSemanticTomlFields::default();
@@ -1441,7 +1451,14 @@ fn parse_semantic_toml_manifest(
     let module_root = entry_path
         .parent()
         .map(|parent| {
-            let value = parent.to_string_lossy().replace('\\', "/");
+            // `entry` is already valid UTF-8 text; only fold '\' into '/' on Windows, for
+            // the same reason as normalize_project_entry above (DL-012/DL-014 shape).
+            let text = parent.to_string_lossy();
+            let value = if cfg!(windows) {
+                text.replace('\\', "/")
+            } else {
+                text.into_owned()
+            };
             if value.is_empty() {
                 ".".to_string()
             } else {
@@ -1496,7 +1513,14 @@ fn normalize_lexical(path: &Path) -> PathBuf {
 }
 
 fn normalize_path(path: &Path) -> String {
-    let normalized = path.to_string_lossy().replace('\\', "/");
+    // Only fold '\' into '/' on Windows, where it is the actual path separator (same
+    // reasoning as normalize_relative_path's DL-012 fix); Unix keeps the raw text.
+    let text = path.to_string_lossy();
+    let normalized = if cfg!(windows) {
+        text.replace('\\', "/")
+    } else {
+        text.into_owned()
+    };
     normalized
         .strip_prefix("//?/")
         .unwrap_or(&normalized)
@@ -2400,6 +2424,28 @@ entry = "\rooted\main.sm"
         assert!(err.message.contains("must be relative"));
     }
 
+    // normalize_project_entry and the module_root-from-entry-parent step both used to
+    // fold '\' into '/' unconditionally. On Unix '\' is an ordinary filename character in
+    // the entry text (this manifest parser does not interpret TOML escapes; see
+    // parse_toml_string), so a literal backslash there must survive unchanged instead of
+    // being folded into a directory separator that changes which file/directory it names
+    // (same defect class as DL-012/DL-014, found by self-review while closing DL-014).
+    #[cfg(unix)]
+    #[test]
+    fn parse_semantic_toml_manifest_preserves_literal_backslash_in_project_entry_on_unix() {
+        let source = r#"
+[package]
+name = "app"
+
+[project]
+entry = "a\b/main.sm"
+"#;
+        let parsed = parse_semantic_toml_manifest(Path::new("semantic.toml"), source)
+            .expect("literal backslash entry must parse on Unix");
+        assert_eq!(parsed.entry, "a\\b/main.sm");
+        assert_eq!(parsed.manifest.package.root.module_root, "a\\b");
+    }
+
     #[cfg(windows)]
     #[test]
     fn validate_contained_relative_path_rejects_rooted_path_without_drive_prefix() {
@@ -2879,5 +2925,14 @@ module_root src
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // normalize_path (used for the PackageModuleAdmission.manifest_path display field) had
+    // the same unconditional backslash-fold bug as the other normalize_* helpers in this
+    // file; only Windows actually uses '\' as a separator.
+    #[cfg(unix)]
+    #[test]
+    fn normalize_path_preserves_literal_backslash_on_unix() {
+        assert_eq!(normalize_path(Path::new("dir\\file.sm")), "dir\\file.sm");
     }
 }

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -23,10 +23,16 @@ thread_local! {
     static PINNED_DEPENDENCY_CONTENT_VERIFIED: RefCell<HashSet<PathBuf>> = RefCell::new(HashSet::new());
 }
 
-/// Clears the pinned-dependency content-fingerprint cache. Must be called by any
-/// long-lived caller (currently only `smc watch`, see `cmd_watch` in `app.rs`) before each
-/// rebuild pass; one-shot commands never need to call this.
-pub(crate) fn reset_pinned_dependency_fingerprint_cache() {
+/// Clears the pinned-dependency content-fingerprint cache. `smc watch` (see `cmd_watch` in
+/// `app.rs`) calls this at the top of every loop iteration, unconditionally, since a change
+/// to a declared-but-unimported dependency does not affect `module_graph_fingerprint` (see
+/// DL-022) and so cannot be relied on to gate the reset. Public so any long-lived library
+/// consumer that calls `admit_package_entry_module` or `CliPipeline::semantic_check_file`
+/// (or the `compile`/`run` equivalents) more than once on the same thread can invalidate
+/// this cache between calls too -- it was `pub(crate)` and reachable only from `cmd_watch`
+/// until DL-022 fixed that gap. One-shot commands never need to call this, since a fresh
+/// process already starts empty.
+pub fn reset_pinned_dependency_fingerprint_cache() {
     PINNED_DEPENDENCY_CONTENT_VERIFIED.with(|cache| cache.borrow_mut().clear());
 }
 
@@ -40,10 +46,9 @@ thread_local! {
         RefCell::new(HashSet::new());
 }
 
-/// Clears the declared-dependency-graph validation cache. Must be called by any long-lived
-/// caller (currently only `smc watch`) before each rebuild pass; one-shot commands never
-/// need to call this.
-pub(crate) fn reset_declared_dependency_graph_cache() {
+/// Clears the declared-dependency-graph validation cache. Same reset discipline and same
+/// visibility reasoning as `reset_pinned_dependency_fingerprint_cache` above (DL-022).
+pub fn reset_declared_dependency_graph_cache() {
     DECLARED_DEPENDENCY_GRAPH_VALIDATED.with(|cache| cache.borrow_mut().clear());
 }
 

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -639,7 +639,6 @@ enum ProjectRootResolutionCode {
     SemanticTomlReadFailed,
     SemanticTomlManifest(SemanticTomlManifestErrorCode),
     SemanticTomlEntryMissing,
-    EntrySymlinkOrReparse,
     MissingProjectManifest,
 }
 
@@ -665,38 +664,6 @@ fn project_root_resolution_error(
     }
 }
 
-fn entry_is_symlink_or_reparse(path: &Path) -> bool {
-    let Ok(metadata) = std::fs::symlink_metadata(path) else {
-        return false;
-    };
-    if metadata.file_type().is_symlink() {
-        return true;
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
-        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-    }
-    #[cfg(not(windows))]
-    false
-}
-
-fn require_entry_not_symlink_or_reparse(
-    entry_path: &Path,
-) -> Result<(), ProjectRootResolutionError> {
-    if entry_is_symlink_or_reparse(entry_path) {
-        return Err(project_root_resolution_error(
-            ProjectRootResolutionCode::EntrySymlinkOrReparse,
-            format!(
-                "project entry '{}' must not be a symlink or reparse point",
-                entry_path.display()
-            ),
-        ));
-    }
-    Ok(())
-}
-
 fn resolve_project_root_check_entry_structured(
     root: &Path,
 ) -> Result<PathBuf, ProjectRootResolutionError> {
@@ -716,7 +683,6 @@ fn resolve_project_root_check_entry_structured(
                 )
             })?;
         let entry_path = root.join(&project_manifest.entry);
-        require_entry_not_symlink_or_reparse(&entry_path)?;
         if !entry_path.is_file() {
             return Err(project_root_resolution_error(
                 ProjectRootResolutionCode::SemanticTomlEntryMissing,
@@ -733,9 +699,7 @@ fn resolve_project_root_check_entry_structured(
 
     let package_manifest = root.join(PACKAGE_MANIFEST_FILE_NAME);
     if package_manifest.is_file() {
-        let entry_path = root.join("src/main.sm");
-        require_entry_not_symlink_or_reparse(&entry_path)?;
-        return Ok(entry_path);
+        return Ok(root.join("src/main.sm"));
     }
 
     Err(project_root_resolution_error(

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -158,6 +158,7 @@ pub enum PackageModuleAdmissionCode {
     ModuleRootResolutionFailed,
     NestedManifestInsideModuleRoot,
     EntryOutsideModuleRoot,
+    NonUtf8ModulePath,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -633,10 +634,16 @@ pub fn admit_package_entry_module(
                 ),
             })?;
 
+    let module_path = normalize_relative_path(module_relative).map_err(|message| {
+        PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::NonUtf8ModulePath,
+            message,
+        }
+    })?;
     Ok(Some(PackageModuleAdmission {
         manifest_path: normalize_path(&manifest_path),
         package_name: manifest.package.name,
-        module_path: normalize_relative_path(module_relative),
+        module_path,
     }))
 }
 
@@ -1486,13 +1493,22 @@ fn normalize_path(path: &Path) -> String {
         .to_string()
 }
 
-fn normalize_relative_path(path: &Path) -> String {
-    let value = normalize_path(path);
-    if value.is_empty() {
+/// Unlike `normalize_path`, this is used to key package content/provenance by relative
+/// path (module paths fed into content fingerprinting, admitted module identity), where
+/// a lossy conversion could let two distinct non-UTF-8 filenames collapse onto the same
+/// key -- silently hiding a real path/content change behind an unchanged fingerprint.
+/// Reject non-UTF-8 relative paths outright instead.
+fn normalize_relative_path(path: &Path) -> Result<String, String> {
+    let text = path
+        .to_str()
+        .ok_or_else(|| format!("package path '{}' is not valid UTF-8", path.display()))?;
+    let normalized = text.replace('\\', "/");
+    let normalized = normalized.strip_prefix("//?/").unwrap_or(&normalized);
+    Ok(if normalized.is_empty() {
         ".".to_string()
     } else {
-        value
-    }
+        normalized.to_string()
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -1830,7 +1846,7 @@ fn collect_package_files(
                 Ok(text) => normalize_line_endings(&text).into_bytes(),
                 Err(error) => error.into_bytes(),
             };
-            files.push((normalize_relative_path(relative), bytes));
+            files.push((normalize_relative_path(relative)?, bytes));
         }
     }
     Ok(())
@@ -2668,6 +2684,38 @@ module_root src
             err.code,
             PackageImportResolutionCode::DependencyPackageNameMismatch
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A lossy relative-path conversion would let two distinct non-UTF-8 filenames
+    // collapse onto the same fingerprint key, so renaming between them while keeping
+    // file bytes unchanged would leave the content fingerprint unchanged too --
+    // silently hiding a real source-tree change from a pinned dependency's provenance
+    // record. Reject non-UTF-8 relative paths outright instead of hashing a lossy
+    // string.
+    #[cfg(unix)]
+    #[test]
+    fn package_content_fingerprint_rejects_non_utf8_module_paths() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = mk_temp_dir("package_content_fingerprint_non_utf8");
+        let module_root = dir.join("src");
+        std::fs::create_dir_all(&module_root).expect("mkdir src");
+        let manifest = dir.join(PACKAGE_MANIFEST_FILE_NAME);
+        std::fs::write(
+            &manifest,
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write manifest");
+        let invalid_name = OsStr::from_bytes(&[0xffu8, b'.', b's', b'm']);
+        std::fs::write(module_root.join(invalid_name), "fn main() { return; }\n")
+            .expect("write non-utf8 module");
+
+        let err = package_content_fingerprint(&module_root, &manifest)
+            .expect_err("non-UTF-8 module path must reject");
+        assert!(err.contains("not valid UTF-8"), "unexpected error: {err}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -622,6 +622,16 @@ pub fn admit_package_entry_module(
             ),
         });
     }
+    // A nested manifest inside module_root is rejected regardless of whether any module
+    // actually imports from it -- `package inspect` already rejects it via
+    // package_content_fingerprint's tree walk, so admission must reject it too, or
+    // `check`/`compile`/`run` would silently accept a tree that `inspect` rejects.
+    package_content_fingerprint(&module_root, &manifest_path).map_err(|message| {
+        PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::NestedManifestInsideModuleRoot,
+            message,
+        }
+    })?;
     let module_relative =
         entry_canonical
             .strip_prefix(&module_root)
@@ -1739,10 +1749,20 @@ impl PackageGraphBuilder {
                     ));
                 }
             }
+            // Only fold '\' into '/' on Windows, where it is the actual path separator --
+            // on Unix it is an ordinary filename character, so an unconditional replacement
+            // would let the provenance record identify a different real directory than the
+            // one that was actually loaded (same defect class fixed for content
+            // fingerprinting; see DL-012).
+            let provenance_local_path = if cfg!(windows) {
+                local_path.replace('\\', "/")
+            } else {
+                local_path
+            };
             dependencies.push(PackageGraphDependencyRecord {
                 alias: dependency.alias,
                 package_name: dependency.package_name,
-                local_path: local_path.replace('\\', "/"),
+                local_path: provenance_local_path,
                 expected_manifest_fingerprint: expected_manifest_fingerprint.map(str::to_string),
                 expected_content_fingerprint: expected_content_fingerprint.map(str::to_string),
             });
@@ -2521,6 +2541,43 @@ dep math math ../math
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // `package inspect` already rejects a nested manifest anywhere under module_root via
+    // package_content_fingerprint's tree walk, regardless of whether any module imports
+    // from it. Admission (used by check/compile/run) must reject the same tree instead of
+    // silently accepting it just because nothing happens to import the nested package.
+    #[test]
+    fn admit_package_entry_module_rejects_unused_nested_manifest() {
+        let dir = mk_temp_dir("pkg_admit_unused_nested");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(src_dir.join("nested")).expect("mkdir src/nested");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            r#"
+format 1
+package app
+manifest_dir .
+module_root src
+"#,
+        )
+        .expect("write manifest");
+        std::fs::write(
+            src_dir.join("nested").join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage nested\nmanifest_dir .\nmodule_root .\n",
+        )
+        .expect("write nested manifest");
+        let entry = src_dir.join("main.sm");
+        std::fs::write(&entry, "fn main() { return; }").expect("write entry");
+
+        let err = admit_package_entry_module(&entry)
+            .expect_err("unused nested manifest must be rejected");
+        assert_eq!(
+            err.code,
+            PackageModuleAdmissionCode::NestedManifestInsideModuleRoot
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn admit_package_entry_module_rejects_entry_outside_module_root() {
         let dir = mk_temp_dir("pkg_admit_outside");
@@ -2776,5 +2833,51 @@ module_root src
 
         let _ = std::fs::remove_dir_all(&real_dir);
         let _ = std::fs::remove_dir_all(&literal_dir);
+    }
+
+    // Same defect class as the content-fingerprint collision above, but for the
+    // dependency-edge provenance record: on Unix a declared local dependency path is not a
+    // separator-delimited OS path, it is raw manifest text, so a literal '\' in it must be
+    // preserved rather than folded into '/' when emitted into the provenance JSON.
+    #[cfg(unix)]
+    #[test]
+    fn inspect_local_package_graph_preserves_literal_backslash_in_dependency_local_path() {
+        let dir = mk_temp_dir("pkg_inspect_backslash_dep_path");
+        let app_dir = dir.join("app");
+        let app_src = app_dir.join("src");
+        std::fs::create_dir_all(&app_src).expect("mkdir app src");
+        let dep_dir = dir.join("dep\\lib");
+        std::fs::create_dir_all(&dep_dir).expect("mkdir literal-backslash dep dir");
+        std::fs::write(
+            dep_dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage libx\nmanifest_dir .\nmodule_root .\n",
+        )
+        .expect("write dependency manifest");
+        std::fs::write(
+            app_dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep libx libx ../dep\\lib\n",
+        )
+        .expect("write app manifest");
+        std::fs::write(app_src.join("main.sm"), "fn main() { return; }\n").expect("write entry");
+
+        let provenance = inspect_local_package_graph(&app_dir).expect("inspect must succeed");
+        let value: serde_json::Value =
+            serde_json::from_str(&provenance).expect("provenance must be valid JSON");
+        let app_node = value["packages"]
+            .as_array()
+            .expect("packages array")
+            .iter()
+            .find(|node| node["name"] == "app")
+            .expect("app node present");
+        let local_path = app_node["dependencies"][0]["local_path"]
+            .as_str()
+            .expect("local_path string");
+        assert_eq!(
+            local_path, "../dep\\lib",
+            "a literal backslash in a declared dependency path must survive into provenance \
+             unchanged on Unix, not be folded into a separator"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
 use std::fs;
@@ -7,6 +9,70 @@ pub const PACKAGE_MANIFEST_BASELINE_VERSION: u32 = 1;
 pub const PACKAGE_MANIFEST_FILE_NAME: &str = "Semantic.package";
 pub const SEMANTIC_TOML_FILE_NAME: &str = "semantic.toml";
 pub const PACKAGE_IMPORT_SEPARATOR: &str = "::";
+
+thread_local! {
+    /// Memoizes which pinned dependency manifests have already had their content
+    /// fingerprint verified, so a dependency imported through many package-qualified
+    /// modules is hashed once per bundle pass instead of once per import (DL-020).
+    /// `smc watch` (a long-lived process) must clear this via
+    /// `reset_pinned_dependency_fingerprint_cache` before each rebuild pass, since the
+    /// filesystem can change between passes; one-shot commands (check/compile/run) never
+    /// need to, since a fresh process already starts empty (same reasoning as DL-017's
+    /// nested-manifest admission cache, which was a `static` and unsafe for exactly this
+    /// reason -- this one is explicitly resettable instead).
+    static PINNED_DEPENDENCY_CONTENT_VERIFIED: RefCell<HashSet<PathBuf>> = RefCell::new(HashSet::new());
+}
+
+/// Clears the pinned-dependency content-fingerprint cache. Must be called by any
+/// long-lived caller (currently only `smc watch`, see `cmd_watch` in `app.rs`) before each
+/// rebuild pass; one-shot commands never need to call this.
+pub(crate) fn reset_pinned_dependency_fingerprint_cache() {
+    PINNED_DEPENDENCY_CONTENT_VERIFIED.with(|cache| cache.borrow_mut().clear());
+}
+
+thread_local! {
+    /// Memoizes which manifests have already had their full DECLARED dependency graph
+    /// validated (missing/cyclic/name-mismatched/stale-pinned), so admitting many modules
+    /// from the same manifest only walks that graph once per bundle pass (DL-021). Same
+    /// reset discipline as `PINNED_DEPENDENCY_CONTENT_VERIFIED` above: `smc watch` must
+    /// clear it before each rebuild pass via `reset_declared_dependency_graph_cache`.
+    static DECLARED_DEPENDENCY_GRAPH_VALIDATED: RefCell<HashSet<PathBuf>> =
+        RefCell::new(HashSet::new());
+}
+
+/// Clears the declared-dependency-graph validation cache. Must be called by any long-lived
+/// caller (currently only `smc watch`) before each rebuild pass; one-shot commands never
+/// need to call this.
+pub(crate) fn reset_declared_dependency_graph_cache() {
+    DECLARED_DEPENDENCY_GRAPH_VALIDATED.with(|cache| cache.borrow_mut().clear());
+}
+
+/// `smc package inspect` rejects a missing/cyclic/name-mismatched/stale-pinned dependency
+/// declared anywhere in a package's graph, regardless of whether any module actually
+/// imports it, by walking the full graph via `PackageGraphBuilder::visit`. Reuse that same
+/// walk here so admission (`check`/`compile`/`run`) enforces the identical contract instead
+/// of only validating dependencies lazily as they happen to be imported (DL-021).
+fn validate_declared_dependency_graph(
+    manifest_path: &Path,
+) -> Result<(), PackageModuleAdmissionError> {
+    let canonical = manifest_path
+        .canonicalize()
+        .map_err(|error| PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::DeclaredDependencyGraphInvalid,
+            message: format!("failed to resolve '{}': {error}", manifest_path.display()),
+        })?;
+    if DECLARED_DEPENDENCY_GRAPH_VALIDATED.with(|cache| cache.borrow().contains(&canonical)) {
+        return Ok(());
+    }
+    PackageGraphBuilder::default()
+        .visit(manifest_path)
+        .map_err(|message| PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::DeclaredDependencyGraphInvalid,
+            message,
+        })?;
+    DECLARED_DEPENDENCY_GRAPH_VALIDATED.with(|cache| cache.borrow_mut().insert(canonical));
+    Ok(())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackageRoot {
@@ -159,6 +225,7 @@ pub enum PackageModuleAdmissionCode {
     NestedManifestInsideModuleRoot,
     EntryOutsideModuleRoot,
     NonUtf8ModulePath,
+    DeclaredDependencyGraphInvalid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -653,6 +720,17 @@ pub fn admit_package_entry_module(
             message,
         }
     })?;
+    // `smc package inspect` walks the FULL declared dependency graph via
+    // PackageGraphBuilder::visit, regardless of which modules are actually imported, and
+    // rejects a missing/cyclic/name-mismatched/stale-pinned dependency deterministically
+    // (docs/spec/package_baseline_v0.md:71-77). Admission previously validated dependencies
+    // only lazily, as each one was actually resolved through an import -- so `check`,
+    // `compile`, and `run` could accept and execute a package with an unused-but-invalid
+    // declared dependency that `inspect` would reject on the same tree. Run the same
+    // full-graph walk here too, last, so a more specific failure already caught above
+    // (e.g. a nested manifest, which this walk would also encounter while hashing content)
+    // reports under its own precise error code rather than this broader one (see DL-021).
+    validate_declared_dependency_graph(&manifest_path)?;
     Ok(Some(PackageModuleAdmission {
         manifest_path: normalize_path(&manifest_path),
         package_name: manifest.package.name,
@@ -894,16 +972,28 @@ fn split_manifest_tokens(
     Ok(out)
 }
 
+/// `semantic.toml` wins over a co-located `Semantic.package` in the same directory
+/// (`docs/spec/project_model_v0.md`). Shared by `find_nearest_manifest`'s upward search
+/// and `inspect_local_package_graph`'s root selection so both apply the same precedence
+/// (see DL-019 -- `package inspect` used to always select `Semantic.package` directly,
+/// disagreeing with what `check`/`compile`/`run` would admit for the same directory).
+fn select_manifest_in_directory(dir: &Path) -> Option<PathBuf> {
+    let semantic_toml = dir.join(SEMANTIC_TOML_FILE_NAME);
+    if semantic_toml.is_file() {
+        return Some(semantic_toml);
+    }
+    let package_manifest = dir.join(PACKAGE_MANIFEST_FILE_NAME);
+    if package_manifest.is_file() {
+        return Some(package_manifest);
+    }
+    None
+}
+
 fn find_nearest_manifest(entry_canonical: &Path) -> Option<PathBuf> {
     let mut current = entry_canonical.parent();
     while let Some(dir) = current {
-        let semantic_toml = dir.join(SEMANTIC_TOML_FILE_NAME);
-        if semantic_toml.is_file() {
-            return Some(semantic_toml);
-        }
-        let package_manifest = dir.join(PACKAGE_MANIFEST_FILE_NAME);
-        if package_manifest.is_file() {
-            return Some(package_manifest);
+        if let Some(manifest) = select_manifest_in_directory(dir) {
+            return Some(manifest);
         }
         current = dir.parent();
     }
@@ -1114,19 +1204,45 @@ fn resolve_dependency_import(
         }
     }
     if let Some(expected) = expected_content {
-        let actual =
-            package_content_fingerprint(&dependency_ctx.module_root, &dependency_manifest_path)
-                .map_err(|message| PackageImportResolutionError {
+        let canonical_dependency_manifest =
+            dependency_manifest_path.canonicalize().map_err(|error| {
+                PackageImportResolutionError {
                     code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
-                    message,
-                })?;
-        if actual != expected {
-            return Err(PackageImportResolutionError {
-                code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
-                message: format!(
-                    "dependency alias '{}' content fingerprint mismatch: expected '{}', found '{}'",
-                    alias, expected, actual
-                ),
+                    message: format!(
+                        "failed to resolve '{}': {error}",
+                        dependency_manifest_path.display()
+                    ),
+                }
+            })?;
+        // A pinned dependency imported through multiple package-qualified modules would
+        // otherwise re-read and re-hash its entire content tree once per import -- O(N*M)
+        // for N importing modules and M dependency files. Cache per dependency manifest
+        // for the life of this thread-local, scoped the same way DL-017 scoped the
+        // nested-manifest admission cache: `smc watch`'s loop explicitly clears it via
+        // reset_pinned_dependency_fingerprint_cache before each rebuild pass, since that
+        // command is long-lived and the filesystem can change between passes; one-shot
+        // commands never need to clear it, since a fresh process already starts empty
+        // (see DL-020).
+        let already_verified = PINNED_DEPENDENCY_CONTENT_VERIFIED
+            .with(|cache| cache.borrow().contains(&canonical_dependency_manifest));
+        if !already_verified {
+            let actual =
+                package_content_fingerprint(&dependency_ctx.module_root, &dependency_manifest_path)
+                    .map_err(|message| PackageImportResolutionError {
+                        code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
+                        message,
+                    })?;
+            if actual != expected {
+                return Err(PackageImportResolutionError {
+                    code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
+                    message: format!(
+                        "dependency alias '{}' content fingerprint mismatch: expected '{}', found '{}'",
+                        alias, expected, actual
+                    ),
+                });
+            }
+            PINNED_DEPENDENCY_CONTENT_VERIFIED.with(|cache| {
+                cache.borrow_mut().insert(canonical_dependency_manifest);
             });
         }
     }
@@ -1608,14 +1724,14 @@ struct PackageGraphBuilder {
 }
 
 pub(crate) fn inspect_local_package_graph(root: &Path) -> Result<String, String> {
-    let manifest_path = root.join(PACKAGE_MANIFEST_FILE_NAME);
-    if !manifest_path.is_file() {
-        return Err(format!(
-            "package inspect requires '{}' at '{}'",
+    let manifest_path = select_manifest_in_directory(root).ok_or_else(|| {
+        format!(
+            "package inspect requires '{}' or '{}' at '{}'",
+            SEMANTIC_TOML_FILE_NAME,
             PACKAGE_MANIFEST_FILE_NAME,
-            manifest_path.display()
-        ));
-    }
+            root.display()
+        )
+    })?;
     reject_reparse_path(&manifest_path)?;
     let mut builder = PackageGraphBuilder::default();
     let root_package = builder.visit(&manifest_path)?;
@@ -1700,8 +1816,26 @@ impl PackageGraphBuilder {
 
         let source = fs::read_to_string(&manifest_path)
             .map_err(|error| format!("failed to read '{}': {error}", manifest_path.display()))?;
-        let manifest = parse_package_manifest_baseline(&source)
-            .map_err(|error| format!("failed to parse '{}': {error}", manifest_path.display()))?;
+        // Dispatch by filename, matching load_and_validate_manifest's rule for
+        // check/compile/run: semantic.toml wins when both manifest kinds are present in
+        // the same directory (docs/spec/project_model_v0.md). `visit` used to always parse
+        // via the Semantic.package line format regardless of which file was selected --
+        // fixed together with inspect_local_package_graph's selection below (DL-019).
+        let manifest = if manifest_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == SEMANTIC_TOML_FILE_NAME)
+        {
+            parse_semantic_toml_manifest(&manifest_path, &source)
+                .map(|project_manifest| project_manifest.manifest)
+                .map_err(|error| {
+                    format!("failed to parse '{}': {error}", manifest_path.display())
+                })?
+        } else {
+            parse_package_manifest_baseline(&source).map_err(|error| {
+                format!("failed to parse '{}': {error}", manifest_path.display())
+            })?
+        };
         validate_package_manifest_baseline(&manifest).map_err(|error| {
             format!("failed to validate '{}': {error}", manifest_path.display())
         })?;
@@ -1945,28 +2079,23 @@ fn path_is_disallowed_nested_manifest(path: &Path, authority_manifest: &Path) ->
 
 /// Lightweight counterpart to `package_content_fingerprint`'s tree walk, used by admission
 /// (`check`/`compile`/`run`) purely to reject a nested manifest. It never reads `.sm`/`.exo`
-/// file bytes, and memoizes per canonicalized `module_root` for the life of the process, so
-/// a package with many imported modules is scanned once rather than once per admitted
-/// module (see DL-016). Safe under the same single-process, static-filesystem assumption
-/// the rest of this admission/resolution pipeline already relies on (e.g. canonicalize()
-/// results are never re-validated against concurrent filesystem changes either).
+/// file bytes -- the dominant cost the original DL-016 finding cited -- so a package with
+/// many imported modules pays only repeated cheap directory listings, not repeated full
+/// content reads. DL-016 also added a process-lifetime memoization cache here, but that is
+/// unsafe for `smc watch` (a genuinely long-lived process, see `cmd_watch` in `app.rs`):
+/// once a module_root was scanned, a nested manifest added later would never be
+/// re-detected for the life of the watch process. Deliberately NOT re-added -- see
+/// DL-017. A future caller that specifically needs cross-call memoization within one
+/// bounded bundle operation (not a whole process) should thread an explicit cache
+/// parameter through that operation instead of reintroducing global state here.
 fn reject_nested_manifests(module_root: &Path, authority_manifest: &Path) -> Result<(), String> {
-    use std::collections::HashSet;
-    use std::sync::{Mutex, OnceLock};
-    static VALIDATED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
-    let cache = VALIDATED.get_or_init(|| Mutex::new(HashSet::new()));
-    if cache.lock().unwrap().contains(module_root) {
-        return Ok(());
-    }
     let authority_manifest = authority_manifest.canonicalize().map_err(|error| {
         format!(
             "failed to resolve '{}': {error}",
             authority_manifest.display()
         )
     })?;
-    reject_nested_manifests_under(module_root, module_root, &authority_manifest)?;
-    cache.lock().unwrap().insert(module_root.to_path_buf());
-    Ok(())
+    reject_nested_manifests_under(module_root, module_root, &authority_manifest)
 }
 
 fn reject_nested_manifests_under(
@@ -2681,7 +2810,6 @@ format 1
 package app
 manifest_dir .
 module_root src
-dep math math ../math
 "#,
         )
         .expect("write manifest");
@@ -2735,6 +2863,94 @@ module_root src
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // `smc package inspect` rejects a package whose declared dependency graph is invalid
+    // (missing/cyclic/name-mismatched/stale-pinned) regardless of whether any module
+    // actually imports the broken dependency, by walking the full graph via
+    // PackageGraphBuilder::visit. Admission used to validate dependencies only lazily, as
+    // each was actually resolved through an import, so `check`/`compile`/`run` accepted
+    // and executed a package with an unused-but-missing declared dependency that `inspect`
+    // would reject on the identical tree -- found by @codex review (DL-021).
+    #[test]
+    fn admit_package_entry_module_rejects_unused_missing_declared_dependency() {
+        let dir = mk_temp_dir("pkg_admit_missing_unused_dep");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            r#"
+format 1
+package app
+manifest_dir .
+module_root src
+dep math math ../math
+"#,
+        )
+        .expect("write manifest");
+        let entry = src_dir.join("main.sm");
+        std::fs::write(&entry, "fn main() { return; }").expect("write entry");
+        // Deliberately do not create ../math -- the declared dependency is missing, and
+        // nothing in `entry` actually imports it.
+
+        let err = admit_package_entry_module(&entry)
+            .expect_err("an unused but missing declared dependency must still be rejected");
+        assert_eq!(
+            err.code,
+            PackageModuleAdmissionCode::DeclaredDependencyGraphInvalid
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The declared-dependency-graph validation is cached per manifest so admitting many
+    // modules from the same manifest only walks the graph once per bundle pass. Prove the
+    // cache is real (a dependency removed after the first admission is NOT caught by a
+    // second admission against the same cache) and that
+    // reset_declared_dependency_graph_cache correctly re-enables detection, mirroring
+    // DL-020's proof for the sibling pinned-content cache.
+    #[test]
+    fn admit_package_entry_module_declared_dependency_graph_cache_is_resettable() {
+        let dir = mk_temp_dir("pkg_admit_dep_graph_cache");
+        let app_src = dir.join("app").join("src");
+        let math_src = dir.join("math").join("src");
+        std::fs::create_dir_all(&app_src).expect("mkdir app src");
+        std::fs::create_dir_all(&math_src).expect("mkdir math src");
+        std::fs::write(
+            dir.join("math").join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage math\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write math manifest");
+        std::fs::write(
+            dir.join("app").join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage dep_graph_cache_app\nmanifest_dir .\nmodule_root src\ndep math math ../math\n",
+        )
+        .expect("write app manifest");
+        let first_entry = app_src.join("first.sm");
+        let second_entry = app_src.join("second.sm");
+        std::fs::write(&first_entry, "fn first() { return; }").expect("write first entry");
+        std::fs::write(&second_entry, "fn second() { return; }").expect("write second entry");
+
+        reset_declared_dependency_graph_cache();
+        admit_package_entry_module(&first_entry)
+            .expect("first admission must succeed and populate the cache")
+            .expect("manifest must exist");
+
+        let _ = std::fs::remove_dir_all(dir.join("math"));
+
+        admit_package_entry_module(&second_entry)
+            .expect("second admission must succeed from the cache despite the removed dependency")
+            .expect("manifest must exist");
+
+        reset_declared_dependency_graph_cache();
+        let err = admit_package_entry_module(&second_entry)
+            .expect_err("after reset, the missing dependency must be re-detected");
+        assert_eq!(
+            err.code,
+            PackageModuleAdmissionCode::DeclaredDependencyGraphInvalid
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // docs/spec/project_model_v0.md permits `semantic.toml` and `Semantic.package` to
     // co-exist in the same directory for compatibility, with `semantic.toml` winning as
     // the authority manifest. The DL-013 fix above wrongly treated the losing, co-located
@@ -2765,21 +2981,22 @@ module_root src
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // reject_nested_manifests memoizes per canonicalized module_root so a package with
-    // many imported modules is scanned once rather than once per admitted module -- found
-    // as a performance issue in the same DL-013 fix by @codex review (DL-016). Prove the
-    // memoization actually takes effect: admit one module to populate the cache, then
-    // introduce a genuinely nested manifest into the same module_root and admit a second,
-    // different module in that tree -- it must still succeed because the structural scan
-    // is cached, not re-run against the now-changed tree.
+    // DL-016 originally memoized the nested-manifest scan per module_root for the life of
+    // the process. `smc watch` (see `cmd_watch` in app.rs) is a genuinely long-lived
+    // process that re-admits the same module_root repeatedly as files change, so that
+    // cache would have permanently hidden a nested manifest added after the first scan --
+    // found by @codex review and fixed in DL-017 by removing the process-wide cache.
+    // Prove there is no stale caching: a nested manifest added between two admissions of
+    // the same module_root must be detected on the second call, not silently accepted
+    // because the first call already "validated" that module_root.
     #[test]
-    fn admit_package_entry_module_memoizes_nested_manifest_scan_per_module_root() {
-        let dir = mk_temp_dir("pkg_admit_memoized_scan");
+    fn admit_package_entry_module_detects_nested_manifest_added_after_prior_admission() {
+        let dir = mk_temp_dir("pkg_admit_no_stale_cache");
         let src_dir = dir.join("src");
         std::fs::create_dir_all(&src_dir).expect("mkdir src");
         std::fs::write(
             dir.join(PACKAGE_MANIFEST_FILE_NAME),
-            "format 1\npackage memoized_scan_app\nmanifest_dir .\nmodule_root src\n",
+            "format 1\npackage no_stale_cache_app\nmanifest_dir .\nmodule_root src\n",
         )
         .expect("write manifest");
         let first_entry = src_dir.join("first.sm");
@@ -2799,10 +3016,12 @@ module_root src
 
         let second_entry = src_dir.join("second.sm");
         std::fs::write(&second_entry, "fn second() { return; }").expect("write second entry");
-        let admitted = admit_package_entry_module(&second_entry)
-            .expect("second admission must not error")
-            .expect("manifest must exist");
-        assert_eq!(admitted.package_name, "memoized_scan_app");
+        let err = admit_package_entry_module(&second_entry)
+            .expect_err("nested manifest added after a prior admission must still be caught");
+        assert_eq!(
+            err.code,
+            PackageModuleAdmissionCode::NestedManifestInsideModuleRoot
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -2982,6 +3201,75 @@ module_root src
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    // A pinned dependency imported through multiple package-qualified modules would
+    // otherwise be re-read and re-hashed on every single import -- O(N*M) for N importing
+    // modules and M dependency files -- found by @codex review as a direct consequence of
+    // DL-016's admission-side memoization fix. Cache the content-fingerprint verification
+    // per dependency manifest, but (learning DL-017's lesson: a process-lifetime cache is
+    // unsafe for `smc watch`) make it explicitly resettable rather than a bare `static`,
+    // and prove both halves: the cache is real (a tamper made after the first resolution
+    // is NOT caught by a second resolution against the same cache), and reset correctly
+    // re-enables detection (DL-020).
+    #[test]
+    fn resolve_package_import_path_caches_pinned_dependency_content_verification() {
+        let dir = mk_temp_dir("pkg_import_pinned_cache");
+        let app_src = dir.join("app").join("src");
+        let math_src = dir.join("math").join("src");
+        std::fs::create_dir_all(&app_src).expect("mkdir app src");
+        std::fs::create_dir_all(&math_src).expect("mkdir math src");
+        let math_manifest_path = dir.join("math").join(PACKAGE_MANIFEST_FILE_NAME);
+        std::fs::write(
+            &math_manifest_path,
+            "format 1\npackage math\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write math manifest");
+        std::fs::write(math_src.join("core.sm"), "fn core() { return; }\n")
+            .expect("write dep content");
+
+        let manifest_fp = manifest_fingerprint(&math_manifest_path).expect("manifest fp");
+        let content_fp =
+            package_content_fingerprint(&math_src, &math_manifest_path).expect("content fp");
+        std::fs::write(
+            dir.join("app").join(PACKAGE_MANIFEST_FILE_NAME),
+            format!(
+                "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep math math ../math {manifest_fp} {content_fp}\n"
+            ),
+        )
+        .expect("write app manifest");
+        let importer = app_src.join("main.sm");
+        std::fs::write(
+            &importer,
+            "Import \"math::core.sm\"\nfn main() { return; }\n",
+        )
+        .expect("write importer");
+
+        reset_pinned_dependency_fingerprint_cache();
+        resolve_package_import_path(&importer, "math::core.sm")
+            .expect("first resolution must succeed and populate the cache");
+
+        std::fs::write(
+            math_src.join("core.sm"),
+            "fn core() { return; } // tampered\n",
+        )
+        .expect("tamper dep content without updating the pin");
+
+        resolve_package_import_path(&importer, "math::core.sm").expect(
+            "second resolution must succeed from the cache despite the tampered content \
+             -- this is the caching behavior under test, not a security hole: the pin was \
+             already verified once this pass",
+        );
+
+        reset_pinned_dependency_fingerprint_cache();
+        let err = resolve_package_import_path(&importer, "math::core.sm")
+            .expect_err("after an explicit reset, the tampered content must be re-detected");
+        assert_eq!(
+            err.code,
+            PackageImportResolutionCode::DependencyContentFingerprintMismatch
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // A lossy relative-path conversion would let two distinct non-UTF-8 filenames
     // collapse onto the same fingerprint key, so renaming between them while keeping
     // file bytes unchanged would leave the content fingerprint unchanged too --
@@ -3062,6 +3350,34 @@ module_root src
 
         let _ = std::fs::remove_dir_all(&real_dir);
         let _ = std::fs::remove_dir_all(&literal_dir);
+    }
+
+    // `smc check`/`compile`/`run` select `semantic.toml` over a co-located `Semantic.package`
+    // (docs/spec/project_model_v0.md:18-20), but `inspect_local_package_graph` used to
+    // always select `Semantic.package` directly, so its provenance record could describe a
+    // different package identity/module_root/dependency graph than the code the project
+    // commands actually admit -- found by @codex review (DL-019).
+    #[test]
+    fn inspect_local_package_graph_honors_semantic_toml_precedence_over_package_manifest() {
+        let dir = mk_temp_dir("pkg_inspect_semantic_toml_precedence");
+        std::fs::write(
+            dir.join(SEMANTIC_TOML_FILE_NAME),
+            "[package]\nname = \"winner_from_semantic_toml\"\n\n[project]\nentry = \"main.sm\"\n",
+        )
+        .expect("write semantic.toml");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage loser_from_package_manifest\nmanifest_dir .\nmodule_root .\n",
+        )
+        .expect("write co-located Semantic.package");
+        std::fs::write(dir.join("main.sm"), "fn main() { return; }\n").expect("write entry");
+
+        let provenance = inspect_local_package_graph(&dir).expect("inspect must succeed");
+        let value: serde_json::Value =
+            serde_json::from_str(&provenance).expect("provenance must be valid JSON");
+        assert_eq!(value["root_package"], "winner_from_semantic_toml");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // Same defect class as the content-fingerprint collision above, but for the

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1603,6 +1603,7 @@ pub(crate) fn inspect_local_package_graph(root: &Path) -> Result<String, String>
 
 impl PackageGraphBuilder {
     fn visit(&mut self, manifest_path: &Path) -> Result<String, String> {
+        reject_reparse_path(manifest_path)?;
         let manifest_path = manifest_path.canonicalize().map_err(|error| {
             format!(
                 "failed to resolve dependency manifest '{}': {error}",

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::fmt;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 pub const PACKAGE_MANIFEST_BASELINE_VERSION: u32 = 1;
@@ -21,7 +22,33 @@ pub struct PackageIdentity {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackageDependencySource {
-    LocalPath { path: String },
+    LocalPath {
+        path: String,
+    },
+    PinnedLocalPath {
+        path: String,
+        manifest_fingerprint: String,
+        content_fingerprint: String,
+    },
+}
+
+impl PackageDependencySource {
+    fn path(&self) -> &str {
+        match self {
+            Self::LocalPath { path } | Self::PinnedLocalPath { path, .. } => path,
+        }
+    }
+
+    fn expected_fingerprints(&self) -> (Option<&str>, Option<&str>) {
+        match self {
+            Self::LocalPath { .. } => (None, None),
+            Self::PinnedLocalPath {
+                manifest_fingerprint,
+                content_fingerprint,
+                ..
+            } => (Some(manifest_fingerprint), Some(content_fingerprint)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +105,12 @@ pub enum PackageManifestValidationCode {
     DuplicateDependencyAlias,
     EmptyDependencyPackageName,
     EmptyLocalDependencyPath,
+    LocalDependencyPathMustBeRelative,
+    InvalidDependencyFingerprint,
+    PackageRootMustBeRelative,
+    PackageRootMustNotEscapeManifest,
+    ModuleRootMustBeRelative,
+    ModuleRootMustNotEscapePackage,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,6 +187,8 @@ pub enum PackageImportResolutionCode {
     DependencyPackageRootResolutionFailed,
     DependencyModuleRootResolutionFailed,
     DependencyPackageNameMismatch,
+    DependencyManifestFingerprintMismatch,
+    DependencyContentFingerprintMismatch,
     DependencyImportOutsideModuleRoot,
 }
 
@@ -179,6 +214,7 @@ pub fn parse_package_manifest_baseline(
     let mut manifest_dir = None::<String>;
     let mut module_root = None::<String>;
     let mut dependencies = Vec::<PackageDependency>::new();
+    let mut capability_requests = std::collections::BTreeSet::<String>::new();
 
     for (index, raw_line) in source.lines().enumerate() {
         let line_no = index + 1;
@@ -239,20 +275,52 @@ pub fn parse_package_manifest_baseline(
                 module_root = Some(tokens[1].clone());
             }
             "dep" => {
-                if tokens.len() != 4 {
+                if tokens.len() != 4 && tokens.len() != 6 {
                     return Err(parse_error(
                         PackageManifestParseCode::InvalidDirective,
                         line_no,
-                        "dep directive must be: dep <alias> <package_name> <local_path>",
+                        "dep directive must be: dep <alias> <package_name> <local_path> [<manifest_fingerprint> <content_fingerprint>]",
                     ));
                 }
+                let source = if tokens.len() == 4 {
+                    PackageDependencySource::LocalPath {
+                        path: tokens[3].clone(),
+                    }
+                } else {
+                    PackageDependencySource::PinnedLocalPath {
+                        path: tokens[3].clone(),
+                        manifest_fingerprint: tokens[4].clone(),
+                        content_fingerprint: tokens[5].clone(),
+                    }
+                };
                 dependencies.push(PackageDependency {
                     alias: tokens[1].clone(),
                     package_name: tokens[2].clone(),
-                    source: PackageDependencySource::LocalPath {
-                        path: tokens[3].clone(),
-                    },
+                    source,
                 });
+            }
+            "capability" => {
+                if tokens.len() != 2 {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "capability directive must be: capability <request-id>",
+                    ));
+                }
+                if tokens[1].trim().is_empty() {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        "capability request id must not be empty",
+                    ));
+                }
+                if !capability_requests.insert(tokens[1].clone()) {
+                    return Err(parse_error(
+                        PackageManifestParseCode::InvalidDirective,
+                        line_no,
+                        &format!("duplicate package capability request '{}'", tokens[1]),
+                    ));
+                }
             }
             other => {
                 return Err(parse_error(
@@ -332,6 +400,12 @@ pub fn validate_package_manifest_baseline(
             message: "package manifest_dir must not be empty".to_string(),
         });
     }
+    validate_contained_relative_path(
+        &manifest.package.root.manifest_dir,
+        PackageManifestValidationCode::PackageRootMustBeRelative,
+        PackageManifestValidationCode::PackageRootMustNotEscapeManifest,
+        "package manifest_dir",
+    )?;
 
     if manifest.package.root.module_root.trim().is_empty() {
         return Err(PackageManifestValidationError {
@@ -339,6 +413,12 @@ pub fn validate_package_manifest_baseline(
             message: "package module_root must not be empty".to_string(),
         });
     }
+    validate_contained_relative_path(
+        &manifest.package.root.module_root,
+        PackageManifestValidationCode::ModuleRootMustBeRelative,
+        PackageManifestValidationCode::ModuleRootMustNotEscapePackage,
+        "package module_root",
+    )?;
 
     let mut seen_aliases = std::collections::BTreeSet::new();
     for dependency in &manifest.dependencies {
@@ -360,21 +440,85 @@ pub fn validate_package_manifest_baseline(
                 message: "package dependency package_name must not be empty".to_string(),
             });
         }
-        match &dependency.source {
-            PackageDependencySource::LocalPath { path } if path.trim().is_empty() => {
+        let path = dependency.source.path();
+        if path.trim().is_empty() {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::EmptyLocalDependencyPath,
+                message: format!(
+                    "package dependency '{}' requires a non-empty local path",
+                    dependency.alias
+                ),
+            });
+        }
+        if Path::new(path).is_absolute()
+            || Path::new(path)
+                .components()
+                .any(|component| matches!(component, std::path::Component::Prefix(_)))
+        {
+            return Err(PackageManifestValidationError {
+                code: PackageManifestValidationCode::LocalDependencyPathMustBeRelative,
+                message: format!(
+                    "package dependency '{}' local path '{}' must be relative",
+                    dependency.alias, path
+                ),
+            });
+        }
+        let (manifest_fingerprint, content_fingerprint) = dependency.source.expected_fingerprints();
+        for fingerprint in [manifest_fingerprint, content_fingerprint]
+            .into_iter()
+            .flatten()
+        {
+            if !is_valid_package_fingerprint(fingerprint) {
                 return Err(PackageManifestValidationError {
-                    code: PackageManifestValidationCode::EmptyLocalDependencyPath,
+                    code: PackageManifestValidationCode::InvalidDependencyFingerprint,
                     message: format!(
-                        "package dependency '{}' requires a non-empty local path",
-                        dependency.alias
+                        "package dependency '{}' has invalid fingerprint '{}'; expected fnv1a64:<16 lowercase hex digits>",
+                        dependency.alias, fingerprint
                     ),
                 });
             }
-            PackageDependencySource::LocalPath { .. } => {}
         }
     }
 
     Ok(())
+}
+
+fn validate_contained_relative_path(
+    value: &str,
+    absolute_code: PackageManifestValidationCode,
+    escape_code: PackageManifestValidationCode,
+    field: &str,
+) -> Result<(), PackageManifestValidationError> {
+    let path = Path::new(value);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::Prefix(_)))
+    {
+        return Err(PackageManifestValidationError {
+            code: absolute_code,
+            message: format!("{} '{}' must be relative", field, value),
+        });
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(PackageManifestValidationError {
+            code: escape_code,
+            message: format!("{} '{}' must not escape its declared root", field, value),
+        });
+    }
+    Ok(())
+}
+
+fn is_valid_package_fingerprint(value: &str) -> bool {
+    value.strip_prefix("fnv1a64:").is_some_and(|hex| {
+        hex.len() == 16
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    })
 }
 
 pub fn admit_package_entry_module(
@@ -394,10 +538,18 @@ pub fn admit_package_entry_module(
         Some(path) => path,
         None => return Ok(None),
     };
+    reject_reparse_path(entry).map_err(|message| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::EntryResolutionFailed,
+        message,
+    })?;
     let manifest = load_and_validate_manifest(&manifest_path)?;
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-    let package_root = manifest_dir
-        .join(&manifest.package.root.manifest_dir)
+    let package_root = manifest_dir.join(&manifest.package.root.manifest_dir);
+    reject_reparse_path(&package_root).map_err(|message| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::PackageRootResolutionFailed,
+        message,
+    })?;
+    let package_root = package_root
         .canonicalize()
         .map_err(|e| PackageModuleAdmissionError {
             code: PackageModuleAdmissionCode::PackageRootResolutionFailed,
@@ -408,8 +560,12 @@ pub fn admit_package_entry_module(
                 e
             ),
         })?;
-    let module_root = package_root
-        .join(&manifest.package.root.module_root)
+    let module_root = package_root.join(&manifest.package.root.module_root);
+    reject_reparse_path(&module_root).map_err(|message| PackageModuleAdmissionError {
+        code: PackageModuleAdmissionCode::ModuleRootResolutionFailed,
+        message,
+    })?;
+    let module_root = module_root
         .canonicalize()
         .map_err(|e| PackageModuleAdmissionError {
             code: PackageModuleAdmissionCode::ModuleRootResolutionFailed,
@@ -420,6 +576,16 @@ pub fn admit_package_entry_module(
                 e
             ),
         })?;
+    if module_root.strip_prefix(&package_root).is_err() {
+        return Err(PackageModuleAdmissionError {
+            code: PackageModuleAdmissionCode::EntryOutsideModuleRoot,
+            message: format!(
+                "package module_root '{}' is outside package root '{}'",
+                module_root.display(),
+                package_root.display()
+            ),
+        });
+    }
     let module_relative =
         entry_canonical
             .strip_prefix(&module_root)
@@ -755,13 +921,17 @@ fn resolve_dependency_import(
             ),
         })?;
 
-    let dependency_path = match &dependency.source {
-        PackageDependencySource::LocalPath { path } => path,
-    };
+    let dependency_path = dependency.source.path();
     let dependency_manifest_path = importer_ctx
         .package_root
         .join(dependency_path)
         .join(PACKAGE_MANIFEST_FILE_NAME);
+    reject_reparse_path(&dependency_manifest_path).map_err(|message| {
+        PackageImportResolutionError {
+            code: PackageImportResolutionCode::DependencyManifestMissing,
+            message,
+        }
+    })?;
     if !dependency_manifest_path.is_file() {
         return Err(PackageImportResolutionError {
             code: PackageImportResolutionCode::DependencyManifestMissing,
@@ -791,6 +961,42 @@ fn resolve_dependency_import(
             ),
         });
     }
+    let (expected_manifest, expected_content) = dependency.source.expected_fingerprints();
+    if let Some(expected) = expected_manifest {
+        let actual = manifest_fingerprint(&dependency_manifest_path).map_err(|message| {
+            PackageImportResolutionError {
+                code: PackageImportResolutionCode::DependencyManifestReadFailed,
+                message,
+            }
+        })?;
+        if actual != expected {
+            return Err(PackageImportResolutionError {
+                code: PackageImportResolutionCode::DependencyManifestFingerprintMismatch,
+                message: format!(
+                    "dependency alias '{}' manifest fingerprint mismatch: expected '{}', found '{}'",
+                    alias, expected, actual
+                ),
+            });
+        }
+    }
+    if let Some(expected) = expected_content {
+        let actual =
+            package_content_fingerprint(&dependency_ctx.module_root).map_err(|message| {
+                PackageImportResolutionError {
+                    code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
+                    message,
+                }
+            })?;
+        if actual != expected {
+            return Err(PackageImportResolutionError {
+                code: PackageImportResolutionCode::DependencyContentFingerprintMismatch,
+                message: format!(
+                    "dependency alias '{}' content fingerprint mismatch: expected '{}', found '{}'",
+                    alias, expected, actual
+                ),
+            });
+        }
+    }
 
     let resolved = normalize_lexical(
         &dependency_ctx
@@ -818,6 +1024,10 @@ fn resolve_manifest_context(
     package_root_code: PackageImportResolutionCode,
     module_root_code: PackageImportResolutionCode,
 ) -> Result<ResolvedPackageContext, PackageImportResolutionError> {
+    reject_reparse_path(manifest_path).map_err(|message| PackageImportResolutionError {
+        code: read_code,
+        message,
+    })?;
     let source =
         std::fs::read_to_string(manifest_path).map_err(|e| PackageImportResolutionError {
             code: read_code,
@@ -834,8 +1044,12 @@ fn resolve_manifest_context(
     })?;
 
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-    let package_root = manifest_dir
-        .join(&manifest.package.root.manifest_dir)
+    let package_root = manifest_dir.join(&manifest.package.root.manifest_dir);
+    reject_reparse_path(&package_root).map_err(|message| PackageImportResolutionError {
+        code: package_root_code,
+        message,
+    })?;
+    let package_root = package_root
         .canonicalize()
         .map_err(|e| PackageImportResolutionError {
             code: package_root_code,
@@ -846,8 +1060,12 @@ fn resolve_manifest_context(
                 e
             ),
         })?;
-    let module_root = package_root
-        .join(&manifest.package.root.module_root)
+    let module_root = package_root.join(&manifest.package.root.module_root);
+    reject_reparse_path(&module_root).map_err(|message| PackageImportResolutionError {
+        code: module_root_code,
+        message,
+    })?;
+    let module_root = module_root
         .canonicalize()
         .map_err(|e| PackageImportResolutionError {
             code: module_root_code,
@@ -858,6 +1076,16 @@ fn resolve_manifest_context(
                 e
             ),
         })?;
+    if module_root.strip_prefix(&package_root).is_err() {
+        return Err(PackageImportResolutionError {
+            code: module_root_code,
+            message: format!(
+                "package module_root '{}' resolves outside package root '{}'",
+                module_root.display(),
+                package_root.display()
+            ),
+        });
+    }
 
     Ok(ResolvedPackageContext {
         manifest,
@@ -1140,6 +1368,382 @@ fn normalize_relative_path(path: &Path) -> String {
     } else {
         value
     }
+}
+
+#[derive(Debug, Clone)]
+struct PackageGraphDependencyRecord {
+    alias: String,
+    package_name: String,
+    local_path: String,
+    expected_manifest_fingerprint: Option<String>,
+    expected_content_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PackageGraphNode {
+    name: String,
+    manifest_fingerprint: String,
+    content_fingerprint: String,
+    capability_requests: Vec<String>,
+    dependencies: Vec<PackageGraphDependencyRecord>,
+}
+
+#[derive(Default)]
+struct PackageGraphBuilder {
+    names: std::collections::BTreeMap<String, PathBuf>,
+    nodes: std::collections::BTreeMap<String, PackageGraphNode>,
+    visiting: Vec<(PathBuf, String)>,
+}
+
+pub(crate) fn inspect_local_package_graph(root: &Path) -> Result<String, String> {
+    let manifest_path = root.join(PACKAGE_MANIFEST_FILE_NAME);
+    if !manifest_path.is_file() {
+        return Err(format!(
+            "package inspect requires '{}' at '{}'",
+            PACKAGE_MANIFEST_FILE_NAME,
+            manifest_path.display()
+        ));
+    }
+    reject_reparse_path(&manifest_path)?;
+    let mut builder = PackageGraphBuilder::default();
+    let root_package = builder.visit(&manifest_path)?;
+
+    let mut graph_material = String::new();
+    let packages = builder
+        .nodes
+        .values()
+        .map(|node| {
+            graph_material.push_str(&node.name);
+            graph_material.push('\n');
+            graph_material.push_str(&node.manifest_fingerprint);
+            graph_material.push('\n');
+            graph_material.push_str(&node.content_fingerprint);
+            graph_material.push('\n');
+            for capability in &node.capability_requests {
+                graph_material.push_str("capability\t");
+                graph_material.push_str(capability);
+                graph_material.push('\n');
+            }
+            let dependencies = node
+                .dependencies
+                .iter()
+                .map(|dependency| {
+                    graph_material.push_str("dependency\t");
+                    graph_material.push_str(&dependency.alias);
+                    graph_material.push('\t');
+                    graph_material.push_str(&dependency.package_name);
+                    graph_material.push('\t');
+                    graph_material.push_str(&dependency.local_path);
+                    graph_material.push('\n');
+                    serde_json::json!({
+                        "alias": dependency.alias,
+                        "package": dependency.package_name,
+                        "local_path": dependency.local_path,
+                        "expected_manifest_fingerprint": dependency.expected_manifest_fingerprint,
+                        "expected_content_fingerprint": dependency.expected_content_fingerprint,
+                    })
+                })
+                .collect::<Vec<_>>();
+            serde_json::json!({
+                "name": node.name,
+                "manifest_fingerprint": node.manifest_fingerprint,
+                "content_fingerprint": node.content_fingerprint,
+                "capability_requests": node.capability_requests,
+                "dependencies": dependencies,
+            })
+        })
+        .collect::<Vec<_>>();
+    let graph_fingerprint = fingerprint(graph_material.as_bytes());
+    serde_json::to_string_pretty(&serde_json::json!({
+        "schema": "semantic.foundation.package.provenance/0.1",
+        "fingerprint_algorithm": "fnv1a64-non-cryptographic",
+        "root_package": root_package,
+        "graph_fingerprint": graph_fingerprint,
+        "packages": packages,
+    }))
+    .map_err(|error| format!("failed to serialize package provenance record: {error}"))
+}
+
+impl PackageGraphBuilder {
+    fn visit(&mut self, manifest_path: &Path) -> Result<String, String> {
+        let manifest_path = manifest_path.canonicalize().map_err(|error| {
+            format!(
+                "failed to resolve dependency manifest '{}': {error}",
+                manifest_path.display()
+            )
+        })?;
+        if let Some(index) = self
+            .visiting
+            .iter()
+            .position(|(path, _)| path == &manifest_path)
+        {
+            let mut cycle = self.visiting[index..]
+                .iter()
+                .map(|(_, name)| name.clone())
+                .collect::<Vec<_>>();
+            cycle.push(self.visiting[index].1.clone());
+            return Err(format!("package dependency cycle: {}", cycle.join(" -> ")));
+        }
+
+        let source = fs::read_to_string(&manifest_path)
+            .map_err(|error| format!("failed to read '{}': {error}", manifest_path.display()))?;
+        let manifest = parse_package_manifest_baseline(&source)
+            .map_err(|error| format!("failed to parse '{}': {error}", manifest_path.display()))?;
+        validate_package_manifest_baseline(&manifest).map_err(|error| {
+            format!("failed to validate '{}': {error}", manifest_path.display())
+        })?;
+        let package_name = manifest.package.name.clone();
+        if let Some(existing_path) = self.names.get(&package_name) {
+            if existing_path != &manifest_path {
+                return Err(format!(
+                    "duplicate package identity '{}': '{}' and '{}'",
+                    package_name,
+                    existing_path.display(),
+                    manifest_path.display()
+                ));
+            }
+            if self.nodes.contains_key(&package_name) {
+                return Ok(package_name);
+            }
+        } else {
+            self.names
+                .insert(package_name.clone(), manifest_path.clone());
+        }
+
+        let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+        let package_root_path = manifest_dir.join(&manifest.package.root.manifest_dir);
+        reject_reparse_path(&package_root_path)?;
+        let package_root = package_root_path.canonicalize().map_err(|error| {
+            format!(
+                "failed to resolve package root '{}' for '{}': {error}",
+                package_root_path.display(),
+                package_name
+            )
+        })?;
+        let module_root_path = package_root.join(&manifest.package.root.module_root);
+        reject_reparse_path(&module_root_path)?;
+        let module_root = module_root_path.canonicalize().map_err(|error| {
+            format!(
+                "failed to resolve module root '{}' for '{}': {error}",
+                module_root_path.display(),
+                package_name
+            )
+        })?;
+        if module_root.strip_prefix(&package_root).is_err() {
+            return Err(format!(
+                "package '{}' module_root '{}' escapes package root '{}'",
+                package_name,
+                module_root.display(),
+                package_root.display()
+            ));
+        }
+
+        self.visiting
+            .push((manifest_path.clone(), package_name.clone()));
+        let mut declared_dependencies = manifest.dependencies.clone();
+        declared_dependencies.sort_by(|left, right| {
+            left.alias
+                .cmp(&right.alias)
+                .then_with(|| left.package_name.cmp(&right.package_name))
+        });
+        let mut dependencies = Vec::with_capacity(declared_dependencies.len());
+        for dependency in declared_dependencies {
+            let local_path = dependency.source.path().to_string();
+            let (expected_manifest_fingerprint, expected_content_fingerprint) =
+                dependency.source.expected_fingerprints();
+            let dependency_root = package_root.join(&local_path);
+            reject_reparse_path(&dependency_root)?;
+            let dependency_manifest = dependency_root.join(PACKAGE_MANIFEST_FILE_NAME);
+            if !dependency_manifest.is_file() {
+                return Err(format!(
+                    "dependency alias '{}' expected {} at '{}'",
+                    dependency.alias,
+                    PACKAGE_MANIFEST_FILE_NAME,
+                    dependency_manifest.display()
+                ));
+            }
+            let resolved_name = self.visit(&dependency_manifest)?;
+            if resolved_name != dependency.package_name {
+                return Err(format!(
+                    "dependency alias '{}' expected package '{}' but manifest declares '{}'",
+                    dependency.alias, dependency.package_name, resolved_name
+                ));
+            }
+            let resolved = self
+                .nodes
+                .get(&resolved_name)
+                .ok_or_else(|| format!("internal package graph error for '{}'", resolved_name))?;
+            if let Some(expected) = expected_manifest_fingerprint {
+                if resolved.manifest_fingerprint != expected {
+                    return Err(format!(
+                        "dependency alias '{}' manifest fingerprint mismatch: expected '{}', found '{}'",
+                        dependency.alias, expected, resolved.manifest_fingerprint
+                    ));
+                }
+            }
+            if let Some(expected) = expected_content_fingerprint {
+                if resolved.content_fingerprint != expected {
+                    return Err(format!(
+                        "dependency alias '{}' content fingerprint mismatch: expected '{}', found '{}'",
+                        dependency.alias, expected, resolved.content_fingerprint
+                    ));
+                }
+            }
+            dependencies.push(PackageGraphDependencyRecord {
+                alias: dependency.alias,
+                package_name: dependency.package_name,
+                local_path: local_path.replace('\\', "/"),
+                expected_manifest_fingerprint: expected_manifest_fingerprint.map(str::to_string),
+                expected_content_fingerprint: expected_content_fingerprint.map(str::to_string),
+            });
+        }
+        let _ = self.visiting.pop();
+
+        let capability_requests = package_capability_requests(&source)?;
+        let node = PackageGraphNode {
+            name: package_name.clone(),
+            manifest_fingerprint: fingerprint(normalize_line_endings(&source).as_bytes()),
+            content_fingerprint: package_content_fingerprint(&module_root)?,
+            capability_requests,
+            dependencies,
+        };
+        self.nodes.insert(package_name.clone(), node);
+        Ok(package_name)
+    }
+}
+
+fn manifest_fingerprint(path: &Path) -> Result<String, String> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+    Ok(fingerprint(normalize_line_endings(&source).as_bytes()))
+}
+
+fn package_capability_requests(source: &str) -> Result<Vec<String>, String> {
+    let mut capabilities = Vec::new();
+    for (index, line) in source.lines().enumerate() {
+        let tokens = split_manifest_tokens(line, index + 1).map_err(|error| error.to_string())?;
+        if tokens.first().is_some_and(|token| token == "capability") {
+            capabilities.push(tokens[1].clone());
+        }
+    }
+    capabilities.sort();
+    Ok(capabilities)
+}
+
+fn package_content_fingerprint(module_root: &Path) -> Result<String, String> {
+    let mut files = Vec::<(String, Vec<u8>)>::new();
+    collect_package_files(module_root, module_root, &mut files)?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut material = Vec::new();
+    for (path, bytes) in files {
+        material.extend_from_slice(&(path.len() as u64).to_le_bytes());
+        material.extend_from_slice(path.as_bytes());
+        material.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+        material.extend_from_slice(&bytes);
+    }
+    Ok(fingerprint(&material))
+}
+
+fn collect_package_files(
+    module_root: &Path,
+    directory: &Path,
+    files: &mut Vec<(String, Vec<u8>)>,
+) -> Result<(), String> {
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| {
+            format!(
+                "failed to read package directory '{}': {error}",
+                directory.display()
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            format!(
+                "failed to enumerate package directory '{}': {error}",
+                directory.display()
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        if path_is_reparse(&path)? {
+            return Err(format!(
+                "package content path '{}' is a symlink or reparse point",
+                path.display()
+            ));
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect '{}': {error}", path.display()))?;
+        if file_type.is_dir() {
+            collect_package_files(module_root, &path, files)?;
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| matches!(extension, "sm" | "exo"))
+        {
+            let relative = path
+                .strip_prefix(module_root)
+                .map_err(|_| format!("package content '{}' escaped module root", path.display()))?;
+            let bytes = fs::read(&path)
+                .map_err(|error| format!("failed to read '{}': {error}", path.display()))?;
+            let bytes = match String::from_utf8(bytes) {
+                Ok(text) => normalize_line_endings(&text).into_bytes(),
+                Err(error) => error.into_bytes(),
+            };
+            files.push((normalize_relative_path(relative), bytes));
+        }
+    }
+    Ok(())
+}
+
+fn reject_reparse_path(path: &Path) -> Result<(), String> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        if current.exists() && path_is_reparse(&current)? {
+            return Err(format!(
+                "package path '{}' contains symlink or reparse point '{}'",
+                path.display(),
+                current.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn path_is_reparse(path: &Path) -> Result<bool, String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        format!(
+            "failed to inspect package path '{}': {error}",
+            path.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Ok(true);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        Ok(metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+    }
+    #[cfg(not(windows))]
+    Ok(false)
+}
+
+fn normalize_line_endings(source: &str) -> String {
+    source.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn fingerprint(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("fnv1a64:{hash:016x}")
 }
 
 #[cfg(test)]

--- a/crates/smc-cli/src/package_manifest.rs
+++ b/crates/smc-cli/src/package_manifest.rs
@@ -625,8 +625,11 @@ pub fn admit_package_entry_module(
     // A nested manifest inside module_root is rejected regardless of whether any module
     // actually imports from it -- `package inspect` already rejects it via
     // package_content_fingerprint's tree walk, so admission must reject it too, or
-    // `check`/`compile`/`run` would silently accept a tree that `inspect` rejects.
-    package_content_fingerprint(&module_root, &manifest_path).map_err(|message| {
+    // `check`/`compile`/`run` would silently accept a tree that `inspect` rejects. Uses the
+    // lightweight, memoized reject_nested_manifests rather than the full content-hashing
+    // walk, since admission (called once per imported module) doesn't need file content,
+    // only the structural nested-manifest fact (see DL-016).
+    reject_nested_manifests(&module_root, &manifest_path).map_err(|message| {
         PackageModuleAdmissionError {
             code: PackageModuleAdmissionCode::NestedManifestInsideModuleRoot,
             message,
@@ -765,6 +768,13 @@ pub fn resolve_package_import_path(
     if let Some((alias, module_spec)) = spec.split_once(PACKAGE_IMPORT_SEPARATOR) {
         validate_package_import_extension(module_spec, spec)?;
         return resolve_dependency_import(&importer_canonical, alias, module_spec, spec);
+    }
+
+    if is_rooted_import_spec(spec) {
+        return Err(PackageImportResolutionError {
+            code: PackageImportResolutionCode::RelativeImportOutsideModuleRoot,
+            message: format!("relative package import '{}' must be relative", spec),
+        });
     }
 
     let base = importer_canonical
@@ -1478,6 +1488,25 @@ fn parse_semantic_toml_manifest(
     );
     Ok(ParsedSemanticTomlManifest { manifest, entry })
 }
+// Same check DL-010 added to `validate_contained_relative_path` et al.: a Windows
+// root-relative spec like `\outside` has a `RootDir` component but no `Prefix`, so
+// `Path::is_absolute()` reports it as NOT absolute -- joining it to `base` resets to the
+// current drive's root (`PathBuf::push`'s documented Windows semantics), escaping
+// containment. `is_absolute()` alone also isn't enough on its own: a fully absolute spec
+// (`C:\outside` or, on Unix, `/outside`) previously resolved straight through with no
+// containment check at all when the importer had no enclosing manifest (see DL-017). A
+// relative `Import` spec must never be rooted or absolute, manifest or not.
+fn is_rooted_import_spec(spec: &str) -> bool {
+    let path = Path::new(spec);
+    path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::Prefix(_) | std::path::Component::RootDir
+            )
+        })
+}
+
 fn resolve_relative_import_path(base: &Path, spec: &str) -> PathBuf {
     let path = append_default_module_extension(spec);
     if path.is_absolute() {
@@ -1870,13 +1899,7 @@ fn collect_package_files(
         if file_type.is_dir() {
             collect_package_files(module_root, &path, authority_manifest, files)?;
         } else if file_type.is_file()
-            && path != authority_manifest
-            && path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| {
-                    name == PACKAGE_MANIFEST_FILE_NAME || name == SEMANTIC_TOML_FILE_NAME
-                })
+            && path_is_disallowed_nested_manifest(&path, authority_manifest)
         {
             return Err(format!(
                 "nested package manifest '{}' is inside package module_root '{}'",
@@ -1899,6 +1922,94 @@ fn collect_package_files(
                 Err(error) => error.into_bytes(),
             };
             files.push((normalize_relative_path(relative)?, bytes));
+        }
+    }
+    Ok(())
+}
+
+/// A manifest is only "nested" (forbidden) when it sits in a directory below the authority
+/// manifest's own directory. A manifest of the other type co-located in the exact same
+/// directory as the authority manifest is a permitted compatibility pairing
+/// (`docs/spec/project_model_v0.md`: `semantic.toml` wins when both are present), not
+/// nested content -- a pre-existing bug in the original nested-manifest check, exposed
+/// once admission started exercising this same check (see DL-016).
+fn path_is_disallowed_nested_manifest(path: &Path, authority_manifest: &Path) -> bool {
+    path.parent() != authority_manifest.parent()
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| {
+                name == PACKAGE_MANIFEST_FILE_NAME || name == SEMANTIC_TOML_FILE_NAME
+            })
+}
+
+/// Lightweight counterpart to `package_content_fingerprint`'s tree walk, used by admission
+/// (`check`/`compile`/`run`) purely to reject a nested manifest. It never reads `.sm`/`.exo`
+/// file bytes, and memoizes per canonicalized `module_root` for the life of the process, so
+/// a package with many imported modules is scanned once rather than once per admitted
+/// module (see DL-016). Safe under the same single-process, static-filesystem assumption
+/// the rest of this admission/resolution pipeline already relies on (e.g. canonicalize()
+/// results are never re-validated against concurrent filesystem changes either).
+fn reject_nested_manifests(module_root: &Path, authority_manifest: &Path) -> Result<(), String> {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+    static VALIDATED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    let cache = VALIDATED.get_or_init(|| Mutex::new(HashSet::new()));
+    if cache.lock().unwrap().contains(module_root) {
+        return Ok(());
+    }
+    let authority_manifest = authority_manifest.canonicalize().map_err(|error| {
+        format!(
+            "failed to resolve '{}': {error}",
+            authority_manifest.display()
+        )
+    })?;
+    reject_nested_manifests_under(module_root, module_root, &authority_manifest)?;
+    cache.lock().unwrap().insert(module_root.to_path_buf());
+    Ok(())
+}
+
+fn reject_nested_manifests_under(
+    module_root: &Path,
+    directory: &Path,
+    authority_manifest: &Path,
+) -> Result<(), String> {
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| {
+            format!(
+                "failed to read package directory '{}': {error}",
+                directory.display()
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            format!(
+                "failed to enumerate package directory '{}': {error}",
+                directory.display()
+            )
+        })?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        if path_is_reparse(&path)? {
+            return Err(format!(
+                "package content path '{}' is a symlink or reparse point",
+                path.display()
+            ));
+        }
+        let file_type = entry
+            .file_type()
+            .map_err(|error| format!("failed to inspect '{}': {error}", path.display()))?;
+        if file_type.is_dir() {
+            reject_nested_manifests_under(module_root, &path, authority_manifest)?;
+        } else if file_type.is_file()
+            && path_is_disallowed_nested_manifest(&path, authority_manifest)
+        {
+            return Err(format!(
+                "nested package manifest '{}' is inside package module_root '{}'",
+                path.display(),
+                module_root.display()
+            ));
         }
     }
     Ok(())
@@ -2620,6 +2731,78 @@ module_root src
             err.code,
             PackageModuleAdmissionCode::NestedManifestInsideModuleRoot
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // docs/spec/project_model_v0.md permits `semantic.toml` and `Semantic.package` to
+    // co-exist in the same directory for compatibility, with `semantic.toml` winning as
+    // the authority manifest. The DL-013 fix above wrongly treated the losing, co-located
+    // manifest as forbidden "nested" content and rejected it -- found by @codex review
+    // (DL-016). A manifest is only nested when it sits *below* the authority manifest's
+    // own directory, not when it merely sits beside it.
+    #[test]
+    fn admit_package_entry_module_permits_co_located_semantic_toml_and_package_manifest() {
+        let dir = mk_temp_dir("pkg_admit_co_located_manifests");
+        std::fs::write(
+            dir.join(SEMANTIC_TOML_FILE_NAME),
+            "[package]\nname = \"app\"\n\n[project]\nentry = \"main.sm\"\n",
+        )
+        .expect("write semantic.toml");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage app\nmanifest_dir .\nmodule_root .\n",
+        )
+        .expect("write co-located Semantic.package");
+        let entry = dir.join("main.sm");
+        std::fs::write(&entry, "fn main() { return; }").expect("write entry");
+
+        let admitted = admit_package_entry_module(&entry)
+            .expect("admission must not error")
+            .expect("semantic.toml manifest must exist");
+        assert_eq!(admitted.package_name, "app");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // reject_nested_manifests memoizes per canonicalized module_root so a package with
+    // many imported modules is scanned once rather than once per admitted module -- found
+    // as a performance issue in the same DL-013 fix by @codex review (DL-016). Prove the
+    // memoization actually takes effect: admit one module to populate the cache, then
+    // introduce a genuinely nested manifest into the same module_root and admit a second,
+    // different module in that tree -- it must still succeed because the structural scan
+    // is cached, not re-run against the now-changed tree.
+    #[test]
+    fn admit_package_entry_module_memoizes_nested_manifest_scan_per_module_root() {
+        let dir = mk_temp_dir("pkg_admit_memoized_scan");
+        let src_dir = dir.join("src");
+        std::fs::create_dir_all(&src_dir).expect("mkdir src");
+        std::fs::write(
+            dir.join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage memoized_scan_app\nmanifest_dir .\nmodule_root src\n",
+        )
+        .expect("write manifest");
+        let first_entry = src_dir.join("first.sm");
+        std::fs::write(&first_entry, "fn first() { return; }").expect("write first entry");
+        admit_package_entry_module(&first_entry)
+            .expect("first admission must not error")
+            .expect("manifest must exist");
+
+        std::fs::create_dir_all(src_dir.join("later_nested")).expect("mkdir later_nested");
+        std::fs::write(
+            src_dir
+                .join("later_nested")
+                .join(PACKAGE_MANIFEST_FILE_NAME),
+            "format 1\npackage later_nested\nmanifest_dir .\nmodule_root .\n",
+        )
+        .expect("write later nested manifest");
+
+        let second_entry = src_dir.join("second.sm");
+        std::fs::write(&second_entry, "fn second() { return; }").expect("write second entry");
+        let admitted = admit_package_entry_module(&second_entry)
+            .expect("second admission must not error")
+            .expect("manifest must exist");
+        assert_eq!(admitted.package_name, "memoized_scan_app");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/docs/roadmap/language_maturity/executable_module_entry_scope.md
+++ b/docs/roadmap/language_maturity/executable_module_entry_scope.md
@@ -129,8 +129,9 @@ silently widening into a general package or registry system.
   semantic path through deterministic bundling
 - admit direct local-path selected helper imports only for the current
   function-only helper slice
-- keep top-level alias, wildcard, re-export, and package-qualified executable
-  import forms explicitly out of scope
+- keep top-level alias, wildcard, and re-export forms explicitly out of scope;
+  package-qualified executable imports were later admitted by the bounded
+  SSF-06 local package contract
 
 ### Wave 3 — Lowering / CLI / End-To-End
 

--- a/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
+++ b/docs/roadmap/stable_foundation/semantic_stable_foundation_matrix.md
@@ -136,14 +136,14 @@ that wording drift; it does not delete or rewrite historical evidence.
 | `smc run <project-root>` | C/V/R | **Landed and qualified on `main`** | PCC9 run path. | SSF-05. |
 | `smc test <project-root>` | C/F/V/R | **Landed and qualified on `main`** | Root-contained sorted discovery; every test compiles, verifies, and runs under the pure profile. | Preserve through SSF-12. |
 | `smc new` | C | **Out of scope** | Project Model v0 is manually creatable; scaffolding is not required. | Excluded from Stable Foundation. |
-| Package identity | C/F/D | **Landed but unqualified** | Package names/manifests exist; long-term identity contract is not frozen. | SSF-06. |
-| Local path dependencies | C/F | **Landed and qualified on `main`** | Deterministic local dependency loading and tests exist. | Requalify Foundation scope in SSF-06. |
-| Deterministic package graph and cycle diagnostics | C/F | **Landed and qualified on `main`** | Import/package cycle positives and negatives. | SSF-06. |
-| Package-qualified imports | C/F | **Landed but unqualified** | Landed beyond the Gate 1 executable import promise. | SSF-06. |
-| Manifest/content hashes | C/D | **Landed but unqualified** | Hash helpers/routes exist without stable provenance promise. | SSF-06/10. |
-| Capability-request inventory | C/V/R | **Roadmap** | Package metadata is not yet a complete explicit inventory contract. | SSF-06. |
-| Lock/provenance record | C/D | **Roadmap** | No canonical lockfile/equivalent reproducibility record. | SSF-06/10. |
-| Bounded workspaces | C/F | **Roadmap** | Not part of the current qualified package baseline. | SSF-06 only if examples require it. |
+| Package identity | C/F/D | **Landed and qualified on `main`** | `semantic.foundation.package/0.1`: name is descriptive; deterministic manifest/content/graph fingerprints carry reproducible identity, not trust. | Cryptographic trust remains SSF-10. |
+| Local path dependencies | C/F | **Landed and qualified on `main`** | Relative local-only dependency loading; absolute paths and undeclared root escape reject. | No remote fetch. |
+| Deterministic package graph and cycle diagnostics | C/F | **Landed and qualified on `main`** | Full declared graph is sorted; cycles, missing nodes, and duplicate identities reject deterministically. | SSF-06 closed contour. |
+| Package-qualified imports | C/F | **Landed and qualified on `main`** | `<alias>::<module>` remains contained by the dependency module root and may enforce pinned identity. | SSF-06 closed contour. |
+| Manifest/content hashes | C/D | **Landed and qualified on `main`** | Normalized `fnv1a64` fingerprints are deterministic change detectors and explicitly non-cryptographic. | Cryptographic artifacts remain SSF-10. |
+| Capability-request inventory | C/V/R | **Landed and qualified on `main`** | Sorted manifest inventory is recorded; request is proven not to grant or propagate capability authority. | Runtime grants remain SSF-04 authority. |
+| Lock/provenance record | C/D | **Landed and qualified on `main`** | Read-only `smc package inspect` emits canonical provenance-equivalent JSON and writes no lockfile. | Signing remains SSF-10. |
+| Bounded workspaces | C/F | **Out of scope** | Local package composition needs no second workspace model. | Reconsider only after Stable Foundation. |
 
 ## Runtime, tooling, compatibility, and onboarding
 

--- a/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
@@ -35,9 +35,9 @@ until the preceding exit gate is accepted.
 | SSF-02 / #1573 | Frozen executable contract | Rust-like/Logos Model A or B, diagnostics and package interaction | Honest profile behavior and examples | Completed: Model B |
 | SSF-03 / #1574 | Frozen language/profile contract | Versioned language-owned stdlib equivalents and builtin boundary | Positive, negative, compatibility tests and canonical index | Completed |
 | SSF-04 / #1575 | Stable value/library carriers | Capabilities, profiles, denial/audit/replay contract | Canonical deterministic file-transform path | Completed |
-| SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | **Active: candidate exit** |
-| SSF-06 / #1577 | Canonical project model | Local package graph, provenance-equivalent record, capability inventory | Multi-package reproducibility and root-security evidence | Complete; SSF-07 entry open |
-| SSF-07 / #1578 | Stable project/package usage needs | Numeric/text/collections/closures/generics/traits/pattern bounds | Ordinary programs without undocumented workarounds | Active after SSF-06 |
+| SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | Completed |
+| SSF-06 / #1577 | Canonical project model | Local package graph, provenance-equivalent record, capability inventory | Multi-package reproducibility and root-security evidence | **Active: candidate exit** |
+| SSF-07 / #1578 | Stable project/package usage needs | Numeric/text/collections/closures/generics/traits/pattern bounds | Ordinary programs without undocumented workarounds | Blocked by SSF-06 |
 | SSF-08 / #1579 | Selected abstraction surface | Ownership Position A/B, value paths, frames, host ownership, quotas | Positive/negative ownership and deterministic failure suite | Blocked by SSF-07 |
 | SSF-09 / #1580 | Canonical diagnostics and project symbols | Diagnostic schema, formatter, LSP/editor baseline | CLI/LSP parity, idempotence, protocol fixtures | Blocked by SSF-08 |
 | SSF-10 / #1581 | Frozen source/tooling/runtime contracts | Compatibility windows, migration, artifact identity/provenance | Inspect/hash/migration evidence and release manifest policy | Blocked by SSF-09 |

--- a/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_dependency_map.md
@@ -36,8 +36,8 @@ until the preceding exit gate is accepted.
 | SSF-03 / #1574 | Frozen language/profile contract | Versioned language-owned stdlib equivalents and builtin boundary | Positive, negative, compatibility tests and canonical index | Completed |
 | SSF-04 / #1575 | Stable value/library carriers | Capabilities, profiles, denial/audit/replay contract | Canonical deterministic file-transform path | Completed |
 | SSF-05 / #1576 | Language, stdlib, and effect contracts | Canonical manifest/project layout/commands/path identity | Reproducible project fixtures including `smc test` | **Active: candidate exit** |
-| SSF-06 / #1577 | Canonical project model | Local package graph, provenance/lock, capability inventory | Multi-package reproducibility and root-security evidence | Blocked by SSF-05 |
-| SSF-07 / #1578 | Stable project/package usage needs | Numeric/text/collections/closures/generics/traits/pattern bounds | Ordinary programs without undocumented workarounds | Blocked by SSF-06 |
+| SSF-06 / #1577 | Canonical project model | Local package graph, provenance-equivalent record, capability inventory | Multi-package reproducibility and root-security evidence | Complete; SSF-07 entry open |
+| SSF-07 / #1578 | Stable project/package usage needs | Numeric/text/collections/closures/generics/traits/pattern bounds | Ordinary programs without undocumented workarounds | Active after SSF-06 |
 | SSF-08 / #1579 | Selected abstraction surface | Ownership Position A/B, value paths, frames, host ownership, quotas | Positive/negative ownership and deterministic failure suite | Blocked by SSF-07 |
 | SSF-09 / #1580 | Canonical diagnostics and project symbols | Diagnostic schema, formatter, LSP/editor baseline | CLI/LSP parity, idempotence, protocol fixtures | Blocked by SSF-08 |
 | SSF-10 / #1581 | Frozen source/tooling/runtime contracts | Compatibility windows, migration, artifact identity/provenance | Inspect/hash/migration evidence and release manifest policy | Blocked by SSF-09 |

--- a/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
+++ b/docs/roadmap/stable_foundation/stable_foundation_target_contract.md
@@ -129,7 +129,7 @@ Andromeda, and broad permanent ABI/ISA promises.
 | Builtin-to-stdlib boundary and APIs | SSF-03 | Existing builtins may be wrapped, renamed, narrowed, or deferred. |
 | Capability names, grants, denial results, audit, replay profiles | SSF-04 | Existing `print` is evidence, not the finished boundary. |
 | Canonical manifest, project layout, discovery, and command shapes | SSF-05 | Resolved by `semantic.foundation.project/0.1`: `semantic.toml` is canonical; `Semantic.package` is an explicit compatibility/package input. |
-| Package identity, provenance, and lock record | SSF-06 | Local dependencies remain unpromoted. |
+| Package identity, provenance, and lock record | SSF-06 | Resolved by `semantic.foundation.package/0.1`: local-only composition, pinned deterministic fingerprints, capability-request inventory, and a read-only provenance-equivalent record. |
 | Numeric, text, collection, closure, generic, trait, and pattern limits | SSF-07 | Prefer the smallest ordinary-program contour. |
 | Ownership Position A or B | SSF-08 | Position A is the conservative candidate, not a pre-decided result. |
 | Diagnostic schema, formatter, LSP, editor baseline | SSF-09 | `smc check` remains source of truth. |

--- a/docs/spec/cli.md
+++ b/docs/spec/cli.md
@@ -296,6 +296,7 @@ Current rule:
 - source-reading commands inherit the current executable bundle admission boundary
 - project-root `smc compile` uses the bounded project entry resolution, then writes the SemCode artifact only to the requested `-o|--out` path
 - `smc check` also accepts a bounded admitted project-root entrypoint through `Semantic.package` + `src/main.sm`
+- `smc package inspect <project-root>` prints the deterministic, read-only local package provenance record defined by `semantic.foundation.package/0.1`
 - project-root `smc check` also resolves a minimal `semantic.toml` manifest when present
 - project-root `smc run` uses the same bounded project entry resolution, then follows the existing verifier-first source execution route
 - project-root `smc dump-ast`, `smc dump-ir`, and `smc dump-bytecode` use the same bounded project entry resolution, then emit the existing dump output for the resolved source

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -110,12 +110,13 @@ specialization, and default methods are experimental or deferred to SSF-07.
 - single-file programs;
 - direct local-path bare helper imports;
 - direct local-path selected imports over the qualified helper-module contour;
+- package-qualified bare helper imports declared by the SSF-06 local package contract;
 - deterministic missing-file, duplicate-symbol, and cycle rejection.
 
 Alias imports, wildcard imports, public re-exports, namespace-qualified access,
-package-qualified executable imports, and broad package graphs are not included
-in this source contract. Project and package contracts are owned by SSF-05 and
-SSF-06.
+and remote/broad package ecosystems are not included in this source contract.
+Project and package identity, containment, and provenance remain owned by
+SSF-05 and SSF-06 rather than by the parser/typechecker.
 
 ### Scalar families
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -20,6 +20,8 @@ Current documents in this PR:
   family index, deterministic semantics, and deferred APIs
 - `project_model_v0.md` - canonical manifest/layout, discovery, project command,
   path-containment, and identity boundary
+- `package_baseline_v0.md` - local-only dependency graph, deterministic
+  fingerprints/provenance record, root containment, and capability-request boundary
 - `syntax.md` - canonical Rust-like source syntax contract
 - `types.md` - source-level type contract and current type-family limits
 - `source_semantics.md` - source-level execution and binding semantics

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -177,6 +177,8 @@ package <name>
 manifest_dir <path>
 module_root <path>
 dep <alias> <package_name> <local_path>
+dep <alias> <package_name> <local_path> <manifest_fingerprint> <content_fingerprint>
+capability <request-id>
 ```
 
 Current `main` now also admits one first-wave package-qualified dependency
@@ -184,7 +186,7 @@ import form:
 
 ```sm
 Import "math::core.sm"
-Import "ui::widgets/button.sm" as Button
+Import "ui::widgets/button.sm"
 ```
 
 Current first-wave package loading rules:
@@ -202,8 +204,11 @@ Current package-baseline limits still remain:
 
 - no registries
 - no semver solving
-- no lockfiles
+- no writable lockfile (the read-only provenance-equivalent record is `smc package inspect`)
 - no publishing workflow
+
+The complete local baseline, fingerprint semantics, capability request boundary,
+and deterministic graph failures are defined in `package_baseline_v0.md`.
 
 ## Validation Evidence
 

--- a/docs/spec/modules.md
+++ b/docs/spec/modules.md
@@ -75,13 +75,15 @@ Current executable-path admission is narrower:
 - selected executable helper imports materialize only the requested public
   bindings plus the required local helper-function call closure before
   checking/lowering
+- package-qualified imports such as `Import "math::core.sm"` are admitted when
+  the dependency is declared by the local package baseline and the resolved
+  `.sm` or `.exo` module remains inside its package `module_root`
 
 The following executable import forms remain out of scope on current `main`:
 
 - explicit top-level alias imports
 - wildcard imports
 - public re-exports
-- package-qualified executable imports
 - namespace-qualified executable access such as `X.Foo`
 
 ## Name Resolution Order

--- a/docs/spec/package_baseline_v0.md
+++ b/docs/spec/package_baseline_v0.md
@@ -22,8 +22,10 @@ capability fs.read
 ```
 
 Package-qualified imports retain the existing `<alias>::<module>` form. All
-resolved modules must remain under the dependency's admitted `module_root`.
-Absolute dependency paths, escaping `manifest_dir`/`module_root` values, and
+resolved modules and their relative imports must remain under the importing
+package's admitted `module_root`. A manifest found below another package's
+`module_root` is rejected rather than becoming a nested authority. Absolute
+dependency paths, escaping `manifest_dir`/`module_root` values, and
 symlink/reparse paths are rejected. Enumeration and diagnostics use sorted,
 normalized paths.
 
@@ -57,10 +59,10 @@ these inputs and never authorize verifier admission.
 
 ## Authority boundary
 
-`capability <id>` is inventory only. It does not construct or modify a runtime
-`CapabilityManifest`, does not propagate transitively, and cannot grant host
-authority. SemCode produced from package sources still passes through normal
-verifier admission before execution.
+`capability <id>` is preserved in the parsed manifest as sorted inventory only.
+It does not construct or modify a runtime `CapabilityManifest`, does not
+propagate transitively, and cannot grant host authority. SemCode produced from
+package sources still passes through normal verifier admission before execution.
 
 The inspector is read-only: it prints a provenance-equivalent record and writes
 no lockfile, source, cache, or package data. There is no network or registry
@@ -70,9 +72,9 @@ path in this contract.
 
 The baseline rejects missing dependency manifests, declared/actual package-name
 mismatch, duplicate package names at different roots, dependency cycles,
-invalid or stale fingerprints, root escape, and link/reparse traversal. Cycle
-diagnostics use logical names in deterministic edge order and contain no
-checkout-specific absolute path.
+invalid or stale fingerprints, root escape, nested manifests below a module
+root, and link/reparse traversal. Cycle diagnostics use logical names in
+deterministic edge order and contain no checkout-specific absolute path.
 
 ## Explicit deferrals
 

--- a/docs/spec/package_baseline_v0.md
+++ b/docs/spec/package_baseline_v0.md
@@ -1,0 +1,85 @@
+# Package Baseline v0
+
+Status: Stable Foundation contract candidate
+Contract: `semantic.foundation.package/0.1`
+
+## Contour
+
+The baseline extends the existing `Semantic.package` loader; it does not add a
+second package authority. A manifest has one descriptive package name, a
+contained package/module root, zero or more local path dependencies, and zero
+or more capability requests. Local dependency paths are explicit and relative.
+They may name a sibling package with `..`; the dependency's own manifest and
+module root then become its declared containment boundary.
+
+```text
+format 1
+package app
+manifest_dir .
+module_root src
+dep math math ../math
+capability fs.read
+```
+
+Package-qualified imports retain the existing `<alias>::<module>` form. All
+resolved modules must remain under the dependency's admitted `module_root`.
+Absolute dependency paths, escaping `manifest_dir`/`module_root` values, and
+symlink/reparse paths are rejected. Enumeration and diagnostics use sorted,
+normalized paths.
+
+## Identity and provenance
+
+`smc package inspect <project-root>` recursively reads every declared local
+dependency and prints deterministic JSON with schema
+`semantic.foundation.package.provenance/0.1`. The record contains:
+
+- the root package label;
+- packages sorted by name;
+- sorted dependency edges and normalized declared local paths;
+- a normalized manifest fingerprint;
+- a source-content fingerprint over sorted module-root files;
+- sorted capability requests;
+- a graph fingerprint binding the complete record.
+
+The baseline fingerprint is `fnv1a64:<16 lowercase hex digits>`. It is a
+deterministic change detector, explicitly **not** a cryptographic trust claim.
+Cryptographic artifact provenance and signing belong to SSF-10.
+
+A dependency may pin both observed values:
+
+```text
+dep math math ../math fnv1a64:0123456789abcdef fnv1a64:fedcba9876543210
+```
+
+When pins are present, loading and graph inspection fail deterministically on
+manifest or content mismatch. Names and future version labels never replace
+these inputs and never authorize verifier admission.
+
+## Authority boundary
+
+`capability <id>` is inventory only. It does not construct or modify a runtime
+`CapabilityManifest`, does not propagate transitively, and cannot grant host
+authority. SemCode produced from package sources still passes through normal
+verifier admission before execution.
+
+The inspector is read-only: it prints a provenance-equivalent record and writes
+no lockfile, source, cache, or package data. There is no network or registry
+path in this contract.
+
+## Deterministic failures
+
+The baseline rejects missing dependency manifests, declared/actual package-name
+mismatch, duplicate package names at different roots, dependency cycles,
+invalid or stale fingerprints, root escape, and link/reparse traversal. Cycle
+diagnostics use logical names in deterministic edge order and contain no
+checkout-specific absolute path.
+
+## Explicit deferrals
+
+No registry, remote fetch, version solver, publish/install workflow, build
+script, install hook, implicit capability grant, cryptographic signature, or
+broad workspace model is included. Bounded workspaces remain deferred because
+the canonical local composition examples do not require them.
+
+SSF-07 may start from this closed local package contour. It may use package
+composition as qualification evidence but must not widen package resolution.

--- a/docs/spec/source_semantics.md
+++ b/docs/spec/source_semantics.md
@@ -44,8 +44,10 @@ Current rules:
   - top-level alias imports
   - wildcard imports
   - public re-exports
-  - package-qualified executable imports
   - namespace-qualified executable access
+- package-qualified bare imports are admitted only through an enclosing
+  `Semantic.package` dependency declaration and remain subject to SSF-06 root,
+  identity, and provenance checks
 - execution begins at `fn main()`
 - `main` must currently have signature `fn main()`
 - there is no dynamic entrypoint discovery or module-level executable code

--- a/examples/canonical/boundary_alias_import/README.md
+++ b/examples/canonical/boundary_alias_import/README.md
@@ -13,4 +13,4 @@
 - expected output:
   - `check` fails
   - the diagnostic contains:
-    `top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2`
+    `top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports`

--- a/tests/canonical_examples.rs
+++ b/tests/canonical_examples.rs
@@ -109,7 +109,7 @@ fn canonical_boundary_example_reports_current_alias_limit() {
     );
     assert!(
         err.contains(
-            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
+            "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports"
         ),
         "expected executable alias boundary diagnostic, got: {err}"
     );

--- a/tests/executable_module_entry.rs
+++ b/tests/executable_module_entry.rs
@@ -107,12 +107,11 @@ fn executable_module_entry_helper_graph_compile_is_deterministic() {
 #[test]
 fn executable_module_entry_negative_out_of_scope_import_forms_report_wave2_boundary() {
     let wave2_boundary =
-        "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2";
+        "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports";
     let cases = [
         "examples/qualification/executable_module_entry/negative_alias_import/src/main.sm",
         "examples/qualification/executable_module_entry/negative_wildcard_import/src/main.sm",
         "examples/qualification/executable_module_entry/negative_reexport_import/src/main.sm",
-        "examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm",
     ];
 
     for rel in cases {
@@ -122,6 +121,17 @@ fn executable_module_entry_negative_out_of_scope_import_forms_report_wave2_bound
             "expected wave2 executable import boundary diagnostic for {rel}, got: {err}"
         );
     }
+}
+
+#[test]
+fn executable_module_entry_package_qualified_import_requires_declared_alias() {
+    let rel =
+        "examples/qualification/executable_module_entry/negative_package_qualified_import/src/main.sm";
+    let err = cli_err("check", rel);
+    assert!(
+        err.contains("does not declare dependency alias 'math'"),
+        "expected package alias diagnostic, got: {err}"
+    );
 }
 
 #[test]

--- a/tests/g1_frontend_trust.rs
+++ b/tests/g1_frontend_trust.rs
@@ -31,7 +31,7 @@ fn g1_frontend_negative_suite_reports_expected_diagnostics() {
     let cases = [
         (
             "examples/qualification/g1_frontend_trust/negative_top_level_import/src/main.sm",
-            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2",
+            "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports",
         ),
         (
             "examples/qualification/g1_frontend_trust/negative_iterable_contract/src/main.sm",

--- a/tests/g1_real_program_trial.rs
+++ b/tests/g1_real_program_trial.rs
@@ -55,13 +55,13 @@ fn g1_top_level_alias_module_program_remains_out_of_scope() {
     let check_err = cli_err("check", rel);
     assert!(
         check_err.contains(
-            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
+            "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports"
         )
     );
     let run_err = cli_err("run", rel);
     assert!(
         run_err.contains(
-            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2"
+            "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports"
         )
     );
 }

--- a/tests/pcc9_project_model_acceptance.rs
+++ b/tests/pcc9_project_model_acceptance.rs
@@ -1960,6 +1960,9 @@ fn pcc9_package_manifest_local_dependency_inventory_is_deterministic() {
         PackageDependencySource::LocalPath { path } => {
             assert_eq!(path, "../math");
         }
+        PackageDependencySource::PinnedLocalPath { .. } => {
+            panic!("fixture declares an unpinned local dependency")
+        }
     }
 }
 

--- a/tests/ssf05_test_path_utf8_and_entry_symlink.rs
+++ b/tests/ssf05_test_path_utf8_and_entry_symlink.rs
@@ -100,12 +100,10 @@ fn non_utf8_test_source_paths_reject_deterministically() {
     std::fs::remove_dir_all(root).expect("remove project");
 }
 
-// resolve_project_root_check_entry_structured rejects a symlinked/reparse project
-// entry deterministically, before it is ever read, across check/compile/run --
-// regardless of whether the symlink target happens to fall under some other
-// package's manifest scope (which admit_package_entry_module's containment check
-// alone does not cover, since it only applies when a manifest is found above the
-// resolved target).
+// admit_package_entry_module's reject_reparse_path(entry) rejects a symlinked/reparse
+// project entry deterministically, before it is ever read, across check/compile/run --
+// unconditionally, before any manifest lookup, so it does not depend on whether the
+// symlink target happens to fall under some other package's manifest scope.
 #[cfg(unix)]
 #[test]
 fn project_entry_symlink_escaping_the_module_root_is_rejected_across_check_compile_run() {
@@ -136,8 +134,7 @@ fn project_entry_symlink_escaping_the_module_root_is_rejected_across_check_compi
             "'{command}' must reject a project entry symlinked outside the module root"
         );
         assert!(
-            String::from_utf8_lossy(&output.stderr)
-                .contains("must not be a symlink or reparse point"),
+            String::from_utf8_lossy(&output.stderr).contains("symlink or reparse point"),
             "'{command}' unexpected stderr: {}",
             String::from_utf8_lossy(&output.stderr)
         );

--- a/tests/ssf05_test_path_utf8_and_entry_symlink.rs
+++ b/tests/ssf05_test_path_utf8_and_entry_symlink.rs
@@ -100,13 +100,16 @@ fn non_utf8_test_source_paths_reject_deterministically() {
     std::fs::remove_dir_all(root).expect("remove project");
 }
 
-// admit_package_entry_module's reject_reparse_path(entry) rejects a symlinked/reparse
-// project entry deterministically, before it is ever read, across check/compile/run --
-// unconditionally, before any manifest lookup, so it does not depend on whether the
-// symlink target happens to fall under some other package's manifest scope.
+// resolve_project_root_check_entry_structured calls reject_reparse_path(entry) directly,
+// so every caller -- including cmd_test, which discards resolve_project_root_check_entry's
+// return value and never routes the entry through admit_package_entry_module -- still
+// rejects a symlinked/reparse project entry deterministically, before it is ever read,
+// across check/compile/run/test. (A prior version of this fix relied solely on
+// admit_package_entry_module's reject_reparse_path call, which cmd_test never reaches;
+// see #1598 DL-009.)
 #[cfg(unix)]
 #[test]
-fn project_entry_symlink_escaping_the_module_root_is_rejected_across_check_compile_run() {
+fn project_entry_symlink_escaping_the_module_root_is_rejected_across_check_compile_run_and_test() {
     use std::os::unix::fs::symlink;
 
     let root = project("entry_symlink");
@@ -122,7 +125,7 @@ fn project_entry_symlink_escaping_the_module_root_is_rejected_across_check_compi
     symlink(&outside, &entry).expect("symlink entry outside module root");
     let root_arg = root.to_string_lossy().replace('\\', "/");
 
-    for command in ["check", "compile", "run"] {
+    for command in ["check", "compile", "run", "test"] {
         let args: Vec<&str> = if command == "compile" {
             vec![command, &root_arg, "-o", "/dev/null"]
         } else {

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -390,6 +390,60 @@ fn authority_manifest_is_allowed_at_package_root_module_root() {
 }
 
 #[test]
+fn package_import_rejects_unfingerprinted_module_extension() {
+    let root = temp_workspace("module_extension");
+    let app = root.join("app");
+    let dependency = root.join("dependency");
+    write_package(
+        &dependency,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "fn unused() { return; }\n",
+    );
+    std::fs::write(
+        dependency.join("src/helper.txt"),
+        "fn helper() -> i32 { return 1; }\n",
+    )
+    .expect("text extension module");
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "Import \"dependency::helper.txt\"\nfn main() { assert(helper() == 1); return; }\n",
+    );
+
+    let output = smc(&["check", &app.to_string_lossy()]);
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("must use a .sm or .exo module extension")
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn authority_manifest_symlink_is_rejected_before_read() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_workspace("manifest_symlink");
+    let package = root.join("app");
+    std::fs::create_dir_all(package.join("src")).expect("source root");
+    std::fs::write(package.join("src/main.sm"), "fn main() { return; }\n").expect("entry source");
+    let outside_manifest = root.join("outside.package");
+    std::fs::write(
+        &outside_manifest,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+    )
+    .expect("outside manifest");
+    symlink(&outside_manifest, package.join("Semantic.package")).expect("manifest symlink");
+
+    let output = smc(&["check", &package.to_string_lossy()]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("symlink or reparse point"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn capability_request_is_inventory_only_and_never_a_grant() {
     let root = temp_workspace("capability");
     write_package(

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -333,6 +333,63 @@ fn dependency_relative_import_cannot_escape_module_root() {
 }
 
 #[test]
+fn nested_manifest_cannot_rebind_package_authority() {
+    let root = temp_workspace("nested_manifest");
+    let app = root.join("app");
+    let dependency = root.join("dependency");
+    write_package(
+        &dependency,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "Import \"nested/helper.sm\"\nfn value() -> i32 { return helper(); }\n",
+    );
+    std::fs::create_dir_all(dependency.join("src/nested")).expect("nested source root");
+    std::fs::write(
+        dependency.join("src/nested/Semantic.package"),
+        "format 1\npackage nested\nmanifest_dir .\nmodule_root .\n",
+    )
+    .expect("nested manifest");
+    std::fs::write(
+        dependency.join("src/nested/helper.sm"),
+        "fn helper() -> i32 { return 1; }\n",
+    )
+    .expect("nested helper");
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "Import \"dependency::main.sm\"\nfn main() { assert(value() == 1); return; }\n",
+    );
+
+    let inspect_output = inspect(&dependency);
+    assert!(!inspect_output.status.success());
+    assert!(String::from_utf8_lossy(&inspect_output.stderr).contains("nested package manifest"));
+
+    let check_output = smc(&["check", &app.to_string_lossy()]);
+    assert!(!check_output.status.success());
+    assert!(String::from_utf8_lossy(&check_output.stderr).contains("nested package manifest"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn authority_manifest_is_allowed_at_package_root_module_root() {
+    let root = temp_workspace("root_module_root");
+    write_package(
+        &root,
+        "format 1\npackage flat\nmanifest_dir .\nmodule_root .\n",
+        "fn main() { return; }\n",
+    );
+
+    let output = inspect(&root);
+    assert!(
+        output.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn capability_request_is_inventory_only_and_never_a_grant() {
     let root = temp_workspace("capability");
     write_package(

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -1,0 +1,296 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn temp_workspace(label: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "semantic_ssf06_{label}_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&root).expect("create workspace");
+    root
+}
+
+fn write_package(root: &Path, manifest: &str, source: &str) {
+    std::fs::create_dir_all(root.join("src")).expect("create source root");
+    std::fs::write(root.join("Semantic.package"), manifest).expect("write manifest");
+    std::fs::write(root.join("src/main.sm"), source).expect("write source");
+}
+
+fn smc(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_smc"))
+        .args(args)
+        .output()
+        .expect("run smc")
+}
+
+fn inspect(root: &Path) -> Output {
+    smc(&["package", "inspect", &root.to_string_lossy()])
+}
+
+#[test]
+fn package_contract_freezes_scope_and_authority_boundaries() {
+    let contract = include_str!("../docs/spec/package_baseline_v0.md");
+    for required in [
+        "semantic.foundation.package/0.1",
+        "semantic.foundation.package.provenance/0.1",
+        "smc package inspect <project-root>",
+        "not** a cryptographic trust claim",
+        "inventory only",
+        "No registry",
+        "SSF-07",
+    ] {
+        assert!(
+            contract.contains(required),
+            "missing contract text: {required}"
+        );
+    }
+}
+
+#[test]
+fn local_graph_record_is_checkout_independent_and_deterministic() {
+    let root = temp_workspace("deterministic");
+    let app = root.join("app");
+    let alpha = root.join("alpha");
+    let zeta = root.join("zeta");
+    write_package(
+        &alpha,
+        "format 1\npackage alpha\nmanifest_dir .\nmodule_root src\ncapability fs.read\n",
+        "fn alpha_value(value: i32) -> i32 { return value; }\n",
+    );
+    write_package(
+        &zeta,
+        "format 1\npackage zeta\nmanifest_dir .\nmodule_root src\n",
+        "fn zeta_value(value: i32) -> i32 { return value; }\n",
+    );
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep z zeta ../zeta\ndep a alpha ../alpha\ncapability stdout.write\n",
+        "Import \"a::main.sm\"\nImport \"z::main.sm\"\nfn main() { assert(alpha_value(1) == zeta_value(1)); return; }\n",
+    );
+
+    let first = inspect(&app);
+    let second = inspect(&app);
+    assert!(
+        first.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(first.stdout, second.stdout);
+    std::fs::write(
+        alpha.join("src/main.sm"),
+        "fn alpha_value(value: i32) -> i32 { return value; }\r\n",
+    )
+    .expect("rewrite with CRLF");
+    assert_eq!(first.stdout, inspect(&app).stdout);
+    let record: serde_json::Value = serde_json::from_slice(&first.stdout).expect("record JSON");
+    assert_eq!(
+        record["schema"],
+        "semantic.foundation.package.provenance/0.1"
+    );
+    assert_eq!(record["fingerprint_algorithm"], "fnv1a64-non-cryptographic");
+    assert_eq!(record["root_package"], "app");
+    assert!(record["graph_fingerprint"]
+        .as_str()
+        .expect("graph fingerprint")
+        .starts_with("fnv1a64:"));
+    let packages = record["packages"].as_array().expect("packages");
+    assert_eq!(
+        packages
+            .iter()
+            .map(|package| package["name"].as_str().expect("name"))
+            .collect::<Vec<_>>(),
+        vec!["alpha", "app", "zeta"]
+    );
+    assert_eq!(packages[1]["capability_requests"][0], "stdout.write");
+    assert!(!String::from_utf8_lossy(&first.stdout).contains(&root.to_string_lossy().as_ref()));
+
+    let app_arg = app.to_string_lossy();
+    for command in ["check", "run"] {
+        let output = smc(&[command, &app_arg]);
+        assert!(
+            output.status.success(),
+            "{command} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn cycles_missing_dependencies_and_duplicate_names_reject_deterministically() {
+    let root = temp_workspace("invalid_graphs");
+    let a = root.join("a");
+    let b = root.join("b");
+    write_package(
+        &a,
+        "format 1\npackage a\nmanifest_dir .\nmodule_root src\ndep b b ../b\n",
+        "fn main() { return; }\n",
+    );
+    write_package(
+        &b,
+        "format 1\npackage b\nmanifest_dir .\nmodule_root src\ndep a a ../a\n",
+        "fn main() { return; }\n",
+    );
+    let cycle_first = inspect(&a);
+    let cycle_second = inspect(&a);
+    assert!(!cycle_first.status.success());
+    assert_eq!(cycle_first.stderr, cycle_second.stderr);
+    assert!(String::from_utf8_lossy(&cycle_first.stderr)
+        .contains("package dependency cycle: a -> b -> a"));
+
+    std::fs::write(
+        a.join("Semantic.package"),
+        "format 1\npackage a\nmanifest_dir .\nmodule_root src\ndep missing missing ../missing\n",
+    )
+    .expect("replace manifest");
+    let missing = inspect(&a);
+    assert!(!missing.status.success());
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("dependency alias 'missing' expected")
+    );
+
+    let first = root.join("first");
+    let second = root.join("second");
+    write_package(
+        &first,
+        "format 1\npackage shared\nmanifest_dir .\nmodule_root src\n",
+        "fn main() { return; }\n",
+    );
+    write_package(
+        &second,
+        "format 1\npackage shared\nmanifest_dir .\nmodule_root src\n",
+        "fn main() { return; }\n",
+    );
+    std::fs::write(
+        a.join("Semantic.package"),
+        "format 1\npackage a\nmanifest_dir .\nmodule_root src\ndep first shared ../first\ndep second shared ../second\n",
+    )
+    .expect("replace manifest");
+    let duplicate = inspect(&a);
+    assert!(!duplicate.status.success());
+    assert!(
+        String::from_utf8_lossy(&duplicate.stderr).contains("duplicate package identity 'shared'")
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn pinned_identity_and_root_policy_fail_closed() {
+    let root = temp_workspace("identity");
+    let app = root.join("app");
+    let dependency = root.join("dependency");
+    write_package(
+        &dependency,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "fn value(input: i32) -> i32 { return input; }\n",
+    );
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "Import \"dependency::main.sm\"\nfn main() { assert(value(1) == 1); return; }\n",
+    );
+    let initial = inspect(&app);
+    assert!(initial.status.success());
+    let record: serde_json::Value = serde_json::from_slice(&initial.stdout).expect("record JSON");
+    let dependency_record = record["packages"]
+        .as_array()
+        .expect("packages")
+        .iter()
+        .find(|package| package["name"] == "dependency")
+        .expect("dependency record");
+    let manifest_fingerprint = dependency_record["manifest_fingerprint"]
+        .as_str()
+        .expect("manifest fingerprint");
+    let content_fingerprint = dependency_record["content_fingerprint"]
+        .as_str()
+        .expect("content fingerprint");
+    std::fs::write(
+        app.join("Semantic.package"),
+        format!(
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency {manifest_fingerprint} {content_fingerprint}\n"
+        ),
+    )
+    .expect("pin dependency");
+    assert!(inspect(&app).status.success());
+    assert!(smc(&["check", &app.to_string_lossy()]).status.success());
+
+    std::fs::write(
+        dependency.join("src/main.sm"),
+        "fn value(input: i32) -> i32 { return input + 1; }\n",
+    )
+    .expect("change dependency content");
+    let mismatch = inspect(&app);
+    assert!(!mismatch.status.success());
+    assert!(String::from_utf8_lossy(&mismatch.stderr).contains("content fingerprint mismatch"));
+    let load_mismatch = smc(&["check", &app.to_string_lossy()]);
+    assert!(!load_mismatch.status.success());
+    assert!(String::from_utf8_lossy(&load_mismatch.stderr).contains("content fingerprint mismatch"));
+
+    std::fs::write(
+        app.join("Semantic.package"),
+        "format 1\npackage app\nmanifest_dir ..\nmodule_root src\n",
+    )
+    .expect("escape manifest");
+    let escape = inspect(&app);
+    assert!(!escape.status.success());
+    assert!(String::from_utf8_lossy(&escape.stderr).contains("must not escape its declared root"));
+
+    std::fs::write(
+        app.join("Semantic.package"),
+        format!(
+            "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency {}\n",
+            dependency.to_string_lossy().replace('\\', "/")
+        ),
+    )
+    .expect("absolute dependency manifest");
+    let absolute = inspect(&app);
+    assert!(!absolute.status.success());
+    assert!(String::from_utf8_lossy(&absolute.stderr).contains("must be relative"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn package_content_symlink_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_workspace("symlink");
+    let package = root.join("app");
+    write_package(
+        &package,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        "fn main() { return; }\n",
+    );
+    std::fs::write(root.join("outside.sm"), "fn outside() { return; }\n").expect("outside");
+    symlink(root.join("outside.sm"), package.join("src/linked.sm")).expect("create symlink");
+
+    let output = inspect(&package);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("symlink or reparse point"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn capability_request_is_inventory_only_and_never_a_grant() {
+    let root = temp_workspace("capability");
+    write_package(
+        &root,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ncapability fs.write\n",
+        "fn main() { fs_write_text(\"output.txt\", \"payload\"); return; }\n",
+    );
+    let root_arg = root.to_string_lossy();
+    let output = smc(&["run", &root_arg, "--profile", "pure", "--root", &root_arg]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("capability FsWrite denied"));
+    assert!(!root.join("output.txt").exists());
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -443,6 +443,39 @@ fn authority_manifest_symlink_is_rejected_before_read() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
+#[cfg(unix)]
+#[test]
+fn dependency_authority_manifest_symlink_is_rejected_by_inspect() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_workspace("dependency_manifest_symlink");
+    let app = root.join("app");
+    let dependency = root.join("dependency");
+    let outside = root.join("outside");
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "fn main() { return; }\n",
+    );
+    std::fs::create_dir_all(&dependency).expect("dependency root");
+    write_package(
+        &outside,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "fn helper() { return; }\n",
+    );
+    symlink(
+        outside.join("Semantic.package"),
+        dependency.join("Semantic.package"),
+    )
+    .expect("dependency manifest symlink");
+
+    let output = inspect(&app);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("symlink or reparse point"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
 #[test]
 fn capability_request_is_inventory_only_and_never_a_grant() {
     let root = temp_workspace("capability");

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -304,6 +304,35 @@ fn package_entry_symlink_cannot_escape_before_manifest_lookup() {
 }
 
 #[test]
+fn dependency_relative_import_cannot_escape_module_root() {
+    let root = temp_workspace("dependency_import_escape");
+    let app = root.join("app");
+    let dependency = root.join("dependency");
+    write_package(
+        &dependency,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "Import \"../../outside.sm\"\nfn value() -> i32 { return leaked(); }\n",
+    );
+    std::fs::write(
+        root.join("outside.sm"),
+        "fn leaked() -> i32 { return 1; }\n",
+    )
+    .expect("outside source");
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "Import \"dependency::main.sm\"\nfn main() { assert(value() == 1); return; }\n",
+    );
+
+    let output = smc(&["check", &app.to_string_lossy()]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("relative package import '../../outside.sm' escapes package module_root"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
 fn capability_request_is_inventory_only_and_never_a_grant() {
     let root = temp_workspace("capability");
     write_package(

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -106,7 +106,7 @@ fn local_graph_record_is_checkout_independent_and_deterministic() {
         vec!["alpha", "app", "zeta"]
     );
     assert_eq!(packages[1]["capability_requests"][0], "stdout.write");
-    assert!(!String::from_utf8_lossy(&first.stdout).contains(&root.to_string_lossy().as_ref()));
+    assert!(!String::from_utf8_lossy(&first.stdout).contains(root.to_string_lossy().as_ref()));
 
     let app_arg = app.to_string_lossy();
     for command in ["check", "run"] {

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -278,6 +278,31 @@ fn package_content_symlink_is_rejected() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
+#[cfg(unix)]
+#[test]
+fn package_entry_symlink_cannot_escape_before_manifest_lookup() {
+    use std::os::unix::fs::symlink;
+
+    let root = temp_workspace("entry_symlink");
+    let package = root.join("app");
+    write_package(
+        &package,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\n",
+        "fn main() { return; }\n",
+    );
+    let entry = package.join("src/main.sm");
+    std::fs::remove_file(&entry).expect("remove real entry");
+    let outside = root.join("outside.sm");
+    std::fs::write(&outside, "fn main() { return; }\n").expect("outside source");
+    symlink(&outside, &entry).expect("create entry symlink");
+
+    let output = smc(&["check", &package.to_string_lossy()]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("symlink or reparse point"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
 #[test]
 fn capability_request_is_inventory_only_and_never_a_grant() {
     let root = temp_workspace("capability");

--- a/tests/ssf06_package_baseline.rs
+++ b/tests/ssf06_package_baseline.rs
@@ -419,6 +419,38 @@ fn package_import_rejects_unfingerprinted_module_extension() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
+#[test]
+fn package_import_surface_rejects_selected_and_multiple_separators() {
+    let root = temp_workspace("package_import_surface");
+    let dependency = root.join("dependency");
+    let app = root.join("app");
+    write_package(
+        &dependency,
+        "format 1\npackage dependency\nmanifest_dir .\nmodule_root src\n",
+        "fn helper() -> i32 { return 1; }\n",
+    );
+    write_package(
+        &app,
+        "format 1\npackage app\nmanifest_dir .\nmodule_root src\ndep dependency dependency ../dependency\n",
+        "Import \"dependency::main.sm\" { helper }\nfn main() { return; }\n",
+    );
+
+    let selected = smc(&["check", &app.to_string_lossy()]);
+    assert!(!selected.status.success());
+    assert!(String::from_utf8_lossy(&selected.stderr).contains("remain out of scope"));
+
+    std::fs::write(
+        app.join("src/main.sm"),
+        "Import \"dependency::core::util.sm\"\nfn main() { return; }\n",
+    )
+    .expect("multiple-separator import");
+    let multiple = smc(&["check", &app.to_string_lossy()]);
+    assert!(!multiple.status.success());
+    assert!(String::from_utf8_lossy(&multiple.stderr).contains("must be '<alias>::<module_path>'"));
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
 #[cfg(unix)]
 #[test]
 fn authority_manifest_symlink_is_rejected_before_read() {

--- a/tests/support/executable_bundle_support.rs
+++ b/tests/support/executable_bundle_support.rs
@@ -220,9 +220,9 @@ fn validate_executable_bundle_import(
     importer: &Path,
     import: &ExecutableImport,
 ) -> Result<(), String> {
-    if import.reexport || import.wildcard || import.alias.is_some() || import.spec.contains("::") {
+    if import.reexport || import.wildcard || import.alias.is_some() {
         return Err(format!(
-            "top-level executable Import currently admits direct local-path helper-module imports plus selected imports in wave2; alias, wildcard, re-export, and package-qualified import forms remain out of scope in '{}'",
+            "top-level executable Import admits direct local-path and package-qualified helper modules plus selected local imports; alias, wildcard, and re-export forms remain out of scope in '{}'",
             importer.display()
         ));
     }


### PR DESCRIPTION
Closes #1577

## SSF phase
SSF-06 — Package Baseline v0

## Problem / demonstrated gap
Current main had `Semantic.package`, local dependency resolution, and package-qualified path resolution, but the executable frontend still rejected package-qualified imports. Package names were only labels; there was no deterministic full declared-graph record, pinned manifest/content identity, capability-request inventory, or package-specific reparse/root qualification.

## Target contract
`semantic.foundation.package/0.1` with read-only provenance schema `semantic.foundation.package.provenance/0.1`.

## Bounded implementation
- retain the existing `Semantic.package` authority and local path loader
- admit bare package-qualified executable helper imports while keeping alias/wildcard/re-export forms out of scope
- validate contained manifest/module roots, relative dependency paths, and symlink/reparse rejection
- add optional pinned manifest/content fingerprints with deterministic mismatch rejection
- add `capability <id>` inventory that never constructs or propagates a runtime grant
- add `smc package inspect <project-root>` deterministic JSON, without writing a lockfile
- traverse all declared local dependencies in sorted order; reject cycles, missing nodes, name mismatches, and duplicate names at different roots

## Tests / evidence
- SSF-06 integration: deterministic multi-package inspect/check/run; CRLF normalization; cycles; missing dependency; duplicate identity; pinned mismatch; root/absolute-path rejection; capability request != grant
- executable module entry: package-qualified positive and missing-alias negative
- smc-cli lib: 132 passed
- sm-front lib: 449 passed
- PCC-9 acceptance: 119 passed
- project diagnostics/surface, SSF-04, SSF-05, public API, status/language drift, and token-first guards passed
- strict clippy for touched crates passed
- no-default library checks passed
- fmt and diff checks passed
- local `cargo test --workspace --quiet` exceeded the 15-minute workspace window without a reported test failure; this is recorded as timeout, not pass/fail. Exact-head CI is required before merge.

## Non-goals
No registry, remote fetch/solver, publish/install flow, build/install hooks, implicit/transitive grants, broad workspace model, cryptographic signing, or Stable promotion.

## SSF-07 entry
After exact-head CI and review evidence pass, SSF-07 may qualify the frozen type/abstraction contour without widening package resolution.