### PR TITLE
fix(frontend): reserve application builtin identifiers (R1)

### DIFF
--- a/crates/sm-front/src/lib.rs
+++ b/crates/sm-front/src/lib.rs
@@ -143,6 +143,17 @@ pub type RecordTable = BTreeMap<SymbolId, RecordDecl>;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type AdtTable = BTreeMap<SymbolId, AdtDecl>;
 
+const APPLICATION_BUILTIN_NAMES: &[&str] = &[
+    "args_read",
+    "stdin_read_text",
+    "stdout_write",
+    "stderr_write",
+    "path_inspect",
+    "fs_read_text",
+    "fs_write_text",
+    "time_duration_ms",
+];
+
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub type SchemaTable = BTreeMap<SymbolId, SchemaDecl>;
 
@@ -472,13 +483,17 @@ pub fn build_fn_table(program: &Program) -> Result<FnTable, FrontendError> {
     let adt_table = build_adt_table(program)?;
     let mut out = BTreeMap::new();
     for f in &program.functions {
+        let name = resolve_symbol_name(&program.arena, f.name)?;
+        if APPLICATION_BUILTIN_NAMES.contains(&name) {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!("function name '{name}' is reserved for the application boundary"),
+            });
+        }
         if out.contains_key(&f.name) {
             return Err(FrontendError {
                 pos: 0,
-                message: format!(
-                    "duplicate function '{}'",
-                    resolve_symbol_name(&program.arena, f.name)?
-                ),
+                message: format!("duplicate function '{name}'"),
             });
         }
         out.insert(

--- a/docs/spec/controlled_application_boundary_v0.md
+++ b/docs/spec/controlled_application_boundary_v0.md
@@ -26,6 +26,11 @@ denies the exact capability, and only then may the host adapter act.
 The dotted names are capability identities. Foundation Source 1.0 remains
 flat and Rust-like, so they are not source namespaces.
 
+Every source builtin identifier in the capability catalog is reserved for the
+application boundary. A function declaration using one of these identifiers is
+rejected before lowering, so an ordinary local call cannot acquire host
+authority through a name collision.
+
 ## Profiles
 
 | Profile | Grants |

--- a/tests/ssf04_application_boundary.rs
+++ b/tests/ssf04_application_boundary.rs
@@ -23,6 +23,17 @@ fn main() {
 }
 "#;
 
+const ORDINARY_LOCAL_CALL: &str = r#"
+fn local_echo(value: text) -> text {
+    return value;
+}
+
+fn main() {
+    assert(local_echo("local") == "local");
+    return;
+}
+"#;
+
 #[test]
 fn published_contract_and_example_name_the_exact_boundary() {
     let contract = include_str!("../docs/spec/controlled_application_boundary_v0.md");
@@ -41,9 +52,49 @@ fn published_contract_and_example_name_the_exact_boundary() {
     }
     assert!(contract.contains("semantic.foundation.application/0.1"));
     assert!(contract.contains("Network, child process, ambient environment"));
+    assert!(contract.contains("rejected before lowering"));
     assert!(example.contains("args_read"));
     assert!(example.contains("fs_read_text"));
     assert!(example.contains("fs_write_text"));
+}
+
+#[test]
+fn application_builtin_names_cannot_be_declared_as_user_functions() {
+    for (name, source) in [
+        (
+            "fs_write_text",
+            r#"
+fn fs_write_text(path: text, value: text) {
+    return;
+}
+
+fn main() {
+    fs_write_text("local", "payload");
+    return;
+}
+"#,
+        ),
+        (
+            "args_read",
+            r#"
+fn args_read(index: u32) -> text {
+    return "local";
+}
+
+fn main() {
+    assert(args_read(0u32) == "local");
+    return;
+}
+"#,
+        ),
+    ] {
+        let error = compile_program_to_semcode(source)
+            .expect_err("application builtin name must reject before lowering");
+        assert_eq!(
+            error.message,
+            format!("function name '{name}' is reserved for the application boundary")
+        );
+    }
 }
 
 #[derive(Default)]
@@ -134,6 +185,38 @@ fn args_read_transform_write_is_exact_and_replay_deterministic() {
         first.writes,
         vec![("output.txt".to_string(), "payload!".to_string())]
     );
+}
+
+#[test]
+fn ordinary_user_function_still_dispatches_locally() {
+    let bytes = compile_program_to_semcode(ORDINARY_LOCAL_CALL).expect("compile local call");
+    let mut host = MemoryApplicationHost::default();
+    run_verified_semcode_with_application_host_and_capabilities_and_config(
+        &bytes,
+        "main",
+        &mut host,
+        &CapabilityManifest::for_application_profile(ApplicationCapabilityProfile::Pure),
+        ExecutionConfig::for_context(ExecutionContext::VerifiedLocal),
+    )
+    .expect("ordinary local call must run under Pure");
+    assert!(host.calls.is_empty());
+}
+
+#[test]
+fn pure_profile_denies_application_builtin_before_host_dispatch() {
+    let mut host = MemoryApplicationHost {
+        args: vec!["input.txt".to_string(), "output.txt".to_string()],
+        input: "payload".to_string(),
+        ..MemoryApplicationHost::default()
+    };
+    let error = run_flow(&mut host, ApplicationCapabilityProfile::Pure)
+        .expect_err("Pure must deny application builtins");
+    let RuntimeError::CapabilityDenied(denied) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    assert_eq!(denied.capability, CapabilityKind::ArgsRead);
+    assert_eq!(denied.call, Some(HostCallId::ArgsRead));
+    assert!(host.calls.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Repair

R1 / SSF04-FIX-01 from #1598.

Base SHA: `a600b3432aa47c8a173555f41eda6fd60745dace`
Head SHA: `3d26ef5983189022fa48974ff12ebe126410ccb3`

## Violated invariant

A user-declared function must not silently acquire application-host authority because its name collides with an application builtin.

## Decision

Reserve the eight controlled-application builtin identifiers in the shared frontend function-table admission path. This rejects collisions before lowering while leaving ordinary user calls and capability-controlled builtin calls unchanged.

No SemCode call-kind or VM dispatch redesign is included.

## Regression evidence

RED on the exact base: `application_builtin_names_cannot_be_declared_as_user_functions` failed because the colliding `fs_write_text` declaration compiled to `SEMCOD17`.

GREEN on this head:

- `cargo test --test ssf04_application_boundary` — 9 passed
- `cargo test -p sm-front` — 449 passed
- `cargo test -p sm-ir` — 99 passed
- `cargo test -p sm-vm` — 61 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo check --no-default-features --quiet` — passed
- `cargo test --test public_api_contracts --quiet` — passed
- `cargo test --test frontend_boundaries --quiet` — passed
- `cargo test --test dependency_boundaries --quiet` — passed
- `cargo test --test trust_boundary_guards --quiet` — passed

## Scope

Three files only: frontend admission, the controlled application-boundary contract, and SSF-04 regressions.

Progresses #1598.