### PR TITLE
docs(logos): reconcile System grammar with the actual parser (R5)

### DIFF
--- a/docs/spec/logos.md
+++ b/docs/spec/logos.md
@@ -41,13 +41,15 @@ they are not the primary long-term public contract for the Logos surface.
 Current `System` form:
 
 ```sm
-System Name(param: type, ...)
+System Name(param = value, ...)
 ```
 
 Current rule:
 
 - `System` declares one top-level system descriptor
-- parameters are explicit and typed
+- parameters are `name = value` pairs (an identifier or numeric-literal value),
+  not typed parameter declarations; `parse_logos_system` in `sm-front` admits
+  `name`/`=`/value, not `name`/`:`/type
 
 ## Entity
 

--- a/tests/ssf02_logos_system_grammar.rs
+++ b/tests/ssf02_logos_system_grammar.rs
@@ -1,0 +1,79 @@
+use semantic_language::frontend::parse_logos_program;
+
+// The canonical documented System form: `System Name(param = value, ...)`.
+// Mirrors the fixture at examples/canonical/quad_cycle_logos/src/main.sm.
+const DOCUMENTED_SYSTEM_EXAMPLE: &str = r#"
+System QuadCycle(sample_count = 48, state_period = 4):
+
+Entity Sensor:
+    state val: quad
+    prop threshold: f64
+
+Law "CheckSignal" [priority 10]:
+    When Sensor.val == T -> Log.emit("Signal OK")
+    When Sensor.val == S -> System.recovery()
+"#;
+
+#[test]
+fn documented_system_example_parses_with_name_equals_value_params() {
+    let program = parse_logos_program(DOCUMENTED_SYSTEM_EXAMPLE).expect("logos parse");
+    let system = program.system.expect("System declaration");
+    assert_eq!(system.name, "QuadCycle");
+    assert_eq!(
+        system.params,
+        vec![
+            ("sample_count".to_string(), "48".to_string()),
+            ("state_period".to_string(), "4".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn logos_md_previously_documented_typed_param_form_is_rejected() {
+    // docs/spec/logos.md previously (incorrectly) documented `System Name(param: type, ...)`.
+    // The actual parser requires `name = value`, not `name: type`. This proves the
+    // previously-documented form was never what the parser admitted, and that the
+    // corrected documentation now matches real rejection behavior.
+    let source = r#"
+System QuadCycle(sample_count: u32):
+
+Entity Sensor:
+    state val: quad
+"#;
+    let error = parse_logos_program(source).expect_err("typed `:` params must be rejected");
+    assert!(
+        error.message.contains("expected '='") && error.message.contains("E0202"),
+        "unexpected error: {}",
+        error.message
+    );
+}
+
+#[test]
+fn system_with_no_parameters_still_parses() {
+    let source = r#"
+System QuadCycle:
+
+Entity Sensor:
+    state val: quad
+"#;
+    let program = parse_logos_program(source).expect("logos parse");
+    let system = program.system.expect("System declaration");
+    assert_eq!(system.name, "QuadCycle");
+    assert!(system.params.is_empty());
+}
+
+#[test]
+fn documentation_matches_the_parser_accepted_system_form() {
+    let logos_md = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/spec/logos.md"),
+    )
+    .expect("read logos.md");
+    assert!(
+        logos_md.contains("System Name(param = value, ...)"),
+        "logos.md must document the parser's actual `name = value` System param form"
+    );
+    assert!(
+        !logos_md.contains("System Name(param: type, ...)"),
+        "logos.md must not still document the unimplemented typed `param: type` System form"
+    );
+}


### PR DESCRIPTION
## Summary

R5 / SSF02-FIX-01 from #1598: `docs/spec/logos.md` documented `System`'s form as `System Name(param: type, ...)` (typed parameter declarations), but `sm-front`'s `parse_logos_system` actually parses `name '=' (ident|num)` pairs — config-style key=value parameters, not typed declarations.

## Investigation

The canonical example (`examples/canonical/quad_cycle_logos/src/main.sm`) already used `System QuadCycle(sample_count = 48, state_period = 4):`, and `docs/spec/source_style.md` already documented the real form and even explicitly called out that `logos.md`'s spelling was wrong (line ~323: "`logos.md`'s illustrative `param: type` spelling is not what `parse_logos_system` accepts"). So the parser, the canonical example, and `source_style.md` were all already correct and consistent — only `logos.md` itself needed fixing. No parser change was made or needed; Model B stays intact (Logos remains inspection-only, non-executable).

## Fix

Corrected `docs/spec/logos.md`'s `System` section to document `System Name(param = value, ...)`.

## Tests

New `tests/ssf02_logos_system_grammar.rs` (4 tests):
- `documented_system_example_parses_with_name_equals_value_params` — the canonical example parses with the expected params
- `logos_md_previously_documented_typed_param_form_is_rejected` — the previously-documented typed `:` form is rejected deterministically (`E0202`)
- `system_with_no_parameters_still_parses` — parameterless `System` still works
- `documentation_matches_the_parser_accepted_system_form` — confirmed RED against the pre-fix doc, GREEN after

Evidence:
- `cargo test --test ssf02_logos_system_grammar`: 4/4 PASS
- `cargo test -p semantic_language`: 718/719 PASS (same 1 pre-existing unrelated CRLF-checkout failure as R1-R4)
- `cargo fmt --check` / `cargo clippy -p semantic_language --tests -- -D warnings`: clean

Progresses #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)