### PR TITLE
fix(frontend): reject named arguments to the assert builtin (R6)

### DIFF
--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -8816,6 +8816,12 @@ fn check_builtin_assert_stmt(
     if !is_builtin_assert_name(*name, arena, table)? {
         return Ok(false);
     }
+    if args.iter().any(|a| a.name.is_some()) {
+        return Err(FrontendError {
+            pos: 0,
+            message: "assert builtin takes exactly one positional argument".to_string(),
+        });
+    }
     if args.len() != 1 {
         return Err(FrontendError {
             pos: 0,

--- a/crates/sm-ir/src/legacy_lowering.rs
+++ b/crates/sm-ir/src/legacy_lowering.rs
@@ -8732,6 +8732,12 @@ fn lower_expr_stmt_with_parts(
     let expr = arena.expr(expr_id);
     if let Expr::Call(name, args) = expr {
         if is_builtin_assert_name(*name, arena, fn_table)? {
+            if args.iter().any(|a| a.name.is_some()) {
+                return Err(FrontendError {
+                    pos: 0,
+                    message: "assert builtin takes exactly one positional argument".to_string(),
+                });
+            }
             if args.len() != 1 {
                 return Err(FrontendError {
                     pos: 0,

--- a/tests/ssf03_assert_positional_only.rs
+++ b/tests/ssf03_assert_positional_only.rs
@@ -1,0 +1,75 @@
+use sm_emit::compile_program_to_semcode;
+use sm_runtime_core::RuntimeTrap;
+use sm_vm::{run_verified_semcode, RuntimeError};
+
+fn program(body: &str) -> String {
+    format!("fn main() {{\n    {body}\n    return;\n}}\n")
+}
+
+#[test]
+fn assert_true_is_accepted_and_runs() {
+    let bytes = compile_program_to_semcode(&program("assert(true);")).expect("compile");
+    run_verified_semcode(&bytes).expect("assert(true) must not trap");
+}
+
+#[test]
+fn assert_false_reaches_deterministic_assertion_trap() {
+    let bytes = compile_program_to_semcode(&program("assert(false);")).expect("compile");
+    let error = run_verified_semcode(&bytes).expect_err("assert(false) must trap");
+    assert!(matches!(
+        error,
+        RuntimeError::Trap(RuntimeTrap::AssertionFailed)
+    ));
+}
+
+#[test]
+fn assert_with_zero_arguments_is_rejected() {
+    let error =
+        compile_program_to_semcode(&program("assert();")).expect_err("assert() must reject");
+    assert!(
+        error.message.contains("assert builtin expects 1 arg"),
+        "unexpected error: {}",
+        error.message
+    );
+}
+
+#[test]
+fn assert_with_two_positional_arguments_is_rejected() {
+    let error = compile_program_to_semcode(&program("assert(true, false);"))
+        .expect_err("assert(true, false) must reject");
+    assert!(
+        error.message.contains("assert builtin expects 1 arg"),
+        "unexpected error: {}",
+        error.message
+    );
+}
+
+#[test]
+fn assert_with_a_named_argument_is_rejected() {
+    // The named-argument call syntax in this language is `name = value` (see
+    // sm-front's parse_call_args), not `name: value`. `assert(condition = true)` must
+    // be rejected exactly like any other malformed assert call, not silently accepted
+    // because it still happens to carry exactly one argument value.
+    let error = compile_program_to_semcode(&program("assert(condition = true);"))
+        .expect_err("assert(condition = true) must reject");
+    assert!(
+        error
+            .message
+            .contains("assert builtin takes exactly one positional argument"),
+        "unexpected error: {}",
+        error.message
+    );
+}
+
+#[test]
+fn assert_with_a_non_bool_argument_is_rejected() {
+    let error =
+        compile_program_to_semcode(&program("assert(1);")).expect_err("assert(1) must reject");
+    assert!(
+        error
+            .message
+            .contains("assert builtin requires bool condition"),
+        "unexpected error: {}",
+        error.message
+    );
+}


### PR DESCRIPTION
## Summary

R6 / SSF03-FIX-01 from #1598: the frozen stdlib contract says `assert(condition)` accepts exactly one positional bool. Both admission gates that special-case the `assert` builtin — `check_builtin_assert_stmt` in `crates/sm-front/src/typecheck.rs` and the statement-lowering arm in `crates/sm-ir/src/legacy_lowering.rs` — checked `args.len() != 1` but never checked whether that single argument was *named*.

Sibling builtins right next to each check (`len`, `is_empty`) already reject named arguments via `args.iter().any(|a| a.name.is_some())`; `assert` did not. Note: this language's named-argument call syntax is `name = value` (see `sm-front::parse_call_args`), not `name: value` as the issue's illustrative text suggested — reproduced and fixed against the real syntax.

## Reproduction

Confirmed RED against current `main`: `assert(condition = true)` silently compiled to identical SemCode as `assert(true)` and ran without error.

## Fix

Added the same named-argument guard to both gates (typecheck and lowering), as its own check ahead of the existing arity check — this preserves the exact `"assert builtin expects 1 arg, got N"` message (pinned by an existing test, `pcc8_assert_wrong_arity_rejects_and_does_not_verify`) for plain arity mismatches, while giving named-argument calls a distinct `"assert builtin takes exactly one positional argument"` message.

## Tests

New `tests/ssf03_assert_positional_only.rs` (6 tests) covering the full R6 checklist:
- `assert(true)` accepted and runs
- `assert(false)` reaches a deterministic `RuntimeTrap::AssertionFailed`
- `assert()` and `assert(true, false)` rejected on arity
- `assert(condition = true)` rejected as a named argument (confirmed RED before the fix)
- `assert(1)` rejected on type

Evidence:
- `cargo test --test ssf03_assert_positional_only`: 6/6 PASS
- `cargo test -p sm-front -p sm-ir -p sm-emit -p sm-verify`: 449 + 99 + 64 (+ existing sm-emit) all PASS — no existing test broke, including the pinned-message arity test
- `cargo test -p semantic_language`: 718/719 PASS (same 1 pre-existing unrelated CRLF-checkout failure as R1-R5)
- `cargo fmt --check` / `cargo clippy -p sm-front -p sm-ir -p semantic_language --tests -- -D warnings`: clean

Progresses #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)