### PR TITLE
docs(spec): correct Map / SemCode header contract to SEMCOD14 (R4)

### DIFF
--- a/docs/roadmap/stable_foundation/stable_public_language_contract.md
+++ b/docs/roadmap/stable_foundation/stable_public_language_contract.md
@@ -81,7 +81,7 @@ working experimental research merely to keep the stable contour small.
 - source contract: `semantic.foundation.source/1.0`;
 - parser acceptance envelope: `semantic.foundation` / `1.0`;
 - SemCode: capability-derived supported header, currently `SEMCODE0` through
-  `SEMCOD13`, never chosen solely from profile permission;
+  `SEMCOD14`, never chosen solely from profile permission;
 - verifier: mandatory admission before standard execution;
 - compatibility retention window: deferred to SSF-10;
 - promotion: deferred to SSF-12 plus explicit human decision.

--- a/docs/spec/foundation_source_profile_v1.md
+++ b/docs/spec/foundation_source_profile_v1.md
@@ -201,9 +201,10 @@ semantic.foundation.source/1.0
 
 Foundation Source 1.0 does not mandate one universal SemCode header. Current
 qualified programs may select a member of the documented supported family from
-`SEMCODE0` through `SEMCOD13` according to actual emitted features. A profile
-permission cannot add unused capabilities, and the VM cannot reinterpret an
-unknown header.
+`SEMCODE0` through `SEMCOD14` according to actual emitted features — `SEMCOD14`
+is the header selected when a program actually uses the included `Map(K, V)`
+operations. A profile permission cannot add unused capabilities, and the VM
+cannot reinterpret an unknown header.
 
 SSF-10 owns the long-term source/SemCode compatibility window and artifact
 trust policy. Until that phase closes, this section is a version relationship,

--- a/docs/spec/semcode.md
+++ b/docs/spec/semcode.md
@@ -45,6 +45,7 @@ Current supported header family:
 - `SEMCOD11`
 - `SEMCOD12`
 - `SEMCOD13`
+- `SEMCOD14`
 
 Observed runtime support in the current toolchain:
 
@@ -62,6 +63,7 @@ Observed runtime support in the current toolchain:
 - `SEMCOD11`: epoch `0`, revision `12`
 - `SEMCOD12`: epoch `0`, revision `13`
 - `SEMCOD13`: epoch `0`, revision `14`
+- `SEMCOD14`: epoch `0`, revision `15`
 
 Header responsibilities:
 
@@ -211,6 +213,18 @@ Discipline rules:
 - does not claim executable user-defined `Iterable` impl dispatch, ADT payload
   iteration, schema iteration, or non-frame-local iterator state
 
+`SEMCOD14`
+
+- promoted contract used when emitted program usage requires the deterministic
+  functional `Map(K, V)` empty/get/set/contains operations
+- keeps `SEMCOD13` fixed for artifacts that do not use `Map(K, V)`
+- uses the fixed-width 8-byte header magic form `SEMCOD14`
+- adds the deterministic execution opcodes `MAP_EMPTY`, `MAP_CONTAINS`,
+  `MAP_GET`, and `MAP_SET`
+- requires `CAP_MAP_VALUES` when any of those opcodes is present
+- does not claim mutable in-place map update, iteration, or non-frame-local
+  map state beyond the admitted functional empty/get/set/contains contour
+
 Important rule:
 
 - header selection is derived from actual emitted usage, not from profile
@@ -243,6 +257,7 @@ Current canonical capability families:
 - `CAP_CLOSURE_VALUES`
 - `CAP_OWNERSHIP_PATHS`
 - `CAP_OWNERSHIP_FIELD_PATHS`
+- `CAP_MAP_VALUES`
 - `CAP_DEBUG_SYMBOLS`
 
 Contract rule:

