### PR TITLE
fix(runtime): charge application builtins against max_effect_calls (R2)

### DIFF
--- a/crates/sm-vm/src/semcode_vm.rs
+++ b/crates/sm-vm/src/semcode_vm.rs
@@ -777,6 +777,8 @@ pub fn run_verified_entry_semcode_with_application_host_and_capabilities_and_con
         host,
         capabilities,
         observed: false,
+        quotas: vm.config.quotas,
+        effect_calls: 0,
     };
     let mut observation = HelloObservationRuntime::discard();
     exec_loop(&mut vm, &mut bridge, &mut observation).map(|_| ())
@@ -1603,6 +1605,8 @@ struct ApplicationVmHost<'a, H: ApplicationHostAbi, C: CapabilityChecker> {
     host: &'a mut H,
     capabilities: &'a C,
     observed: bool,
+    quotas: RuntimeQuotas,
+    effect_calls: usize,
 }
 
 impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> ApplicationVmHost<'a, H, C> {
@@ -1622,6 +1626,16 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> ApplicationVmHost<'a, H, C
                 "application writes require a preceding captured observation",
             )))
         }
+    }
+
+    /// Charges one effect-call quota unit for an application host operation that
+    /// already passed its capability check. Must run after `require`/`require_observation`
+    /// and before the actual host dispatch, so quota exhaustion blocks the effect itself.
+    fn bump_effect_calls(&mut self) -> Result<(), RuntimeError> {
+        let next = self.effect_calls + 1;
+        enforce_quota(&self.quotas, QuotaKind::EffectCalls, next)?;
+        self.effect_calls = next;
+        Ok(())
     }
 }
 
