### PR TITLE
fix(smc-cli): frame application stderr to keep it distinct from audit evidence (R7)

### DIFF
--- a/crates/smc-cli/src/application_host.rs
+++ b/crates/smc-cli/src/application_host.rs
@@ -8,6 +8,24 @@ pub(crate) const APPLICATION_AUDIT_SCHEMA: &str = "semantic.foundation.applicati
 const MAX_APPLICATION_TEXT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_APPLICATION_PATH_BYTES: usize = 4096;
 
+/// Every physical stderr line written on behalf of the application carries this
+/// prefix. Trusted audit lines (rendered separately by the CLI, see
+/// `ApplicationAuditRecord::render`) always start with `schema=` and never with
+/// this prefix, so a payload that embeds literal audit-schema-looking text still
+/// renders as unambiguously application-controlled, and cannot concatenate onto
+/// a following trusted line since every framed line is newline-terminated here
+/// regardless of whether the application's own text was.
+const APPLICATION_STDERR_LINE_PREFIX: &str = "application| ";
+
+fn write_framed_application_stderr<W: Write>(writer: &mut W, text: &str) -> io::Result<()> {
+    for line in text.lines() {
+        writer.write_all(APPLICATION_STDERR_LINE_PREFIX.as_bytes())?;
+        writer.write_all(line.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ApplicationAuditRecord {
     sequence: u64,
@@ -327,7 +345,7 @@ impl ApplicationHostAbi for CliApplicationHost {
     fn stderr_write(&mut self, text: &str) -> Result<(), AbiError> {
         self.require_observation(HostCallId::StderrWrite)?;
         self.ensure_text_limit(HostCallId::StderrWrite, text.len())?;
-        io::stderr().write_all(text.as_bytes()).map_err(|error| {
+        write_framed_application_stderr(&mut io::stderr(), text).map_err(|error| {
             self.error(
                 HostCallId::StderrWrite,
                 AbiFailureKind::HostFault,
@@ -519,5 +537,49 @@ mod tests {
             .expect("symlink root must fail");
         assert!(error.contains("symlink or reparse point"));
         fs::remove_file(link).expect("cleanup");
+    }
+
+    #[test]
+    fn framed_stderr_prefixes_every_line_and_always_newline_terminates() {
+        let mut out = Vec::new();
+        write_framed_application_stderr(&mut out, "first\nsecond").expect("write");
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            "application| first\napplication| second\n"
+        );
+    }
+
+    #[test]
+    fn framed_stderr_cannot_impersonate_a_trusted_audit_line() {
+        // A payload that embeds a literal audit-schema-looking line must still render
+        // with the application prefix, never bare, so it can never be confused with a
+        // genuine ApplicationAuditRecord::render() line (which always starts with `schema=`
+        // and is never framed this way).
+        let forged = "schema=semantic.foundation.application.audit/0.1 seq=0 capability=fs.write decision=allow bytes=0 path_hash=- payload_hash=-";
+        let mut out = Vec::new();
+        write_framed_application_stderr(&mut out, forged).expect("write");
+        let rendered = String::from_utf8(out).expect("utf8");
+        assert_eq!(
+            rendered,
+            format!("{APPLICATION_STDERR_LINE_PREFIX}{forged}\n")
+        );
+        assert!(!rendered.starts_with("schema="));
+    }
+
+    #[test]
+    fn framed_stderr_of_an_unterminated_payload_cannot_merge_onto_a_following_line() {
+        let mut out = Vec::new();
+        write_framed_application_stderr(&mut out, "no trailing newline").expect("write");
+        // The framed output always ends in `\n`, so anything written to the same stream
+        // immediately afterward (such as a trusted audit line) starts on a fresh line
+        // rather than concatenating onto the application's payload.
+        assert!(out.ends_with(b"\n"));
+    }
+
+    #[test]
+    fn framed_stderr_of_empty_text_writes_nothing() {
+        let mut out = Vec::new();
+        write_framed_application_stderr(&mut out, "").expect("write");
+        assert!(out.is_empty());
     }
 }

--- a/docs/spec/controlled_application_boundary_v0.md
+++ b/docs/spec/controlled_application_boundary_v0.md
@@ -73,6 +73,16 @@ audit stream. A denied operation has `decision=deny`, no payload hashes, and is
 also returned as a structured runtime or ABI error. Records for any preceding
 admitted operations are still emitted.
 
+Application-controlled `stderr_write` payload and the CLI's own audit records
+share process stderr, so untrusted application text is never written raw.
+Every physical line the application writes to stderr is prefixed with
+`application| ` and always newline-terminated, regardless of whether the
+application's own text ended in a newline. Audit records always start with
+`schema=` and are never prefixed that way. This keeps the two evidence
+classes unambiguous even if application text embeds newlines or literally
+contains audit-schema-looking text, and prevents an unterminated application
+write from concatenating onto a following audit line.
+
 ## CLI contour
 
 The existing one-argument `smc run <input>` behavior remains the controlled


### PR DESCRIPTION
## Summary

R7 / SSF04-FIX-03 from #1598: application-controlled `stderr_write` payload and the CLI's trusted audit records (`ApplicationAuditRecord::render`, always starting with `schema=`) share process stderr. Application text was written raw via `io::stderr().write_all(text.as_bytes())`: payload without a trailing newline could concatenate onto a following audit line, and payload could embed a literal audit-schema-looking line that would be visually indistinguishable from genuine trusted evidence.

## Fix

Chosen design (option 2 from the issue's three acceptable bounded designs — "unambiguous structured/framed audit output"): added `write_framed_application_stderr`, which prefixes every physical line of application-controlled stderr output with `application| ` and always newline-terminates it, regardless of whether the application's own text was newline-terminated. Genuine audit lines never carry that prefix and always start with `schema=`, so the two evidence classes stay unambiguous even when application text embeds newlines or the literal audit schema string.

A true separate sink (option 1) was not chosen: it would add a new file descriptor/channel, which the checklist explicitly wants avoided ("avoids new ambient capability") when framing alone is sufficient.

Redaction/hashing in the audit record itself (`ApplicationAuditRecord::render`, `record_denied`) is untouched — this is a framing fix at the raw-byte-write site only, not an audit-format change. `stdout_write` is untouched (out of scope: the CLI has no trusted stdout evidence stream to protect).

## Tests

Four new unit tests in `crates/smc-cli/src/application_host.rs::tests`:
- `framed_stderr_prefixes_every_line_and_always_newline_terminates`
- `framed_stderr_cannot_impersonate_a_trusted_audit_line` — a forged payload containing the literal audit schema string still renders prefixed, never bare
- `framed_stderr_of_an_unterminated_payload_cannot_merge_onto_a_following_line`
- `framed_stderr_of_empty_text_writes_nothing`

Evidence:
- `cargo test -p smc-cli`: 136/136 PASS
- `cargo test -p semantic_language`: 718/719 PASS (same 1 pre-existing unrelated CRLF-checkout failure as R1-R6)
- `cargo fmt --check` / `cargo clippy -p smc-cli --tests -- -D warnings`: clean

Progresses #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)