### PR TITLE
SSF-07: reject blanket/generic impls, pin deterministic rejection for deferred trait forms

### DIFF
--- a/crates/sm-front/src/parser.rs
+++ b/crates/sm-front/src/parser.rs
@@ -6498,6 +6498,68 @@ trait Display {
         assert_eq!(method.ret, Type::I32);
     }
 
+    // SSF-07 (issue #1578) explicitly defers default methods in trait bodies as
+    // a non-goal. A method body in the trait declaration itself (rather than a
+    // bare `;`-terminated signature) is already a deterministic parse error
+    // via parse_trait_method_sig's `expect(Semi, ...)` -- pin that behavior.
+    #[test]
+    fn default_method_in_trait_body_is_rejected() {
+        let src = r#"
+trait Greet {
+    fn hello(self: i32) -> i32 {
+        return 1;
+    }
+}
+"#;
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("a trait method with a default body must be rejected");
+        assert!(
+            err.message.contains("';'") || err.message.contains("Semi"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    // SSF-07 explicitly defers trait objects (`dyn Trait`) as a non-goal. `dyn`
+    // is not a reserved keyword, so it lexes as a plain identifier and is
+    // parsed as an ordinary (nonexistent) nominal type named `dyn`, leaving
+    // the following type name dangling -- a deterministic parse error, though
+    // an incidental one rather than a purpose-built diagnostic. Pin the
+    // current behavior rather than invent dedicated `dyn` handling for a
+    // feature this phase explicitly does not support.
+    #[test]
+    fn dyn_trait_object_syntax_is_rejected() {
+        let src = r#"
+trait Show {
+    fn show(self: i32, other: dyn Show) -> i32;
+}
+"#;
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("`dyn Trait` trait-object syntax must be rejected");
+        assert!(!err.message.is_empty(), "expected a parse error");
+    }
+
+    // SSF-07 explicitly defers associated types as a non-goal. `type Item;`
+    // inside a trait body is already a deterministic parse error, since
+    // parse_trait_decl's body loop unconditionally requires `fn` -- pin that
+    // behavior.
+    #[test]
+    fn associated_type_in_trait_is_rejected() {
+        let src = r#"
+trait Container {
+    type Item;
+    fn get(self: i32) -> i32;
+}
+"#;
+        let err = parse_rustlike_with_profile(src, &ParserProfile::foundation_default())
+            .expect_err("an associated type declaration in a trait must be rejected");
+        assert!(
+            err.message.contains("'fn'") || err.message.contains("KwFn"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn trait_decl_with_multiple_method_sigs_is_parsed() {
         let src = r#"

--- a/crates/sm-front/src/typecheck.rs
+++ b/crates/sm-front/src/typecheck.rs
@@ -6826,6 +6826,39 @@ mod tests {
 
     // M9.2 Wave 3 — trait coherence, conformance, and bound satisfaction
 
+    // SSF-07 explicitly defers blanket/generic impls (`impl<T> Trait for T`) --
+    // ImplDecl.type_params is documented as "Empty in first-wave canonical form"
+    // but nothing previously enforced that, so a blanket-shaped impl silently
+    // typechecked as an ordinary impl for a nominal type literally named `T`.
+    // Reject any impl with non-empty type_params deterministically instead.
+    #[test]
+    fn blanket_impl_with_type_params_is_rejected() {
+        let src = r#"
+            trait Show {
+                fn show(self: MyType) -> i32;
+            }
+
+            record MyType { x: i32 }
+
+            impl<T> Show for MyType {
+                fn show(self: MyType) -> i32 {
+                    return 0;
+                }
+            }
+
+            fn main() {
+                return;
+            }
+        "#;
+        let err = typecheck_source(src)
+            .expect_err("blanket/generic impl with type_params must be rejected");
+        assert!(
+            err.message.contains("generic") || err.message.contains("type param"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn duplicate_impl_same_trait_and_type_is_rejected() {
         let src = r#"
@@ -9285,10 +9318,29 @@ fn check_loop_expr_stmt(
     }
 }
 
-/// Coherence check: at most one impl per (trait_name, for_type) pair.
+/// Coherence check: at most one impl per (trait_name, for_type) pair, and no
+/// generic/blanket impls. `ImplDecl.type_params` is documented as "Empty in
+/// first-wave canonical form" (see its doc comment in types.rs), but nothing
+/// previously enforced that -- a blanket-shaped impl such as
+/// `impl<T> Trait for T` or an impl declaring an unused type parameter both
+/// silently typechecked. Trait objects, associated types, blanket impls,
+/// specialization, and default methods are explicit SSF-07 non-goals
+/// (docs/spec/foundation_source_profile_v1.md); this is the enforcement point
+/// for the blanket-impl/specialization carve-out specifically.
 fn validate_trait_coherence(impls: &[ImplDecl], arena: &AstArena) -> Result<(), FrontendError> {
     let mut seen: BTreeSet<(SymbolId, SymbolId)> = BTreeSet::new();
     for imp in impls {
+        if !imp.type_params.is_empty() {
+            return Err(FrontendError {
+                pos: 0,
+                message: format!(
+                    "impl of trait '{}' for type '{}' declares type parameters; \
+                     generic/blanket impls are not supported",
+                    resolve_symbol_name(arena, imp.trait_name)?,
+                    resolve_symbol_name(arena, imp.for_type)?,
+                ),
+            });
+        }
         let key = (imp.trait_name, imp.for_type);
         if !seen.insert(key) {
             return Err(FrontendError {


### PR DESCRIPTION
## Summary

First implementation slice for SSF-07 (#1578, "Type and abstraction closure"), the phase activated after SSF-06's repair program closed (#1598, PR #1597).

`docs/spec/foundation_source_profile_v1.md` explicitly lists trait objects, associated types, blanket impls, specialization, and default methods as "deterministically unsupported forms" that must fail before execution with a canonical diagnostic. Four of the five already did, incidentally, at parse time. **Blanket/generic impls did not**: `ImplDecl.type_params` is documented as "Empty in first-wave canonical form," but nothing enforced it — `impl<T> Trait for T` (or any impl declaring an unused type parameter) silently typechecked as an ordinary impl for a nominal type literally named by the parameter, contradicting the spec's own claim.

`validate_trait_coherence` now rejects any impl with non-empty `type_params` before the existing duplicate-impl check. No `.sm` fixture anywhere in the repo uses `impl<...>` syntax, so this closes a real, previously-undetected spec-violating gap with no legitimate-usage risk.

## Regression coverage

- `blanket_impl_with_type_params_is_rejected` (`typecheck.rs`) — the real fix; confirmed RED (silently accepted) before the fix, GREEN after.
- `default_method_in_trait_body_is_rejected`, `associated_type_in_trait_is_rejected`, `dyn_trait_object_syntax_is_rejected` (`parser.rs`) — pin the three forms that were already correctly, if incidentally, rejected at parse time.
- Specialization needs no new test: already covered by `trait_self_contract_allows_multiple_impl_targets`, and now fully moot since a true blanket impl can no longer be constructed to overlap with a concrete one.

## Test plan
- [x] `cargo test -p sm-front`: 454/454 PASS (450 baseline + 4 new).
- [x] `cargo test -p sm-ir -p sm-sema -p sm-verify -p sm-vm`: all PASS, no regressions.
- [x] `cargo fmt --check` / `cargo clippy -p sm-front --all-targets -- -D warnings`: clean.
- [x] `tools/7hell/run.ps1`: ALL 7 GATES PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)