@@ -1661,6 +1675,7 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
 
     fn args_read(&mut self, index: u32) -> Result<Value, RuntimeError> {
         self.require(HostCallId::ArgsRead)?;
+        self.bump_effect_calls()?;
         let value = self.host.args_read(index).map_err(RuntimeError::HostAbi)?;
         self.observed = true;
         Ok(Value::Text(value))
@@ -1668,6 +1683,7 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
 
     fn stdin_read_text(&mut self) -> Result<Value, RuntimeError> {
         self.require(HostCallId::StdinReadText)?;
+        self.bump_effect_calls()?;
         let value = self.host.stdin_read_text().map_err(RuntimeError::HostAbi)?;
         self.observed = true;
         Ok(Value::Text(value))
@@ -1676,17 +1692,20 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
     fn stdout_write(&mut self, text: &str) -> Result<(), RuntimeError> {
         self.require(HostCallId::StdoutWrite)?;
         self.require_observation(HostCallId::StdoutWrite)?;
+        self.bump_effect_calls()?;
         self.host.stdout_write(text).map_err(RuntimeError::HostAbi)
     }
 
     fn stderr_write(&mut self, text: &str) -> Result<(), RuntimeError> {
         self.require(HostCallId::StderrWrite)?;
         self.require_observation(HostCallId::StderrWrite)?;
+        self.bump_effect_calls()?;
         self.host.stderr_write(text).map_err(RuntimeError::HostAbi)
     }
 
     fn path_inspect(&mut self, path: &str) -> Result<Value, RuntimeError> {
         self.require(HostCallId::PathInspect)?;
+        self.bump_effect_calls()?;
         let value = self
             .host
             .path_inspect(path)
@@ -1697,6 +1716,7 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
 
     fn fs_read_text(&mut self, path: &str) -> Result<Value, RuntimeError> {
         self.require(HostCallId::FsRead)?;
+        self.bump_effect_calls()?;
         let value = self
             .host
             .fs_read_text(path)
@@ -1708,6 +1728,7 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
     fn fs_write_text(&mut self, path: &str, text: &str) -> Result<(), RuntimeError> {
         self.require(HostCallId::FsWrite)?;
         self.require_observation(HostCallId::FsWrite)?;
+        self.bump_effect_calls()?;
         self.host
             .fs_write_text(path, text)
             .map_err(RuntimeError::HostAbi)
@@ -1715,6 +1736,7 @@ impl<'a, H: ApplicationHostAbi, C: CapabilityChecker> VmHostBridge for Applicati
 
     fn time_duration_millis(&mut self) -> Result<Value, RuntimeError> {
         self.require(HostCallId::TimeDuration)?;
+        self.bump_effect_calls()?;
         let value = self
             .host
             .time_duration_millis()

--- a/tests/ssf04_effect_quota.rs
+++ b/tests/ssf04_effect_quota.rs
@@ -1,0 +1,273 @@
+use prom_abi::{AbiError, AbiFailureKind, ApplicationHostAbi, HostCallId};
+use prom_cap::{ApplicationCapabilityProfile, CapabilityManifest};
+use sm_emit::compile_program_to_semcode;
+use sm_runtime_core::{ExecutionConfig, ExecutionContext, QuotaKind, RuntimeQuotas};
+use sm_vm::{run_verified_semcode_with_application_host_and_capabilities_and_config, RuntimeError};
+
+const FLOW: &str = r#"
+fn main() {
+    let input_path: text = args_read(0u32);
+    let output_path: text = args_read(1u32);
+    let input: text = fs_read_text(input_path);
+    fs_write_text(output_path, input + "!");
+    return;
+}
+"#;
+
+// Exercises all eight application-boundary builtins exactly once each, in the
+// canonical read -> observation -> write -> time order.
+const ALL_EIGHT_BUILTINS_FLOW: &str = r#"
+fn main() {
+    let name: text = args_read(0u32);
+    let piped: text = stdin_read_text();
+    stdout_write(name + piped);
+    stderr_write(name);
+    let exists: bool = path_inspect(name);
+    let content: text = fs_read_text(name);
+    fs_write_text(name, content);
+    let millis: u32 = time_duration_ms();
+    assert(exists == true);
+    assert(millis == 7u32);
+    return;
+}
+"#;
+
+#[derive(Default)]
+struct MemoryApplicationHost {
+    args: Vec<String>,
+    input: String,
+    stdin: String,
+    duration_millis: u32,
+    calls: Vec<HostCallId>,
+    writes: Vec<(String, String)>,
+}
+
+impl MemoryApplicationHost {
+    fn unavailable(call: HostCallId) -> AbiError {
+        AbiError::new(call, AbiFailureKind::Unavailable, "not configured")
+    }
+}
+
+impl ApplicationHostAbi for MemoryApplicationHost {
+    fn args_read(&mut self, index: u32) -> Result<String, AbiError> {
+        self.calls.push(HostCallId::ArgsRead);
+        self.args
+            .get(index as usize)
+            .cloned()
+            .ok_or_else(|| Self::unavailable(HostCallId::ArgsRead))
+    }
+
+    fn stdin_read_text(&mut self) -> Result<String, AbiError> {
+        self.calls.push(HostCallId::StdinReadText);
+        Ok(self.stdin.clone())
+    }
+
+    fn stdout_write(&mut self, _text: &str) -> Result<(), AbiError> {
+        self.calls.push(HostCallId::StdoutWrite);
+        Ok(())
+    }
+
+    fn stderr_write(&mut self, _text: &str) -> Result<(), AbiError> {
+        self.calls.push(HostCallId::StderrWrite);
+        Ok(())
+    }
+
+    fn path_inspect(&mut self, _path: &str) -> Result<bool, AbiError> {
+        self.calls.push(HostCallId::PathInspect);
+        Ok(true)
+    }
+
+    fn fs_read_text(&mut self, _path: &str) -> Result<String, AbiError> {
+        self.calls.push(HostCallId::FsRead);
+        Ok(self.input.clone())
+    }
+
+    fn fs_write_text(&mut self, path: &str, text: &str) -> Result<(), AbiError> {
+        self.calls.push(HostCallId::FsWrite);
+        self.writes.push((path.to_string(), text.to_string()));
+        Ok(())
+    }
+
+    fn time_duration_millis(&mut self) -> Result<u32, AbiError> {
+        self.calls.push(HostCallId::TimeDuration);
+        Ok(self.duration_millis)
+    }
+}
+
+fn build_host() -> MemoryApplicationHost {
+    MemoryApplicationHost {
+        args: vec!["input.txt".to_string(), "output.txt".to_string()],
+        input: "payload".to_string(),
+        ..MemoryApplicationHost::default()
+    }
+}
+
+fn run_flow_with_quota(
+    host: &mut MemoryApplicationHost,
+    max_effect_calls: usize,
+) -> Result<(), RuntimeError> {
+    let bytes = compile_program_to_semcode(FLOW).expect("compile");
+    let quotas = RuntimeQuotas {
+        max_effect_calls,
+        ..RuntimeQuotas::verified_local()
+    };
+    run_verified_semcode_with_application_host_and_capabilities_and_config(
+        &bytes,
+        "main",
+        host,
+        &CapabilityManifest::for_application_profile(
+            ApplicationCapabilityProfile::CliFileTransform,
+        ),
+        ExecutionConfig::new(ExecutionContext::VerifiedLocal, quotas),
+    )
+}
+
+// FLOW performs exactly 4 admitted application host effects:
+// args_read, args_read, fs_read_text, fs_write_text.
+
+#[test]
+fn admitted_application_host_effects_up_to_the_quota_all_pass() {
+    let mut host = build_host();
+    run_flow_with_quota(&mut host, 4).expect("4 admitted effects must fit a quota of 4");
+    assert_eq!(
+        host.writes,
+        vec![("output.txt".to_string(), "payload!".to_string())]
+    );
+}
+
+#[test]
+fn the_fifth_admitted_effect_would_be_denied_but_the_fourth_stays_under_quota_of_four() {
+    // Sanity boundary: one below the required count must already fail deterministically,
+    // proving the quota is actually being enforced per-effect and not just at completion.
+    let mut host = build_host();
+    let error = run_flow_with_quota(&mut host, 3)
+        .expect_err("3 admitted effects must exceed a 4-effect flow");
+    let RuntimeError::QuotaExceeded(exceeded) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    assert_eq!(exceeded.kind, QuotaKind::EffectCalls);
+    assert_eq!(exceeded.limit, 3);
+    assert_eq!(exceeded.used, 4);
+    // The quota must block the fourth host effect (fs_write_text) itself: no write observed.
+    assert!(host.writes.is_empty());
+    // Only the first three admitted effects (args_read, args_read, fs_read_text) executed.
+    assert_eq!(
+        host.calls,
+        vec![
+            HostCallId::ArgsRead,
+            HostCallId::ArgsRead,
+            HostCallId::FsRead
+        ]
+    );
+}
+
+#[test]
+fn a_single_application_host_effect_exceeds_a_zero_quota_deterministically() {
+    let mut host = build_host();
+    let error =
+        run_flow_with_quota(&mut host, 0).expect_err("zero quota must deny the first effect");
+    let RuntimeError::QuotaExceeded(exceeded) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    assert_eq!(exceeded.kind, QuotaKind::EffectCalls);
+    assert_eq!(exceeded.limit, 0);
+    assert_eq!(exceeded.used, 1);
+    assert!(host.calls.is_empty());
+}
+
+#[test]
+fn capability_denied_application_builtins_are_not_charged_against_the_effect_quota() {
+    // Pure denies every application builtin on the capability check, which runs
+    // before the quota charge. A denied attempt must not consume any quota, and
+    // the failure must surface as CapabilityDenied rather than QuotaExceeded even
+    // though the configured quota (1) is otherwise tight enough to matter.
+    let bytes = compile_program_to_semcode(FLOW).expect("compile");
+    let mut host = build_host();
+    let quotas = RuntimeQuotas {
+        max_effect_calls: 1,
+        ..RuntimeQuotas::verified_local()
+    };
+    let error = run_verified_semcode_with_application_host_and_capabilities_and_config(
+        &bytes,
+        "main",
+        &mut host,
+        &CapabilityManifest::for_application_profile(ApplicationCapabilityProfile::Pure),
+        ExecutionConfig::new(ExecutionContext::VerifiedLocal, quotas),
+    )
+    .expect_err("Pure must deny the first application builtin on capability, not quota");
+    assert!(
+        matches!(error, RuntimeError::CapabilityDenied(_)),
+        "unexpected error: {error:?}"
+    );
+    assert!(host.calls.is_empty());
+}
+
+fn run_all_eight_with_quota(
+    host: &mut MemoryApplicationHost,
+    max_effect_calls: usize,
+) -> Result<(), RuntimeError> {
+    let bytes = compile_program_to_semcode(ALL_EIGHT_BUILTINS_FLOW).expect("compile");
+    let quotas = RuntimeQuotas {
+        max_effect_calls,
+        ..RuntimeQuotas::verified_local()
+    };
+    run_verified_semcode_with_application_host_and_capabilities_and_config(
+        &bytes,
+        "main",
+        host,
+        &CapabilityManifest::for_application_profile(
+            ApplicationCapabilityProfile::CliFileTransform,
+        ),
+        ExecutionConfig::new(ExecutionContext::VerifiedLocal, quotas),
+    )
+}
+
+#[test]
+fn every_application_builtin_kind_is_charged_against_the_effect_quota() {
+    // Covers read (args_read/fs_read_text), write (fs_write_text), stdout, stderr,
+    // observation (path_inspect/stdin_read_text) and time paths in one flow: all
+    // eight application builtins, one call each, exactly filling a quota of 8.
+    let mut host = MemoryApplicationHost {
+        args: vec!["input.txt".to_string()],
+        input: "payload".to_string(),
+        stdin: "piped".to_string(),
+        duration_millis: 7,
+        ..MemoryApplicationHost::default()
+    };
+    run_all_eight_with_quota(&mut host, 8).expect("8 admitted effects must fit a quota of 8");
+    assert_eq!(
+        host.calls,
+        vec![
+            HostCallId::ArgsRead,
+            HostCallId::StdinReadText,
+            HostCallId::StdoutWrite,
+            HostCallId::StderrWrite,
+            HostCallId::PathInspect,
+            HostCallId::FsRead,
+            HostCallId::FsWrite,
+            HostCallId::TimeDuration,
+        ]
+    );
+}
+
+#[test]
+fn the_eighth_distinct_builtin_kind_is_blocked_by_a_seven_call_quota() {
+    let mut host = MemoryApplicationHost {
+        args: vec!["input.txt".to_string()],
+        input: "payload".to_string(),
+        stdin: "piped".to_string(),
+        duration_millis: 7,
+        ..MemoryApplicationHost::default()
+    };
+    let error = run_all_eight_with_quota(&mut host, 7)
+        .expect_err("7 admitted effects must exceed an 8-builtin flow");
+    let RuntimeError::QuotaExceeded(exceeded) = error else {
+        panic!("unexpected error: {error:?}");
+    };
+    assert_eq!(exceeded.kind, QuotaKind::EffectCalls);
+    assert_eq!(exceeded.limit, 7);
+    assert_eq!(exceeded.used, 8);
+    // The quota must block time_duration_ms (the eighth effect) itself.
+    assert_eq!(host.calls.len(), 7);
+    assert!(!host.calls.contains(&HostCallId::TimeDuration));
+}


### PR DESCRIPTION
## Summary

R2 / SSF04-FIX-02 from #1598: application host builtins (`args_read`, `stdin_read_text`, `stdout_write`, `stderr_write`, `path_inspect`, `fs_read_text`, `fs_write_text`, `time_duration_ms`), dispatched through generic `Opcode::Call`, never consumed `ExecutionConfig.quotas.max_effect_calls`. Only the dedicated `Gate*/Pulse*/State*/Event*/Clock*` opcodes called `bump_effect_calls`. A loop of application-boundary calls could run unbounded until an unrelated quota (steps/calls) eventually intervened.

## Fix

`ApplicationVmHost` (the `VmHostBridge` used for application-boundary execution) now carries its own `RuntimeQuotas` snapshot and `effect_calls` counter, and charges exactly one effect-call unit per **admitted** application host operation — after the existing capability check (and, for writes, the observation check) and immediately before the actual host dispatch. This means:

- Quota exhaustion blocks the host effect itself (never partially executes it).
- Capability-denied attempts are **not** charged (decision documented below).
- Dedicated host opcodes (Gate/Pulse/State/Event/Clock) are untouched — they already charge via `bump_effect_calls(vm)` at their own call sites, unaffected by this change.

### Decision: denied attempts do not consume quota

Ordering is: capability check → (observation check) → quota charge → host dispatch. A capability-denied call therefore surfaces as `CapabilityDenied`, not `QuotaExceeded`, and leaves the quota untouched. Regression: `capability_denied_application_builtins_are_not_charged_against_the_effect_quota`.

## Tests

New `tests/ssf04_effect_quota.rs` (6 tests):
- `admitted_application_host_effects_up_to_the_quota_all_pass`
- `the_fifth_admitted_effect_would_be_denied_but_the_fourth_stays_under_quota_of_four`
- `a_single_application_host_effect_exceeds_a_zero_quota_deterministically`
- `capability_denied_application_builtins_are_not_charged_against_the_effect_quota`
- `every_application_builtin_kind_is_charged_against_the_effect_quota` (all 8 builtins, one call each)
- `the_eighth_distinct_builtin_kind_is_blocked_by_a_seven_call_quota`

Confirmed RED against pre-fix `main` (all four "must exceed quota" assertions failed with `()` instead of `QuotaExceeded`), GREEN after the fix.

## Evidence

- `cargo test --test ssf04_effect_quota --test ssf04_application_boundary`: 15/15 PASS
- `cargo test -p sm-vm`: 61/61 PASS
- `cargo test -p sm-front -p sm-ir -p sm-verify -p sm-emit`: PASS
- `cargo test -p semantic_language`: 718/719 PASS (1 pre-existing unrelated failure: `canonical_pack_all_sm_files_are_fmt_clean_and_lexically_sound` fails only under local Windows `core.autocrlf=true` checkouts — confirmed via `git diff` that the flagged file is byte-identical to `origin/main`; not present on Linux CI, out of scope for R2)
- `cargo test --test public_api_contracts --test trust_boundary_guards`: 9/9 PASS
- `cargo fmt --check`: clean
- `cargo clippy -p sm-vm -p semantic_language --tests -- -D warnings`: clean

Progresses #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)