--- a/tests/ssf01_map_semcode14_contract.rs
+++ b/tests/ssf01_map_semcode14_contract.rs
@@ -1,0 +1,75 @@
+use std::{fs, path::Path};
+
+fn read(root: &Path, relative: &str) -> String {
+    fs::read_to_string(root.join(relative))
+        .unwrap_or_else(|error| panic!("failed to read {relative}: {error}"))
+}
+
+/// Collapses newlines/indentation to single spaces so prose assertions don't depend on
+/// exact markdown line wrapping.
+fn normalize(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+const MAP_PROGRAM: &str = r#"
+fn main() {
+    let m: Map(i32, i32) = map_empty();
+    let m2: Map(i32, i32) = map_set(m, 1, 2);
+    assert(map_contains(m2, 1) == true);
+    assert(map_get(m2, 1, 0) == 2);
+    return;
+}
+"#;
+
+#[test]
+fn map_program_selects_the_semcod14_header() {
+    let bytes = sm_emit::compile_program_to_semcode(MAP_PROGRAM).expect("compile Map program");
+    assert_eq!(
+        &bytes[..8],
+        b"SEMCOD14",
+        "a program that actually uses Map(K, V) must select the SEMCOD14 header"
+    );
+}
+
+#[test]
+fn map_program_is_verifier_admitted_and_vm_executed() {
+    let bytes = sm_emit::compile_program_to_semcode(MAP_PROGRAM).expect("compile Map program");
+    sm_vm::run_verified_semcode(&bytes)
+        .expect("verifier must admit and VM must execute the SEMCOD14 artifact");
+}
+
+#[test]
+fn foundation_source_profile_and_semcode_spec_document_semcod14_for_map() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let profile = normalize(&read(root, "docs/spec/foundation_source_profile_v1.md"));
+    assert!(
+        profile.contains("SEMCODE0` through `SEMCOD14`"),
+        "foundation_source_profile_v1.md must document SEMCOD14 as the supported cap now that Map(K, V) is included"
+    );
+    assert!(
+        !profile.contains("SEMCODE0` through `SEMCOD13`"),
+        "foundation_source_profile_v1.md must not still cap the supported family at SEMCOD13"
+    );
+
+    let semcode_spec = read(root, "docs/spec/semcode.md");
+    assert!(
+        semcode_spec.contains("`SEMCOD14`"),
+        "semcode.md must list SEMCOD14 in the versioned header family"
+    );
+    assert!(
+        semcode_spec.contains("CAP_MAP_VALUES"),
+        "semcode.md must document CAP_MAP_VALUES as a canonical capability family"
+    );
+
+    // stable_public_language_contract.md is an SSF-01 evidence/closure record, but its pinned
+    // base commit postdates SEMCOD14's introduction, so it must not undercount the header cap.
+    let contract = normalize(&read(
+        root,
+        "docs/roadmap/stable_foundation/stable_public_language_contract.md",
+    ));
+    assert!(
+        !contract.contains("SEMCODE0` through `SEMCOD13`"),
+        "stable_public_language_contract.md must not still cap the supported family at SEMCOD13"
+    );
+}

--- a/tests/ssf_language_contract_drift.rs
+++ b/tests/ssf_language_contract_drift.rs
@@ -21,7 +21,7 @@ fn ssf_01_language_contract_keeps_its_version_and_evidence_map() {
         "Experimental but currently accepted extensions",
         "Deterministically unsupported forms",
         "Source-to-SemCode relationship",
-        "SEMCODE0` through `SEMCOD13",
+        "SEMCODE0` through `SEMCOD14",
         "not published stable",
     ] {
         assert!(


### PR DESCRIPTION
## Summary

R4 / SSF01-FIX-01 from #1598: Foundation Source 1.0 includes bounded `Map(K, V)` (`docs/spec/foundation_source_profile_v1.md`), and the lowering pipeline already correctly selects the `SEMCOD14` header when Map instructions are actually present (`has_v14_map_instr` in `crates/sm-ir/src/legacy_lowering.rs`) — **the code was already correct**. But the frozen source-profile documentation, `docs/spec/semcode.md`, and the SSF-01 evidence/closure record all still capped the documented supported emitted family at `SEMCOD13`, contradicting the included Map feature's actual runtime requirement.

## Investigation

Confirmed via `git log -S`/`merge-base --is-ancestor` that SEMCOD14/Map support (commit `37a5c8e0`) landed **before** the SSF-01 closure record's own pinned base commit (`4de0b6eb`) — so this was a genuine documentation error at closure time, not information that became stale later. By contrast, `docs/roadmap/language_maturity/semcode_version_discipline.md` genuinely predates SEMCOD14 (its creation commit `03e86c22` predates `37a5c8e0`), so it's left untouched as honest frozen historical snapshot evidence, per the repair issue's rule to preserve historical facts.

## Fix

- `docs/spec/foundation_source_profile_v1.md`: cap raised from `SEMCOD13` to `SEMCOD14`.
- `docs/spec/semcode.md`: added a `SEMCOD14` section (mirroring the existing per-version documentation pattern) and `CAP_MAP_VALUES` to the capability list.
- `docs/roadmap/stable_foundation/stable_public_language_contract.md`: cap raised to `SEMCOD14`.
- `tests/ssf_language_contract_drift.rs`: this existing anti-drift guard had **pinned the stale `SEMCOD13` cap as required text** — updated to require `SEMCOD14`.

## Tests

New `tests/ssf01_map_semcode14_contract.rs` (3 tests):
- `map_program_selects_the_semcod14_header` — a program that actually uses `Map(K, V)` emits header magic `SEMCOD14`
- `map_program_is_verifier_admitted_and_vm_executed` — the verifier admits it and the VM executes it
- `foundation_source_profile_and_semcode_spec_document_semcod14_for_map` — confirmed RED against the pre-fix docs (failed with "must document SEMCOD14... now that Map(K, V) is included"), GREEN after

Evidence:
- `cargo test --test ssf01_map_semcode14_contract --test ssf_language_contract_drift --test ssf_status_drift`: 5/5 PASS
- `cargo test -p semantic_language`: 718/719 PASS (same 1 pre-existing unrelated CRLF failure as R1/R2/R3)
- `cargo fmt --check`: clean
- `cargo clippy -p semantic_language --tests -- -D warnings`: clean

Progresses #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)